### PR TITLE
feat(apps): derive app_listing_metrics.open_count from App_Open events (2/4)

### DIFF
--- a/src/server/jobs/update-metrics.ts
+++ b/src/server/jobs/update-metrics.ts
@@ -24,8 +24,11 @@ const metricSets = {
 const metricSchedules: Record<string, string> = {
   'model-collections': '*/5 * * * *', // every 5 minutes
   basemodels: '*/5 * * * *', // every 5 minutes
-  // Install/connect counts don't need minute-freshness — the store `popular`
-  // sort tolerates a few minutes of lag. Off-peak the affected set is empty.
+  // Install and play (open) counts don't need minute-freshness — the store
+  // `popular` sort tolerates a few minutes of lag. Off-peak the affected set is
+  // empty. The interval is also a cost knob: each run's play count is an unbounded
+  // ClickHouse scan (see appListing.metrics.sql.ts), so tightening this multiplies
+  // that scan rather than the useful work.
   'app-listings': '*/5 * * * *', // every 5 minutes
 };
 

--- a/src/server/metrics/__tests__/appListing.metrics.processor.test.ts
+++ b/src/server/metrics/__tests__/appListing.metrics.processor.test.ts
@@ -1,0 +1,118 @@
+import client from 'prom-client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 THE SEAM, NOT EITHER SIDE OF IT.
+ *
+ * appListing.metrics.test.ts proves the soft-degrade POLICY (a query rejection
+ * degrades; a builder or mapping throw propagates). appListing.metrics.prom.test.ts
+ * proves the SIGNAL exists on the registry `/api/metrics` scrapes and increments.
+ * Both pass with the processor's `onDegrade` never calling the emitter at all — the
+ * counter would be a correct, registered, permanently-zero series, and "blipped
+ * once" vs "dead for a week" would still be indistinguishable, which is the entire
+ * reason the counter was added.
+ *
+ * So this file drives the REAL `appListingMetrics.update()` with a real (unmocked)
+ * `appListing.metrics.sql` and a real prom registry, and mocks only the infra edges
+ * the processor talks to: ClickHouse, Postgres, the job-date/queue plumbing.
+ */
+
+const { chQuery, pgCancellableQuery } = vi.hoisted(() => ({
+  chQuery: vi.fn(),
+  pgCancellableQuery: vi.fn(),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: { query: chQuery } }));
+vi.mock('~/server/jobs/job', () => ({
+  // An hour ago, so base.metrics' `shouldUpdate` gate is open.
+  getJobDate: async () => [new Date(Date.now() - 3_600_000), async () => undefined],
+}));
+vi.mock('~/server/redis/queues', () => ({
+  checkoutQueue: async () => ({ content: [], commit: async () => undefined }),
+  addToQueue: async () => undefined,
+}));
+vi.mock('~/server/db/pgDb', () => ({
+  pgDbWrite: { cancellableQuery: pgCancellableQuery },
+  pgDbRead: { cancellableQuery: pgCancellableQuery },
+  pgDbReadLong: { cancellableQuery: pgCancellableQuery },
+}));
+
+import { appListingMetrics } from '../appListing.metrics';
+
+const METRIC = 'civitai_app_listing_open_discovery_degraded_total';
+const jobContext = { checkIfCanceled: () => undefined, on: () => undefined } as never;
+
+/** A @clickhouse/client ResultSet stand-in. */
+const chRows = (rows: unknown[]) => ({ json: async () => rows });
+/** A pg `cancellableQuery` stand-in. */
+const pgRows = (rows: unknown[]) => ({ result: async () => rows, cancel: async () => undefined });
+
+async function degradeCount(): Promise<number> {
+  const metric = client.register.getSingleMetric(METRIC) as
+    | { get(): Promise<{ values: Array<{ value: number }> }> }
+    | undefined;
+  if (!metric) return Number.NaN;
+  return (await metric.get()).values[0]?.value ?? Number.NaN;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // `resetMetrics()`, NOT `removeSingleMetric()`: the counter is registered eagerly
+  // at the prom module's scope (which this file's import of the processor pulls in),
+  // and removing it would delete exactly the "healthy pod reports 0" property the
+  // negative control below is asserting.
+  client.register.resetMetrics();
+});
+
+describe('appListingMetrics.update — the degrade signal is actually wired', () => {
+  it('🔴 a ClickHouse DISCOVERY failure increments the counter AND the run continues', async () => {
+    // The regression the soft path exists to prevent is `install_count` being held
+    // hostage by a ClickHouse blip, so both halves are asserted together: the signal
+    // fires, and the Postgres affected-set query still runs.
+    chQuery.mockRejectedValue(new Error('MEMORY_LIMIT_EXCEEDED'));
+    pgCancellableQuery.mockResolvedValue(pgRows([]));
+
+    await expect(appListingMetrics.update(jobContext)).resolves.toBeUndefined();
+
+    expect(await degradeCount()).toBe(1);
+    expect(pgCancellableQuery).toHaveBeenCalledTimes(1);
+    expect(pgCancellableQuery.mock.calls[0][0]).toContain('app_listings');
+  });
+
+  it('🔴 NEGATIVE CONTROL: a HEALTHY run leaves the counter at 0', async () => {
+    // Without this the counter could be incremented unconditionally — a series that
+    // is always non-zero cannot distinguish a degrade from a normal cycle, which is
+    // the same blindness with the opposite sign.
+    chQuery
+      .mockResolvedValueOnce(chRows([{ appBlockId: 'apb_x' }])) // discovery
+      .mockResolvedValueOnce(chRows([{ appBlockId: 'apb_x', openCount: 4 }])); // count
+    pgCancellableQuery
+      .mockResolvedValueOnce(pgRows([{ id: 'apl_1', app_block_id: 'apb_x' }])) // affected
+      .mockResolvedValueOnce(pgRows([])); // upsert
+
+    await appListingMetrics.update(jobContext);
+
+    expect(await degradeCount()).toBe(0);
+    // Positive control on the fixture: the run really did do its work, so the 0
+    // above is "nothing degraded", not "nothing ran".
+    expect(chQuery).toHaveBeenCalledTimes(2);
+    expect(pgCancellableQuery).toHaveBeenCalledTimes(2);
+    expect(pgCancellableQuery.mock.calls[1][0]).toContain('ON CONFLICT');
+  });
+
+  it('🔴 the COUNT read fails HARD and does NOT touch the degrade counter', async () => {
+    // The asymmetry, at the seam: `open_count` is derived, so a partial count map is
+    // written over live counts as 0. That must fail the run, not degrade it — and it
+    // must not be reported on the counter that means "we degraded and carried on".
+    chQuery
+      .mockResolvedValueOnce(chRows([{ appBlockId: 'apb_x' }])) // discovery succeeds
+      .mockRejectedValueOnce(new Error('Code: 62. DB::Exception: Max query size exceeded'));
+    pgCancellableQuery.mockResolvedValueOnce(pgRows([{ id: 'apl_1', app_block_id: 'apb_x' }]));
+
+    await expect(appListingMetrics.update(jobContext)).rejects.toThrow('Code: 62');
+
+    expect(await degradeCount()).toBe(0);
+    // No upsert ran — the counts stay at their last good values.
+    expect(pgCancellableQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/metrics/__tests__/appListing.metrics.prom.test.ts
+++ b/src/server/metrics/__tests__/appListing.metrics.prom.test.ts
@@ -1,0 +1,144 @@
+import client from 'prom-client';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  ensureRegisterAppListingMetrics,
+  recordAppListingOpenDiscoveryDegrade,
+} from '../appListing.metrics.prom';
+
+/**
+ * The REAL prom-client side of the AppListing play-discovery degrade signal.
+ *
+ * 🔴 WHY THIS SIGNAL EXISTS AT ALL. `fetchRecentlyOpenedBlockIds` fails SOFT: when
+ * ClickHouse cannot answer, the run recomputes `install_count` only and returns an
+ * empty play-candidate set. That degraded state is by construction
+ * INDISTINGUISHABLE from a quiet cycle — both produce an empty list and an
+ * unchanged `open_count` — so "blipped once" and "dead for a week" look identical
+ * from the outside. One Axiom warning per run cannot express that difference as an
+ * alert; a counter's rate over time can.
+ *
+ * 🔴 WHY IT IS TESTED AGAINST THE REAL REGISTRY. A metric-name typo or a registry
+ * the scrape does not read would produce an alert rule that silently never fires —
+ * the same class of defect the counter exists to remove. So this file drives the
+ * actual default registry that `/api/metrics` collects, rather than a spy.
+ */
+
+const METRIC = 'civitai_app_listing_open_discovery_degraded_total';
+
+/**
+ * 🔴 CAPTURED AT MODULE SCOPE, ON PURPOSE — this is the ONLY place the eager
+ * registration is observable.
+ *
+ * ES imports are evaluated before this line, so this records the registry state
+ * produced by NOTHING BUT importing the module. Every `it` below runs after a
+ * `beforeEach` that removes the metric, and the first one to call the emitter
+ * registers it again — so inside a test body "is it registered?" is answered by
+ * whatever ran earlier in the file, not by the module. Measured: deleting the
+ * module-scope `ensureRegisterAppListingMetrics()` call left the whole suite GREEN
+ * until this capture existed.
+ */
+const REGISTERED_BY_IMPORT_ALONE = client.register.getSingleMetric(METRIC) !== undefined;
+
+/** Read the counter's single (unlabelled) series from the default registry. */
+async function read(): Promise<number> {
+  const metric = client.register.getSingleMetric(METRIC) as
+    | { get(): Promise<{ values: Array<{ value: number }> }> }
+    | undefined;
+  if (!metric) return Number.NaN;
+  const { values } = await metric.get();
+  return values[0]?.value ?? Number.NaN;
+}
+
+beforeEach(() => {
+  // Full isolation, not `resetMetrics()`: two tests below deliberately re-register
+  // the name (once absent, once with an incompatible TYPE), and `resetMetrics` only
+  // zeroes values — it would leave those registrations standing for the next test.
+  client.register.removeSingleMetric(METRIC);
+});
+
+describe(METRIC, () => {
+  it('is registered on the DEFAULT registry — the one /api/metrics scrapes', () => {
+    ensureRegisterAppListingMetrics();
+    expect(client.register.getSingleMetric(METRIC)).toBeDefined();
+  });
+
+  it('🔴 is registered by IMPORTING the module — a never-degraded pod is 0, not absent', () => {
+    // If registration only happened inside the emitter, the series would not exist
+    // until the first degrade: a healthy pod would scrape `no data`, which reads as
+    // "nothing ever degraded" but equally means "the instrument was never wired" —
+    // precisely the ambiguity this counter exists to remove. The processor imports
+    // this module, so import-time registration is what makes the 0 real in prod.
+    expect(REGISTERED_BY_IMPORT_ALONE).toBe(true);
+  });
+
+  it('reports an observable 0 before anything degrades, not `no data`', async () => {
+    // An absent series is ambiguous — it reads as "nothing ever went wrong" when it
+    // may equally mean "nobody loaded the module". An unlabelled prom-client counter
+    // materialises its single series at registration, which is what removes that.
+    ensureRegisterAppListingMetrics();
+    expect(await read()).toBe(0);
+  });
+
+  it('increments once per degraded run', async () => {
+    ensureRegisterAppListingMetrics();
+    expect(await read()).toBe(0);
+    recordAppListingOpenDiscoveryDegrade();
+    expect(await read()).toBe(1);
+    recordAppListingOpenDiscoveryDegrade();
+    recordAppListingOpenDiscoveryDegrade();
+    expect(await read()).toBe(3);
+  });
+
+  it('registers itself when the emitter is the first caller', async () => {
+    // The processor's onDegrade calls only the emitter — it never calls the
+    // ensure-register helper first. If registration were left to some other module,
+    // the very first degrade would be lost.
+    client.register.removeSingleMetric(METRIC);
+    expect(client.register.getSingleMetric(METRIC)).toBeUndefined();
+    recordAppListingOpenDiscoveryDegrade();
+    expect(await read()).toBe(1);
+  });
+
+  it('🔴 declares NO labels — persistence is read from the rate, attribution from the log', async () => {
+    // Asserted against the DECLARED labelNames, not the emitted series: prom-client
+    // omits a declared-but-never-supplied label from the output, so inspecting
+    // `values[].labels` stays green while the metric is declared wide open. The
+    // natural label here would be the ClickHouse error message — an unbounded
+    // population that would blow the cardinality budget. It lives in the Axiom
+    // warning instead.
+    const metric = ensureRegisterAppListingMetrics().openDiscoveryDegradedTotal as unknown as {
+      labelNames: string[];
+    };
+    expect([...metric.labelNames]).toEqual([]);
+
+    recordAppListingOpenDiscoveryDegrade();
+    const values = await (
+      client.register.getSingleMetric(METRIC) as unknown as {
+        get(): Promise<{ values: Array<{ labels: Record<string, string> }> }>;
+      }
+    ).get();
+    expect(values.values).toHaveLength(1);
+    expect(values.values[0].labels).toEqual({});
+  });
+
+  it('is get-or-create — a second import reuses the instance instead of throwing', () => {
+    const first = ensureRegisterAppListingMetrics().openDiscoveryDegradedTotal;
+    const second = ensureRegisterAppListingMetrics().openDiscoveryDegradedTotal;
+    expect(second).toBe(first);
+  });
+
+  it('🔴 NEVER THROWS — a metrics failure must not fail the run it is observing', () => {
+    // The emitter sits inside the catch that keeps `install_count` running through a
+    // ClickHouse outage, so a registry collision must not convert a degrade into a
+    // failed run. Claim the name with an INCOMPATIBLE type (a Histogram has
+    // `observe`, not `inc`), so the get-or-create's unchecked cast hands the emitter
+    // an object whose `.inc` is undefined.
+    new client.Histogram({ name: METRIC, help: 'collision', registers: [client.register] });
+    // Positive control: without this, a future prom-client where the collision does
+    // NOT produce a throwing call site would make the assertion below vacuous.
+    const claimed = client.register.getSingleMetric(METRIC) as unknown as { inc?: unknown };
+    expect(typeof claimed.inc).toBe('undefined');
+
+    expect(() => recordAppListingOpenDiscoveryDegrade()).not.toThrow();
+  });
+});

--- a/src/server/metrics/__tests__/appListing.metrics.test.ts
+++ b/src/server/metrics/__tests__/appListing.metrics.test.ts
@@ -5,6 +5,8 @@ import {
   APP_LISTING_BATCH_SIZE,
   APP_LISTING_METRIC_UPSERT_SQL,
   APP_OPEN_ACTION_TYPE,
+  APP_OPEN_CH_CHUNK_SIZE,
+  APP_OPEN_COUNT_QUERY_MARKER,
   appOpenActorKey,
   appOpenUtcDay,
   buildAppOpenCountSql,
@@ -587,6 +589,14 @@ describe('affected-set selection — arms, including the repair arm', () => {
   });
 
   it('REPAIR: also fires on a non-zero install_count, and on an OFF-SITE row', () => {
+    // 🔴 THE PREDICATE IS "NULL JOIN KEY + NON-ZERO COUNT", NOT "the AppBlock was
+    // deleted". `app_block_id IS NULL` is not a kind discriminator (schema.prisma
+    // on `AppListing.appBlockId`), so the arm also covers a natively-created
+    // off-site listing that never had a block to lose — `apl_offsite` here IS that
+    // population. In production its counters are written 0 by the same upsert, so
+    // the arm is a no-op over it; a row that does hold a non-zero count is wrong by
+    // definition and wants the same clearing. Do not read a firing of this arm as
+    // evidence of a deletion.
     const out = selectAffectedApprovedListings(
       affectedInput({
         listings: [
@@ -813,11 +823,17 @@ describe('spec ⇄ SQL lockstep', () => {
  * so one over-long query takes `install_count` down with it — and two live triggers
  * reach that size: the seed arm on a fresh or restored `app_listing_metrics`, and
  * the store simply growing past ~7,700 approved on-site listings.
+ *
+ * 🔴 BUT CHUNKING SMALLER IS NOT "SAFER" — IT IS LINEARLY MORE EXPENSIVE, AND EVERY
+ * ASSERTION IN THIS BLOCK IS RELATIVE TO THE CONSTANT, SO NONE OF THEM CAN SEE IT.
+ * Each chunk is an unbounded `actions` scan whose cost does not shrink with the `IN`
+ * list, so the chunk COUNT is the cost. The absolute block below is the guard that
+ * survives the constant moving in either direction.
  */
 describe('fetchAppOpenCounts — chunking and merge', () => {
-  // Deliberately NOT a multiple of the batch size: the last chunk is partial, so a
+  // Deliberately NOT a multiple of the chunk size: the last chunk is partial, so a
   // mutant that drops or double-counts a trailing chunk cannot land on the boundary.
-  const BLOCK_COUNT = APP_LISTING_BATCH_SIZE * 2 + 37;
+  const BLOCK_COUNT = APP_OPEN_CH_CHUNK_SIZE * 2 + 37;
   const allIds = Array.from({ length: BLOCK_COUNT }, (_, i) => `apb_${i}`);
   // Per-id distinct, and distinct from the batch size, the chunk count and the
   // index — a mutant returning a constant or the wrong chunk's numbers cannot pass.
@@ -843,12 +859,12 @@ describe('fetchAppOpenCounts — chunking and merge', () => {
     expect(idsIn(buildAppOpenCountSql(['apb_a', 'apb_b']))).toEqual(['apb_a', 'apb_b']);
   });
 
-  it('splits into ceil(n / APP_LISTING_BATCH_SIZE) queries, none over the batch size', async () => {
+  it('splits into ceil(n / APP_OPEN_CH_CHUNK_SIZE) queries, none over the chunk size', async () => {
     const { queries, runQuery } = recordingRunner();
     await fetchAppOpenCounts(allIds, runQuery);
-    expect(queries).toHaveLength(Math.ceil(BLOCK_COUNT / APP_LISTING_BATCH_SIZE));
+    expect(queries).toHaveLength(Math.ceil(BLOCK_COUNT / APP_OPEN_CH_CHUNK_SIZE));
     for (const sql of queries) {
-      expect(idsIn(sql).length).toBeLessThanOrEqual(APP_LISTING_BATCH_SIZE);
+      expect(idsIn(sql).length).toBeLessThanOrEqual(APP_OPEN_CH_CHUNK_SIZE);
     }
   });
 
@@ -894,6 +910,150 @@ describe('fetchAppOpenCounts — chunking and merge', () => {
         throw new Error('Code: 62. DB::Exception: Max query size exceeded');
       })
     ).rejects.toThrow('Code: 62');
+  });
+});
+
+/**
+ * 🔴 THE ABSOLUTE BOUNDS ON THE CLICKHOUSE CHUNK SIZE. Everything in the block above
+ * is stated RELATIVE to `APP_OPEN_CH_CHUNK_SIZE` ("no chunk exceeds the constant",
+ * "ceil(n / the constant) queries"), so all of it stays green for ANY value of the
+ * constant — including values that are a hard query error at one end and a ~39x cost
+ * regression at the other. That blindness is not hypothetical: it is exactly how a
+ * shared constant of 200 was adopted for a query whose cost is flat in its `IN` list.
+ *
+ * Every number below is a LITERAL, on purpose. None of them moves when
+ * `APP_OPEN_CH_CHUNK_SIZE` or `APP_LISTING_BATCH_SIZE` moves, which is the whole
+ * point — the constant is bracketed from BOTH sides:
+ *
+ *   • UPPER — ClickHouse `max_query_size` defaults to 262,144 bytes and an over-long
+ *     `IN` list is `Code: 62`, not a slow query. The budget asserted here is HALF of
+ *     that (131,072), because the ceiling is a per-server SETTING that can be lowered
+ *     under us, not a protocol constant.
+ *   • LOWER — the seed/restore path (~7,700 approved on-site listings) must not cost
+ *     more than 4 full `actions` scans. At the old shared value of 200 it cost 39.
+ */
+describe('🔴 ABSOLUTE bounds on the ClickHouse chunk size (literals, not relatives)', () => {
+  /** ClickHouse's `max_query_size` default, in bytes. A LITERAL — do not import it. */
+  const MAX_QUERY_SIZE_BYTES = 262_144;
+  /** Half of it: the headroom budget a full chunk must fit inside. */
+  const HEADROOM_BUDGET_BYTES = MAX_QUERY_SIZE_BYTES / 2;
+  /** The largest `IN` list round 1 measured returning HTTP 200 from a live server. */
+  const MEASURED_SAFE_IDS = 7_000;
+  /** The seed/restore population this file's docstrings size against. */
+  const SEED_LISTINGS = 7_700;
+
+  /**
+   * A production-shaped id: `apb_` + a 26-char ULID = 30 chars, which renders into
+   * the `IN` list as `'<id>', ` = 34 bytes. Using `apb_1` here instead would make
+   * every byte figure below an underestimate — i.e. would make the guard pass a
+   * chunk size that is a `Code: 62` in production.
+   */
+  const realisticIds = (n: number) =>
+    Array.from({ length: n }, (_, i) => `apb_${String(i).padStart(26, '0')}`);
+  const queryBytes = (n: number) =>
+    Buffer.byteLength(buildAppOpenCountSql(realisticIds(n)), 'utf8');
+
+  it('POSITIVE CONTROL: the byte measurement can actually exceed the ceiling', () => {
+    // Without this, a `realisticIds` that silently produced short or zero ids would
+    // make every "under the budget" assertion below pass over a tiny query. This
+    // also re-derives round 1's live finding from the builder alone: 8,000 ids is
+    // over `max_query_size`, which is the `Code: 62` it measured.
+    expect(realisticIds(1)[0]).toHaveLength(30);
+    expect(queryBytes(8_000)).toBeGreaterThan(MAX_QUERY_SIZE_BYTES);
+  });
+
+  it('the docstring arithmetic bytes(n) = 460 + 34n reproduces the live measurement', () => {
+    // 238,460 at 7,000 ids is the figure round 1 measured against ClickHouse
+    // 26.8.2.7. The builder reproducing it exactly is what licenses using the model
+    // to state an EXACT ceiling instead of the 7,000/8,000 bracket.
+    expect(queryBytes(MEASURED_SAFE_IDS)).toBe(238_460);
+    expect(queryBytes(1)).toBe(460 + 34);
+    expect(queryBytes(2_000)).toBe(460 + 34 * 2_000);
+  });
+
+  it('the EXACT hard ceiling is 7,696 ids — 7,697 does not fit', () => {
+    expect(queryBytes(7_696)).toBeLessThanOrEqual(MAX_QUERY_SIZE_BYTES);
+    expect(queryBytes(7_697)).toBeGreaterThan(MAX_QUERY_SIZE_BYTES);
+  });
+
+  it('🔴 UPPER BOUND: one FULL chunk of realistic ids fits in half of max_query_size', () => {
+    // The assertion the relative ones cannot make. Raise APP_OPEN_CH_CHUNK_SIZE past
+    // ~3,841 and this reds; raise it past 7,696 and production returns `Code: 62`
+    // while every relative assertion above stays green.
+    expect(queryBytes(APP_OPEN_CH_CHUNK_SIZE)).toBeLessThan(HEADROOM_BUDGET_BYTES);
+  });
+
+  it('🔴 UPPER BOUND: the chunk size never exceeds the largest list measured safe', () => {
+    expect(APP_OPEN_CH_CHUNK_SIZE).toBeLessThanOrEqual(MEASURED_SAFE_IDS);
+  });
+
+  it('🔴 LOWER BOUND: the ~7,700-listing seed path costs at most 4 ClickHouse scans', async () => {
+    // Each chunk is a FULL `actions` scan whose cost does not shrink with the `IN`
+    // list, so the chunk count IS the cost — and also the number of chances to hit
+    // the fail-hard path. At the Postgres batch size of 200 this is 39.
+    const queries: string[] = [];
+    await fetchAppOpenCounts(realisticIds(SEED_LISTINGS), async (sql) => {
+      queries.push(sql);
+      return [];
+    });
+    expect(queries.length).toBeLessThanOrEqual(4);
+  });
+
+  it('🔴 the ClickHouse chunk and the Postgres batch are SEPARATE, non-equal constants', () => {
+    // Their optima push in opposite directions (see the two-directional-pressure
+    // note on both). Re-merging them is the round-1 defect; equality is its tell.
+    expect(APP_OPEN_CH_CHUNK_SIZE).not.toBe(APP_LISTING_BATCH_SIZE);
+    expect(APP_OPEN_CH_CHUNK_SIZE).toBeGreaterThan(APP_LISTING_BATCH_SIZE);
+  });
+
+  it('🔴 fetchAppOpenCounts DEFAULTS to the ClickHouse constant, not the Postgres batch', async () => {
+    // Called without an explicit size, as the spec tests above do. A default wired
+    // back to APP_LISTING_BATCH_SIZE would reintroduce the 39-scan seed path with
+    // every relative assertion still green.
+    const queries: string[] = [];
+    await fetchAppOpenCounts(realisticIds(SEED_LISTINGS), async (sql) => {
+      queries.push(sql);
+      return [];
+    });
+    expect(queries.length).toBe(Math.ceil(SEED_LISTINGS / APP_OPEN_CH_CHUNK_SIZE));
+    expect(queries.length).toBeLessThan(Math.ceil(SEED_LISTINGS / APP_LISTING_BATCH_SIZE));
+  });
+});
+
+/**
+ * 🔴 THE MV-TRIGGER RUNBOOK'S DIAGNOSTIC QUERY MUST BE ABLE TO SEE THE EXPENSIVE
+ * READ ALONE. Both queries in the module embed the literal `App_Open`, so the
+ * obvious `system.query_log` filter matches the unbounded count scan AND the cheap
+ * time-bounded discovery read — and the cheap one runs at least as often, so it
+ * dominates the sample and drags `query_duration_ms` / `read_rows` down. An operator
+ * reads "nowhere near the trigger" and defers the MV past the point the comment
+ * exists to catch.
+ */
+describe('MV-trigger diagnostic — the marker discriminates the expensive read', () => {
+  const recent = buildAppOpenRecentBlockIdsSql('2026-09-05T10:00:00.000Z');
+  const counts = buildAppOpenCountSql(['apb_alpha']);
+
+  it('POSITIVE CONTROL: `App_Open` alone CANNOT discriminate — both queries carry it', () => {
+    // The defect being fixed, stated as an assertion rather than as prose. If this
+    // ever fails, the marker below is solving a problem that no longer exists and
+    // the runbook should be re-read rather than the test relaxed.
+    expect(counts).toContain(APP_OPEN_ACTION_TYPE);
+    expect(recent).toContain(APP_OPEN_ACTION_TYPE);
+  });
+
+  it('the marker IS present in the expensive all-time count query', () => {
+    expect(counts).toContain(APP_OPEN_COUNT_QUERY_MARKER);
+  });
+
+  it('🔴 the marker is ABSENT from the cheap discovery query', () => {
+    expect(recent).not.toContain(APP_OPEN_COUNT_QUERY_MARKER);
+  });
+
+  it('the marker is what the count query is actually built from (no second spelling)', () => {
+    // Interpolated, not duplicated — so renaming `dailyActors` moves the constant
+    // and the runbook stays correct instead of silently grading the wrong queries.
+    expect(counts).toContain(`${APP_OPEN_COUNT_QUERY_MARKER} AS openCount`);
+    expect(APP_OPEN_COUNT_QUERY_MARKER).toBe('sum(dailyActors)');
   });
 });
 
@@ -954,5 +1114,64 @@ describe('fetchRecentlyOpenedBlockIds — discovery degrades, it does not fail t
         }
       )
     ).rejects.toThrow('Job was canceled');
+  });
+
+  /**
+   * 🔴 THE SOFT PATH COVERS *ONE* FAILURE MODE — "ClickHouse could not answer" —
+   * AND MUST NOT COVER PROGRAMMING ERRORS. The `try` used to wrap the SQL builder,
+   * the awaited query AND the `rows.map(...)`. Under that shape a builder throw or a
+   * non-array result returns `[]` on EVERY run, not just this one: the play arm
+   * never fires, and any listing whose only change is new plays is never recomputed
+   * again. Unlike a ClickHouse blip, that does not self-heal on the next watermark —
+   * and the only outward sign is a per-run warning log, which cannot distinguish
+   * "blipped once" from "dead for a week" (hence the Prometheus counter on the
+   * processor's onDegrade).
+   *
+   * These two cases fail ONLY when the `try` is widened back, which is what makes
+   * them the guard rather than decoration.
+   */
+  it('🔴 a BUILDER throw PROPAGATES — it is a bug, not a ClickHouse outage', async () => {
+    // The builder runs `escapeClickhouseString(sinceIso).replace(...)`; a non-string
+    // watermark is a TypeError inside it. It is constructed OUTSIDE the try, so it
+    // must surface. Widen the try and this degrades to [] instead.
+    const degraded: unknown[] = [];
+    await expect(
+      fetchRecentlyOpenedBlockIds(
+        null as unknown as string,
+        async () => [],
+        (error) => degraded.push(error)
+      )
+    ).rejects.toThrow(TypeError);
+    expect(degraded).toEqual([]);
+  });
+
+  it('🔴 a non-array result PROPAGATES from rows.map — a contract violation, not an outage', async () => {
+    // The exact edit the audit named: a later change makes the result non-array, so
+    // `.map` is a TypeError. Inside the try that is silently "no plays", forever.
+    const degraded: unknown[] = [];
+    await expect(
+      fetchRecentlyOpenedBlockIds(
+        SINCE,
+        async () => undefined as unknown as { appBlockId: string }[],
+        (error) => degraded.push(error)
+      )
+    ).rejects.toThrow(TypeError);
+    expect(degraded).toEqual([]);
+  });
+
+  it('NEGATIVE CONTROL: a genuine query REJECTION still degrades, in the same file', async () => {
+    // The pair matters: the two assertions above must not be satisfiable by simply
+    // deleting the try. Same function, same shape of failure, opposite outcome.
+    const degraded: unknown[] = [];
+    await expect(
+      fetchRecentlyOpenedBlockIds(
+        SINCE,
+        async () => {
+          throw new TypeError('socket hang up');
+        },
+        (error) => degraded.push(error)
+      )
+    ).resolves.toEqual([]);
+    expect(degraded).toHaveLength(1);
   });
 });

--- a/src/server/metrics/__tests__/appListing.metrics.test.ts
+++ b/src/server/metrics/__tests__/appListing.metrics.test.ts
@@ -3,17 +3,26 @@ import { describe, expect, it } from 'vitest';
 import {
   AFFECTED_APPROVED_LISTINGS_SQL,
   APP_LISTING_METRIC_UPSERT_SQL,
+  APP_OPEN_ACTION_TYPE,
+  appOpenActorKey,
+  appOpenUtcDay,
+  buildAppOpenCountSql,
+  buildAppOpenRecentBlockIdsSql,
   computeAppListingMetricUpdates,
+  computeAppOpenCounts,
+  escapeClickhouseString,
   type AppListingComputeInput,
+  type AppOpenEvent,
 } from '~/server/metrics/appListing.metrics.sql';
 
 /**
- * W13 — AppListingMetric install ROLLUP job.
+ * W13 — AppListingMetric install + open (PLAY) ROLLUP job.
  *
- * The SQL runs in Postgres; `computeAppListingMetricUpdates` is the executable
- * spec that mirrors it, so the aggregate invariants are testable without a DB.
- * The final blocks assert the invariants directly against the production SQL
- * strings (the thumbs-ownership contract is enforced structurally there).
+ * The SQL runs in Postgres (installs) and ClickHouse (plays);
+ * `computeAppListingMetricUpdates` is the executable spec that mirrors both, so
+ * the aggregate invariants are testable without either. The later blocks assert
+ * invariants directly against the production SQL strings — the thumbs-ownership
+ * contract and the spec⇄SQL lockstep are enforced structurally there.
  */
 
 const base = (over: Partial<AppListingComputeInput['listings'][number]>) => ({
@@ -21,6 +30,19 @@ const base = (over: Partial<AppListingComputeInput['listings'][number]>) => ({
   kind: 'onsite' as const,
   status: 'approved',
   appBlockId: null,
+  ...over,
+});
+
+/**
+ * A play. Defaults are deliberately NOT the sentinel values the rules key on:
+ * `userId` is non-zero and `ip` is a real address, so a test that means to
+ * exercise the anonymous path has to say so.
+ */
+const play = (over: Partial<AppOpenEvent> = {}): AppOpenEvent => ({
+  appBlockId: 'apb_alpha',
+  userId: 71,
+  ip: '203.0.113.7',
+  time: '2026-09-05T10:00:00.000Z',
   ...over,
 });
 
@@ -35,10 +57,11 @@ describe('computeAppListingMetricUpdates — install aggregate spec', () => {
         { appBlockId: 'ab_1', enabled: false }, // toggled-off → NOT an active install
         { appBlockId: 'ab_other', enabled: true }, // different app → excluded
       ],
+      openEvents: [],
     };
 
     expect(computeAppListingMetricUpdates(input)).toEqual([
-      { appListingId: 'apl_onsite', installCount: 3 },
+      { appListingId: 'apl_onsite', installCount: 3, openCount: 0 },
     ]);
   });
 
@@ -48,6 +71,7 @@ describe('computeAppListingMetricUpdates — install aggregate spec', () => {
       // Even if a subscription somehow matched, an off-site listing must never
       // count installs — the CASE gates on kind='onsite'.
       subscriptions: [{ appBlockId: 'ab_1', enabled: true }],
+      openEvents: [],
     };
 
     const [row] = computeAppListingMetricUpdates(input);
@@ -58,10 +82,11 @@ describe('computeAppListingMetricUpdates — install aggregate spec', () => {
     const input: AppListingComputeInput = {
       listings: [base({ id: 'apl_noblock', kind: 'onsite', appBlockId: null })],
       subscriptions: [{ appBlockId: 'ab_1', enabled: true }],
+      openEvents: [],
     };
 
     expect(computeAppListingMetricUpdates(input)).toEqual([
-      { appListingId: 'apl_noblock', installCount: 0 },
+      { appListingId: 'apl_noblock', installCount: 0, openCount: 0 },
     ]);
   });
 
@@ -75,20 +100,229 @@ describe('computeAppListingMetricUpdates — install aggregate spec', () => {
         base({ id: 'apl_ok', status: 'approved', appBlockId: 'ab_1' }),
       ],
       subscriptions: [{ appBlockId: 'ab_1', enabled: true }],
+      openEvents: [],
     };
 
     const out = computeAppListingMetricUpdates(input);
     expect(out.map((r) => r.appListingId)).toEqual(['apl_ok']);
   });
+
+  it('REGRESSION: adding plays does not disturb installCount', () => {
+    // The play stream and the subscription table are independent sources; a
+    // listing with 2 active installs and 5 raw plays still reports 2 installs.
+    const listings = [base({ id: 'apl_both', kind: 'onsite', appBlockId: 'apb_alpha' })];
+    const subscriptions = [
+      { appBlockId: 'apb_alpha', enabled: true },
+      { appBlockId: 'apb_alpha', enabled: true },
+      { appBlockId: 'apb_alpha', enabled: false },
+    ];
+
+    const withoutPlays = computeAppListingMetricUpdates({
+      listings,
+      subscriptions,
+      openEvents: [],
+    });
+    const withPlays = computeAppListingMetricUpdates({
+      listings,
+      subscriptions,
+      openEvents: [
+        play({ userId: 11 }),
+        play({ userId: 12 }),
+        play({ userId: 13, time: '2026-09-06T01:00:00.000Z' }),
+      ],
+    });
+
+    expect(withoutPlays[0].installCount).toBe(2);
+    expect(withPlays[0].installCount).toBe(2);
+    expect(withPlays[0].openCount).toBe(3);
+  });
 });
 
-describe('production SQL — thumbs-ownership contract (regression guard)', () => {
+describe('play dedup — one distinct actor per app per UTC day', () => {
+  it('a refresh loop by ONE signed-in actor collapses to 1', () => {
+    const counts = computeAppOpenCounts([
+      play({ userId: 71, time: '2026-09-05T10:00:00.000Z' }),
+      play({ userId: 71, time: '2026-09-05T10:00:05.000Z' }),
+      play({ userId: 71, time: '2026-09-05T10:00:09.000Z' }),
+      play({ userId: 71, time: '2026-09-05T23:59:59.000Z' }),
+    ]);
+    expect(counts.get('apb_alpha')).toBe(1);
+  });
+
+  it('two distinct userIds on the same day count 2', () => {
+    const counts = computeAppOpenCounts([
+      play({ userId: 71 }),
+      play({ userId: 82 }),
+      play({ userId: 82 }), // and a repeat, which must not add
+    ]);
+    expect(counts.get('apb_alpha')).toBe(2);
+  });
+
+  it('two ANONYMOUS actors on different IPs count 2', () => {
+    // 🔴 The hazard: `userId` is 0 for BOTH, so an actor key built from userId
+    // alone would collapse every anonymous visitor site-wide into one play.
+    const counts = computeAppOpenCounts([
+      play({ userId: 0, ip: '198.51.100.4' }),
+      play({ userId: 0, ip: '198.51.100.9' }),
+    ]);
+    expect(counts.get('apb_alpha')).toBe(2);
+  });
+
+  it('the same anonymous IP twice in a day counts 1', () => {
+    const counts = computeAppOpenCounts([
+      play({ userId: 0, ip: '198.51.100.4', time: '2026-09-05T00:00:01.000Z' }),
+      play({ userId: 0, ip: '198.51.100.4', time: '2026-09-05T18:30:00.000Z' }),
+    ]);
+    expect(counts.get('apb_alpha')).toBe(1);
+  });
+
+  it('the same actor on two different UTC days counts 2', () => {
+    const counts = computeAppOpenCounts([
+      play({ userId: 71, time: '2026-09-05T23:59:59.000Z' }),
+      play({ userId: 71, time: '2026-09-06T00:00:01.000Z' }),
+    ]);
+    expect(counts.get('apb_alpha')).toBe(2);
+  });
+
+  it('the day boundary is UTC, not local — two instants 2s apart across midnight UTC are 2 days', () => {
+    // Pinned explicitly because the SQL says `toDate(time, 'UTC')`: a bucketing
+    // that used the server's local zone would merge or split these differently.
+    expect(appOpenUtcDay('2026-09-05T23:59:59.000Z')).toBe('2026-09-05');
+    expect(appOpenUtcDay('2026-09-06T00:00:01.000Z')).toBe('2026-09-06');
+  });
+
+  it('an AUTHED actor and an ANON actor on the same day are never merged', () => {
+    // Same request IP, one signed in and one not: two distinct people.
+    const counts = computeAppOpenCounts([
+      play({ userId: 71, ip: '198.51.100.4' }),
+      play({ userId: 0, ip: '198.51.100.4' }),
+    ]);
+    expect(counts.get('apb_alpha')).toBe(2);
+  });
+
+  it('a userId and an ip that render the same string are still two actors', () => {
+    // Without the `u:` / `i:` prefixes these two collapse: user 5 and the literal
+    // ip "5" both stringify to "5".
+    expect(appOpenActorKey({ userId: 5, ip: '198.51.100.4' })).not.toBe(
+      appOpenActorKey({ userId: 0, ip: '5' })
+    );
+    const counts = computeAppOpenCounts([
+      play({ userId: 5, ip: '198.51.100.4' }),
+      play({ userId: 0, ip: '5' }),
+    ]);
+    expect(counts.get('apb_alpha')).toBe(2);
+  });
+
+  it('userId 0 is the ANONYMOUS sentinel, never an identity', () => {
+    expect(appOpenActorKey({ userId: 0, ip: '198.51.100.4' })).toBe('i:198.51.100.4');
+    expect(appOpenActorKey({ userId: 71, ip: '198.51.100.4' })).toBe('u:71');
+  });
+
+  it('plays are scoped per app — one actor opening two apps is 1 play each', () => {
+    const counts = computeAppOpenCounts([
+      play({ appBlockId: 'apb_alpha', userId: 71 }),
+      play({ appBlockId: 'apb_beta', userId: 71 }),
+      play({ appBlockId: 'apb_beta', userId: 71 }),
+    ]);
+    expect(counts.get('apb_alpha')).toBe(1);
+    expect(counts.get('apb_beta')).toBe(1);
+  });
+
+  it('a row whose details carried no appBlockId is dropped, not counted under ""', () => {
+    const counts = computeAppOpenCounts([play({ appBlockId: '' }), play({ userId: 71 })]);
+    expect(counts.has('')).toBe(false);
+    expect(counts.get('apb_alpha')).toBe(1);
+  });
+
+  it('an app block with no events has no entry (the caller reads that as 0)', () => {
+    expect(computeAppOpenCounts([]).get('apb_alpha')).toBeUndefined();
+  });
+});
+
+describe('computeAppListingMetricUpdates — openCount projection', () => {
+  const events: AppOpenEvent[] = [
+    // apb_alpha: 3 distinct actors on 09-05 (two authed, one anon) + the SAME
+    // authed actor again on 09-06 → 3 + 1 = 4. Deliberately not equal to the raw
+    // row count (6) nor to any other fixture constant in this file.
+    play({ appBlockId: 'apb_alpha', userId: 71 }),
+    play({ appBlockId: 'apb_alpha', userId: 71 }),
+    play({ appBlockId: 'apb_alpha', userId: 82 }),
+    play({ appBlockId: 'apb_alpha', userId: 0, ip: '198.51.100.4' }),
+    play({ appBlockId: 'apb_alpha', userId: 0, ip: '198.51.100.4' }),
+    play({ appBlockId: 'apb_alpha', userId: 71, time: '2026-09-06T09:00:00.000Z' }),
+  ];
+
+  it('an on-site listing gets its app block’s deduped all-time play count', () => {
+    const out = computeAppListingMetricUpdates({
+      listings: [base({ id: 'apl_onsite', kind: 'onsite', appBlockId: 'apb_alpha' })],
+      subscriptions: [],
+      openEvents: events,
+    });
+    expect(out).toEqual([{ appListingId: 'apl_onsite', installCount: 0, openCount: 4 }]);
+  });
+
+  it('OFF-SITE listing → openCount 0, even with events on a block id it does not own', () => {
+    // Off-site listings have no `app_block_id`; a play stream cannot reach them.
+    const out = computeAppListingMetricUpdates({
+      listings: [base({ id: 'apl_offsite', kind: 'offsite', appBlockId: null })],
+      subscriptions: [],
+      openEvents: events,
+    });
+    expect(out[0].openCount).toBe(0);
+  });
+
+  it('OFF-SITE listing carrying a stray app_block_id STILL gets 0 (kind gates it)', () => {
+    // Defence in depth: the requirement is "off-site never accumulates a play
+    // count". If the column were ever populated on an off-site row, the `kind`
+    // gate — not the null-ness of the join key — is what has to hold.
+    const out = computeAppListingMetricUpdates({
+      listings: [base({ id: 'apl_offsite2', kind: 'offsite', appBlockId: 'apb_alpha' })],
+      subscriptions: [{ appBlockId: 'apb_alpha', enabled: true }],
+      openEvents: events,
+    });
+    expect(out[0].openCount).toBe(0);
+    expect(out[0].installCount).toBe(0);
+  });
+
+  it('on-site listing with a null app_block_id → openCount 0', () => {
+    const out = computeAppListingMetricUpdates({
+      listings: [base({ id: 'apl_noblock', kind: 'onsite', appBlockId: null })],
+      subscriptions: [],
+      openEvents: events,
+    });
+    expect(out[0].openCount).toBe(0);
+  });
+
+  it('a NON-APPROVED listing is excluded even when its block has plays', () => {
+    const out = computeAppListingMetricUpdates({
+      listings: [
+        base({ id: 'apl_pending', status: 'pending', kind: 'onsite', appBlockId: 'apb_alpha' }),
+        base({ id: 'apl_ok', status: 'approved', kind: 'onsite', appBlockId: 'apb_alpha' }),
+      ],
+      subscriptions: [],
+      openEvents: events,
+    });
+    expect(out.map((r) => r.appListingId)).toEqual(['apl_ok']);
+  });
+
+  it('a listing whose block has no events → openCount 0, not undefined/NaN', () => {
+    const out = computeAppListingMetricUpdates({
+      listings: [base({ id: 'apl_quiet', kind: 'onsite', appBlockId: 'apb_quiet' })],
+      subscriptions: [],
+      openEvents: events,
+    });
+    expect(out[0].openCount).toBe(0);
+  });
+});
+
+describe('production SQL — ownership contract (regression guard)', () => {
   // Normalize whitespace so the assertions are robust to formatting.
   const upsert = APP_LISTING_METRIC_UPSERT_SQL.replace(/\s+/g, ' ');
   const doUpdate = upsert.slice(upsert.indexOf('ON CONFLICT'));
 
-  it('the ON CONFLICT DO UPDATE writes ONLY install_count / updated_at', () => {
+  it('the ON CONFLICT DO UPDATE writes install_count / open_count / updated_at', () => {
     expect(doUpdate).toContain('"install_count" = EXCLUDED."install_count"');
+    expect(doUpdate).toContain('"open_count" = EXCLUDED."open_count"');
     expect(doUpdate).toContain('"updated_at" = NOW()');
   });
 
@@ -100,16 +334,36 @@ describe('production SQL — thumbs-ownership contract (regression guard)', () =
     expect(upsert).not.toContain('thumbs_down_count');
   });
 
-  it('does not write connect/open/visit/tipped counters (no reader; feature not live)', () => {
-    // Only install_count is populated; the rest stay at their schema default 0.
+  it('does not write connect/visit/tipped counters (no reader; feature not live)', () => {
+    // 🔴 DELIBERATELY NARROWED. This guard used to include `open_count`, on the
+    // grounds that nothing read it. Stage 2 gave it a reader and a trusted source
+    // (the ClickHouse `App_Open` stream), so open_count moved OUT of this list and
+    // INTO the ON CONFLICT assertion above. The remaining three are unchanged:
+    // connect is a locked-deferred product decision, visit has no server-side
+    // source, and AppListing is not a BuzzTip entity.
     expect(upsert).not.toContain('connect_count');
-    expect(upsert).not.toContain('open_count');
     expect(upsert).not.toContain('visit_count');
     expect(upsert).not.toContain('tipped_count');
   });
 
   it('the active-install filter is enabled = TRUE', () => {
     expect(upsert).toContain('bus."enabled" = TRUE');
+  });
+
+  it('open_count is DERIVED from the supplied map, never incremented', () => {
+    // A `+1` path is the thing the ownership contract forbids outright. The
+    // written value must be the joined map value (or 0), with no reference to the
+    // column's own current value.
+    expect(upsert).toContain('COALESCE(oc."open_count", 0)');
+    expect(upsert).not.toMatch(/"open_count"\s*\+/);
+    expect(doUpdate).not.toContain('app_listing_metrics."open_count"');
+  });
+
+  it('both counters gate on kind = onsite AND a non-null app_block_id', () => {
+    const gates = upsert.match(/WHEN al\."kind" = 'onsite' AND al\."app_block_id" IS NOT NULL/g);
+    // One gate for install_count, one for open_count. If a counter is added
+    // without its gate, this count moves and the off-site guarantee is gone.
+    expect(gates).toHaveLength(2);
   });
 });
 
@@ -120,5 +374,165 @@ describe('production SQL — approved-only scoping', () => {
 
   it('the upsert scopes to approved listings', () => {
     expect(APP_LISTING_METRIC_UPSERT_SQL).toContain(`al."status" = 'approved'`);
+  });
+});
+
+describe('production SQL — affected-set discovery includes new plays', () => {
+  const affected = AFFECTED_APPROVED_LISTINGS_SQL.replace(/\s+/g, ' ');
+
+  it('has an arm keyed on the ClickHouse-supplied app_block_id list ($2)', () => {
+    // Without this, a listing whose ONLY change is new plays is never recomputed:
+    // nothing in Postgres moves when a play happens.
+    expect(affected).toContain(`al."kind" = 'onsite' AND al."app_block_id" = ANY($2::text[])`);
+  });
+
+  it('returns app_block_id so the caller can query ClickHouse without a second round trip', () => {
+    expect(affected).toContain('SELECT al.id, al."app_block_id"');
+  });
+
+  it('still has the subscription-change arm and the seed arm', () => {
+    expect(affected).toContain(`bus."created_at" > $1 OR bus."updated_at" > $1`);
+    expect(affected).toContain('NOT EXISTS');
+  });
+});
+
+describe('production SQL — the upsert consumes the play map', () => {
+  const upsert = APP_LISTING_METRIC_UPSERT_SQL.replace(/\s+/g, ' ');
+
+  it('joins the parallel (app_block_id, open_count) arrays by LEFT JOIN unnest', () => {
+    expect(upsert).toContain(
+      `LEFT JOIN unnest($2::text[], $3::int[]) AS oc("app_block_id", "open_count") ON oc."app_block_id" = al."app_block_id"`
+    );
+  });
+
+  it('is a LEFT join, so a listing absent from the map is written 0 rather than dropped', () => {
+    expect(upsert).not.toContain('INNER JOIN unnest');
+    expect(upsert).toContain('COALESCE(oc."open_count", 0)');
+  });
+});
+
+describe('ClickHouse SQL — App_Open reads', () => {
+  const recent = buildAppOpenRecentBlockIdsSql('2026-09-05T10:00:00.000Z');
+  const counts = buildAppOpenCountSql(['apb_alpha', 'apb_beta']);
+
+  it('matches the action type by toString(type), NOT by Enum comparison', () => {
+    // 🔴 `actions.type` is an Enum16. `type = 'App_Open'` is a QUERY ERROR — not an
+    // empty result — until the widening migration is applied, which would take the
+    // whole metric processor (install_count included) down with it. `toString(type)`
+    // simply matches nothing, which is the inert behaviour this rollup wants.
+    for (const sql of [recent, counts]) {
+      expect(sql).toContain(`toString(type) = '${APP_OPEN_ACTION_TYPE}'`);
+      expect(sql).not.toMatch(/[^(]\btype\s*=\s*'App_Open'/);
+    }
+  });
+
+  it('applies the type filter in PREWHERE (the count query has no time bound to prune on)', () => {
+    for (const sql of [recent, counts]) {
+      expect(sql).toContain(`PREWHERE toString(type) = '${APP_OPEN_ACTION_TYPE}'`);
+    }
+  });
+
+  it('reads appBlockId out of the JSON-STRING details column', () => {
+    // tracker.action() JSON.stringify()s `details` before insert, so it is a String
+    // column — a bare `details.appBlockId` would not resolve.
+    for (const sql of [recent, counts]) {
+      expect(sql).toContain(`JSONExtractString(details, 'appBlockId')`);
+    }
+  });
+
+  it('the recent-blocks query is bounded by the watermark and drops empty ids', () => {
+    expect(recent).toContain(`time >= parseDateTimeBestEffort('2026-09-05T10:00:00.000Z')`);
+    expect(recent).toContain(`JSONExtractString(details, 'appBlockId') != ''`);
+    expect(recent).toContain('SELECT DISTINCT');
+  });
+
+  it('the count query buckets by UTC day and counts DISTINCT actors per bucket', () => {
+    expect(counts).toContain(`toDate(time, 'UTC') AS day`);
+    expect(counts).toContain(
+      `uniqExact(if(userId != 0, concat('u:', toString(userId)), concat('i:', ip))) AS dailyActors`
+    );
+    expect(counts).toContain('GROUP BY appBlockId, day');
+    expect(counts).toContain('sum(dailyActors) AS openCount');
+  });
+
+  it('the count query is all-time (no time predicate) — AppListingMetric has no timeframe', () => {
+    expect(counts).not.toContain('time >=');
+    expect(counts).not.toContain('time >');
+  });
+
+  it('the count query filters to the requested app block ids', () => {
+    expect(counts).toContain(
+      `WHERE JSONExtractString(details, 'appBlockId') IN ('apb_alpha', 'apb_beta')`
+    );
+  });
+
+  it('escapes quotes and backslashes in the IN list rather than dropping the id', () => {
+    // Dropping an id would omit it from the count map, and the upsert writes a
+    // missing entry as 0 — silent data loss. Escaping keeps it queryable.
+    expect(escapeClickhouseString(`ap'b`)).toBe(`ap\\'b`);
+    expect(escapeClickhouseString('ap\\b')).toBe('ap\\\\b');
+    const sql = buildAppOpenCountSql([`ap'b`]);
+    expect(sql).toContain(`IN ('ap\\'b')`);
+  });
+});
+
+describe('spec ⇄ SQL lockstep', () => {
+  /**
+   * 🔴 A RELATIONSHIP, NOT A SPELLING. The pure spec and the upsert are a matched
+   * pair; changing one without the other is exactly the drift the pair exists to
+   * prevent. This derives the counter set from BOTH sides and requires them equal,
+   * so it fails when either side GROWS or SHRINKS — including on a counter nobody
+   * thought to name here.
+   */
+  const specCounters = Object.keys(
+    computeAppListingMetricUpdates({
+      listings: [base({ id: 'apl_probe', kind: 'onsite', appBlockId: 'apb_alpha' })],
+      subscriptions: [],
+      openEvents: [],
+    })[0]
+  )
+    .filter((k) => k !== 'appListingId')
+    .map((k) => k.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`))
+    .sort();
+
+  const doUpdate = APP_LISTING_METRIC_UPSERT_SQL.replace(/\s+/g, ' ');
+  const sqlCounters = [
+    ...doUpdate
+      .slice(doUpdate.indexOf('ON CONFLICT'))
+      .matchAll(/"([a-z_]+)"\s*=\s*(?:EXCLUDED|NOW\(\))/g),
+  ]
+    .map((m) => m[1])
+    .filter((c) => c !== 'updated_at')
+    .sort();
+
+  const insertColumns = [
+    ...APP_LISTING_METRIC_UPSERT_SQL.slice(
+      APP_LISTING_METRIC_UPSERT_SQL.indexOf('('),
+      APP_LISTING_METRIC_UPSERT_SQL.indexOf(')')
+    ).matchAll(/"([a-z_]+)"/g),
+  ]
+    .map((m) => m[1])
+    .filter((c) => c !== 'app_listing_id' && c !== 'updated_at')
+    .sort();
+
+  it('the parser found something to compare (positive control)', () => {
+    // A regex that matched nothing would make every equality below pass vacuously.
+    expect(specCounters.length).toBeGreaterThan(0);
+    expect(sqlCounters.length).toBeGreaterThan(0);
+    expect(insertColumns.length).toBeGreaterThan(0);
+  });
+
+  it('the spec emits exactly the counters the ON CONFLICT set writes', () => {
+    expect(specCounters).toEqual(sqlCounters);
+  });
+
+  it('the INSERT column list matches the ON CONFLICT set', () => {
+    expect(insertColumns).toEqual(sqlCounters);
+  });
+
+  it('and that set is install_count + open_count', () => {
+    // The literal, so the derived comparison above cannot drift silently in both
+    // directions at once (two wrongs agreeing is still a pass for the pair test).
+    expect(sqlCounters).toEqual(['install_count', 'open_count']);
   });
 });

--- a/src/server/metrics/__tests__/appListing.metrics.test.ts
+++ b/src/server/metrics/__tests__/appListing.metrics.test.ts
@@ -917,9 +917,11 @@ describe('fetchAppOpenCounts — chunking and merge', () => {
  * 🔴 THE ABSOLUTE BOUNDS ON THE CLICKHOUSE CHUNK SIZE. Everything in the block above
  * is stated RELATIVE to `APP_OPEN_CH_CHUNK_SIZE` ("no chunk exceeds the constant",
  * "ceil(n / the constant) queries"), so all of it stays green for ANY value of the
- * constant — including values that are a hard query error at one end and a ~39x cost
- * regression at the other. That blindness is not hypothetical: it is exactly how a
- * shared constant of 200 was adopted for a query whose cost is flat in its `IN` list.
+ * constant — including values that are a hard query error at one end and a 9.75x cost
+ * regression at the other (39 scans against the 4 the split constant gives; 39x is
+ * the other comparison, against the single unchunked query). That blindness is not
+ * hypothetical: it is exactly how a shared constant of 200 was adopted for a query
+ * whose cost is flat in its `IN` list.
  *
  * Every number below is a LITERAL, on purpose. None of them moves when
  * `APP_OPEN_CH_CHUNK_SIZE` or `APP_LISTING_BATCH_SIZE` moves, which is the whole
@@ -1054,15 +1056,31 @@ describe('MV-trigger diagnostic — the marker discriminates the expensive read'
     // actually built from (no second spelling)", and neither assertion can observe
     // that. Measured: replacing the interpolated `${APP_OPEN_COUNT_QUERY_MARKER}` in
     // `buildAppOpenCountSql` with a literal `sum(dailyActors)` — exactly the second
-    // spelling the old title forbade — leaves this file 93/93 GREEN. A `toContain`
-    // cannot distinguish interpolation from duplication; only reading the source
-    // could, and that is not what this asserts.
+    // spelling the old title forbade — leaves this whole file GREEN, every test
+    // passing. A `toContain` cannot distinguish interpolation from duplication; only
+    // reading the source could, and that is not what this asserts.
     //
-    // The HAZARD is still covered, just not here: renaming the aggregate in the SQL
-    // while leaving the constant reds three assertions in this block (including the
-    // one above, which requires the marker to be absent from the discovery query).
-    // So the drift is caught by a sibling — this test is the cheap consistency pin,
-    // and its title now claims only that.
+    // 🔴 WHERE THE RENAME HAZARD IS ACTUALLY COVERED — and the first version of this
+    // note got it WRONG, which is why it is now spelled out per-mutation. It claimed
+    // "three assertions in this block, including the one above". Both halves are
+    // false. Measured, on the two readings of "rename the aggregate":
+    //
+    //   • alias only (`AS dailyActors` -> `AS dailyActrs2`, constant untouched):
+    //     ONE test reds — `the count query buckets by UTC day and counts DISTINCT
+    //     actors per bucket` — and NOTHING in this block does.
+    //   • de-interpolate AND rename (literal `sum(dailyActrs2) AS openCount` plus the
+    //     alias, constant left at `sum(dailyActors)`): THREE tests red — that same
+    //     one, plus TWO in this block (`the marker IS present…` and this test).
+    //
+    // 🔴 `the marker is ABSENT from the cheap discovery query` PASSES UNDER BOTH and
+    // always will: `recent` never contains `dailyActors` in any spelling, so its
+    // `not.toContain` is satisfied whatever the count query says. It provides ZERO of
+    // this coverage. Crediting it was the defect — a coverage claim wider than its
+    // implementation, which is the very thing this test's own retitling was fixing.
+    //
+    // So the sibling that actually pins the alias literal is `the count query buckets
+    // by UTC day…`; if you trim or move THAT, this hazard loses its only guard under
+    // an alias-only rename.
     expect(counts).toContain(`${APP_OPEN_COUNT_QUERY_MARKER} AS openCount`);
     expect(APP_OPEN_COUNT_QUERY_MARKER).toBe('sum(dailyActors)');
   });

--- a/src/server/metrics/__tests__/appListing.metrics.test.ts
+++ b/src/server/metrics/__tests__/appListing.metrics.test.ts
@@ -1049,9 +1049,20 @@ describe('MV-trigger diagnostic — the marker discriminates the expensive read'
     expect(recent).not.toContain(APP_OPEN_COUNT_QUERY_MARKER);
   });
 
-  it('the marker is what the count query is actually built from (no second spelling)', () => {
-    // Interpolated, not duplicated — so renaming `dailyActors` moves the constant
-    // and the runbook stays correct instead of silently grading the wrong queries.
+  it('the marker matches the count query and names the aggregate the runbook greps for', () => {
+    // ⚠️ TITLE NARROWED DELIBERATELY — it used to say "is what the count query is
+    // actually built from (no second spelling)", and neither assertion can observe
+    // that. Measured: replacing the interpolated `${APP_OPEN_COUNT_QUERY_MARKER}` in
+    // `buildAppOpenCountSql` with a literal `sum(dailyActors)` — exactly the second
+    // spelling the old title forbade — leaves this file 93/93 GREEN. A `toContain`
+    // cannot distinguish interpolation from duplication; only reading the source
+    // could, and that is not what this asserts.
+    //
+    // The HAZARD is still covered, just not here: renaming the aggregate in the SQL
+    // while leaving the constant reds three assertions in this block (including the
+    // one above, which requires the marker to be absent from the discovery query).
+    // So the drift is caught by a sibling — this test is the cheap consistency pin,
+    // and its title now claims only that.
     expect(counts).toContain(`${APP_OPEN_COUNT_QUERY_MARKER} AS openCount`);
     expect(APP_OPEN_COUNT_QUERY_MARKER).toBe('sum(dailyActors)');
   });

--- a/src/server/metrics/__tests__/appListing.metrics.test.ts
+++ b/src/server/metrics/__tests__/appListing.metrics.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   AFFECTED_APPROVED_LISTINGS_SQL,
+  APP_LISTING_BATCH_SIZE,
   APP_LISTING_METRIC_UPSERT_SQL,
   APP_OPEN_ACTION_TYPE,
   appOpenActorKey,
@@ -11,7 +12,12 @@ import {
   computeAppListingMetricUpdates,
   computeAppOpenCounts,
   escapeClickhouseString,
+  fetchAppOpenCounts,
+  fetchRecentlyOpenedBlockIds,
+  selectAffectedApprovedListings,
+  type AffectedListingsInput,
   type AppListingComputeInput,
+  type AppOpenCountRow,
   type AppOpenEvent,
 } from '~/server/metrics/appListing.metrics.sql';
 
@@ -187,6 +193,14 @@ describe('play dedup — one distinct actor per app per UTC day', () => {
   it('the day boundary is UTC, not local — two instants 2s apart across midnight UTC are 2 days', () => {
     // Pinned explicitly because the SQL says `toDate(time, 'UTC')`: a bucketing
     // that used the server's local zone would merge or split these differently.
+    //
+    // 🔴 ON ITS OWN THIS ASSERTION IS VACUOUS WHEREVER IT ACTUALLY GATES. It only
+    // fails on a runner whose local zone differs from UTC; `vitest.config.mts` pins
+    // no `TZ` and CI containers are conventionally UTC, where "local" and "UTC" are
+    // the same thing and a `toLocaleDateString('en-CA')` implementation passes it.
+    // Measured: that mutant gave 3 failed / 45 passed under TZ=America/Chicago and
+    // 48 passed — SURVIVED — under TZ=UTC. The zone-varying block below is the real
+    // guard; this one is kept as the plain statement of the expected values.
     expect(appOpenUtcDay('2026-09-05T23:59:59.000Z')).toBe('2026-09-05');
     expect(appOpenUtcDay('2026-09-06T00:00:01.000Z')).toBe('2026-09-06');
   });
@@ -236,6 +250,82 @@ describe('play dedup — one distinct actor per app per UTC day', () => {
 
   it('an app block with no events has no entry (the caller reads that as 0)', () => {
     expect(computeAppOpenCounts([]).get('apb_alpha')).toBeUndefined();
+  });
+});
+
+/**
+ * 🔴 THE UTC-DAY RULE, PROVEN AS A PROPERTY RATHER THAN AS AN ACCIDENT OF THE
+ * RUNNER'S ZONE.
+ *
+ * The spec⇄SQL lockstep rests on `appOpenUtcDay` mirroring `toDate(time, 'UTC')`.
+ * A single-zone assertion cannot see the failure it is written to catch: on a UTC
+ * runner — which `vitest.config.mts` does not pin, and which CI containers
+ * conventionally are — a local-zone implementation IS the UTC one, so it passes.
+ * Measured on the `toLocaleDateString('en-CA')` mutant: KILLED (3 failed / 45
+ * passed) under TZ=America/Chicago, SURVIVED (48 passed) under TZ=UTC. The guard
+ * held nowhere it actually gates.
+ *
+ * So the property is exercised under SEVERAL ambient zones, straddling the instants
+ * in both directions (UTC-5 pulls a just-after-midnight instant back a day; UTC+14
+ * pushes a just-before-midnight instant forward one). Whatever zone the runner is
+ * in, at least two of these disagree with it.
+ */
+describe('appOpenUtcDay is independent of the runner ambient timezone', () => {
+  const ZONES = ['UTC', 'America/Chicago', 'Asia/Kolkata', 'Pacific/Kiritimati'];
+  /** Renders as the NEXT day in Kiritimati (UTC+14). */
+  const LATE = '2026-09-05T23:59:59.000Z';
+  /** Renders as the PREVIOUS day in Chicago (UTC-5). */
+  const EARLY = '2026-09-06T00:00:01.000Z';
+
+  function withAmbientTimezone<T>(tz: string, fn: () => T): T {
+    const previous = process.env.TZ;
+    process.env.TZ = tz;
+    try {
+      return fn();
+    } finally {
+      if (previous === undefined) delete process.env.TZ;
+      else process.env.TZ = previous;
+    }
+  }
+
+  const localDay = (tz: string, instant: string) =>
+    withAmbientTimezone(tz, () => new Date(instant).toLocaleDateString('en-CA'));
+
+  it('POSITIVE CONTROL: the zone override actually moves a local-zone reading', () => {
+    // Without this, a Node/pool combination that ignored a runtime `process.env.TZ`
+    // change would turn every assertion below into a re-run of the ambient zone —
+    // the exact vacuity this block exists to remove, wearing four zone names.
+    expect(localDay('UTC', LATE)).toBe('2026-09-05');
+    expect(localDay('Pacific/Kiritimati', LATE)).toBe('2026-09-06');
+    expect(localDay('America/Chicago', EARLY)).toBe('2026-09-05');
+  });
+
+  it.each(ZONES)('bucket boundaries stay UTC under TZ=%s', (tz) => {
+    withAmbientTimezone(tz, () => {
+      expect(appOpenUtcDay(LATE)).toBe('2026-09-05');
+      expect(appOpenUtcDay(EARLY)).toBe('2026-09-06');
+    });
+  });
+
+  it.each(ZONES)('the dedup buckets by UTC day, not local day, under TZ=%s', (tz) => {
+    withAmbientTimezone(tz, () => {
+      // Same actor, two instants inside ONE UTC day that fall on DIFFERENT local
+      // days in Kiritimati (UTC+14 renders them 23:59:59 and 00:00:01). Still 1.
+      expect(
+        computeAppOpenCounts([
+          play({ userId: 71, time: '2026-09-05T09:59:59.000Z' }),
+          play({ userId: 71, time: '2026-09-05T10:00:01.000Z' }),
+        ]).get('apb_alpha')
+      ).toBe(1);
+      // Same actor either side of UTC midnight, which Chicago (UTC-5) renders as a
+      // single local day. Still 2.
+      expect(
+        computeAppOpenCounts([
+          play({ userId: 71, time: LATE }),
+          play({ userId: 71, time: EARLY }),
+        ]).get('apb_alpha')
+      ).toBe(2);
+    });
   });
 });
 
@@ -334,16 +424,21 @@ describe('production SQL — ownership contract (regression guard)', () => {
     expect(upsert).not.toContain('thumbs_down_count');
   });
 
-  it('does not write connect/visit/tipped counters (no reader; feature not live)', () => {
-    // 🔴 DELIBERATELY NARROWED. This guard used to include `open_count`, on the
-    // grounds that nothing read it. Stage 2 gave it a reader and a trusted source
-    // (the ClickHouse `App_Open` stream), so open_count moved OUT of this list and
-    // INTO the ON CONFLICT assertion above. The remaining three are unchanged:
-    // connect is a locked-deferred product decision, visit has no server-side
-    // source, and AppListing is not a BuzzTip entity.
+  it('does not write connect/visit/tipped counters (no source; feature not live)', () => {
+    // 🔴 DELIBERATELY NARROWED — and NOT because open_count gained a reader. It has
+    // no reader at this ref; its consumer lands in stage 3. What it gained in stage
+    // 2 is a trusted server-side SOURCE (the ClickHouse `App_Open` stream) feeding
+    // a value that is derived and idempotent, which is what makes writing it ahead
+    // of its reader safe. So it moved OUT of this list and INTO the ON CONFLICT
+    // assertion above. The remaining four have no source at all: connect is a
+    // locked-deferred product decision, visit is never recorded server-side, and
+    // AppListing is not a BuzzTip entity. Do not cite open_count to populate them.
     expect(upsert).not.toContain('connect_count');
     expect(upsert).not.toContain('visit_count');
-    expect(upsert).not.toContain('tipped_count');
+    // `tipped` unqualified, so BOTH tipped_count and tipped_amount_count are
+    // covered — `tipped_count` is not a substring of `tipped_amount_count`, so the
+    // narrower spelling silently asserted nothing about the amount column.
+    expect(upsert).not.toContain('tipped');
   });
 
   it('the active-install filter is enabled = TRUE', () => {
@@ -393,6 +488,180 @@ describe('production SQL — affected-set discovery includes new plays', () => {
   it('still has the subscription-change arm and the seed arm', () => {
     expect(affected).toContain(`bus."created_at" > $1 OR bus."updated_at" > $1`);
     expect(affected).toContain('NOT EXISTS');
+  });
+
+  it('has the REPAIR arm — a lost join key with a non-zero count still published', () => {
+    // 🔴 Pinned as the WHOLE normalised arm, not a keyword. `AppListing.appBlock` is
+    // `onDelete: SetNull`; once `app_block_id` goes NULL the listing matches none of
+    // the three arms above (it has a metric row, so not the seed arm; the install
+    // arm requires a non-null key; `NULL = ANY($2)` is NULL, never true) and a
+    // published `open_count = 777` is frozen at 777 with no path to correct it. A
+    // reworded-but-equivalent arm is meant to fail this and be re-read, not slip
+    // through on a matching keyword. The behaviour it produces is asserted against
+    // the executable spec in the block below.
+    expect(affected).toContain(
+      `OR ( al."app_block_id" IS NULL AND EXISTS ( SELECT 1 FROM "app_listing_metrics" m ` +
+        `WHERE m."app_listing_id" = al.id AND (m."open_count" <> 0 OR m."install_count" <> 0) ) )`
+    );
+  });
+});
+
+/**
+ * The affected-set arms, behaviourally — `selectAffectedApprovedListings` is the
+ * in-memory mirror of `AFFECTED_APPROVED_LISTINGS_SQL`, so the arms are testable
+ * without Postgres. The repair arm is the reason this mirror exists: its absence is
+ * SILENT in production (the listing simply never comes back), so a structural
+ * assertion alone would leave the behaviour unpinned.
+ */
+describe('affected-set selection — arms, including the repair arm', () => {
+  const WATERMARK = '2026-09-05T10:00:00.000Z';
+  const BEFORE = '2026-09-05T09:00:00.000Z';
+  const AFTER = '2026-09-05T11:00:00.000Z';
+
+  const affectedInput = (over: Partial<AffectedListingsInput> = {}): AffectedListingsInput => ({
+    listings: [],
+    metrics: [],
+    subscriptions: [],
+    recentlyOpenedBlockIds: [],
+    since: WATERMARK,
+    ...over,
+  });
+
+  it('SEED: an approved listing with no metric row is selected', () => {
+    const out = selectAffectedApprovedListings(
+      affectedInput({
+        listings: [base({ id: 'apl_new', kind: 'onsite', appBlockId: 'apb_alpha' })],
+      })
+    );
+    expect(out).toEqual(['apl_new']);
+  });
+
+  it('INSTALL: a subscription touched after the watermark selects its listing', () => {
+    const listings = [base({ id: 'apl_1', kind: 'onsite', appBlockId: 'apb_alpha' })];
+    const metrics = [{ appListingId: 'apl_1', installCount: 2, openCount: 4 }];
+
+    expect(
+      selectAffectedApprovedListings(
+        affectedInput({
+          listings,
+          metrics,
+          subscriptions: [{ appBlockId: 'apb_alpha', createdAt: BEFORE, updatedAt: AFTER }],
+        })
+      )
+    ).toEqual(['apl_1']);
+
+    // Untouched since the watermark → not affected. (Negative control: without it,
+    // an arm that selected everything would pass the assertion above.)
+    expect(
+      selectAffectedApprovedListings(
+        affectedInput({
+          listings,
+          metrics,
+          subscriptions: [{ appBlockId: 'apb_alpha', createdAt: BEFORE, updatedAt: BEFORE }],
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it('PLAY: a block ClickHouse reports as opened selects its listing', () => {
+    const out = selectAffectedApprovedListings(
+      affectedInput({
+        listings: [base({ id: 'apl_1', kind: 'onsite', appBlockId: 'apb_alpha' })],
+        metrics: [{ appListingId: 'apl_1', installCount: 0, openCount: 1 }],
+        recentlyOpenedBlockIds: ['apb_alpha'],
+      })
+    );
+    expect(out).toEqual(['apl_1']);
+  });
+
+  it('REPAIR: a NULL join key with a non-zero published open_count is selected', () => {
+    // The frozen-count shape: the AppBlock was deleted, `app_block_id` was
+    // SetNull'd, and open_count = 777 is still on a public card.
+    const out = selectAffectedApprovedListings(
+      affectedInput({
+        listings: [base({ id: 'apl_orphan', kind: 'onsite', appBlockId: null })],
+        metrics: [{ appListingId: 'apl_orphan', installCount: 0, openCount: 777 }],
+      })
+    );
+    expect(out).toEqual(['apl_orphan']);
+  });
+
+  it('REPAIR: also fires on a non-zero install_count, and on an OFF-SITE row', () => {
+    const out = selectAffectedApprovedListings(
+      affectedInput({
+        listings: [
+          base({ id: 'apl_installs', kind: 'onsite', appBlockId: null }),
+          base({ id: 'apl_offsite', kind: 'offsite', appBlockId: null }),
+        ],
+        metrics: [
+          { appListingId: 'apl_installs', installCount: 12, openCount: 0 },
+          { appListingId: 'apl_offsite', installCount: 0, openCount: 5 },
+        ],
+      })
+    );
+    expect(out).toEqual(['apl_installs', 'apl_offsite']);
+  });
+
+  it('REPAIR is SELF-TERMINATING: once the counts are 0 the row stops being selected', () => {
+    // 🔴 Not decoration. An arm that kept matching after the repair would put every
+    // orphaned listing into every 5-minute run forever.
+    const out = selectAffectedApprovedListings(
+      affectedInput({
+        listings: [base({ id: 'apl_orphan', kind: 'onsite', appBlockId: null })],
+        metrics: [{ appListingId: 'apl_orphan', installCount: 0, openCount: 0 }],
+      })
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('END TO END: the repaired listing then recomputes to 0, not to its stale value', () => {
+    // The repair is only worth anything if the upsert that follows CLEARS the
+    // number. Selection + recompute, together.
+    const listing = base({ id: 'apl_orphan', kind: 'onsite', appBlockId: null });
+    expect(
+      selectAffectedApprovedListings(
+        affectedInput({
+          listings: [listing],
+          metrics: [{ appListingId: 'apl_orphan', installCount: 3, openCount: 777 }],
+        })
+      )
+    ).toEqual(['apl_orphan']);
+
+    expect(
+      computeAppListingMetricUpdates({
+        listings: [listing],
+        subscriptions: [{ appBlockId: 'apb_alpha', enabled: true }],
+        openEvents: [play({ appBlockId: 'apb_alpha', userId: 71 })],
+      })
+    ).toEqual([{ appListingId: 'apl_orphan', installCount: 0, openCount: 0 }]);
+  });
+
+  it('a NON-APPROVED listing is never selected, by any arm', () => {
+    const out = selectAffectedApprovedListings(
+      affectedInput({
+        listings: [
+          base({ id: 'apl_draft', status: 'draft', kind: 'onsite', appBlockId: null }),
+          base({ id: 'apl_pending', status: 'pending', kind: 'onsite', appBlockId: 'apb_alpha' }),
+        ],
+        metrics: [{ appListingId: 'apl_draft', installCount: 0, openCount: 777 }],
+        recentlyOpenedBlockIds: ['apb_alpha'],
+      })
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('a settled approved listing matches NO arm (negative control)', () => {
+    // If this ever passes something through, every "is selected" assertion above is
+    // vacuous — they would all be reading an arm that selects unconditionally.
+    const out = selectAffectedApprovedListings(
+      affectedInput({
+        listings: [base({ id: 'apl_settled', kind: 'onsite', appBlockId: 'apb_alpha' })],
+        metrics: [{ appListingId: 'apl_settled', installCount: 2, openCount: 4 }],
+        subscriptions: [{ appBlockId: 'apb_alpha', createdAt: BEFORE, updatedAt: BEFORE }],
+        recentlyOpenedBlockIds: ['apb_other'],
+      })
+    );
+    expect(out).toEqual([]);
   });
 });
 
@@ -534,5 +803,156 @@ describe('spec ⇄ SQL lockstep', () => {
     // The literal, so the derived comparison above cannot drift silently in both
     // directions at once (two wrongs agreeing is still a pass for the pair test).
     expect(sqlCounters).toEqual(['install_count', 'open_count']);
+  });
+});
+
+/**
+ * 🔴 THE `IN` LIST IS A HARD CEILING, NOT A SLOW PATH. Measured against ClickHouse
+ * 26.8.2.7: 7,000 ids returns HTTP 200 (238,460 bytes of query text); 8,000 ids
+ * returns `Code: 62 Max query size exceeded`. The count read fails HARD by design,
+ * so one over-long query takes `install_count` down with it — and two live triggers
+ * reach that size: the seed arm on a fresh or restored `app_listing_metrics`, and
+ * the store simply growing past ~7,700 approved on-site listings.
+ */
+describe('fetchAppOpenCounts — chunking and merge', () => {
+  // Deliberately NOT a multiple of the batch size: the last chunk is partial, so a
+  // mutant that drops or double-counts a trailing chunk cannot land on the boundary.
+  const BLOCK_COUNT = APP_LISTING_BATCH_SIZE * 2 + 37;
+  const allIds = Array.from({ length: BLOCK_COUNT }, (_, i) => `apb_${i}`);
+  // Per-id distinct, and distinct from the batch size, the chunk count and the
+  // index — a mutant returning a constant or the wrong chunk's numbers cannot pass.
+  const expectedCount = (id: string) => Number(id.slice('apb_'.length)) * 3 + 11;
+
+  function idsIn(sql: string): string[] {
+    const inList = sql.slice(sql.indexOf('IN ('));
+    return [...inList.matchAll(/'([^']*)'/g)].map((m) => m[1]);
+  }
+
+  const recordingRunner = () => {
+    const queries: string[] = [];
+    const runQuery = async (sql: string): Promise<AppOpenCountRow[]> => {
+      queries.push(sql);
+      return idsIn(sql).map((id) => ({ appBlockId: id, openCount: expectedCount(id) }));
+    };
+    return { queries, runQuery };
+  };
+
+  it('POSITIVE CONTROL: the id extractor can actually see ids in a query', () => {
+    // A regex that matched nothing would make every "chunk contents" assertion
+    // below pass over an empty list.
+    expect(idsIn(buildAppOpenCountSql(['apb_a', 'apb_b']))).toEqual(['apb_a', 'apb_b']);
+  });
+
+  it('splits into ceil(n / APP_LISTING_BATCH_SIZE) queries, none over the batch size', async () => {
+    const { queries, runQuery } = recordingRunner();
+    await fetchAppOpenCounts(allIds, runQuery);
+    expect(queries).toHaveLength(Math.ceil(BLOCK_COUNT / APP_LISTING_BATCH_SIZE));
+    for (const sql of queries) {
+      expect(idsIn(sql).length).toBeLessThanOrEqual(APP_LISTING_BATCH_SIZE);
+    }
+  });
+
+  it('the merged map is COMPLETE and per-id correct across every chunk', async () => {
+    const { runQuery } = recordingRunner();
+    const counts = await fetchAppOpenCounts(allIds, runQuery);
+    expect(counts.size).toBe(BLOCK_COUNT);
+    for (const id of allIds) expect(counts.get(id)).toBe(expectedCount(id));
+  });
+
+  it('every id is asked about exactly once — chunks are disjoint and cover the set', async () => {
+    const { queries, runQuery } = recordingRunner();
+    await fetchAppOpenCounts(allIds, runQuery);
+    expect(queries.flatMap(idsIn)).toEqual(allIds);
+  });
+
+  it('dedupes and drops empty ids before chunking', async () => {
+    const { queries, runQuery } = recordingRunner();
+    await fetchAppOpenCounts(['apb_1', 'apb_1', '', 'apb_2'], runQuery);
+    expect(queries).toHaveLength(1);
+    expect(idsIn(queries[0])).toEqual(['apb_1', 'apb_2']);
+  });
+
+  it('runs ZERO queries for an empty set (`IN ()` is a syntax error)', async () => {
+    const { queries, runQuery } = recordingRunner();
+    const counts = await fetchAppOpenCounts([], runQuery);
+    expect(queries).toEqual([]);
+    expect(counts.size).toBe(0);
+  });
+
+  it('coerces a string openCount (ClickHouse 64-bit rendering) to a number', async () => {
+    const counts = await fetchAppOpenCounts(['apb_a'], async () => [
+      { appBlockId: 'apb_a', openCount: '42' },
+    ]);
+    expect(counts.get('apb_a')).toBe(42);
+  });
+
+  it('a chunk failure PROPAGATES — the count read fails hard by design', async () => {
+    // Asymmetric with the discovery read on purpose: `open_count` is derived, so a
+    // partial map is written over live counts as 0 rather than left alone.
+    await expect(
+      fetchAppOpenCounts(allIds, async () => {
+        throw new Error('Code: 62. DB::Exception: Max query size exceeded');
+      })
+    ).rejects.toThrow('Code: 62');
+  });
+});
+
+describe('fetchRecentlyOpenedBlockIds — discovery degrades, it does not fail the run', () => {
+  const SINCE = '2026-09-05T10:00:00.000Z';
+
+  it('returns the deduped, non-empty ids on a good read (positive control)', async () => {
+    const seen: string[] = [];
+    const out = await fetchRecentlyOpenedBlockIds(
+      SINCE,
+      async (sql) => {
+        seen.push(sql);
+        return [
+          { appBlockId: 'apb_a' },
+          { appBlockId: 'apb_a' },
+          { appBlockId: '' },
+          { appBlockId: 'apb_b' },
+        ];
+      },
+      () => {
+        throw new Error('onDegrade must not be called on a successful read');
+      }
+    );
+    expect(out).toEqual(['apb_a', 'apb_b']);
+    expect(seen[0]).toContain(`parseDateTimeBestEffort('${SINCE}')`);
+  });
+
+  it('🔴 a ClickHouse failure degrades to "no new plays" so install_count still runs', async () => {
+    // The regression this exists to prevent: the discovery read happens BEFORE the
+    // `if (!affected.length) return`, so a throw here aborted `update()`,
+    // `setLastUpdate()` never ran, and the store's `popular` sort
+    // (`install_count DESC`) froze for the whole ClickHouse outage — a pure-Postgres
+    // counter held hostage, with a retry of exactly the same shape.
+    const degraded: unknown[] = [];
+    const out = await fetchRecentlyOpenedBlockIds(
+      SINCE,
+      async () => {
+        throw new Error('MEMORY_LIMIT_EXCEEDED');
+      },
+      (error) => degraded.push(error)
+    );
+    expect(out).toEqual([]);
+    expect(degraded).toHaveLength(1);
+    expect((degraded[0] as Error).message).toBe('MEMORY_LIMIT_EXCEEDED');
+  });
+
+  it('onDegrade MAY VETO by throwing — a canceled job is not "no plays"', async () => {
+    // The processor's onDegrade calls `jobContext.checkIfCanceled()` first, so an
+    // aborted query surfaces as a cancellation instead of being swallowed.
+    await expect(
+      fetchRecentlyOpenedBlockIds(
+        SINCE,
+        async () => {
+          throw new Error('The user aborted a request.');
+        },
+        () => {
+          throw new Error('Job was canceled');
+        }
+      )
+    ).rejects.toThrow('Job was canceled');
   });
 });

--- a/src/server/metrics/appListing.metrics.prom.ts
+++ b/src/server/metrics/appListing.metrics.prom.ts
@@ -1,0 +1,103 @@
+// App Store Listings (W13) — the prom-client half of the AppListing rollup's
+// soft-degrade signal.
+//
+// WHY IT IS ITS OWN MODULE. `appListing.metrics.ts` (the processor) imports the
+// heavy metric framework — clickhouse / db / redis clients via base.metrics — so a
+// test that wanted to drive the REAL prom registry through it would have to boot or
+// mock all of that first. `appListing.metrics.sql.ts` is dependency-free by
+// contract and cannot import prom-client either. This module imports prom-client
+// and nothing else, so the emitter is exercisable against the real default registry
+// (the one `/api/metrics` scrapes) in a plain unit test. Same shape as
+// app-block-runtime.metrics.ts, and tested the same way.
+//
+// prom-client GOTCHA: Next.js can import a module twice (hot reload / route
+// bundling) and prom-client throws on a duplicate metric name, so the getter below
+// is a get-or-create guard against the DEFAULT global registry.
+import client, { type Counter, type Registry } from 'prom-client';
+
+/**
+ * Every run in which the `App_Open` play-DISCOVERY read could not be answered by
+ * ClickHouse and the rollup degraded to "no new plays this run".
+ *
+ * 🔴 WHAT IT DISTINGUISHES, AND WHY A LOG LINE COULD NOT. The discovery read fails
+ * SOFT by design (see `fetchRecentlyOpenedBlockIds`): on failure the rollup returns
+ * an empty candidate set, so the play arm of the affected query does not fire and a
+ * listing whose ONLY change is new plays is not recomputed. One run of that is
+ * self-healing — the next run's watermark still covers the gap. A WEEK of it is a
+ * silently frozen `open_count` on every app whose installs never move.
+ *
+ * The degraded state is by construction indistinguishable from "nobody played
+ * anything": both produce an empty list and an unchanged column. So the only thing
+ * that can tell a blip from a stuck rollup is the RATE of this counter over time,
+ * which is exactly what a `logToAxiom({ type: 'warning' })` per run cannot express
+ * as an alert. Alert on persistence, not on presence — e.g.
+ * `increase(civitai_app_listing_open_discovery_degraded_total[1h])` staying at the
+ * run rate, rather than on any single increment.
+ *
+ * 🔴 IT DOES NOT COUNT THE COUNT READ. `getAllTimeOpenCounts` fails HARD on purpose
+ * and surfaces as a failed job; there is nothing to degrade and nothing to hide.
+ * This counter is only ever incremented on the soft path.
+ *
+ * UNLABELLED, so a healthy pod that has loaded this module reports an observable 0
+ * rather than `no data` (prom-client materialises an unlabelled counter's single
+ * series at registration). Honest caveat, since an absent series is otherwise
+ * ambiguous: the series exists on a pod only once the AppListing processor has been
+ * loaded there, i.e. on the pool that actually runs metric jobs.
+ */
+const OPEN_DISCOVERY_DEGRADED = 'civitai_app_listing_open_discovery_degraded_total';
+
+export type AppListingPromBundle = {
+  openDiscoveryDegradedTotal: Counter<string>;
+};
+
+/** Get-or-create this module's metrics on `reg`, idempotently. */
+export function ensureRegisterAppListingMetrics(
+  reg: Registry = client.register
+): AppListingPromBundle {
+  const existing = reg.getSingleMetric(OPEN_DISCOVERY_DEGRADED) as Counter<string> | undefined;
+  const openDiscoveryDegradedTotal =
+    existing ??
+    new client.Counter({
+      name: OPEN_DISCOVERY_DEGRADED,
+      help: 'AppListing metric runs whose ClickHouse App_Open play-discovery read failed, degrading that run to install_count only',
+      registers: [reg],
+    });
+  return { openDiscoveryDegradedTotal };
+}
+
+/**
+ * Fail-soft emit of one degraded discovery run.
+ *
+ * 🔴 TOTAL, like every emitter of its kind here. The thing it instruments is the
+ * fallback path of a metric job: a metrics error (registry collision, a name
+ * claimed elsewhere with a different labelset) must never propagate out of a
+ * `catch` whose entire job is to keep `install_count` running through a ClickHouse
+ * outage. Losing the count is survivable; converting a degrade into a failed run is
+ * the regression the soft path exists to prevent.
+ */
+export function recordAppListingOpenDiscoveryDegrade(): void {
+  try {
+    ensureRegisterAppListingMetrics().openDiscoveryDegradedTotal.inc();
+  } catch {
+    /* instrument-only — never let a metrics error fail the run it is observing */
+  }
+}
+
+// 🔴 EAGER REGISTRATION AT MODULE SCOPE, AND IT IS LOAD-BEARING RATHER THAN TIDY.
+// Registration inside the emitter alone means the series does not exist until the
+// FIRST degrade — so a healthy pod scrapes `no data`, which is exactly the ambiguity
+// this counter was added to remove: absent reads as "nothing ever degraded" when it
+// may equally mean "the instrument was never wired". Measured while writing the
+// processor seam test: on a healthy run `getSingleMetric` returned undefined, not a
+// 0. The processor imports this module, so this line is what makes the 0 real on any
+// pod that runs the AppListing rollup.
+//
+// Guarded because it runs at module scope: the get-or-create's cast is unchecked, so
+// if this name is ever claimed elsewhere with a different type, an unguarded throw
+// here would break the IMPORT of the metric processor — a far worse outcome than a
+// missing series.
+try {
+  ensureRegisterAppListingMetrics();
+} catch {
+  /* seeding is a readability nicety; losing it must not cost the module load */
+}

--- a/src/server/metrics/appListing.metrics.sql.ts
+++ b/src/server/metrics/appListing.metrics.sql.ts
@@ -65,21 +65,39 @@ export const APP_OPEN_ACTION_TYPE = 'App_Open';
  * problem: its source rows are append-only ClickHouse events and the count is a
  * full recompute over all of them, never a delta.
  *
- * 🔴 THE REPAIR ARM EXISTS BECAUSE LOSING THE JOIN KEY OTHERWISE FREEZES A
- * PUBLISHED NUMBER RATHER THAN CLEARING IT. `AppListing.appBlock` is
- * `onDelete: SetNull`, so deleting an AppBlock nulls the listing's
- * `app_block_id`. Once that happens the listing matches NONE of the three arms
- * above — it has a metric row (so not the seed arm), its `app_block_id` is NULL
- * (so the install arm's `IS NOT NULL` fails and the play arm's `= ANY($2)` is
- * NULL, never true) — and a listing sitting at `open_count = 777` stays at 777
- * forever, with no path back. Under stage 4 that is a permanently stale PUBLIC
- * number for an app whose block no longer exists. The repair arm selects exactly
- * that shape so the upsert's `measurable` gate recomputes it to 0.
+ * 🔴 THE REPAIR ARM'S PREDICATE IS "NULL JOIN KEY WITH A NON-ZERO PUBLISHED
+ * COUNT" — IT IS NOT "the AppBlock was deleted", AND MUST NOT BE READ AS ONE.
+ * `app_block_id IS NULL` is not a kind discriminator; the schema says so at the
+ * field itself (`AppListing.appBlockId` in
+ * packages/civitai-db-schema/prisma/schema.prisma): "It is NOT a kind
+ * discriminator: discriminate on `kind`, never on appBlockId nullness. Only a
+ * natively-created off-site listing (no backing AppBlock) leaves it NULL." So the
+ * arm covers TWO populations, and only the first is a deletion:
+ *
+ *   1. THE FROZEN-NUMBER CASE — the reason the arm exists. `AppListing.appBlock`
+ *      is `onDelete: SetNull`, so deleting an AppBlock nulls that listing's
+ *      `app_block_id`. It then matches NONE of the three arms above — it has a
+ *      metric row (so not the seed arm), its `app_block_id` is NULL (so the
+ *      install arm's `IS NOT NULL` fails and the play arm's `= ANY($2)` is NULL,
+ *      never true) — and a listing sitting at `open_count = 777` stays at 777
+ *      forever, with no path back. Under stage 4 that is a permanently stale
+ *      PUBLIC number for an app whose block no longer exists. The arm selects
+ *      exactly that shape so the upsert's `measurable` gate recomputes it to 0.
+ *
+ *   2. A NATIVELY-CREATED OFF-SITE LISTING, which never had an AppBlock to lose:
+ *      its `app_block_id` was NULL from birth. The upsert writes both counters 0
+ *      for every off-site row, so such a listing should never hold a non-zero
+ *      count and this population is expected to be EMPTY — the arm is a no-op over
+ *      it. If a row does show up, the published number is wrong by definition and
+ *      clearing it to 0 is the correct repair, which is why the arm is
+ *      deliberately NOT gated on `kind`.
+ *
+ * 🔴 CONSEQUENCE FOR ANY FOLLOW-UP: do not build an alert or a report that reads
+ * "the repair arm fired ⇒ an AppBlock was deleted". Population 2 makes that
+ * inference invalid. To count deletions, observe deletions.
  *
  * It is SELF-TERMINATING, not a per-run treadmill: the run it fires on writes the
- * counters to 0, after which the `<> 0` predicate no longer matches. It is
- * deliberately NOT gated on `kind` — an off-site row carrying a stale non-zero
- * count is the same defect and wants the same repair.
+ * counters to 0, after which the `<> 0` predicate no longer matches.
  */
 export const AFFECTED_APPROVED_LISTINGS_SQL = `
   SELECT al.id, al."app_block_id"
@@ -102,10 +120,13 @@ export const AFFECTED_APPROVED_LISTINGS_SQL = `
       OR (
         al."kind" = 'onsite' AND al."app_block_id" = ANY($2::text[])
       )
-      -- Repair: the join key is gone (AppBlock deleted -> app_block_id SetNull)
-      -- but a non-zero count is still published. Matches no arm above, so without
-      -- this the stale number is frozen forever. Self-terminating: the upsert
-      -- writes 0, and then this predicate stops matching.
+      -- Repair: NULL join key + a non-zero count still published. That predicate
+      -- covers the deleted-AppBlock case (SetNull froze a public number, which is
+      -- why this arm exists) AND -- vacuously, since their counters are always
+      -- written 0 -- natively-created off-site rows, which never had an AppBlock:
+      -- app_block_id nullness is NOT a kind discriminator. Matches no arm above,
+      -- so without this the stale number is frozen forever. Self-terminating: the
+      -- upsert writes 0, and then this predicate stops matching.
       OR (
         al."app_block_id" IS NULL AND EXISTS (
           SELECT 1 FROM "app_listing_metrics" m
@@ -213,12 +234,30 @@ export const APP_LISTING_METRIC_UPSERT_SQL = `
 //
 // 🔴 CONCRETE TRIGGER FOR DOING IT — do not wait for a page to time out: build the
 // MV when ANY of these is true.
-//   • the count query's wall time exceeds ~5 s, or its `read_rows` exceeds ~100M
-//     (`SELECT query_duration_ms, read_rows FROM system.query_log
-//        WHERE query LIKE '%App_Open%' AND type = 'QueryFinish'`);
+//   • the count query's wall time exceeds ~5 s, or its `read_rows` exceeds ~100M;
 //   • `App_Open` passes ~1% of the `actions` table's total rows;
 //   • this rollup's schedule is tightened below the current 5 minutes, or the
 //     all-time figure gains a timeframe/window variant (either multiplies the scan).
+//
+// 🔴 THE DIAGNOSTIC QUERY MUST DISCRIMINATE THE EXPENSIVE READ FROM THE CHEAP ONE.
+// BOTH queries in this file embed the literal `App_Open`, so `query LIKE
+// '%App_Open%'` matches the unbounded count read AND the time-bounded discovery
+// read — and the discovery read runs at least as often and is cheap, so its rows
+// DOMINATE the result set and drag the numbers down. An operator reading that mix
+// concludes "nowhere near the trigger" and defers the MV past the point this note
+// exists to catch. `sum(dailyActors)` appears ONLY in the count query
+// (`APP_OPEN_COUNT_QUERY_MARKER` below, which is interpolated into it rather than
+// spelled twice, so the two cannot drift; the spec test asserts it is absent from
+// the discovery query). Bound the window and order by cost, or a years-long
+// unordered dump buries the slow tail:
+//
+//   SELECT event_time, query_duration_ms, read_rows, memory_usage
+//     FROM system.query_log
+//    WHERE type = 'QueryFinish'
+//      AND event_date >= today() - 7
+//      AND query LIKE '%sum(dailyActors)%'
+//    ORDER BY query_duration_ms DESC
+//    LIMIT 20
 // ---------------------------------------------------------------------------
 
 /**
@@ -275,20 +314,51 @@ export type AppOpenRecentRow = { appBlockId: string };
  * `onDegrade` receives the error before the degrade and MAY THROW to veto it. The
  * processor uses that to rethrow a job cancellation — an aborted query is not a
  * ClickHouse failure and must not be swallowed into "no plays".
+ *
+ * 🔴 THE `try` WRAPS THE AWAITED QUERY AND NOTHING ELSE — DELIBERATELY, AND IT MUST
+ * NOT BE WIDENED BACK. The soft-fail contract above is a claim about ONE failure
+ * mode: ClickHouse could not answer. A `try` that also covered the SQL builder or
+ * the `rows.map(...)` below would convert every PROGRAMMING error into the same
+ * silent `[]` — a builder that throws on a bad `sinceIso`, or a `runQuery` that
+ * resolves to something non-array so `.map` is a `TypeError`. Those do not
+ * self-heal on the next run the way a ClickHouse blip does: they return `[]` on
+ * EVERY run, forever, so the play arm never fires and a listing whose only change
+ * is new plays is never recomputed again. Degrading is right for the outage and
+ * wrong for the bug; the narrow `try` is what tells them apart. The spec file pins
+ * both directions (a query rejection degrades; a builder or mapping throw
+ * propagates).
  */
 export async function fetchRecentlyOpenedBlockIds(
   sinceIso: string,
   runQuery: (sql: string) => Promise<AppOpenRecentRow[]>,
   onDegrade: (error: unknown) => void
 ): Promise<string[]> {
+  // OUTSIDE the try on purpose: a builder throw is a bug, not a ClickHouse outage.
+  const sql = buildAppOpenRecentBlockIdsSql(sinceIso);
+  let rows: AppOpenRecentRow[];
   try {
-    const rows = await runQuery(buildAppOpenRecentBlockIdsSql(sinceIso));
-    return [...new Set(rows.map((r) => r.appBlockId).filter(Boolean))];
+    rows = await runQuery(sql);
   } catch (error) {
     onDegrade(error);
     return [];
   }
+  // Also outside: a non-array result is a contract violation, not an outage.
+  return [...new Set(rows.map((r) => r.appBlockId).filter(Boolean))];
 }
+
+/**
+ * The aggregate expression that appears ONLY in the all-time count query — never
+ * in the cheap, time-bounded discovery query beside it.
+ *
+ * 🔴 IT IS A DIAGNOSTIC DISCRIMINATOR, NOT DECORATION. Both queries embed
+ * `App_Open`, so the obvious `system.query_log` filter (`query LIKE '%App_Open%'`)
+ * cannot tell the unbounded scan from the cheap read and returns a set the cheap
+ * one dominates. This string is interpolated into `buildAppOpenCountSql` rather
+ * than spelled there and quoted here, so the MV-trigger runbook above and the
+ * query it grades cannot drift apart. If you rename `dailyActors`, this constant
+ * moves with it and the runbook stays correct.
+ */
+export const APP_OPEN_COUNT_QUERY_MARKER = 'sum(dailyActors)';
 
 /**
  * ALL-TIME deduped play count per app_block_id.
@@ -321,7 +391,7 @@ export async function fetchRecentlyOpenedBlockIds(
 export function buildAppOpenCountSql(appBlockIds: string[]): string {
   const inList = appBlockIds.map((id) => `'${escapeClickhouseString(id)}'`).join(', ');
   return `
-    SELECT appBlockId, sum(dailyActors) AS openCount
+    SELECT appBlockId, ${APP_OPEN_COUNT_QUERY_MARKER} AS openCount
     FROM (
       SELECT
         JSONExtractString(details, 'appBlockId') AS appBlockId,
@@ -337,10 +407,60 @@ export function buildAppOpenCountSql(appBlockIds: string[]): string {
 }
 
 /**
- * Chunk size for BOTH the Postgres upsert batches and the ClickHouse count reads.
- * Single-sourced here so the two cannot drift apart.
+ * Chunk size for the POSTGRES upsert batches (`APP_LISTING_METRIC_UPSERT_SQL`).
+ *
+ * 🔴 THIS IS NOT THE CLICKHOUSE CHUNK SIZE, AND THE TWO MUST NEVER BE RE-MERGED —
+ * THEIR OPTIMA PUSH IN OPPOSITE DIRECTIONS. A single shared constant is what made
+ * the round-1 fix cost ~39x more than the defect it fixed.
+ *
+ *   • THIS constant wants to be SMALL. Each batch is a real write transaction with
+ *     five of them in flight (`limitConcurrency(tasks, 5)`); a bigger batch means a
+ *     longer-held row-lock set, a fatter `ANY($1::text[])` and a coarser
+ *     cancellation granularity. Nothing about the upsert gets cheaper by asking
+ *     about more listings at once.
+ *
+ *   • `APP_OPEN_CH_CHUNK_SIZE` wants to be LARGE, for the reason spelled out on it:
+ *     each ClickHouse chunk is a FULL SCAN of `actions` whose cost does not shrink
+ *     with the size of the `IN` list, so halving the chunk size doubles the total
+ *     work. Its only upper bound is `max_query_size`.
+ *
+ * Moving one for the other's reasons is therefore always wrong. A relative test
+ * ("no chunk exceeds the constant") cannot see that — the guard is the ABSOLUTE
+ * byte/id ceiling pinned in the spec file, which does not move when either
+ * constant does.
  */
 export const APP_LISTING_BATCH_SIZE = 200;
+
+/**
+ * Chunk size for the CLICKHOUSE all-time count reads (`buildAppOpenCountSql`).
+ *
+ * 🔴 SIZED TO MINIMISE THE NUMBER OF FULL SCANS, SUBJECT TO `max_query_size`. Every
+ * chunk is an unbounded scan of `actions` (see the EXPLAIN note above), so the cost
+ * of this read is ~linear in the CHUNK COUNT and ~flat in the chunk size. The only
+ * thing pushing the chunk size down is the hard query-text ceiling.
+ *
+ * THE ARITHMETIC, so the next person can re-derive it rather than trusting it. An
+ * app block id is `apb_` + a 26-char ULID = 30 chars, rendered into the `IN` list as
+ * `'<id>', ` = 34 bytes. The rest of the query is a fixed 460 bytes, so
+ *
+ *     bytes(n) = 460 + 34n
+ *
+ * (measured, not estimated: `bytes(7000) = 238,460`, which is exactly the figure
+ * the ceiling note on `fetchAppOpenCounts` reports from a live ClickHouse.) Against
+ * the `max_query_size` default of 262,144 bytes:
+ *
+ *   • the exact hard ceiling is 7,696 ids (262,124 bytes); 7,697 is 262,158 and
+ *     fails with `Code: 62`;
+ *   • at n = 2,000 the query is 68,460 bytes — 3.83x under the ceiling;
+ *   • the seed/restore path this file's docstrings name (~7,700 approved on-site
+ *     listings) takes ceil(7700/2000) = 4 scans here, against ceil(7700/200) = 39
+ *     at the old shared constant of 200. That 39x is the cost of merging them.
+ *
+ * Raising it further buys little (4 -> 2 scans at n = 4,000) and spends most of the
+ * headroom; 2,000 keeps ~3.8x of margin against a ceiling that is a per-server
+ * SETTING, not a protocol constant, and so can be lowered under us.
+ */
+export const APP_OPEN_CH_CHUNK_SIZE = 2_000;
 
 /** One row of `buildAppOpenCountSql`'s result set. */
 export type AppOpenCountRow = { appBlockId: string; openCount: number | string };
@@ -352,11 +472,21 @@ export type AppOpenCountRow = { appBlockId: string; openCount: number | string }
  * 🔴 THE IN LIST IS A HARD CEILING, NOT A SOFT ONE — an over-long list is a query
  * ERROR, not a slow query. Measured against ClickHouse 26.8.2.7: 7,000 ids returns
  * HTTP 200 (238,460 bytes of query text); **8,000 ids returns `Code: 62 Max query
- * size exceeded`**. The count read is HARD-failing by design (see the processor),
- * so an unchunked query past that ceiling takes `install_count` down with it. Two
- * live triggers reach it: the seed arm on a fresh or restored
- * `app_listing_metrics` table, and the store simply growing past ~7,700 approved
- * on-site listings. Chunking at `APP_LISTING_BATCH_SIZE` leaves ~38x of headroom.
+ * size exceeded`**. By the `bytes(n) = 460 + 34n` model on `APP_OPEN_CH_CHUNK_SIZE`
+ * — which reproduces that 238,460 exactly — the ceiling falls at 7,696 ids against
+ * the 262,144-byte `max_query_size` default. The count read is HARD-failing by
+ * design (see the processor), so an unchunked query past that ceiling takes
+ * `install_count` down with it. Two live triggers reach it: the seed arm on a fresh
+ * or restored `app_listing_metrics` table, and the store simply growing past ~7,700
+ * approved on-site listings.
+ *
+ * 🔴 CHUNKED AT `APP_OPEN_CH_CHUNK_SIZE` (2,000 => 68,460 bytes, 3.83x of headroom)
+ * AND EXPLICITLY *NOT* AT `APP_LISTING_BATCH_SIZE`. Chunking is not free here: each
+ * chunk is a FULL `actions` scan whose cost does not shrink with the `IN` list, so
+ * the chunk count is the cost. At the Postgres batch size of 200 the same seed-path
+ * workload costs 39 scans instead of 4 — and 39 chances to hit the fail-hard path
+ * instead of 4. See the two-directional pressure note on both constants; do not
+ * re-merge them.
  *
  * Chunks are disjoint by construction (ids are deduped first), so merging is a
  * plain `set` with no clobber; a block absent from every chunk's result set is
@@ -371,7 +501,7 @@ export type AppOpenCountRow = { appBlockId: string; openCount: number | string }
 export async function fetchAppOpenCounts(
   appBlockIds: string[],
   runQuery: (sql: string) => Promise<AppOpenCountRow[]>,
-  batchSize: number = APP_LISTING_BATCH_SIZE
+  batchSize: number = APP_OPEN_CH_CHUNK_SIZE
 ): Promise<Map<string, number>> {
   const unique = [...new Set(appBlockIds.filter(Boolean))];
   const counts = new Map<string, number>();

--- a/src/server/metrics/appListing.metrics.sql.ts
+++ b/src/server/metrics/appListing.metrics.sql.ts
@@ -454,11 +454,26 @@ export const APP_LISTING_BATCH_SIZE = 200;
  *   • at n = 2,000 the query is 68,460 bytes — 3.83x under the ceiling;
  *   • the seed/restore path this file's docstrings name (~7,700 approved on-site
  *     listings) takes ceil(7700/2000) = 4 scans here, against ceil(7700/200) = 39
- *     at the old shared constant of 200. That 39x is the cost of merging them.
+ *     at the old shared constant of 200 — i.e. splitting the constants is worth
+ *     **9.75x** on that path (39 -> 4).
  *
- * Raising it further buys little (4 -> 2 scans at n = 4,000) and spends most of the
- * headroom; 2,000 keeps ~3.8x of margin against a ceiling that is a per-server
- * SETTING, not a protocol constant, and so can be lowered under us.
+ * ⚠️ TWO DENOMINATORS, DO NOT CONFLATE THEM. The "39x" quoted at the count query's
+ * own docstring is 39 scans against the ONE unchunked query that preceded chunking;
+ * the 9.75x here is 39 against 4. An earlier draft of this paragraph used "39x" for
+ * both, which is right for neither comparison as stated.
+ *
+ * Raising it further buys at most ONE scan, and part of the range is unavailable.
+ * The literal byte budget asserted in the tests (a full chunk under 131,072 bytes,
+ * half of `max_query_size`) caps this constant at **3,841 ids** (131,054 bytes;
+ * 3,842 is 131,088 and reds). Against the ~7,700 seed path that leaves exactly one
+ * improvement in reach — **4 -> 3 scans, from n >= 2,567** — while 2 scans needs
+ * n >= 3,850 (131,360 bytes) and n = 4,000 (136,460) are both OVER the budget and
+ * cannot be chosen at all.
+ *
+ * 2,000 is kept over 2,567 deliberately: one scan is not worth a 28% larger query
+ * (68,460 -> 87,738 bytes, i.e. 14.7% more of the 131,072 budget) against a ceiling
+ * that is a per-server SETTING, not a protocol constant, and so can be lowered
+ * under us.
  */
 export const APP_OPEN_CH_CHUNK_SIZE = 2_000;
 

--- a/src/server/metrics/appListing.metrics.sql.ts
+++ b/src/server/metrics/appListing.metrics.sql.ts
@@ -452,15 +452,35 @@ export const APP_LISTING_BATCH_SIZE = 200;
  *   • the exact hard ceiling is 7,696 ids (262,124 bytes); 7,697 is 262,158 and
  *     fails with `Code: 62`;
  *   • at n = 2,000 the query is 68,460 bytes — 3.83x under the ceiling;
- *   • the seed/restore path this file's docstrings name (~7,700 approved on-site
- *     listings) takes ceil(7700/2000) = 4 scans here, against ceil(7700/200) = 39
- *     at the old shared constant of 200 — i.e. splitting the constants is worth
- *     **9.75x** on that path (39 -> 4).
+ *   • at a seed/restore population of 7,700 listings the read takes
+ *     ceil(7700/2000) = 4 scans here, against ceil(7700/200) = 39 at the old shared
+ *     constant of 200 — i.e. splitting the constants is worth **9.75x** at that
+ *     size (39 -> 4).
  *
- * ⚠️ TWO DENOMINATORS, DO NOT CONFLATE THEM. The "39x" quoted at the count query's
- * own docstring is 39 scans against the ONE unchunked query that preceded chunking;
- * the 9.75x here is 39 against 4. An earlier draft of this paragraph used "39x" for
- * both, which is right for neither comparison as stated.
+ * 🔴 WHERE 7,700 COMES FROM, BECAUSE IT IS NOT A MEASUREMENT AND EVERY THRESHOLD
+ * BELOW IS DERIVED FROM IT. It is this file's own hard ceiling (7,696 ids) rounded
+ * up — i.e. the largest population an UNCHUNKED query could have served — reused as
+ * a stand-in for the seed population. It was never a count of approved on-site
+ * listings, and an earlier draft cited it as "the seed/restore path this file's
+ * docstrings name", which is a self-reference, not a source.
+ * The real seed size is today's approved on-site listing count, which is not
+ * recorded anywhere in this repo. So treat 7,700 as an ORDER OF MAGNITUDE chosen
+ * because it is where the unchunked query broke: the 9.75x and the 2,567 / 3,850
+ * thresholds below are exact GIVEN that input and move with it. If you need them to
+ * be load-bearing, measure the population first.
+ *
+ * ⚠️ TWO DENOMINATORS, DO NOT CONFLATE THEM — and here is the full census, because
+ * an earlier draft of this paragraph used "39x" for both (right for neither as
+ * stated) and then pointed at the wrong file for one of them:
+ *
+ *   • 39 vs the ONE unchunked query that preceded chunking — `39x`. Stated at
+ *     `APP_LISTING_BATCH_SIZE`'s docstring above, NOT at `buildAppOpenCountSql`'s,
+ *     which quotes no such figure.
+ *   • 39 vs the 4 scans this constant produces — `9.75x`. That is the value of
+ *     SPLITTING the constants, and it is the number this paragraph is about.
+ *
+ * `fetchAppOpenCounts`'s docstring says "39 scans instead of 4", which is the second
+ * comparison written out rather than as a ratio.
  *
  * Raising it further buys at most ONE scan, and part of the range is unavailable.
  * The literal byte budget asserted in the tests (a full chunk under 131,072 bytes,

--- a/src/server/metrics/appListing.metrics.sql.ts
+++ b/src/server/metrics/appListing.metrics.sql.ts
@@ -7,13 +7,31 @@
 // of that. See appListing.metrics.ts for the full ownership/sourcing rationale.
 //
 // SCOPE: this job populates `install_count` (from Postgres) and `open_count`
-// (from the ClickHouse `App_Open` event stream) — the two AppListingMetric
-// counters with a reader. Every remaining counter (`connect_count`,
-// `visit_count`, `tipped_count`, `tipped_amount_count`) is left at its schema
-// default 0: none is read, and each maps to a feature that isn't live yet
+// (from the ClickHouse `App_Open` event stream). Every remaining counter
+// (`connect_count`, `visit_count`, `tipped_count`, `tipped_amount_count`) is left
+// at its schema default 0: each maps to a feature that isn't live yet
 // (OAuth-connect submission is a locked-deferred product decision; visit/tip have
 // no server-side source). Populate each with the PR that ships its consumer, not
 // speculatively.
+//
+// 🔴 `open_count` IS A DELIBERATE EXCEPTION TO THAT LAST SENTENCE, AND IT IS NOT A
+// PRECEDENT FOR THE OTHER FOUR. AT THIS REF NOTHING READS IT. The only non-metrics
+// occurrences in the tree are generated schema/type declarations
+// (`packages/civitai-db-schema/src/kysely/types.ts`,
+// `packages/civitai-db-schema/src/models.ts`, the Prisma schema + its migration) —
+// declarations, not readers. The consumer lands in STAGE 3.
+//
+// Populating it one stage ahead of its reader is safe because of a property the
+// other four do not have: it has a TRUSTED SERVER-SIDE SOURCE today (the `App_Open`
+// stream) and the written value is DERIVED AND IDEMPOTENT — every run recomputes it
+// in full from that stream, so there is no accumulating state to get wrong while it
+// is unread, and no backfill to get right when the reader lands. Stage 3 can simply
+// start reading a column that has been correct all along.
+//
+// `connect_count` / `visit_count` / `tipped_count` / `tipped_amount_count` have NO
+// such source: populating any of them would mean inventing one, and an invented
+// counter written for months before anyone looks at it is exactly the drift this
+// file's ownership contract exists to prevent. Do not cite this exception for them.
 // ---------------------------------------------------------------------------
 
 /**
@@ -46,6 +64,22 @@ export const APP_OPEN_ACTION_TYPE = 'App_Open';
  * periodic full recompute could close it later. `open_count` does NOT have this
  * problem: its source rows are append-only ClickHouse events and the count is a
  * full recompute over all of them, never a delta.
+ *
+ * 🔴 THE REPAIR ARM EXISTS BECAUSE LOSING THE JOIN KEY OTHERWISE FREEZES A
+ * PUBLISHED NUMBER RATHER THAN CLEARING IT. `AppListing.appBlock` is
+ * `onDelete: SetNull`, so deleting an AppBlock nulls the listing's
+ * `app_block_id`. Once that happens the listing matches NONE of the three arms
+ * above — it has a metric row (so not the seed arm), its `app_block_id` is NULL
+ * (so the install arm's `IS NOT NULL` fails and the play arm's `= ANY($2)` is
+ * NULL, never true) — and a listing sitting at `open_count = 777` stays at 777
+ * forever, with no path back. Under stage 4 that is a permanently stale PUBLIC
+ * number for an app whose block no longer exists. The repair arm selects exactly
+ * that shape so the upsert's `measurable` gate recomputes it to 0.
+ *
+ * It is SELF-TERMINATING, not a per-run treadmill: the run it fires on writes the
+ * counters to 0, after which the `<> 0` predicate no longer matches. It is
+ * deliberately NOT gated on `kind` — an off-site row carrying a stale non-zero
+ * count is the same defect and wants the same repair.
  */
 export const AFFECTED_APPROVED_LISTINGS_SQL = `
   SELECT al.id, al."app_block_id"
@@ -67,6 +101,17 @@ export const AFFECTED_APPROVED_LISTINGS_SQL = `
       -- New plays since the watermark (discovered in ClickHouse, not Postgres).
       OR (
         al."kind" = 'onsite' AND al."app_block_id" = ANY($2::text[])
+      )
+      -- Repair: the join key is gone (AppBlock deleted -> app_block_id SetNull)
+      -- but a non-zero count is still published. Matches no arm above, so without
+      -- this the stale number is frozen forever. Self-terminating: the upsert
+      -- writes 0, and then this predicate stops matching.
+      OR (
+        al."app_block_id" IS NULL AND EXISTS (
+          SELECT 1 FROM "app_listing_metrics" m
+          WHERE m."app_listing_id" = al.id
+            AND (m."open_count" <> 0 OR m."install_count" <> 0)
+        )
       )
     )
 `;
@@ -149,6 +194,31 @@ export const APP_LISTING_METRIC_UPSERT_SQL = `
 // large table ordered by (time, type), so nothing prunes. PREWHERE reads the
 // narrow `type` column first and only then reads `details`/`userId`/`ip`/`time`
 // for the surviving rows. Do not move that predicate into the WHERE clause.
+//
+// 🔴 KNOWN AND ACCEPTED (NOT FIXED HERE): THE COUNT READ IS STRUCTURALLY UNBOUNDED,
+// AND ITS COST DOES NOT SHRINK WHEN YOU ASK ABOUT FEWER BLOCKS. Measured with
+// `EXPLAIN indexes=1`: primary-key usage on `actions` is `type` ONLY (a generic
+// exclusion search), and the `JSONExtractString(details, 'appBlockId') IN (…)`
+// predicate is applied ABOVE `ReadFromMergeTree`, not as a key condition. So every
+// run reads `details` / `userId` / `ip` / `time` for EVERY `App_Open` row ever
+// written, no matter how few app blocks are in the IN list — every 5 minutes,
+// forever. `actions` has no TTL, so this grows monotonically with the event stream
+// and never with the workload.
+//
+// It is affordable today only because `App_Open` is a young, low-volume event type.
+// THE STANDARD REMEDY is an `AggregatingMergeTree` materialized view keyed
+// `(appBlockId, day)` holding `uniqExactState(actor)`, which turns this scan into a
+// point lookup on the already-deduped per-day state (the `sum(uniqExactMerge(...))`
+// then reproduces the exact same number this query computes).
+//
+// 🔴 CONCRETE TRIGGER FOR DOING IT — do not wait for a page to time out: build the
+// MV when ANY of these is true.
+//   • the count query's wall time exceeds ~5 s, or its `read_rows` exceeds ~100M
+//     (`SELECT query_duration_ms, read_rows FROM system.query_log
+//        WHERE query LIKE '%App_Open%' AND type = 'QueryFinish'`);
+//   • `App_Open` passes ~1% of the `actions` table's total rows;
+//   • this rollup's schedule is tightened below the current 5 minutes, or the
+//     all-time figure gains a timeframe/window variant (either multiplies the scan).
 // ---------------------------------------------------------------------------
 
 /**
@@ -184,6 +254,40 @@ export function buildAppOpenRecentBlockIdsSql(sinceIso: string): string {
     WHERE time >= parseDateTimeBestEffort('${escapeClickhouseString(sinceIso)}')
       AND JSONExtractString(details, 'appBlockId') != ''
   `;
+}
+
+/** One row of `buildAppOpenRecentBlockIdsSql`'s result set. */
+export type AppOpenRecentRow = { appBlockId: string };
+
+/**
+ * The discovery half, with its failure policy — deduped app_block_ids opened since
+ * `sinceIso`, or an EMPTY LIST if ClickHouse could not answer.
+ *
+ * 🔴 SOFT-FAILING BY CONTRACT, and asymmetric with `fetchAppOpenCounts` on purpose.
+ * This read only proposes CANDIDATES for recompute; it cannot make a number wrong.
+ * Degrading to "no new plays this run" is self-healing — the next run's watermark
+ * still covers the gap. Failing the run instead would take `install_count`, a pure
+ * Postgres counter, down with a ClickHouse blip; the store's `popular` sort
+ * (`install_count DESC`) then freezes for the whole outage, and the retry has the
+ * same shape. `fetchAppOpenCounts` is the opposite and must stay that way: a
+ * partial answer THERE is written over live counts as 0.
+ *
+ * `onDegrade` receives the error before the degrade and MAY THROW to veto it. The
+ * processor uses that to rethrow a job cancellation — an aborted query is not a
+ * ClickHouse failure and must not be swallowed into "no plays".
+ */
+export async function fetchRecentlyOpenedBlockIds(
+  sinceIso: string,
+  runQuery: (sql: string) => Promise<AppOpenRecentRow[]>,
+  onDegrade: (error: unknown) => void
+): Promise<string[]> {
+  try {
+    const rows = await runQuery(buildAppOpenRecentBlockIdsSql(sinceIso));
+    return [...new Set(rows.map((r) => r.appBlockId).filter(Boolean))];
+  } catch (error) {
+    onDegrade(error);
+    return [];
+  }
 }
 
 /**
@@ -232,14 +336,63 @@ export function buildAppOpenCountSql(appBlockIds: string[]): string {
   `;
 }
 
+/**
+ * Chunk size for BOTH the Postgres upsert batches and the ClickHouse count reads.
+ * Single-sourced here so the two cannot drift apart.
+ */
+export const APP_LISTING_BATCH_SIZE = 200;
+
+/** One row of `buildAppOpenCountSql`'s result set. */
+export type AppOpenCountRow = { appBlockId: string; openCount: number | string };
+
+/**
+ * ALL-TIME deduped play counts for an arbitrary number of app block ids, merged
+ * across as many ClickHouse round trips as it takes.
+ *
+ * 🔴 THE IN LIST IS A HARD CEILING, NOT A SOFT ONE — an over-long list is a query
+ * ERROR, not a slow query. Measured against ClickHouse 26.8.2.7: 7,000 ids returns
+ * HTTP 200 (238,460 bytes of query text); **8,000 ids returns `Code: 62 Max query
+ * size exceeded`**. The count read is HARD-failing by design (see the processor),
+ * so an unchunked query past that ceiling takes `install_count` down with it. Two
+ * live triggers reach it: the seed arm on a fresh or restored
+ * `app_listing_metrics` table, and the store simply growing past ~7,700 approved
+ * on-site listings. Chunking at `APP_LISTING_BATCH_SIZE` leaves ~38x of headroom.
+ *
+ * Chunks are disjoint by construction (ids are deduped first), so merging is a
+ * plain `set` with no clobber; a block absent from every chunk's result set is
+ * absent from the map, which the upsert reads as 0. Sequential rather than
+ * concurrent on purpose — see the unbounded-scan note above: each of these is a
+ * full-table read, so firing them in parallel multiplies peak ClickHouse memory
+ * for no wall-clock win worth having.
+ *
+ * `runQuery` is injected rather than taking `ctx.ch` so this stays dependency-free
+ * and the chunk/merge is exercisable without booting a ClickHouse client.
+ */
+export async function fetchAppOpenCounts(
+  appBlockIds: string[],
+  runQuery: (sql: string) => Promise<AppOpenCountRow[]>,
+  batchSize: number = APP_LISTING_BATCH_SIZE
+): Promise<Map<string, number>> {
+  const unique = [...new Set(appBlockIds.filter(Boolean))];
+  const counts = new Map<string, number>();
+  // `IN ()` is a syntax error, and there is nothing to ask about anyway — an empty
+  // input runs ZERO queries rather than one bad one.
+  for (let i = 0; i < unique.length; i += batchSize) {
+    const rows = await runQuery(buildAppOpenCountSql(unique.slice(i, i + batchSize)));
+    for (const row of rows) counts.set(row.appBlockId, Number(row.openCount));
+  }
+  return counts;
+}
+
 // ---------------------------------------------------------------------------
 // Executable spec of the aggregate semantics (mirrors the SQL above).
 //
 // The SQL is the production path (install_count in Postgres, open_count in
-// ClickHouse); this pure function encodes the SAME rules over in-memory rows so
-// the invariants — approved-only, on-site-only, ACTIVE (enabled) install
+// ClickHouse); these pure functions encode the SAME rules over in-memory rows so
+// the invariants — which listings are AFFECTED (seed / install-change / new-play /
+// lost-join-key repair), approved-only, on-site-only, ACTIVE (enabled) install
 // filtering, the one-actor-per-UTC-day play dedup, and NEVER emitting thumbs —
-// are unit-testable without a database. Keep it in lockstep with the SQL above:
+// are unit-testable without a database. Keep them in lockstep with the SQL above:
 // they are a matched pair, and changing one without the other is precisely the
 // drift the pair exists to prevent.
 // ---------------------------------------------------------------------------
@@ -273,6 +426,74 @@ export type AppListingMetricUpdate = {
   openCount: number;
 };
 
+/** An existing `app_listing_metrics` row, as the affected-set query sees it. */
+export type AppListingMetricRow = {
+  appListingId: string;
+  installCount: number;
+  openCount: number;
+};
+
+export type AffectedListingsInput = {
+  listings: AppListingComputeInput['listings'];
+  /** Existing metric rows. A listing absent from this list is a SEED candidate. */
+  metrics: AppListingMetricRow[];
+  /** BlockUserSubscription rows with the timestamps `$1` is compared against. */
+  subscriptions: Array<{
+    appBlockId: string;
+    createdAt: Date | string;
+    updatedAt: Date | string;
+  }>;
+  /** `$2` — app_block_ids ClickHouse reported as opened since the watermark. */
+  recentlyOpenedBlockIds: string[];
+  /** `$1` — the incremental watermark. */
+  since: Date | string;
+};
+
+/**
+ * Which approved listings this run must recompute — the in-memory mirror of
+ * `AFFECTED_APPROVED_LISTINGS_SQL`, arm for arm.
+ *
+ * Exists so the arm set is testable without Postgres. The repair arm in particular
+ * is not observable any other way in a unit test, and it is the one arm whose
+ * absence is SILENT in production: the listing simply never comes back.
+ */
+export function selectAffectedApprovedListings(input: AffectedListingsInput): string[] {
+  const since = new Date(input.since).getTime();
+  const hasMetricRow = new Set(input.metrics.map((m) => m.appListingId));
+  const nonZeroMetric = new Set(
+    input.metrics
+      .filter((m) => m.openCount !== 0 || m.installCount !== 0)
+      .map((m) => m.appListingId)
+  );
+  const recentlyOpened = new Set(input.recentlyOpenedBlockIds);
+
+  return input.listings
+    .filter((l) => l.status === 'approved')
+    .filter((l) => {
+      // Seed: no metric row yet.
+      if (!hasMetricRow.has(l.id)) return true;
+      // On-site install source changed since the watermark.
+      if (
+        l.kind === 'onsite' &&
+        l.appBlockId !== null &&
+        input.subscriptions.some(
+          (s) =>
+            s.appBlockId === l.appBlockId &&
+            (new Date(s.createdAt).getTime() > since || new Date(s.updatedAt).getTime() > since)
+        )
+      )
+        return true;
+      // New plays since the watermark. Mirrors `= ANY($2)`, which is NULL — never
+      // true — for a listing with no app_block_id.
+      if (l.kind === 'onsite' && l.appBlockId !== null && recentlyOpened.has(l.appBlockId))
+        return true;
+      // Repair: join key lost while a non-zero count is still published.
+      if (l.appBlockId === null && nonZeroMetric.has(l.id)) return true;
+      return false;
+    })
+    .map((l) => l.id);
+}
+
 /**
  * The dedup identity of one play. Mirrors
  * `if(userId != 0, concat('u:', toString(userId)), concat('i:', ip))`.
@@ -286,7 +507,17 @@ export function appOpenActorKey(event: Pick<AppOpenEvent, 'userId' | 'ip'>): str
   return event.userId !== 0 ? `u:${event.userId}` : `i:${event.ip}`;
 }
 
-/** The UTC calendar day of a play. Mirrors `toDate(time, 'UTC')`. */
+/**
+ * The UTC calendar day of a play. Mirrors `toDate(time, 'UTC')`.
+ *
+ * 🔴 MUST NOT DEPEND ON THE PROCESS'S AMBIENT TIMEZONE. `toISOString()` is fixed to
+ * UTC; anything that renders a LOCAL date (`toLocaleDateString`, `getDate()`,
+ * `getFullYear()`, dayjs without `.utc()`) agrees with this on a UTC host and
+ * silently disagrees everywhere else — which would shear the in-memory spec away
+ * from the SQL's `toDate(time, 'UTC')` while every UTC-runner test stayed green.
+ * The guard for that is the zone-varying block in the test file; it deliberately
+ * exercises this under several ambient zones rather than trusting the runner's.
+ */
 export function appOpenUtcDay(time: Date | string): string {
   return new Date(time).toISOString().slice(0, 10);
 }

--- a/src/server/metrics/appListing.metrics.sql.ts
+++ b/src/server/metrics/appListing.metrics.sql.ts
@@ -6,32 +6,49 @@
 // the executable spec live here so they can be unit-tested WITHOUT booting any
 // of that. See appListing.metrics.ts for the full ownership/sourcing rationale.
 //
-// SCOPE: this job populates ONLY `install_count` — the single AppListingMetric
-// counter the read path actually consumes (the store `popular` sort =
-// `install_count DESC`, and the `top-rated` Bayesian tiebreak). Every other
-// counter (`connect_count`, `open_count`, `visit_count`, `tipped_count`,
-// `tipped_amount_count`) is left at its schema default 0: none is read today, and
-// each maps to a feature that isn't live yet (OAuth-connect submission is a
-// locked-deferred product decision; open/visit/tip have no server-side source
-// table). Populate each with the PR that ships its consumer, not speculatively.
+// SCOPE: this job populates `install_count` (from Postgres) and `open_count`
+// (from the ClickHouse `App_Open` event stream) — the two AppListingMetric
+// counters with a reader. Every remaining counter (`connect_count`,
+// `visit_count`, `tipped_count`, `tipped_amount_count`) is left at its schema
+// default 0: none is read, and each maps to a feature that isn't live yet
+// (OAuth-connect submission is a locked-deferred product decision; visit/tip have
+// no server-side source). Populate each with the PR that ships its consumer, not
+// speculatively.
 // ---------------------------------------------------------------------------
 
 /**
- * Approved listings whose install source changed since `$1` (= ctx.lastUpdate),
+ * The ClickHouse `actions.type` value the run-page SSR resolver emits per on-site
+ * app launch. Deliberately a bare string rather than an import from the tracker's
+ * `ActionType` union: this module is dependency-free by design, and the rollup
+ * must keep working (returning 0) on a deploy where the emitter is absent.
+ */
+export const APP_OPEN_ACTION_TYPE = 'App_Open';
+
+/**
+ * Approved listings whose metrics may have changed since `$1` (= ctx.lastUpdate),
  * UNION approved listings with no metric row yet (seed a real 0-row so the
  * `popular` sort orders them correctly instead of NULL-first).
  *
  * $1 :: timestamptz — the incremental watermark.
+ * $2 :: text[]      — app_block_ids ClickHouse reports as having had an `App_Open`
+ *                     event since the watermark. Without this arm a listing whose
+ *                     ONLY change is new plays would never be recomputed: nothing
+ *                     in Postgres moves when a play happens.
+ *
+ * Returns `app_block_id` alongside the id so the caller can ask ClickHouse for
+ * those blocks' play counts without a second Postgres round trip.
  *
  * NOTE (delete-blindness): a HARD-deleted source row (a hard uninstall that
  * DELETEs a BlockUserSubscription) has no create/update timestamp after it's
  * gone, so it can't be caught by "changed since lastUpdate". The common path is
  * covered — a toggle-off flips `enabled=false` and bumps `updated_at`, so it IS
  * caught. For a tiny dark cohort this residual staleness is acceptable; a
- * periodic full recompute could close it later.
+ * periodic full recompute could close it later. `open_count` does NOT have this
+ * problem: its source rows are append-only ClickHouse events and the count is a
+ * full recompute over all of them, never a delta.
  */
 export const AFFECTED_APPROVED_LISTINGS_SQL = `
-  SELECT al.id
+  SELECT al.id, al."app_block_id"
   FROM "app_listings" al
   WHERE al."status" = 'approved'
     AND (
@@ -47,27 +64,43 @@ export const AFFECTED_APPROVED_LISTINGS_SQL = `
             AND (bus."created_at" > $1 OR bus."updated_at" > $1)
         )
       )
+      -- New plays since the watermark (discovered in ClickHouse, not Postgres).
+      OR (
+        al."kind" = 'onsite' AND al."app_block_id" = ANY($2::text[])
+      )
     )
 `;
 
 /**
- * Recompute install_count for a batch of listing ids and upsert into
- * app_listing_metrics. $1 :: text[] — the listing ids.
+ * Recompute install_count + open_count for a batch of listing ids and upsert into
+ * app_listing_metrics.
  *
- * The count is computed LIVE (not derived from the affected-query), so even a
- * freshly-seeded row (or a row created by the thumbs writer with install=0) gets
- * its true current count. Scoped to approved listings only.
+ * $1 :: text[] — the listing ids.
+ * $2 :: text[] — app_block_ids, parallel to $3.
+ * $3 :: int[]  — the ALL-TIME deduped play count for each app_block_id in $2.
+ *
+ * 🔴 $2/$3 MUST COVER EVERY on-site listing in $1, including the ones with zero
+ * plays. `open_count` is DERIVED — a full recompute, never a `+1` — so a listing
+ * missing from the map is written as 0, not left alone. Feeding a partial map
+ * (e.g. only the blocks with events since the watermark) would zero the count of
+ * every listing recomputed for an unrelated reason. The caller therefore queries
+ * ClickHouse for the whole affected set, not just the recently-active part.
+ *
+ * install_count is computed LIVE from Postgres (not derived from the
+ * affected-query), so even a freshly-seeded row (or a row created by the thumbs
+ * writer with install=0) gets its true current count. Scoped to approved listings.
  *
  * 🔴 The INSERT column list AND the ON CONFLICT DO UPDATE set name ONLY
- * install_count / updated_at. thumbs_up_count / thumbs_down_count are NEVER
- * touched (ownership contract with app-listing-review.service.ts); connect/open/
- * visit/tipped stay at their schema default 0 (see the SCOPE note above). Do not
- * add any of them here without a reader to justify it.
+ * install_count / open_count / updated_at. thumbs_up_count / thumbs_down_count are
+ * NEVER touched (ownership contract with app-listing-review.service.ts);
+ * connect/visit/tipped stay at their schema default 0 (see the SCOPE note above).
+ * Do not add any of them here without a reader to justify it.
  */
 export const APP_LISTING_METRIC_UPSERT_SQL = `
   INSERT INTO "app_listing_metrics" (
     "app_listing_id",
     "install_count",
+    "open_count",
     "updated_at"
   )
   SELECT
@@ -81,25 +114,146 @@ export const APP_LISTING_METRIC_UPSERT_SQL = `
       )
       ELSE 0
     END AS install_count,
+    CASE
+      WHEN al."kind" = 'onsite' AND al."app_block_id" IS NOT NULL
+        THEN COALESCE(oc."open_count", 0)
+      ELSE 0
+    END AS open_count,
     NOW() AS updated_at
   FROM "app_listings" al
+  LEFT JOIN unnest($2::text[], $3::int[]) AS oc("app_block_id", "open_count")
+    ON oc."app_block_id" = al."app_block_id"
   WHERE al.id = ANY($1::text[])
     AND al."status" = 'approved'
   ON CONFLICT ("app_listing_id") DO UPDATE
     SET
       "install_count" = EXCLUDED."install_count",
+      "open_count" = EXCLUDED."open_count",
       "updated_at" = NOW()
 `;
 
 // ---------------------------------------------------------------------------
+// ClickHouse side — the `App_Open` event stream.
+//
+// 🔴 WHY `toString(type) = 'App_Open'` AND NOT `type = 'App_Open'`.
+// `actions.type` is an Enum16. Comparing an Enum column to a literal the enum
+// does not carry is a QUERY ERROR in ClickHouse ("Unknown element ... for enum"),
+// not an empty result — so the plain form would make this metric processor throw
+// on every run, taking `install_count` down with it, on any deploy where the
+// widening migration has not been applied yet. `toString(type)` compares the
+// rendered name and simply matches nothing, which is exactly the inert behaviour
+// this rollup wants until the migration lands.
+//
+// 🔴 WHY `PREWHERE`. The count query below is deliberately UNBOUNDED IN TIME (an
+// all-time figure — AppListingMetric has no timeframe column), and `actions` is a
+// large table ordered by (time, type), so nothing prunes. PREWHERE reads the
+// narrow `type` column first and only then reads `details`/`userId`/`ip`/`time`
+// for the surviving rows. Do not move that predicate into the WHERE clause.
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape a value for a single-quoted ClickHouse string literal.
+ *
+ * These ids come from Postgres (`apb_<ULID>`), so in practice nothing needs
+ * escaping — but `ctx.ch.$query`'s template interpolation does NOT quote or escape
+ * string values, so building an `IN (...)` list by hand without this would be an
+ * injection surface the moment an id shape changes. Escaping (rather than
+ * rejecting) is deliberate: rejecting an id would drop it from the count map, and
+ * a missing entry is written as a 0 — silent data loss instead of a wrong query.
+ */
+export function escapeClickhouseString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+/**
+ * app_block_ids with at least one `App_Open` event since `sinceIso`.
+ *
+ * This is the affected-set discovery half: Postgres cannot see a play (no row of
+ * its own moves), so ClickHouse is asked which apps were opened and those app
+ * blocks are fed into `AFFECTED_APPROVED_LISTINGS_SQL` as `$2`. Mirrors the
+ * ClickHouse-first pattern in model3d.metrics.ts (`getDownloadTasks`).
+ *
+ * `sinceIso` is an ISO-8601 instant; the caller passes `ctx.lastUpdate`, which
+ * base.metrics has already widened by 2 minutes to let the tracker catch up.
+ */
+export function buildAppOpenRecentBlockIdsSql(sinceIso: string): string {
+  return `
+    SELECT DISTINCT JSONExtractString(details, 'appBlockId') AS appBlockId
+    FROM actions
+    PREWHERE toString(type) = '${APP_OPEN_ACTION_TYPE}'
+    WHERE time >= parseDateTimeBestEffort('${escapeClickhouseString(sinceIso)}')
+      AND JSONExtractString(details, 'appBlockId') != ''
+  `;
+}
+
+/**
+ * ALL-TIME deduped play count per app_block_id.
+ *
+ * ── THE SEMANTICS, IN PLAIN ENGLISH ─────────────────────────────────────────
+ * One play = ONE DISTINCT ACTOR PER APP PER UTC DAY. An actor is the signed-in
+ * `userId` when there is one, and the request `ip` when there is not. `open_count`
+ * is the sum of those per-day distinct counts over ALL TIME.
+ *
+ * So: reloading an app twenty times this afternoon is 1. Opening it again tomorrow
+ * is 2. Two different signed-in users today is 2. Two signed-out visitors on
+ * different IPs today is 2. A signed-in user and a signed-out visitor are always
+ * two different actors — `userId` 0 is the tracker's "anonymous" sentinel, so it is
+ * never used as an identity; those rows fall back to `ip`.
+ *
+ * 🔴 STAGE 4 PUTS A PUBLIC LABEL NEXT TO THIS NUMBER. It is closer to "people who
+ * opened this" than to "times opened", and it is a LOWER bound on both: every
+ * signed-out visitor behind one NAT egress IP collapses to a single daily actor,
+ * and the tracker's `ip` fallback is the literal string `unknown` when the client
+ * IP cannot be resolved, which collapses all such requests for a day into one.
+ * Undercounting is the deliberate direction — the emit is an unauthenticated,
+ * unrated-limited GET on an optional catch-all route, so the raw row count is
+ * inflatable by a refresh loop, a crawler or a chat-client link unfurler, and an
+ * inflated public number is worse than a conservative one.
+ * ────────────────────────────────────────────────────────────────────────────
+ *
+ * Returns no row for an app block with no events; the caller must treat a missing
+ * entry as 0 (which is what the upsert's COALESCE does).
+ */
+export function buildAppOpenCountSql(appBlockIds: string[]): string {
+  const inList = appBlockIds.map((id) => `'${escapeClickhouseString(id)}'`).join(', ');
+  return `
+    SELECT appBlockId, sum(dailyActors) AS openCount
+    FROM (
+      SELECT
+        JSONExtractString(details, 'appBlockId') AS appBlockId,
+        toDate(time, 'UTC') AS day,
+        uniqExact(if(userId != 0, concat('u:', toString(userId)), concat('i:', ip))) AS dailyActors
+      FROM actions
+      PREWHERE toString(type) = '${APP_OPEN_ACTION_TYPE}'
+      WHERE JSONExtractString(details, 'appBlockId') IN (${inList})
+      GROUP BY appBlockId, day
+    )
+    GROUP BY appBlockId
+  `;
+}
+
+// ---------------------------------------------------------------------------
 // Executable spec of the aggregate semantics (mirrors the SQL above).
 //
-// The SQL is the production path (it runs in Postgres); this pure function
-// encodes the SAME rules over in-memory rows so the invariants — approved-only,
-// on-site-only installs, ACTIVE (enabled) install filtering, and NEVER emitting
-// thumbs — are unit-testable without a database. Keep it in lockstep with the
-// SQL above.
+// The SQL is the production path (install_count in Postgres, open_count in
+// ClickHouse); this pure function encodes the SAME rules over in-memory rows so
+// the invariants — approved-only, on-site-only, ACTIVE (enabled) install
+// filtering, the one-actor-per-UTC-day play dedup, and NEVER emitting thumbs —
+// are unit-testable without a database. Keep it in lockstep with the SQL above:
+// they are a matched pair, and changing one without the other is precisely the
+// drift the pair exists to prevent.
 // ---------------------------------------------------------------------------
+
+/** One raw ClickHouse `actions` row of type `App_Open`, as the rollup reads it. */
+export type AppOpenEvent = {
+  appBlockId: string;
+  /** The tracker's actor `userId`; **0 means anonymous**, never "user zero". */
+  userId: number;
+  /** The tracker's actor `ip`; the literal `'unknown'` when unresolvable. */
+  ip: string;
+  time: Date | string;
+};
+
 export type AppListingComputeInput = {
   listings: Array<{
     id: string;
@@ -109,23 +263,99 @@ export type AppListingComputeInput = {
   }>;
   /** BlockUserSubscription rows. `enabled=false` = toggled-off (not an active install). */
   subscriptions: Array<{ appBlockId: string; enabled: boolean }>;
+  /** `App_Open` rows. Required, not optional — an omitted stream must not read as "no plays". */
+  openEvents: AppOpenEvent[];
 };
 
 export type AppListingMetricUpdate = {
   appListingId: string;
   installCount: number;
+  openCount: number;
 };
+
+/**
+ * The dedup identity of one play. Mirrors
+ * `if(userId != 0, concat('u:', toString(userId)), concat('i:', ip))`.
+ *
+ * The prefixes matter: without them a signed-in user id could collide with an ip
+ * string, and `userId` 0 must never be an identity of its own — it is the
+ * tracker's anonymous sentinel, so every anonymous request would otherwise
+ * collapse into ONE actor site-wide.
+ */
+export function appOpenActorKey(event: Pick<AppOpenEvent, 'userId' | 'ip'>): string {
+  return event.userId !== 0 ? `u:${event.userId}` : `i:${event.ip}`;
+}
+
+/** The UTC calendar day of a play. Mirrors `toDate(time, 'UTC')`. */
+export function appOpenUtcDay(time: Date | string): string {
+  return new Date(time).toISOString().slice(0, 10);
+}
+
+/**
+ * ALL-TIME deduped play count per app_block_id — the in-memory mirror of
+ * `buildAppOpenCountSql`. Exported so the dedup rule can be exercised directly.
+ */
+export function computeAppOpenCounts(events: AppOpenEvent[]): Map<string, number> {
+  // appBlockId -> utcDay -> set of actor keys
+  const byBlock = new Map<string, Map<string, Set<string>>>();
+  for (const event of events) {
+    // Mirrors the SQL's `JSONExtractString(details, 'appBlockId') != ''` filter:
+    // a row whose details carried no appBlockId joins to nothing.
+    if (!event.appBlockId) continue;
+    let byDay = byBlock.get(event.appBlockId);
+    if (!byDay) {
+      byDay = new Map<string, Set<string>>();
+      byBlock.set(event.appBlockId, byDay);
+    }
+    const day = appOpenUtcDay(event.time);
+    let actors = byDay.get(day);
+    if (!actors) {
+      actors = new Set<string>();
+      byDay.set(day, actors);
+    }
+    actors.add(appOpenActorKey(event));
+  }
+
+  const counts = new Map<string, number>();
+  for (const [appBlockId, byDay] of byBlock) {
+    let total = 0;
+    for (const actors of byDay.values()) total += actors.size;
+    counts.set(appBlockId, total);
+  }
+  return counts;
+}
 
 export function computeAppListingMetricUpdates(
   input: AppListingComputeInput
 ): AppListingMetricUpdate[] {
+  const openCounts = computeAppOpenCounts(input.openEvents);
+
   return input.listings
     .filter((l) => l.status === 'approved')
-    .map((l) => ({
-      appListingId: l.id,
-      installCount:
-        l.kind === 'onsite' && l.appBlockId
+    .map((l) => {
+      // Both counters are on-site-only, and for the same structural reason: the
+      // join key IS `app_block_id`, which off-site listings do not have. An
+      // off-site listing's CTA is a third-party anchor, so no on-platform request
+      // follows the click and there is nothing trustworthy to count.
+      //
+      // 🔴 A 0 HERE MEANS "no plays OR not measurable" — the two are not
+      // distinguishable in this column. Stage 3 must therefore project `openCount`
+      // as `null` for `kind='offsite'` rather than 0: an off-site card omits the
+      // stat entirely instead of showing a zero that reads as "nobody used it".
+      //
+      // Of the two conjuncts only `kind === 'onsite'` is load-bearing here: with a
+      // null `appBlockId` both lookups below miss anyway (no subscription row has a
+      // null app_block_id, and `Map.get(null)` is undefined), so the `!!l.appBlockId`
+      // half is REDUNDANT BY CONSTRUCTION — measured, mutating it away leaves the
+      // whole suite green. It is kept for intent and to mirror the SQL's
+      // `IS NOT NULL`, not as a behavioural guard; do not read it as one.
+      const measurable = l.kind === 'onsite' && !!l.appBlockId;
+      return {
+        appListingId: l.id,
+        installCount: measurable
           ? input.subscriptions.filter((s) => s.appBlockId === l.appBlockId && s.enabled).length
           : 0,
-    }));
+        openCount: measurable ? openCounts.get(l.appBlockId as string) ?? 0 : 0,
+      };
+    });
 }

--- a/src/server/metrics/appListing.metrics.ts
+++ b/src/server/metrics/appListing.metrics.ts
@@ -20,8 +20,10 @@ const log = createLogger('metrics:appListing');
 /**
  * POSTGRES upsert batch size. NOT the ClickHouse chunk size — see the
  * two-directional-pressure note on both constants in appListing.metrics.sql.ts.
- * They were one constant until it was measured that sharing them costs ~39x on the
- * ClickHouse side at seed scale.
+ * They were one constant until it was measured that sharing them costs 9.75x on the
+ * ClickHouse side at seed scale — 39 scans against the 4 that splitting them gives.
+ * (39x is a DIFFERENT comparison: 39 scans against the one unchunked query that
+ * preceded chunking at all. The two are censused at the constants' own docstrings.)
  */
 const BATCH_SIZE = APP_LISTING_BATCH_SIZE;
 

--- a/src/server/metrics/appListing.metrics.ts
+++ b/src/server/metrics/appListing.metrics.ts
@@ -1,18 +1,21 @@
 import { chunk } from 'lodash-es';
 import type { MetricProcessorRunContext } from '~/server/metrics/base.metrics';
 import { createMetricProcessor } from '~/server/metrics/base.metrics';
+import type { AppOpenCountRow, AppOpenRecentRow } from '~/server/metrics/appListing.metrics.sql';
 import {
   AFFECTED_APPROVED_LISTINGS_SQL,
+  APP_LISTING_BATCH_SIZE,
   APP_LISTING_METRIC_UPSERT_SQL,
-  buildAppOpenCountSql,
-  buildAppOpenRecentBlockIdsSql,
+  fetchAppOpenCounts,
+  fetchRecentlyOpenedBlockIds,
 } from '~/server/metrics/appListing.metrics.sql';
+import { logToAxiom } from '~/server/logging/client';
 import type { Task } from '~/server/utils/concurrency-helpers';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { createLogger } from '~/utils/logging';
 
 const log = createLogger('metrics:appListing');
-const BATCH_SIZE = 200;
+const BATCH_SIZE = APP_LISTING_BATCH_SIZE;
 
 /** One affected listing plus the join key both counters need. */
 type AffectedListing = { id: string; appBlockId: string | null };
@@ -75,11 +78,24 @@ type AffectedListing = { id: string; appBlockId: string | null };
 // as "nobody used it". Do not close the gap with a client beacon either — that
 // would put a spoofable count beside a trusted one under one label.
 //
-// 🔴 RECOMPUTABILITY HAS ONE HOLE. The recompute joins `details.appBlockId` to
-// `AppListing.appBlockId`, and that relation is `onDelete: SetNull` — deleting an
-// AppBlock nulls the listing's `app_block_id` and every historical play row for it
-// becomes permanently unjoinable. If that becomes a real case, carry the listing
-// id in `details` as well.
+// 🔴 RECOMPUTABILITY HAS ONE HOLE, AND IT NOW FAILS TO ZERO RATHER THAN FREEZING.
+// The recompute joins `details.appBlockId` to `AppListing.appBlockId`, and that
+// relation is `onDelete: SetNull` — deleting an AppBlock nulls the listing's
+// `app_block_id` and every historical play row for it becomes permanently
+// unjoinable. That much is unchanged. What WAS worse: such a listing matched no arm
+// of the affected query, so a published `open_count = 777` was frozen at 777
+// forever with no path to correct it. The affected query's REPAIR ARM now selects
+// it so the recompute writes 0 — "we cannot measure this any more" instead of a
+// stale public number. Recovering the real count still needs the listing id carried
+// in `details`; do that if deletions become a real case.
+//
+// 🔴 `open_count` HAS NO READER AT THIS REF — its consumer lands in STAGE 3. The
+// rule below ("populate with the PR that ships its consumer") is real and this
+// column is a deliberate, argued exception to it, not an oversight and not a
+// precedent. The argument in full — trusted server-side source + a derived,
+// idempotent value with no accumulating state and no backfill — is on the SCOPE
+// block in appListing.metrics.sql.ts. Read it before citing this file to populate
+// anything else.
 //
 // NOT POPULATED (left at their schema default 0 — no reader today, and each maps
 // to a feature that isn't live): `connect_count` (off-site OAuth-connect grants —
@@ -87,7 +103,9 @@ type AffectedListing = { id: string; appBlockId: string | null };
 // connect listings yet and nothing reads the count), `visit_count`, `tipped_count`,
 // `tipped_amount_count` (visit is never recorded server-side; AppListing is not a
 // BuzzTip entity — BuzzTip.entityId is Int, AppListing.id is a string ULID).
-// Populate each with the PR that ships its consumer, not speculatively.
+// Populate each with the PR that ships its consumer, not speculatively. None of the
+// four has a source to derive from, so the `open_count` exception does not reach
+// them: populating one would mean inventing the number.
 // ---------------------------------------------------------------------------
 
 export const appListingMetrics = createMetricProcessor({
@@ -97,6 +115,7 @@ export const appListingMetrics = createMetricProcessor({
     //    in Postgres moves when a play happens, so without this a listing whose
     //    only change is new plays would never be recomputed. (ClickHouse-first
     //    affected discovery — same shape as model3d.metrics.ts getDownloadTasks.)
+    //    FAILS SOFT — see the asymmetry note on getRecentlyOpenedBlockIds.
     const recentlyOpened = await getRecentlyOpenedBlockIds(ctx);
 
     // 2. Collect affected approved listing ids (string ULIDs — the shared
@@ -110,6 +129,7 @@ export const appListingMetrics = createMetricProcessor({
     //    unrelated reason (a new subscription, a seed row) is written from this
     //    map too; a block missing from it is written as 0. Feeding only the
     //    recently-active blocks here would zero every other listing's play count.
+    //    FAILS HARD, deliberately — see the asymmetry note on this function.
     const openCounts = await getAllTimeOpenCounts(ctx, affected);
 
     // 4. Batched live-recompute + upsert (install/open only; thumbs untouched).
@@ -117,9 +137,16 @@ export const appListingMetrics = createMetricProcessor({
       ctx.jobContext.checkIfCanceled();
       log('appListing upsert batch', i + 1, 'of', tasks.length);
       const ids = batch.map((l) => l.id);
-      // Parallel arrays for the upsert's `unnest($2, $3)` join. Keyed through a Map
-      // so a duplicated app_block_id can never widen the join and trip the
-      // "ON CONFLICT DO UPDATE cannot affect row a second time" error.
+      // Parallel arrays for the upsert's `unnest($2, $3)` join, keyed through a Map
+      // so the (app_block_id, open_count) pairs are unique.
+      //
+      // DEFENSIVE, NOT LOAD-BEARING — do not read this as the thing preventing
+      // "ON CONFLICT DO UPDATE cannot affect row a second time". That error is real
+      // and a widened join is how you'd reach it, but `AppListing.appBlockId` is
+      // `@unique`, so two listings in one batch cannot share an app_block_id and no
+      // batch can contain a duplicate to begin with. The Map costs nothing and
+      // keeps the invariant local instead of borrowed from a schema constraint
+      // three files away.
       const batchCounts = new Map<string, number>();
       for (const listing of batch) {
         if (!listing.appBlockId) continue;
@@ -144,20 +171,77 @@ export const appListingMetrics = createMetricProcessor({
 });
 
 /**
+ * Run a ClickHouse query with this job's cancellation wired in.
+ *
+ * `ctx.ch.$query` exposes no abort handle, so these reads used to outlive a
+ * cancelled job while the Postgres queries beside them (which DO get a
+ * `jobContext.on('cancel', query.cancel)`) were torn down. Dropping to
+ * `ctx.ch.query` is what makes `abort_signal` reachable. The count read in
+ * particular is a full `actions` scan — exactly the thing that must not be left
+ * running server-side after the job that asked for it is gone.
+ */
+async function chCancellableQuery<T extends object>(
+  ctx: MetricProcessorRunContext,
+  sql: string
+): Promise<T[]> {
+  const controller = new AbortController();
+  ctx.jobContext.on('cancel', async () => controller.abort());
+  const response = await ctx.ch.query({
+    query: sql,
+    format: 'JSONEachRow',
+    abort_signal: controller.signal,
+  });
+  // `ResultSet.json<T>()` resolves to `T` itself, not `T[]` — the row type has to
+  // be passed as the array.
+  return await response.json<T[]>();
+}
+
+/**
  * app_block_ids with an `App_Open` event since the watermark.
  *
- * Errors are NOT swallowed, deliberately: a broken ClickHouse read must not
- * silently degrade into "no plays", which would then be written as 0 over real
- * counts. The one failure mode this DOES tolerate is the pre-migration one — see
- * the `toString(type)` note in appListing.metrics.sql.ts, which is why this query
- * returns an empty set (rather than throwing) until the `App_Open` Enum16 widening
- * is applied to production.
+ * 🔴 FAILS SOFT, AND THE ASYMMETRY WITH getAllTimeOpenCounts IS THE WHOLE POINT.
+ * This half only DISCOVERS candidates; it cannot corrupt a number. Degrading to
+ * "no new plays this run" is self-healing — `setLastUpdate()` still runs, but the
+ * watermark the NEXT run reads still covers the gap, so the plays this run missed
+ * are picked up then. (`base.metrics` also widens `lastUpdate` by 2 minutes.)
+ *
+ * Before this, a ClickHouse blip took `install_count` down with it: this read
+ * happens BEFORE the `if (!affected.length) return`, so on a quiet cycle with
+ * nothing to do at all, a throw here aborted `update()`, `setLastUpdate()` never
+ * ran, and the store's `popular` sort (`install_count DESC`) froze for the whole
+ * outage — a pure-Postgres counter held hostage by a ClickHouse outage, with a
+ * retry of exactly the same shape. This processor was pure Postgres before the
+ * `open_count` work; that regression is not one it gets to introduce.
+ *
+ * The COUNT read (getAllTimeOpenCounts) deliberately does NOT do this: a partial
+ * or empty answer there is written over real counts as 0. Discovery degrades,
+ * counting fails the run. Do not "make these consistent".
+ *
+ * A cancelled job is NOT a ClickHouse failure — `checkIfCanceled()` rethrows it
+ * rather than letting it be swallowed into "no plays".
+ *
+ * The pre-migration failure mode needs none of this: see the `toString(type)` note
+ * in appListing.metrics.sql.ts, which is why this query returns an EMPTY SET rather
+ * than erroring until the `App_Open` Enum16 widening is applied to production.
  */
 async function getRecentlyOpenedBlockIds(ctx: MetricProcessorRunContext): Promise<string[]> {
-  const rows = await ctx.ch.$query<{ appBlockId: string }>(
-    buildAppOpenRecentBlockIdsSql(ctx.lastUpdate.toISOString())
+  return fetchRecentlyOpenedBlockIds(
+    ctx.lastUpdate.toISOString(),
+    (sql) => chCancellableQuery<AppOpenRecentRow>(ctx, sql),
+    (error) => {
+      // Rethrows if the job was canceled — an aborted query is not a ClickHouse
+      // failure, and must not be reported as "no plays".
+      ctx.jobContext.checkIfCanceled();
+      log('appListingMetrics play-discovery read failed; continuing without it', error);
+      logToAxiom({
+        type: 'warning',
+        name: 'app-listing-metrics-open-discovery-degraded',
+        message:
+          'AppListing metrics could not read App_Open discovery from ClickHouse; this run recomputes install_count only and picks up missed plays on the next run',
+        details: { error: (error as Error)?.message },
+      }).catch();
+    }
   );
-  return [...new Set(rows.map((r) => r.appBlockId).filter(Boolean))];
 }
 
 async function getAffectedListings(
@@ -176,19 +260,28 @@ async function getAffectedListings(
   return [...byId.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 }
 
-/** ALL-TIME deduped play count per app_block_id, for every affected on-site listing. */
+/**
+ * ALL-TIME deduped play count per app_block_id, for every affected on-site listing.
+ *
+ * 🔴 FAILS HARD, unlike the discovery read above. `open_count` is DERIVED — a block
+ * missing from this map is WRITTEN AS 0, not left alone — so a partial or empty
+ * answer here does not degrade the run, it silently zeroes real published counts.
+ * Failing the run is the correct outcome: the counts stay at their last good values
+ * and the next run recomputes them.
+ *
+ * CHUNKED at APP_LISTING_BATCH_SIZE because the `IN` list has a hard ceiling that
+ * this read can genuinely reach (measured: 8,000 ids => `Code: 62 Max query size
+ * exceeded`). Combined with the fail-hard above, one over-long query would take
+ * `install_count` down with it — see the ceiling note on `fetchAppOpenCounts`.
+ */
 async function getAllTimeOpenCounts(
   ctx: MetricProcessorRunContext,
   affected: AffectedListing[]
 ): Promise<Map<string, number>> {
-  const appBlockIds = [
-    ...new Set(affected.map((l) => l.appBlockId).filter((id): id is string => !!id)),
-  ];
-  // `IN ()` is a syntax error, and there is nothing to ask about anyway.
-  if (!appBlockIds.length) return new Map();
-
-  const rows = await ctx.ch.$query<{ appBlockId: string; openCount: number | string }>(
-    buildAppOpenCountSql(appBlockIds)
+  const appBlockIds = affected.map((l) => l.appBlockId).filter((id): id is string => !!id);
+  return fetchAppOpenCounts(
+    appBlockIds,
+    (sql) => chCancellableQuery<AppOpenCountRow>(ctx, sql),
+    BATCH_SIZE
   );
-  return new Map(rows.map((r) => [r.appBlockId, Number(r.openCount)]));
 }

--- a/src/server/metrics/appListing.metrics.ts
+++ b/src/server/metrics/appListing.metrics.ts
@@ -4,6 +4,8 @@ import { createMetricProcessor } from '~/server/metrics/base.metrics';
 import {
   AFFECTED_APPROVED_LISTINGS_SQL,
   APP_LISTING_METRIC_UPSERT_SQL,
+  buildAppOpenCountSql,
+  buildAppOpenRecentBlockIdsSql,
 } from '~/server/metrics/appListing.metrics.sql';
 import type { Task } from '~/server/utils/concurrency-helpers';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
@@ -12,11 +14,14 @@ import { createLogger } from '~/utils/logging';
 const log = createLogger('metrics:appListing');
 const BATCH_SIZE = 200;
 
+/** One affected listing plus the join key both counters need. */
+type AffectedListing = { id: string; appBlockId: string | null };
+
 // ---------------------------------------------------------------------------
 // App Store Listings (W13) — AllTime-only rollup for AppListingMetric.
 //
 // AppListingMetric is a SINGLE row per listing keyed by `app_listing_id` (no
-// `timeframe` column, like Model3DMetric). This processor owns ONLY the counter
+// `timeframe` column, like Model3DMetric). This processor owns the two counters
 // the read path actually consumes:
 //
 //   • installCount  — on-site listings: count of ACTIVE BlockUserSubscription
@@ -26,41 +31,108 @@ const BATCH_SIZE = 200;
 //     has NO soft-delete/`deletedAt` column; a toggle-off flips `enabled=false`
 //     (which bumps `updated_at` via @updatedAt, so the incremental affected-query
 //     catches it). A hard uninstall (row DELETE) is NOT catchable incrementally —
-//     see the SQL note in appListing.metrics.sql. This is the only counter read
-//     today (the store `popular` sort = `install_count DESC` + the top-rated
-//     Bayesian tiebreak).
+//     see the SQL note in appListing.metrics.sql. This drives the store `popular`
+//     sort (`install_count DESC`) and the top-rated Bayesian tiebreak.
+//
+//   • openCount     — on-site listings: PLAYS, derived from the ClickHouse
+//     `App_Open` event stream that the `/apps/run/<slug>` SSR resolver emits per
+//     launch (`app-listing-open.service.ts`). See below.
 //
 // 🔴 OWNERSHIP CONTRACT: `thumbs_up_count` / `thumbs_down_count` are owned by the
 // SYNCHRONOUS writer in app-listing-review.service.ts (upsert tx). This job MUST
 // NEVER write those two columns — the ON CONFLICT DO UPDATE names ONLY
-// install_count / updated_at, so a metric row that already exists (created by the
-// thumbs writer) keeps its thumbs untouched. On CREATE, thumbs default to 0
-// (schema default), correct for a never-reviewed listing.
+// install_count / open_count / updated_at, so a metric row that already exists
+// (created by the thumbs writer) keeps its thumbs untouched. On CREATE, thumbs
+// default to 0 (schema default), correct for a never-reviewed listing.
+//
+// 🔴 `open_count` IS DERIVED, NEVER INCREMENTED — that is the whole reason this
+// arc uses an event stream. The contract in app-listing-review.service.ts reads:
+// "'No recompute' is a TWO-SIDED contract … A third writer is only safe if it
+// brings a full recompute with it." This is that third writer, and the recompute
+// it brings is total: every run recomputes each affected listing's play count from
+// ALL of its `App_Open` rows. There is no `+1` path anywhere and there must never
+// be one — a delta counter over a stream nobody can replay is exactly the drift
+// the thumbs pair is grandfathered into and nothing new should join.
+//
+// 🔴 THE RAW ROW COUNT IS NOT THE NUMBER — DEDUP HAPPENS AT READ TIME. The emit is
+// triggered by an unauthenticated GET on an optional catch-all route with no rate
+// limit and no robots disallow, so a refresh loop, a crawler or a chat-client link
+// unfurler each manufacture rows. The rollup therefore counts ONE PLAY PER
+// DISTINCT ACTOR PER APP PER UTC DAY (actor = `userId` when non-zero, else `ip`)
+// and sums those daily distinct counts over all time. The full plain-English
+// semantics — including why the figure is deliberately a LOWER bound — live on
+// `buildAppOpenCountSql` in appListing.metrics.sql.ts, next to the SQL that
+// implements them. Stage 4 prints this next to the review count on a public card;
+// the label has to match what it counts.
+//
+// 🔴 OFF-SITE LISTINGS ARE STRUCTURALLY UNMEASURABLE, NOT AT ZERO. Their CTA is a
+// third-party anchor, so no on-platform request follows the click. Both counters
+// gate on `app_block_id`, which is NULL for off-site, so this falls out of the
+// join — but a `0` in `open_count` therefore means "no plays OR not measurable",
+// and the two are not distinguishable in the column. Stage 3 must project
+// `openCount` as `null` for `kind='offsite'` rather than 0: the operator's
+// decision is that off-site cards OMIT the stat rather than show a zero that reads
+// as "nobody used it". Do not close the gap with a client beacon either — that
+// would put a spoofable count beside a trusted one under one label.
+//
+// 🔴 RECOMPUTABILITY HAS ONE HOLE. The recompute joins `details.appBlockId` to
+// `AppListing.appBlockId`, and that relation is `onDelete: SetNull` — deleting an
+// AppBlock nulls the listing's `app_block_id` and every historical play row for it
+// becomes permanently unjoinable. If that becomes a real case, carry the listing
+// id in `details` as well.
 //
 // NOT POPULATED (left at their schema default 0 — no reader today, and each maps
 // to a feature that isn't live): `connect_count` (off-site OAuth-connect grants —
 // OAuth-connect submission is a locked-deferred product decision, so there are no
-// connect listings yet and nothing reads the count), `open_count`, `visit_count`,
-// `tipped_count`, `tipped_amount_count` (open/visit are never recorded
-// server-side; AppListing is not a BuzzTip entity — BuzzTip.entityId is Int,
-// AppListing.id is a string ULID). Populate each with the PR that ships its
-// consumer, not speculatively.
+// connect listings yet and nothing reads the count), `visit_count`, `tipped_count`,
+// `tipped_amount_count` (visit is never recorded server-side; AppListing is not a
+// BuzzTip entity — BuzzTip.entityId is Int, AppListing.id is a string ULID).
+// Populate each with the PR that ships its consumer, not speculatively.
 // ---------------------------------------------------------------------------
 
 export const appListingMetrics = createMetricProcessor({
   name: 'AppListing',
   async update(ctx) {
-    // 1. Collect affected approved listing ids (string ULIDs — the shared
+    // 1. Ask ClickHouse which app blocks were PLAYED since the watermark. Nothing
+    //    in Postgres moves when a play happens, so without this a listing whose
+    //    only change is new plays would never be recomputed. (ClickHouse-first
+    //    affected discovery — same shape as model3d.metrics.ts getDownloadTasks.)
+    const recentlyOpened = await getRecentlyOpenedBlockIds(ctx);
+
+    // 2. Collect affected approved listing ids (string ULIDs — the shared
     //    number-typed getAffected helper can't be reused, so this is inline).
-    const affected = await getAffectedListingIds(ctx);
+    const affected = await getAffectedListings(ctx, recentlyOpened);
     log('appListingMetrics update', affected.length, 'affected listings');
     if (!affected.length) return;
 
-    // 2. Batched live-recompute + upsert (install/connect only; thumbs untouched).
-    const tasks: Task[] = chunk(affected, BATCH_SIZE).map((ids, i) => async () => {
+    // 3. FULL play recompute for the WHOLE affected set — not just the blocks
+    //    from step 1. `open_count` is derived, so a listing recomputed for an
+    //    unrelated reason (a new subscription, a seed row) is written from this
+    //    map too; a block missing from it is written as 0. Feeding only the
+    //    recently-active blocks here would zero every other listing's play count.
+    const openCounts = await getAllTimeOpenCounts(ctx, affected);
+
+    // 4. Batched live-recompute + upsert (install/open only; thumbs untouched).
+    const tasks: Task[] = chunk(affected, BATCH_SIZE).map((batch, i) => async () => {
       ctx.jobContext.checkIfCanceled();
       log('appListing upsert batch', i + 1, 'of', tasks.length);
-      const query = await ctx.pg.cancellableQuery(APP_LISTING_METRIC_UPSERT_SQL, [ids]);
+      const ids = batch.map((l) => l.id);
+      // Parallel arrays for the upsert's `unnest($2, $3)` join. Keyed through a Map
+      // so a duplicated app_block_id can never widen the join and trip the
+      // "ON CONFLICT DO UPDATE cannot affect row a second time" error.
+      const batchCounts = new Map<string, number>();
+      for (const listing of batch) {
+        if (!listing.appBlockId) continue;
+        batchCounts.set(listing.appBlockId, openCounts.get(listing.appBlockId) ?? 0);
+      }
+      const blockIds = [...batchCounts.keys()];
+      const counts = blockIds.map((id) => batchCounts.get(id) ?? 0);
+
+      const query = await ctx.pg.cancellableQuery(APP_LISTING_METRIC_UPSERT_SQL, [
+        ids,
+        blockIds,
+        counts,
+      ]);
       ctx.jobContext.on('cancel', query.cancel);
       await query.result();
       log('appListing upsert batch', i + 1, 'done');
@@ -71,12 +143,52 @@ export const appListingMetrics = createMetricProcessor({
   // AppListingMetric directly. Only `update` is implemented (no refreshRank).
 });
 
-async function getAffectedListingIds(ctx: MetricProcessorRunContext): Promise<string[]> {
-  const query = await ctx.pg.cancellableQuery<{ id: string }>(AFFECTED_APPROVED_LISTINGS_SQL, [
-    ctx.lastUpdate,
-  ]);
+/**
+ * app_block_ids with an `App_Open` event since the watermark.
+ *
+ * Errors are NOT swallowed, deliberately: a broken ClickHouse read must not
+ * silently degrade into "no plays", which would then be written as 0 over real
+ * counts. The one failure mode this DOES tolerate is the pre-migration one — see
+ * the `toString(type)` note in appListing.metrics.sql.ts, which is why this query
+ * returns an empty set (rather than throwing) until the `App_Open` Enum16 widening
+ * is applied to production.
+ */
+async function getRecentlyOpenedBlockIds(ctx: MetricProcessorRunContext): Promise<string[]> {
+  const rows = await ctx.ch.$query<{ appBlockId: string }>(
+    buildAppOpenRecentBlockIdsSql(ctx.lastUpdate.toISOString())
+  );
+  return [...new Set(rows.map((r) => r.appBlockId).filter(Boolean))];
+}
+
+async function getAffectedListings(
+  ctx: MetricProcessorRunContext,
+  recentlyOpenedBlockIds: string[]
+): Promise<AffectedListing[]> {
+  const query = await ctx.pg.cancellableQuery<{ id: string; app_block_id: string | null }>(
+    AFFECTED_APPROVED_LISTINGS_SQL,
+    [ctx.lastUpdate, recentlyOpenedBlockIds]
+  );
   ctx.jobContext.on('cancel', query.cancel);
   const rows = await query.result();
   // ULIDs sort lexicographically; dedupe defensively.
-  return [...new Set(rows.map((r) => r.id))].sort();
+  const byId = new Map<string, AffectedListing>();
+  for (const row of rows) byId.set(row.id, { id: row.id, appBlockId: row.app_block_id });
+  return [...byId.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+/** ALL-TIME deduped play count per app_block_id, for every affected on-site listing. */
+async function getAllTimeOpenCounts(
+  ctx: MetricProcessorRunContext,
+  affected: AffectedListing[]
+): Promise<Map<string, number>> {
+  const appBlockIds = [
+    ...new Set(affected.map((l) => l.appBlockId).filter((id): id is string => !!id)),
+  ];
+  // `IN ()` is a syntax error, and there is nothing to ask about anyway.
+  if (!appBlockIds.length) return new Map();
+
+  const rows = await ctx.ch.$query<{ appBlockId: string; openCount: number | string }>(
+    buildAppOpenCountSql(appBlockIds)
+  );
+  return new Map(rows.map((r) => [r.appBlockId, Number(r.openCount)]));
 }

--- a/src/server/metrics/appListing.metrics.ts
+++ b/src/server/metrics/appListing.metrics.ts
@@ -6,15 +6,23 @@ import {
   AFFECTED_APPROVED_LISTINGS_SQL,
   APP_LISTING_BATCH_SIZE,
   APP_LISTING_METRIC_UPSERT_SQL,
+  APP_OPEN_CH_CHUNK_SIZE,
   fetchAppOpenCounts,
   fetchRecentlyOpenedBlockIds,
 } from '~/server/metrics/appListing.metrics.sql';
+import { recordAppListingOpenDiscoveryDegrade } from '~/server/metrics/appListing.metrics.prom';
 import { logToAxiom } from '~/server/logging/client';
 import type { Task } from '~/server/utils/concurrency-helpers';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { createLogger } from '~/utils/logging';
 
 const log = createLogger('metrics:appListing');
+/**
+ * POSTGRES upsert batch size. NOT the ClickHouse chunk size — see the
+ * two-directional-pressure note on both constants in appListing.metrics.sql.ts.
+ * They were one constant until it was measured that sharing them costs ~39x on the
+ * ClickHouse side at seed scale.
+ */
 const BATCH_SIZE = APP_LISTING_BATCH_SIZE;
 
 /** One affected listing plus the join key both counters need. */
@@ -88,6 +96,18 @@ type AffectedListing = { id: string; appBlockId: string | null };
 // it so the recompute writes 0 — "we cannot measure this any more" instead of a
 // stale public number. Recovering the real count still needs the listing id carried
 // in `details`; do that if deletions become a real case.
+//
+// 🔴 BUT THE ARM'S PREDICATE IS NOT "an AppBlock was deleted" — it is "NULL join
+// key AND a non-zero published count", and `app_block_id IS NULL` is NOT a kind
+// discriminator (the schema says so on `AppListing.appBlockId`: "discriminate on
+// `kind`, never on appBlockId nullness"). It therefore also matches a
+// NATIVELY-CREATED OFF-SITE listing, which never had an AppBlock to lose. That
+// population is expected to be empty — off-site rows are written 0 by this very
+// upsert — so the arm is a no-op over it and there is no behavioural defect; a row
+// that DID appear there would be wrong by definition and wants the same clearing.
+// The consequence is for FOLLOW-UPS: an alert reading "repair arm fired ⇒ an
+// AppBlock was deleted" would misfire on ordinary off-site rows. Full statement of
+// both populations is on `AFFECTED_APPROVED_LISTINGS_SQL`.
 //
 // 🔴 `open_count` HAS NO READER AT THIS REF — its consumer lands in STAGE 3. The
 // rule below ("populate with the PR that ships its consumer") is real and this
@@ -176,9 +196,26 @@ export const appListingMetrics = createMetricProcessor({
  * `ctx.ch.$query` exposes no abort handle, so these reads used to outlive a
  * cancelled job while the Postgres queries beside them (which DO get a
  * `jobContext.on('cancel', query.cancel)`) were torn down. Dropping to
- * `ctx.ch.query` is what makes `abort_signal` reachable. The count read in
- * particular is a full `actions` scan — exactly the thing that must not be left
- * running server-side after the job that asked for it is gone.
+ * `ctx.ch.query` is what makes `abort_signal` reachable.
+ *
+ * 🔴 WHAT THIS ACTUALLY BUYS, STATED NARROWLY — IT IS A CLIENT-SIDE TEARDOWN, NOT A
+ * SERVER-SIDE KILL. `AbortController.abort()` ends the Node-side HTTP request: the
+ * `@clickhouse/client` promise rejects, the response stream stops being consumed
+ * and the socket is released, so a cancelled job stops holding a connection and
+ * stops buffering rows. It does NOT cancel the query inside ClickHouse. A
+ * server-side abort on client disconnect requires
+ * `cancel_http_readonly_queries_on_client_close`, which defaults to 0 and which
+ * `createClickhouseClient` does not set — its `clickhouse_settings` are
+ * `async_insert`, `wait_for_async_insert` and
+ * `output_format_json_quote_64bit_integers` only
+ * (packages/civitai-clickhouse/src/client.ts).
+ *
+ * 🔴 SO SIZE CLICKHOUSE FOR THE SCAN RUNNING TO COMPLETION. That matters
+ * concretely for the count read, which is a full `actions` scan issued once per
+ * `APP_OPEN_CH_CHUNK_SIZE` chunk: on the seed path those in-flight scans finish
+ * server-side whether or not the job that asked for them still exists. To make the
+ * stronger claim true, set that setting (per-query or on the client) — do not
+ * assume it from the presence of `abort_signal`.
  */
 async function chCancellableQuery<T extends object>(
   ctx: MetricProcessorRunContext,
@@ -233,6 +270,14 @@ async function getRecentlyOpenedBlockIds(ctx: MetricProcessorRunContext): Promis
       // failure, and must not be reported as "no plays".
       ctx.jobContext.checkIfCanceled();
       log('appListingMetrics play-discovery read failed; continuing without it', error);
+      // 🔴 THE AGGREGABLE SIGNAL, and the reason the log line beside it is not
+      // enough. A degraded run is INDISTINGUISHABLE from a quiet one — both yield
+      // an empty candidate set and an unchanged `open_count` — so the only way to
+      // tell "blipped once" from "dead for a week" is a rate over time, which one
+      // Axiom warning per run cannot express as an alert. The counter makes
+      // PERSISTENCE alertable; the log keeps the per-run attribution (the error
+      // message) that a label-free counter deliberately does not carry.
+      recordAppListingOpenDiscoveryDegrade();
       logToAxiom({
         type: 'warning',
         name: 'app-listing-metrics-open-discovery-degraded',
@@ -269,10 +314,16 @@ async function getAffectedListings(
  * Failing the run is the correct outcome: the counts stay at their last good values
  * and the next run recomputes them.
  *
- * CHUNKED at APP_LISTING_BATCH_SIZE because the `IN` list has a hard ceiling that
- * this read can genuinely reach (measured: 8,000 ids => `Code: 62 Max query size
- * exceeded`). Combined with the fail-hard above, one over-long query would take
- * `install_count` down with it — see the ceiling note on `fetchAppOpenCounts`.
+ * CHUNKED at APP_OPEN_CH_CHUNK_SIZE — its OWN constant, not the Postgres batch size
+ * — because the `IN` list has a hard ceiling this read can genuinely reach
+ * (measured: 8,000 ids => `Code: 62 Max query size exceeded`; the arithmetic puts
+ * the exact ceiling at 7,696 ids). Combined with the fail-hard above, one over-long
+ * query would take `install_count` down with it. But chunking is NOT free here:
+ * every chunk is a full `actions` scan whose cost is flat in the `IN` list size, so
+ * the chunk count IS the cost, and it is also the number of chances to hit that
+ * fail-hard path. Hence a large ClickHouse chunk (2,000, ~3.8x under the ceiling)
+ * against a small Postgres batch (200). See the ceiling note on
+ * `fetchAppOpenCounts`.
  */
 async function getAllTimeOpenCounts(
   ctx: MetricProcessorRunContext,
@@ -282,6 +333,6 @@ async function getAllTimeOpenCounts(
   return fetchAppOpenCounts(
     appBlockIds,
     (sql) => chCancellableQuery<AppOpenCountRow>(ctx, sql),
-    BATCH_SIZE
+    APP_OPEN_CH_CHUNK_SIZE
   );
 }

--- a/src/server/services/blocks/app-listing-review.service.ts
+++ b/src/server/services/blocks/app-listing-review.service.ts
@@ -88,8 +88,11 @@ function reviewKey(appListingId: string, userId: number) {
 // 🔴 "No recompute" is a TWO-SIDED contract, not a property of this file. The
 // `app_listing_metrics` row is ALSO written by the metric processor
 // (`src/server/metrics/appListing.metrics.sql.ts`), which deliberately names only
-// `install_count` in its INSERT and ON CONFLICT lists so a row created here
-// survives the rollup untouched. Each side pins the other:
+// `install_count` / `open_count` in its INSERT and ON CONFLICT lists so a row
+// created here survives the rollup untouched. Both of those counters are FULL
+// RECOMPUTES (installs from `block_user_subscriptions`, plays from the ClickHouse
+// `App_Open` event stream) — which is what makes that side a legal writer under
+// the last line of this paragraph. Each side pins the other:
 //   - that side is pinned by `src/server/metrics/__tests__/appListing.metrics.test.ts`
 //     ("NEVER writes thumbs_up_count / thumbs_down_count");
 //   - this side is pinned by the writer-set ledger in


### PR DESCRIPTION
Stage **2 of 4** of the app-store play-count arc. Stage 1 is #4652.

## What this does

`app_listing_metrics.open_count` has existed in the schema, defaulted to 0, and **never been written**. This populates it from the trusted ClickHouse `App_Open` event stream that the `/apps/run/<slug>` SSR resolver emits (stage 1), with **dedup applied at read time**.

Three moving parts:

1. **Affected-set discovery now sees plays.** Nothing in Postgres moves when a play happens, so `AFFECTED_APPROVED_LISTINGS_SQL` would never notice one. The processor now asks ClickHouse which `app_block_id`s had an `App_Open` since the watermark and passes them to the affected query as `$2` — the ClickHouse-first pattern from `model3d.metrics.ts` (`getDownloadTasks`). The affected query also now returns `app_block_id` alongside the id, so the count query needs no second Postgres round trip.
2. **A full all-time recompute per run**, over the **whole** affected set — not just the recently-active part. That matters: `open_count` is derived, so a listing recomputed for an unrelated reason (a new subscription, a seed row) is also written from this map, and a block missing from the map is written as **0**. Feeding a partial map would zero the play count of every listing recomputed for an unrelated reason. There is a 🔴 note on the upsert saying exactly that.
3. **The upsert consumes the map** via `LEFT JOIN unnest($2::text[], $3::int[])` on `app_block_id`, `COALESCE(…, 0)`.

## Dedup semantics — in plain English

> **One play = one distinct actor per app per UTC day**, where actor = the signed-in `userId` when it is non-zero, and the request `ip` when it is not. `open_count` is the sum of those per-day distinct counts over **all time**.

`AppListingMetric` has no timeframe column, so all-time is the only figure it can hold.

- Reloading an app twenty times this afternoon → **1**. Opening it again tomorrow → **2**.
- Two different signed-in users today → **2**. Two signed-out visitors on different IPs today → **2**.
- A signed-in user and a signed-out visitor are always two different actors. `userId` 0 is the tracker's *anonymous sentinel*, never an identity — those rows fall back to `ip`, so anonymous traffic does not collapse into a single site-wide actor.

This is written as a comment block on `buildAppOpenCountSql`, next to the SQL that implements it, because **stage 4 puts a public label next to this number** and the label has to match what it counts. It is closer to *"people who opened this"* than to *"times opened"*, and it is a **lower bound on both**: every signed-out visitor behind one NAT egress IP collapses to a single daily actor, and the tracker's `ip` fallback is the literal string `unknown` when the client IP cannot be resolved, collapsing all such requests for a day into one.

**Undercounting is the deliberate direction.** The emit is an unauthenticated, unrate-limited `GET` on an optional catch-all route with no `robots.txt` disallow, so the raw row count is inflatable by a refresh loop, a crawler or a chat-client link unfurler. An inflated public number is worse than a conservative one.

**If you want a different window, say so now** — the definition is one expression in `buildAppOpenCountSql` and one mirror in the pure spec. The two obvious alternatives and why I did not take them: dropping the daily bucket (`uniqExact` over all time) makes a returning user worth 1 forever, which reads badly next to "installs"; using a rolling 30-day window would make a public number that silently *decreases*, which is worse on a store card than one that only grows.

## On-site only

Off-site listings have no trustworthy source at all — their CTA is a plain third-party anchor, so no on-platform request follows the click. Both counters gate on `kind = 'onsite' AND app_block_id IS NOT NULL`, and this is **asserted**, not left to fall out of the join: a test counts the gate occurrences (2, one per counter) and another feeds an off-site listing that *does* carry an `app_block_id` and requires 0.

🔴 **A `0` in this column therefore means "no plays OR not measurable"**, and nothing in the column distinguishes them. **Stage 3 must project `openCount` as `null` for `kind='offsite'` rather than 0** — the operator's decision is that off-site cards omit the stat entirely rather than show a zero that reads as "nobody used it". Documented in both `appListing.metrics.ts` and `appListing.metrics.sql.ts`.

## Ownership contract

`app-listing-review.service.ts` says *"'No recompute' is a TWO-SIDED contract … A third writer is only safe if it brings a full recompute with it."* This is that third writer, and the recompute it brings is total. **There is no `+1` path anywhere**, and a test pins that: the ON CONFLICT set must not match `/"open_count"\s*\+/` and must not reference the column's own current value.

The INSERT column list and the ON CONFLICT DO UPDATE set now name `install_count`, `open_count`, `updated_at` — and still **never** `thumbs_up_count` / `thumbs_down_count`. `connect_count` / `visit_count` / `tipped_*` remain absent. I also corrected the now-stale claim in `app-listing-review.service.ts` that the processor "names only `install_count`".

## An existing guard was deliberately narrowed

`appListing.metrics.test.ts` asserted *"does not write connect/open/visit/tipped counters (no reader; feature not live)"*. `open` now has a reader and a trusted source, so `open_count` moved **out** of that not-written list and **into** the positive ON CONFLICT assertion. The other three are unchanged and still asserted absent. The narrowing is explained inline at the assertion and in the commit message.

## 🔴 One non-obvious design decision, with the measurement behind it

The ClickHouse reads use **`toString(type) = 'App_Open'`, not `type = 'App_Open'`**. `actions.type` is an `Enum16`, and comparing it to a literal the enum does not carry is a **hard query error**, not an empty result. Measured directly against ClickHouse 26.7.5 with a pre-migration enum definition:

| form | result |
|---|---|
| `PREWHERE type = 'App_Open'` | `Code: 691. DB::Exception: Unknown element 'App_Open' for enum … (UNKNOWN_ELEMENT_OF_ENUM)` |
| `PREWHERE toString(type) = 'App_Open'` | `0` — clean, no error |

The bare form would make this processor **throw on every run — taking `install_count` down with it** — on any deploy where #4652's widening migration has not been applied. `toString` simply matches nothing, which is precisely the inert behaviour this rollup wants until the migration lands. Both queries also apply the type predicate in `PREWHERE`, because the count query is intentionally unbounded in time and nothing prunes it otherwise.

## Verification

### Live SQL — both engines, not just string assertions

**Postgres 17**, throwaway instance, real tables, `PREPARE` + `EXECUTE` of the actual exported SQL strings:

- The upsert and the affected query both **parse and execute** (the `LEFT JOIN unnest($2::text[], $3::int[]) AS oc(...)` form is valid).
- Fixture: `apl_on` (on-site, 3 subs / 1 disabled) with a **pre-existing metric row created by the thumbs writer** carrying `thumbs 17/4` and `connect/visit/tipped 91/92/93/94`.
- Result: `install_count 2`, `open_count 4` (from the supplied map), and **`thumbs_up 17`, `thumbs_down 4`, `connect 91`, `visit 92`, `tipped 93`, `tipped_amount 94` all unchanged**. That is the ownership contract verified against a real database, not just against a regex.
- `apl_off` / `apl_noblock` → `0 / 0`. `apl_pending` (non-approved) excluded — `INSERT 0 4`, not 5.
- Play-only affected arm: with a watermark set to **2999-01-01** (so no subscription arm can fire) and every listing already holding a metric row (so no seed arm can fire), passing `ARRAY['apb_beta']` returned exactly `apl_on2`. Positive control that the new arm is what selected it.
- **Empty parallel arrays** (`$2 = '{}'`, `$3 = '{}'` — the batch where every listing has a null `app_block_id`): executes cleanly, `open_count` COALESCEs to 0, thumbs preserved. That case is not exercised by any string assertion and would have surfaced only in production.
- The same probe also **demonstrates the hazard the design note warns about**: re-running the upsert for `apl_on` with an *empty* map rewrote its `open_count` from 4 back to 0. That is precisely why the processor queries ClickHouse for the **whole** affected set rather than only the recently-active blocks — a partial map is not a no-op, it is a zeroing.

**ClickHouse 26.7.5** (`clickhouse-local`), real `MergeTree` `actions` table with an `Enum16` `type` and a hand-built fixture:

- `apb_alpha` → **4** (one user refresh-looping 3× on 09-05 = 1, a second user = +1, one anon IP twice = +1, the first user again on 09-06 = +1).
- `apb_beta` → **4** (two anon actors on different IPs, plus `userId 5` and the literal ip `'5'` which must **not** collapse).
- A `Generator_Submit` row on the same app was not counted; a row with `details = '{}'` was dropped; `apb_gamma` (not in the `IN` list) was absent from the count but present in the recent-blocks result.

### Mutation matrix — 27 mutants, 26 killed

Each mutant was applied to the production source, the suite run, the failing test names and assertion messages recorded, and the source restored. Baseline before **and** after the sweep: `Tests 48 passed (48)`.

| # | Mutant | Result | Test that reds | Message |
|---|---|---|---|---|
| M1 | actor key ignores the anonymous sentinel (always `u:<userId>`) | KILLED | `two ANONYMOUS actors on different IPs count 2` | `expected 1 to be 2` |
| M2 | actor key drops the `u:` / `i:` prefixes | KILLED | `a userId and an ip that render the same string are still two actors` | `expected '5' not to be '5'` |
| M3 | no dedup — count raw rows per day | KILLED | `a refresh loop by ONE signed-in actor collapses to 1` | `expected 4 to be 1` |
| M4 | no per-day bucketing — one bucket for all time | KILLED | `the same actor on two different UTC days counts 2` | `expected 1 to be 2` |
| M5 | day bucket uses the LOCAL calendar day, not UTC | KILLED | `the day boundary is UTC, not local` | `expected '2026-09-05' to be '2026-09-06'` |
| M6 | spec: `measurable` drops the `kind==='onsite'` gate | KILLED | `OFF-SITE listing carrying a stray app_block_id STILL gets 0` | `expected 4 to be +0` |
| M7 | spec: `measurable` drops the non-null `app_block_id` gate | **SURVIVED** | — | see below |
| M8 | spec: approved-only filter removed | KILLED | `non-approved listings … are excluded` | `expected [ 'apl_draft', … ] to deeply equal [ 'apl_ok' ]` |
| M9 | spec: install count stops filtering on `enabled` | KILLED | `installCount = its ACTIVE (enabled) subscription count` | `expected 3 to be 2` |
| M10 | upsert: `open_count` dropped from the ON CONFLICT set | KILLED | `the ON CONFLICT DO UPDATE writes install_count / open_count / updated_at` | `expected 'ON CONFLICT…' to contain '"open_count" = EXCLUDED."open_count"'` |
| M11 | upsert: `thumbs_up_count` added to the ON CONFLICT set | KILLED | `NEVER writes thumbs_up_count / thumbs_down_count` | `expected ' INSERT INTO…' not to contain 'thumbs_up_count'` |
| M12 | upsert: `connect_count` re-added to the INSERT list | KILLED | `does not write connect/visit/tipped counters` | `expected ' INSERT INTO…' not to contain 'connect_count'` |
| M13 | CH **count** query: bare Enum comparison | KILLED | `matches the action type by toString(type), NOT by Enum comparison` | `expected '…' to contain 'toString(type) = \'App_Open\''` |
| M14 | affected query: the `$2` play arm removed | KILLED | `has an arm keyed on the ClickHouse-supplied app_block_id list ($2)` | `expected ' SELECT al.id, …' to contain 'al."kind" = \'onsite\' AND al."app_bl…'` |
| M15 | upsert: `LEFT JOIN unnest` → `INNER JOIN` | KILLED | `is a LEFT join, so a listing absent from the map is written 0` | `expected ' INSERT INTO…' not to contain 'INNER JOIN unnest'` |
| M16 | CH count query: `uniqExact` → `count()` | KILLED | `the count query buckets by UTC day and counts DISTINCT actors per bucket` | `expected '…' to contain 'uniqExact(if(userId != 0, …'` |
| M17 | `escapeClickhouseString` becomes the identity function | KILLED | `escapes quotes and backslashes in the IN list rather than dropping the id` | `expected 'ap\'b' to be 'ap\\\'b'` |
| M18 | spec: `openCount` hardcoded to 0 | KILLED | `an on-site listing gets its app block's deduped all-time play count` | `expected +0 to be 3` |
| M19 | upsert: `open_count` gate loses `kind==='onsite'` | KILLED | `both counters gate on kind = onsite AND a non-null app_block_id` | `expected [ Array(1) ] to have a length of 2 but got 1` |
| M20 | upsert: `open_count` becomes an **increment** | KILLED | `open_count is DERIVED from the supplied map, never incremented` | `expected ' INSERT INTO…' not to match /"open_count"\s*\+/` |
| M21 | CH **recent** query: bare Enum comparison | KILLED | `matches the action type by toString(type)…` | `expected '\n    SELECT DISTINCT…' to contain 'toString(type) = \'App_Open\''` |
| M22 | CH recent query: loses the watermark bound | KILLED | `the recent-blocks query is bounded by the watermark and drops empty ids` | `expected '…' to contain 'time >= parseDateTimeBestEffort(…'` |
| M23 | CH recent query: stops dropping empty `appBlockId` | KILLED | same as M22 | `expected '…' to contain 'JSONExtractString(details, \'appBlock…'` |
| M24 | affected query: stops returning `app_block_id` | KILLED | `returns app_block_id so the caller can query ClickHouse without a second round trip` | `expected ' SELECT al.id FROM…' to contain 'SELECT al.id, al."app_block_id"'` |
| M25 | spec: stops dropping empty-`appBlockId` rows | KILLED | `a row whose details carried no appBlockId is dropped, not counted under ""` | `expected true to be false` |
| M26 | CH count query: drops the app-block `IN` filter | KILLED | `the count query filters to the requested app block ids` | `expected '…' to contain 'WHERE JSONExtractString(details, \'ap…'` |
| M27 | CH count query: gains a 30-day window | KILLED | `the count query is all-time (no time predicate)` | `expected '…' not to contain 'time >='` |

**M7 survived, and I am reporting it as a real result rather than papering over it.** With `measurable = l.kind === 'onsite'` alone, a null-`appBlockId` listing still produces `0/0`: no subscription row has a null `app_block_id`, and `Map.get(null)` is `undefined`. The same holds in SQL — `bus.app_block_id = al.app_block_id` never matches NULL, and the LEFT JOIN COALESCEs to 0. So that conjunct is **redundant by construction, not merely untested**: no observable behaviour depends on it. I kept it (it mirrors the SQL's `IS NOT NULL` and states intent) and added a comment saying it is *not* a behavioural guard, so nobody later reads it as coverage it does not provide.

Two other guardrails on the sweep itself: the spec⇄SQL lockstep block has an explicit **positive control** (`the parser found something to compare`) so a regex that matched nothing cannot make the equality assertions pass vacuously, and it pairs the derived comparison with a literal (`and that set is install_count + open_count`) so both sides drifting together is still caught.

### Gates

All run from the worktree through the repo's dev shell.

| Gate | Command | Result |
|---|---|---|
| Unit (target file) | `npx vitest run --project unit src/server/metrics/__tests__/appListing.metrics.test.ts` | **48 passed (48)** |
| Unit (adjacent contracts) | `npx vitest run --project unit …/app-listing-review.mod-exclude.test.ts …/action-type-enum-drift.test.ts` | **40 passed (40)**, 2 files |
| Unit (full project) | `npx vitest run --project unit` | **1637 files passed / 3 skipped**, **38137 tests passed / 33 skipped**, 0 failed |
| Typecheck | `pnpm typecheck` | `typecheck: OK — 0 type errors in 54s` |
| Typecheck negative control | same, with a planted return-type error | `typecheck: 3 type error(s)`, rc 2 — the gate can go red |
| ESLint | `npx eslint --format unix <the 4 changed files>` | no output (0 problems) |
| Prettier | `npx prettier --check <the 4 changed files>` | `All matched files use Prettier code style!` (it flagged one file on the first run; fixed with `--write`, so this verdict is about files it actually read) |

## 🔴 Inert until #4652 merges

This branch is based **directly on `origin/main`** and imports nothing from #4652 — it matches the literal string `'App_Open'` in ClickHouse. That makes the two PRs genuinely independent and avoids a stacked PR.

The consequence is that **`open_count` computes and writes 0 until #4652 merges and its `Enum16` widening migration (`2026-09-05-app-open-action.sql`) is applied to production.** No `App_Open` row can exist before both of those happen: the tracker's insert is rejected at the tracker service for a value the column does not carry. This is safe rather than merely harmless — the `toString(type)` form above means the query returns an empty set instead of erroring in the meantime.

**Merge-order note:** both PRs edit the header comment block of `src/server/metrics/appListing.metrics.ts`, so whichever merges second will need a trivial comment-only conflict resolution. #4652's version of that block states the two obligations this PR discharges (dedupe at read time; add `open_count` to the ON CONFLICT list); this PR's version documents them as discharged. Keep this PR's version when resolving.

## Not verified

- **No production ClickHouse or Postgres was touched.** The Postgres and ClickHouse results above are from throwaway local instances with hand-built fixtures matching the documented schemas — they prove the SQL parses, executes and computes the right numbers, but not that production's `actions` table has exactly the column types I assumed (`userId` numeric, `ip` String, `details` String, `time` DateTime), which I read out of `tracker.ts` rather than from the live cluster.
- **Query cost on the real table is unmeasured.** The all-time count query has no time bound by design. `PREWHERE toString(type)` is there to keep it to a narrow column scan, and it only runs when the affected set is non-empty (this processor is on a `*/5 * * * *` schedule), but I have not run it against production's 92.8M-row `actions`. Worth watching the first time real rows exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXFskJ3JuYmGAmTFj8cFDU
