### PR TITLE
feat(metrics): measure the brotli codec behind redis.packed compression

### DIFF
--- a/packages/civitai-redis/src/__tests__/cached-array-compress.test.ts
+++ b/packages/civitai-redis/src/__tests__/cached-array-compress.test.ts
@@ -367,8 +367,12 @@ describe('SEAM LEDGER: every redis.packed call site in cached-array.ts is compre
     expect(missing).toEqual([]);
   });
 
-  it('packedOptions is derived from the option, not hardcoded', () => {
-    expect(src).toMatch(/const packedOptions = \{ compress \} as const;/);
+  // `cacheName: key` joined the binding when the codec duration histogram landed. It is pinned in
+  // the same assertion because it carries its own hazard: `key` is the cache PREFIX, and the label
+  // must never become the per-id `${key}:${id}` (that would be unbounded prom cardinality). Both
+  // halves are the shorthand/identifier form, i.e. derived from the caller, never hardcoded.
+  it('packedOptions is derived from the options, not hardcoded', () => {
+    expect(src).toMatch(/const packedOptions = \{ compress, cacheName: key \} as const;/);
   });
 });
 

--- a/packages/civitai-redis/src/__tests__/packed-codec-metrics.test.ts
+++ b/packages/civitai-redis/src/__tests__/packed-codec-metrics.test.ts
@@ -197,6 +197,8 @@ describe('packed codec metrics — labels and wiring', () => {
   });
 
   it('does not throw when the app has published no metrics bridge', async () => {
+    // NOTE: absence is a no-op — `?.` short-circuits and no callback runs. That is a strictly
+    // weaker claim than the throwing-bridge block below, which is where the damage lives.
     removeBridge();
     await expect(
       redis.packed.set(KEY, record, undefined, { compress: true, cacheName: DIRECT_CACHE })
@@ -253,5 +255,86 @@ describe('packed codec metrics — labels and wiring', () => {
     );
     expect(readLabels).toEqual(new Set([BUILDER_CACHE]));
     expect(observed.filter((o) => o.op === 'decompress')).toHaveLength(2);
+  });
+});
+
+/**
+ * 🔴 A METRICS FAULT MUST NOT DESTROY A CACHE ENTRY.
+ *
+ * The timer call sits INSIDE `decompressPacked`, which sits inside `safeUnpackCompressed`'s try —
+ * and that catch does not mean "something went wrong", it means "the stored bytes are corrupt", so
+ * it logs, UNLINKS the key and returns null. A bridge whose `observe()` throws (duplicate metric
+ * registration, a rejected label value, an exhausted registry) therefore does not merely lose a
+ * sample: a VALID entry is reported as a miss and DELETED, on every read, for as long as the fault
+ * lasts — an observability change turning into a cache-eviction bug that presents as a cache with
+ * a mysterious 0% hit rate.
+ *
+ * The "no metrics bridge" test above cannot see this: absence short-circuits at `?.` and no
+ * callback runs at all. Absence and throw are different mechanisms, and only one of them is
+ * dangerous.
+ */
+describe('packed codec metrics — a metrics fault must never fail a read or a write', () => {
+  /**
+   * Counts every call BEFORE throwing. The count is the positive control: without it, all three
+   * tests below would also pass against a client that had stopped calling the timer entirely —
+   * "nothing threw" is exactly what a dead wire looks like too. Asserting `attempts > 0` says the
+   * throwing path was really entered and really swallowed.
+   */
+  let attempts = 0;
+  const BOOM = 'prom registry exploded';
+
+  function installThrowingBridge() {
+    attempts = 0;
+    (globalThis as unknown as { __civitaiRedisMetrics?: unknown }).__civitaiRedisMetrics = {
+      packedCodecDuration: {
+        observe: () => {
+          attempts += 1;
+          throw new Error(BOOM);
+        },
+      },
+    };
+  }
+
+  it('a throwing observe() neither loses the value nor unlinks the key on a compressed get', async () => {
+    store.set(KEY, await compressPacked(Buffer.from(pack(record))));
+    installThrowingBridge();
+
+    const got = await redis.packed.get<typeof record>(KEY, {
+      compress: true,
+      cacheName: DIRECT_CACHE,
+    });
+
+    expect(attempts, 'the throwing observe() was actually reached').toBe(1);
+    // Asserted BEFORE the value: the deletion is the damaging half, and it outlives the request.
+    expect(store.has(KEY), 'the healthy entry was NOT unlinked by a metrics fault').toBe(true);
+    expect(got, 'a valid entry is still returned when the metrics bridge throws').toEqual(record);
+  });
+
+  it('a throwing observe() does not fail a compressed set', async () => {
+    installThrowingBridge();
+
+    await expect(
+      redis.packed.set(KEY, record, undefined, { compress: true, cacheName: DIRECT_CACHE })
+    ).resolves.toBeDefined();
+    expect(attempts, 'the throwing observe() was actually reached').toBe(1);
+    expect(store.has(KEY), 'the compressed write still landed').toBe(true);
+  });
+
+  it('a throwing observe() leaves a whole compressed mGet batch intact', async () => {
+    store.set(KEY, await compressPacked(Buffer.from(pack(record))));
+    store.set(KEY_LEGACY, await compressPacked(Buffer.from(pack(record))));
+    installThrowingBridge();
+
+    const got = await redis.packed.mGet<typeof record>([KEY, KEY_LEGACY], {
+      compress: true,
+      cacheName: DIRECT_CACHE,
+    });
+
+    expect(attempts, 'the throwing observe() was reached once per compressed value').toBe(2);
+    expect(
+      [store.has(KEY), store.has(KEY_LEGACY)],
+      'no key in the batch was unlinked by a metrics fault'
+    ).toEqual([true, true]);
+    expect(got, 'every entry in the batch still decodes').toEqual([record, record]);
   });
 });

--- a/packages/civitai-redis/src/__tests__/packed-codec-metrics.test.ts
+++ b/packages/civitai-redis/src/__tests__/packed-codec-metrics.test.ts
@@ -74,7 +74,11 @@ vi.mock('redis', () => {
 });
 
 import { createCacheBuilders } from '../cached-array';
-import { createCacheRedis, PACKED_CODEC_UNNAMED_CACHE } from '../client';
+import {
+  createCacheRedis,
+  PACKED_CODEC_UNNAMED_CACHE,
+  __resetPackedCodecObserveFailureState,
+} from '../client';
 import type { RedisKeyTemplateCache } from '../client';
 import { compressPacked } from '../packed-compression';
 
@@ -336,5 +340,106 @@ describe('packed codec metrics — a metrics fault must never fail a read or a w
       'no key in the batch was unlinked by a metrics fault'
     ).toEqual([true, true]);
     expect(got, 'every entry in the batch still decodes').toEqual([record, record]);
+  });
+});
+
+/**
+ * 🔴 A SWALLOWED FAILURE MUST NOT BE A SILENT ONE.
+ *
+ * The block above proves the catch protects the cache. It says nothing about whether anyone would
+ * ever find out. A bridge whose `observe()` throws on every call yields a histogram that never has
+ * data — which is byte-for-byte what "no cache opted into compress" looks like, on the only metric
+ * that can answer whether compression is worth its cost. A reassuring zero is indistinguishable
+ * from a probe wired to nothing, so the catch has to say so.
+ *
+ * It is rate-limited rather than one-shot: a throwing bridge throws on EVERY codec call, so an
+ * unthrottled line would be per-cache-read log spam, while a strict one-shot would go quiet for the
+ * whole life of the process no matter how long the fault lasted. The three properties below are
+ * asserted in one test on purpose — the throttle is module-scoped state, so "did not log" only
+ * means "throttled" relative to a known earlier log in the same sequence.
+ */
+describe('packed codec metrics — a swallowed observe failure leaves a breadcrumb', () => {
+  const BREADCRUMB = 'packed codec metrics observe FAILED';
+  const BOOM_MSG = 'prom registry exploded';
+  let attempts = 0;
+
+  function installThrowingBridgeHere() {
+    attempts = 0;
+    (globalThis as unknown as { __civitaiRedisMetrics?: unknown }).__civitaiRedisMetrics = {
+      packedCodecDuration: {
+        observe: () => {
+          attempts += 1;
+          throw new Error(BOOM_MSG);
+        },
+      },
+    };
+  }
+
+  it('logs the first failure, throttles the next, and speaks again once the window has passed', async () => {
+    __resetPackedCodecObserveFailureState();
+    const lines: string[] = [];
+    // `log` is module-scoped in ../client and injected here; this rebinds it for the rest of the
+    // file, which is why the bridge is restored in the `finally` below.
+    createCacheRedis({ log: (msg: string) => lines.push(String(msg)) });
+    installThrowingBridgeHere();
+
+    // A controlled clock: the throttle reads Date.now(). Nothing else on this path does — the
+    // deadline wrapper uses setTimeout — so freezing it cannot stall the client.
+    let clock = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock);
+    const breadcrumbs = () => lines.filter((l) => l.includes(BREADCRUMB));
+
+    try {
+      await redis.packed.set(KEY, record, undefined, { compress: true, cacheName: DIRECT_CACHE });
+
+      // Positive control: the throwing path was actually entered. Without it every "logged N
+      // times" assertion below would also hold against a client that stopped timing entirely.
+      expect(attempts, 'the throwing observe() was actually reached').toBe(1);
+      expect(breadcrumbs(), 'the FIRST swallowed failure is reported').toHaveLength(1);
+      // The line has to be diagnosable on its own: which op, which cache, and the underlying
+      // error. A bare "metrics failed" would not distinguish this from any other swallow.
+      expect(breadcrumbs()[0]).toContain('op=compress');
+      expect(breadcrumbs()[0]).toContain(DIRECT_CACHE);
+      expect(breadcrumbs()[0]).toContain(BOOM_MSG);
+      expect(breadcrumbs()[0]).toContain('failures=1');
+
+      // Same window → counted, not logged.
+      await redis.packed.set(KEY, record, undefined, { compress: true, cacheName: DIRECT_CACHE });
+      expect(attempts, 'the second failure really happened').toBe(2);
+      expect(
+        breadcrumbs(),
+        'a second failure inside the window is throttled, not logged'
+      ).toHaveLength(1);
+
+      // Past the window → speaks again, and carries the count accumulated while it was quiet.
+      clock += 60_001;
+      await redis.packed.set(KEY, record, undefined, { compress: true, cacheName: DIRECT_CACHE });
+      expect(breadcrumbs(), 'the breadcrumb returns after the throttle window').toHaveLength(2);
+      expect(
+        breadcrumbs()[1],
+        'the throttled failures are still counted, so the line reports 3 rather than 1'
+      ).toContain('failures=3');
+    } finally {
+      nowSpy.mockRestore();
+      createCacheRedis({ log: () => undefined });
+      installBridge();
+      __resetPackedCodecObserveFailureState();
+    }
+  });
+
+  it('NEGATIVE CONTROL: a healthy bridge logs no breadcrumb at all', async () => {
+    __resetPackedCodecObserveFailureState();
+    const lines: string[] = [];
+    createCacheRedis({ log: (msg: string) => lines.push(String(msg)) });
+    installBridge();
+
+    try {
+      await redis.packed.set(KEY, record, undefined, { compress: true, cacheName: DIRECT_CACHE });
+      expect(observed, 'the healthy bridge really did receive the sample').toHaveLength(1);
+      expect(lines.filter((l) => l.includes(BREADCRUMB))).toHaveLength(0);
+    } finally {
+      createCacheRedis({ log: () => undefined });
+      __resetPackedCodecObserveFailureState();
+    }
   });
 });

--- a/packages/civitai-redis/src/__tests__/packed-codec-metrics.test.ts
+++ b/packages/civitai-redis/src/__tests__/packed-codec-metrics.test.ts
@@ -354,9 +354,11 @@ describe('packed codec metrics — a metrics fault must never fail a read or a w
  *
  * It is rate-limited rather than one-shot: a throwing bridge throws on EVERY codec call, so an
  * unthrottled line would be per-cache-read log spam, while a strict one-shot would go quiet for the
- * whole life of the process no matter how long the fault lasted. The three properties below are
- * asserted in one test on purpose — the throttle is module-scoped state, so "did not log" only
- * means "throttled" relative to a known earlier log in the same sequence.
+ * whole life of the process no matter how long the fault lasted. The properties below are asserted
+ * in one test on purpose — the throttle is module-scoped state, so "did not log" only means
+ * "throttled" relative to a known earlier log in the same sequence. The window is walked from BOTH
+ * sides (just under it, then just over it) so the interval constant is bracketed rather than merely
+ * bounded from above; see the comment at the 59_999 advance for why the one-sided version was inert.
  */
 describe('packed codec metrics — a swallowed observe failure leaves a breadcrumb', () => {
   const BREADCRUMB = 'packed codec metrics observe FAILED';
@@ -411,16 +413,84 @@ describe('packed codec metrics — a swallowed observe failure leaves a breadcru
         'a second failure inside the window is throttled, not logged'
       ).toHaveLength(1);
 
+      // 🔴 LOWER BOUND ON THE INTERVAL, and it is the half that is easy to leave out. Crossing the
+      // window (below) pins the constant only from ABOVE — it says "no larger than the advance",
+      // which every value down to 1 ms satisfies. Measured: with the interval set to 1 the whole
+      // package stayed 193/193 green, so a 60_000 → 60 unit slip would restore near-per-call log
+      // spam under a sustained fault with nothing red. This advance stops JUST SHORT of the window
+      // and must still be throttled, which pins it from BELOW; the two together bracket the
+      // constant into (59_999, 60_001].
+      clock += 59_999;
+      await redis.packed.set(KEY, record, undefined, { compress: true, cacheName: DIRECT_CACHE });
+      expect(attempts, 'the third failure really happened').toBe(3);
+      expect(
+        breadcrumbs(),
+        'a failure just BELOW the throttle window is still throttled — the window is ~60s, not milliseconds'
+      ).toHaveLength(1);
+
       // Past the window → speaks again, and carries the count accumulated while it was quiet.
-      clock += 60_001;
+      clock += 2; // 60_001 since the first (and so far only) breadcrumb
       await redis.packed.set(KEY, record, undefined, { compress: true, cacheName: DIRECT_CACHE });
       expect(breadcrumbs(), 'the breadcrumb returns after the throttle window').toHaveLength(2);
       expect(
         breadcrumbs()[1],
-        'the throttled failures are still counted, so the line reports 3 rather than 1'
-      ).toContain('failures=3');
+        'the throttled failures are still counted, so the line reports 4 rather than 1'
+      ).toContain('failures=4');
     } finally {
       nowSpy.mockRestore();
+      createCacheRedis({ log: () => undefined });
+      installBridge();
+      __resetPackedCodecObserveFailureState();
+    }
+  });
+
+  // 🔴 THE REPORTING PATH IS ITSELF INSIDE THE LOAD-BEARING CATCH, and it has to be, because `log`
+  // is INJECTED BY THE APP and is therefore arbitrary code. A throw from it escapes the swallow and
+  // lands in `safeUnpackCompressed`'s catch — which UNLINKS THE KEY. That is the same
+  // observability-change-becomes-cache-eviction bug the outer catch exists to stop, reintroduced
+  // one layer further in by the very line that reports the swallow. Verified by mutation: remove
+  // the nested try/catch in `packedCodecTimer` and this test deletes a healthy entry.
+  it('a throwing log() on the breadcrumb path still does not unlink a healthy entry', async () => {
+    __resetPackedCodecObserveFailureState();
+    store.set(KEY, await compressPacked(Buffer.from(pack(record))));
+    // Throws ONLY on the breadcrumb line, not on every call: `createCacheRedis` logs during client
+    // construction, so a globally-throwing logger would blow up before reaching the path under
+    // test — and a real logger failing on one payload (an over-long line, a serialiser choking on
+    // an interpolated value) is the shape this is actually defending against anyway.
+    let breadcrumbThrows = 0;
+    createCacheRedis({
+      log: (msg: string) => {
+        if (!String(msg).includes(BREADCRUMB)) return;
+        breadcrumbThrows += 1;
+        throw new Error('the injected logger exploded');
+      },
+    });
+    installThrowingBridgeHere();
+
+    try {
+      const got = await redis.packed.get<typeof record>(KEY, {
+        compress: true,
+        cacheName: DIRECT_CACHE,
+      });
+
+      // Positive controls, both needed. `attempts` says the observe threw, so the outer catch ran;
+      // `breadcrumbThrows` says the throttle then ADMITTED the line, the logger really was called,
+      // and it really threw. Without the second, this test would also pass against a build where
+      // the breadcrumb never fires at all — i.e. against no guard being exercised.
+      expect(attempts, 'the throwing observe() was reached, so the swallow path really ran').toBe(
+        1
+      );
+      expect(
+        breadcrumbThrows,
+        'the breadcrumb line was actually emitted and the injected logger actually threw'
+      ).toBe(1);
+      // Asserted before the value: the deletion is the damaging half and it outlives the request.
+      expect(
+        store.has(KEY),
+        'the healthy entry survived a throwing LOGGER, not merely a throwing observe()'
+      ).toBe(true);
+      expect(got, 'a valid entry is still returned').toEqual(record);
+    } finally {
       createCacheRedis({ log: () => undefined });
       installBridge();
       __resetPackedCodecObserveFailureState();

--- a/packages/civitai-redis/src/__tests__/packed-codec-metrics.test.ts
+++ b/packages/civitai-redis/src/__tests__/packed-codec-metrics.test.ts
@@ -1,0 +1,257 @@
+import { pack } from 'msgpackr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * SEAM coverage for the packed brotli codec's prom instrumentation
+ * (`civitai_app_packed_codec_duration_seconds`, labels `op` + `cache_name`).
+ *
+ * WHY THIS DRIVES THE REAL CLIENT. The unit test beside this one
+ * (./packed-codec-timing.test.ts) proves `compressPacked`/`decompressPacked` CALL their timing
+ * callback. That is a claim about one module. The thing that can actually be wrong in production
+ * is the SEAM: whether `client.packed.set/get/mGet` pass a callback at all, whether it reaches the
+ * globalThis metrics bridge the app publishes, and whether the `cache_name` it carries is the
+ * bounded cache PREFIX rather than a per-id key. A test that mocked `packed` would pass against a
+ * client that instruments nothing.
+ *
+ * So the only faked thing here is the TRANSPORT: `redis`'s client factory is replaced by an
+ * in-memory server holding raw Buffers (same approach as ./cached-array-compress.test.ts).
+ * `createCacheRedis`, `client.packed.*`, the msgpack + brotli codec, `createCacheBuilders` and the
+ * bridge lookup are all the real modules.
+ */
+
+// process.env must be populated BEFORE ../client is imported: loadRedisEnv() validates it.
+vi.hoisted(() => {
+  process.env.REDIS_URL ??= 'redis://localhost:6379';
+  process.env.REDIS_SYS_URL ??= 'redis://localhost:6379';
+  process.env.REDIS_CLUSTER = 'false';
+});
+
+/** The in-memory "server": key -> raw stored bytes, exactly as a real Redis would hold them. */
+const { store } = vi.hoisted(() => ({ store: new Map<string, Buffer>() }));
+
+vi.mock('redis', () => {
+  const toBuffer = (v: unknown): Buffer =>
+    Buffer.isBuffer(v) ? v : Buffer.from(v as string, 'binary');
+
+  const makeClient = (bufferMode = false): Record<string, unknown> => {
+    const self: Record<string, any> = {
+      connect: () => Promise.resolve(self),
+      on: () => self,
+      withTypeMapping: () => makeClient(true),
+      get: async (key: string) => {
+        const v = store.get(key);
+        if (v === undefined) return null;
+        return bufferMode ? v : v.toString('binary');
+      },
+      set: async (key: string, value: unknown, options?: { NX?: boolean; XX?: boolean }) => {
+        const exists = store.has(key);
+        if (options?.NX && exists) return null;
+        if (options?.XX && !exists) return null;
+        store.set(key, toBuffer(value));
+        return 'OK';
+      },
+      del: async (key: string) => (store.delete(key) ? 1 : 0),
+      unlink: async (key: string) => (store.delete(key) ? 1 : 0),
+      eval: async (_script: string, opts: { keys: string[] }) => {
+        const key = opts.keys[0];
+        if (store.has(key)) return 0;
+        store.set(key, Buffer.from('1'));
+        return 1;
+      },
+      scanIterator: async function* () {
+        /* unused */
+      },
+    };
+    return self;
+  };
+
+  return {
+    createClient: () => makeClient(false),
+    createCluster: () => makeClient(false),
+    createSentinel: () => makeClient(false),
+    RESP_TYPES: { BLOB_STRING: 36 },
+  };
+});
+
+import { createCacheBuilders } from '../cached-array';
+import { createCacheRedis, PACKED_CODEC_UNNAMED_CACHE } from '../client';
+import type { RedisKeyTemplateCache } from '../client';
+import { compressPacked } from '../packed-compression';
+
+const redis = createCacheRedis();
+
+type Observation = { op: string; cache_name: string; seconds: number };
+let observed: Observation[] = [];
+
+/**
+ * Stand-in for what `src/server/prom/client.ts` publishes on globalThis. Only the handle under
+ * test is populated: the client reads each handle independently, so an over-complete fake would
+ * hide a wiring mistake behind a shape that production does not have to have.
+ */
+function installBridge() {
+  (globalThis as unknown as { __civitaiRedisMetrics?: unknown }).__civitaiRedisMetrics = {
+    packedCodecDuration: {
+      observe: (labels: { op: string; cache_name: string }, value: number) =>
+        observed.push({ op: labels.op, cache_name: labels.cache_name, seconds: value }),
+    },
+  };
+}
+
+function removeBridge() {
+  delete (globalThis as unknown as { __civitaiRedisMetrics?: unknown }).__civitaiRedisMetrics;
+}
+
+// Distinct, non-overlapping label values so a mutant that hardcodes or swaps one is visible.
+// None of them equals PACKED_CODEC_UNNAMED_CACHE, which is asserted separately.
+const DIRECT_CACHE = 'packed:caches:test-codec-direct';
+const BUILDER_CACHE = 'packed:caches:test-codec-builder' as RedisKeyTemplateCache;
+const KEY = 'packed:caches:test-codec-direct:v1' as RedisKeyTemplateCache;
+const KEY_LEGACY = 'packed:caches:test-codec-direct:v2' as RedisKeyTemplateCache;
+
+// Redundant payload: brotli must produce a genuinely smaller, sentinel-tagged value.
+const blob = 'prompt, masterpiece, highly detailed, '.repeat(120);
+const record = { id: 7, blob, cachedAt: 1_700_000_000_000 };
+
+beforeEach(() => {
+  store.clear();
+  observed = [];
+  installBridge();
+});
+
+describe('packed codec metrics — write path', () => {
+  it('a compressed set observes exactly one compress sample under the given cache_name', async () => {
+    await redis.packed.set(KEY, record, undefined, {
+      compress: true,
+      cacheName: DIRECT_CACHE,
+    });
+
+    expect(observed).toEqual([
+      { op: 'compress', cache_name: DIRECT_CACHE, seconds: expect.any(Number) },
+    ]);
+  });
+
+  it('an UNCOMPRESSED set observes nothing (no codec ran)', async () => {
+    await redis.packed.set(KEY, record);
+    expect(observed).toEqual([]);
+  });
+});
+
+describe('packed codec metrics — read path', () => {
+  it('a compressed get observes exactly one decompress sample under the given cache_name', async () => {
+    store.set(KEY, await compressPacked(Buffer.from(pack(record))));
+    observed = [];
+
+    const got = await redis.packed.get<typeof record>(KEY, {
+      compress: true,
+      cacheName: DIRECT_CACHE,
+    });
+
+    expect(got).toEqual(record); // the read still works
+    expect(observed).toEqual([
+      { op: 'decompress', cache_name: DIRECT_CACHE, seconds: expect.any(Number) },
+    ]);
+  });
+
+  // 🔴 The legacy pre-compression value is a sentinel check and a return, not a codec call.
+  // Counting it would make the histogram report the cost of NOT decompressing.
+  it('a LEGACY (uncompressed) value read through the compress-aware get observes nothing', async () => {
+    store.set(KEY_LEGACY, Buffer.from(pack(record)));
+
+    const got = await redis.packed.get<typeof record>(KEY_LEGACY, {
+      compress: true,
+      cacheName: DIRECT_CACHE,
+    });
+
+    expect(got).toEqual(record); // back-compat decode still works
+    expect(observed).toEqual([]);
+  });
+
+  it('a compressed mGet observes one decompress per COMPRESSED value only', async () => {
+    store.set(KEY, await compressPacked(Buffer.from(pack(record))));
+    store.set(KEY_LEGACY, Buffer.from(pack(record))); // legacy sibling in the same batch
+    observed = [];
+
+    const got = await redis.packed.mGet<typeof record>([KEY, KEY_LEGACY], {
+      compress: true,
+      cacheName: DIRECT_CACHE,
+    });
+
+    expect(got).toEqual([record, record]); // both decode
+    expect(observed).toEqual([
+      { op: 'decompress', cache_name: DIRECT_CACHE, seconds: expect.any(Number) },
+    ]);
+  });
+
+  it('an UNCOMPRESSED get observes nothing', async () => {
+    await redis.packed.set(KEY, record);
+    observed = [];
+    await redis.packed.get<typeof record>(KEY);
+    expect(observed).toEqual([]);
+  });
+});
+
+describe('packed codec metrics — labels and wiring', () => {
+  it('falls back to the explicit unnamed-cache label when no cacheName is given', async () => {
+    await redis.packed.set(KEY, record, undefined, { compress: true });
+    expect(observed.map((o) => o.cache_name)).toEqual([PACKED_CODEC_UNNAMED_CACHE]);
+  });
+
+  it('does not throw when the app has published no metrics bridge', async () => {
+    removeBridge();
+    await expect(
+      redis.packed.set(KEY, record, undefined, { compress: true, cacheName: DIRECT_CACHE })
+    ).resolves.toBeDefined();
+    const got = await redis.packed.get<typeof record>(KEY, {
+      compress: true,
+      cacheName: DIRECT_CACHE,
+    });
+    expect(got).toEqual(record);
+    installBridge();
+  });
+
+  // The label must be the cache PREFIX. `createCachedObject` writes/reads `${key}:${id}`, so
+  // labelling with the per-id key would make `cache_name` unbounded — one series per cached id.
+  it('createCachedObject labels with the cache PREFIX, never the per-id key', async () => {
+    const noop = () => undefined;
+    const { createCachedObject } = createCacheBuilders({
+      redis,
+      defaultTtl: 300,
+      metrics: {
+        hit: noop,
+        miss: noop,
+        revalidate: noop,
+        failOpenDegraded: noop,
+        failOpenOriginFetch: noop,
+      },
+      logFailOpen: noop,
+      logRefreshError: noop,
+      log: noop,
+      clearByPattern: async () => undefined,
+    });
+    const cache = createCachedObject<{ id: number; blob: string }>({
+      key: BUILDER_CACHE,
+      idKey: 'id',
+      lookupFn: async (ids: number[]) =>
+        Object.fromEntries(ids.map((id) => [id, { id, blob }])) as Record<
+          string,
+          { id: number; blob: string }
+        >,
+      ttl: 3600,
+      compress: true,
+    });
+
+    await cache.fetch([11, 22]); // miss → lookup → compressed writes
+    const writeLabels = new Set(
+      observed.filter((o) => o.op === 'compress').map((o) => o.cache_name)
+    );
+    expect(writeLabels).toEqual(new Set([BUILDER_CACHE]));
+
+    observed = [];
+    await cache.fetch([11, 22]); // hit → compressed reads
+    const readLabels = new Set(
+      observed.filter((o) => o.op === 'decompress').map((o) => o.cache_name)
+    );
+    expect(readLabels).toEqual(new Set([BUILDER_CACHE]));
+    expect(observed.filter((o) => o.op === 'decompress')).toHaveLength(2);
+  });
+});

--- a/packages/civitai-redis/src/__tests__/packed-codec-timing.test.ts
+++ b/packages/civitai-redis/src/__tests__/packed-codec-timing.test.ts
@@ -1,0 +1,115 @@
+import { pack } from 'msgpackr';
+import { describe, expect, it } from 'vitest';
+import {
+  PACKED_BROTLI_SENTINEL,
+  compressPacked,
+  decompressPacked,
+  type PackedCodecTimer,
+} from '../packed-compression';
+
+/**
+ * Unit coverage for the codec's OWN timing contract (the `civitai_app_packed_codec_duration_seconds`
+ * histogram is fed from these callbacks — see ../client for the prom wiring, and
+ * ./packed-codec-metrics.test.ts for the end-to-end seam).
+ *
+ * Why the timing has to be measured HERE rather than inferred from anything already present:
+ * the codec is `promisify(zlib.brotli*)`, so it executes on the libuv threadpool with no JS
+ * stack — a V8 CPU profile contains no `brotli*` frame at all. And the redis command histogram
+ * closes at the round trip, before decode; a compressed payload is also smaller on the wire, so
+ * that histogram gets BETTER as this codec gets more expensive.
+ *
+ * The contract pinned below:
+ *   - compress always records exactly one `compress` sample,
+ *   - decompress records exactly one `decompress` sample ONLY when brotli actually ran,
+ *   - the LEGACY raw-msgpack passthrough records NOTHING (see the test for why that matters),
+ *   - the recorded value is in SECONDS, bounded above by the caller's own wall clock.
+ */
+
+type Sample = { op: 'compress' | 'decompress'; seconds: number };
+
+function recorder() {
+  const samples: Sample[] = [];
+  const timer: PackedCodecTimer = (op, seconds) => samples.push({ op, seconds });
+  return { samples, timer };
+}
+
+// Real redundancy so brotli has measurable work to do — a few random bytes would compress in
+// well under the clock's resolution and make the bounds assertions a coin flip.
+const repetitive = Buffer.from(
+  pack({
+    data: {
+      tensors: Array.from(
+        { length: 4000 },
+        (_, i) => `model.diffusion_model.blocks.${i}.attn.to_q.weight`
+      ),
+    },
+    cachedAt: 1_700_000_000_000,
+  })
+);
+
+describe('packed codec timing callback', () => {
+  it('compressPacked records exactly one compress sample', async () => {
+    const { samples, timer } = recorder();
+    await compressPacked(repetitive, timer);
+    expect(samples.map((s) => s.op)).toEqual(['compress']);
+  });
+
+  it('decompressPacked records exactly one decompress sample when brotli actually ran', async () => {
+    const { samples, timer } = recorder();
+    const compressed = await compressPacked(repetitive);
+    expect(compressed[0]).toBe(PACKED_BROTLI_SENTINEL); // precondition: this IS the codec path
+    await decompressPacked(compressed, timer);
+    expect(samples.map((s) => s.op)).toEqual(['decompress']);
+  });
+
+  // 🔴 THE ONE THAT CHANGES WHAT THE NUMBER MEANS. `decompressPacked` returns a legacy
+  // (pre-compression) value untouched after a single byte comparison. Recording those as
+  // `decompress` observations would fill the histogram with near-zero samples measuring the cost
+  // of NOT decompressing, dragging p50/p95 toward zero — the metric would then answer "how often
+  // is this cache still legacy", which is not the question it exists for.
+  it('decompressPacked records NOTHING for a legacy raw-msgpack value (no sentinel)', async () => {
+    const { samples, timer } = recorder();
+    const legacy = Buffer.from(pack({ data: { hello: 'world' }, cachedAt: 1 }));
+    expect(legacy[0]).not.toBe(PACKED_BROTLI_SENTINEL); // precondition: this is the passthrough
+    const out = await decompressPacked(legacy, timer);
+    expect(Buffer.compare(out, legacy)).toBe(0); // passthrough still correct
+    expect(samples).toEqual([]);
+  });
+
+  it('decompressPacked records NOTHING for an empty buffer', async () => {
+    const { samples, timer } = recorder();
+    await decompressPacked(Buffer.alloc(0), timer);
+    expect(samples).toEqual([]);
+  });
+
+  // SECONDS, not milliseconds — prom convention, and the histogram's buckets are seconds. Bounded
+  // against the caller's OWN wall clock rather than a fixed threshold, so it is load-independent:
+  // a millisecond value would exceed the elapsed-seconds bound by ~1000x on any machine.
+  it('records SECONDS: 0 < sample <= the caller-observed elapsed time, both ops', async () => {
+    const { samples, timer } = recorder();
+
+    const compressStart = performance.now();
+    const compressed = await compressPacked(repetitive, timer);
+    const compressElapsedSeconds = (performance.now() - compressStart) / 1000;
+
+    const decompressStart = performance.now();
+    await decompressPacked(compressed, timer);
+    const decompressElapsedSeconds = (performance.now() - decompressStart) / 1000;
+
+    const compressSample = samples.find((s) => s.op === 'compress');
+    const decompressSample = samples.find((s) => s.op === 'decompress');
+    expect(compressSample, 'a compress sample was recorded').toBeDefined();
+    expect(decompressSample, 'a decompress sample was recorded').toBeDefined();
+
+    expect(compressSample!.seconds).toBeGreaterThan(0);
+    expect(compressSample!.seconds).toBeLessThanOrEqual(compressElapsedSeconds);
+    expect(decompressSample!.seconds).toBeGreaterThan(0);
+    expect(decompressSample!.seconds).toBeLessThanOrEqual(decompressElapsedSeconds);
+  });
+
+  it('is optional: both functions still work with no timer passed', async () => {
+    const compressed = await compressPacked(repetitive);
+    const restored = await decompressPacked(compressed);
+    expect(Buffer.compare(restored, repetitive)).toBe(0);
+  });
+});

--- a/packages/civitai-redis/src/cached-array.ts
+++ b/packages/civitai-redis/src/cached-array.ts
@@ -76,13 +76,13 @@ type PackedClient = {
   packed: {
     mGet<T>(
       keys: RedisKeyTemplateCache[],
-      packedOptions?: { compress?: boolean }
+      packedOptions?: { compress?: boolean; cacheName?: string }
     ): Promise<(T | null)[]>;
     set<T>(
       key: RedisKeyTemplateCache,
       value: T,
       options?: { EX?: number; NX?: boolean; XX?: boolean },
-      packedOptions?: { compress?: boolean }
+      packedOptions?: { compress?: boolean; cacheName?: string }
     ): Promise<unknown>;
   };
   del(key: RedisKeyTemplateCache | RedisKeyTemplateCache[]): Promise<unknown>;
@@ -171,7 +171,11 @@ export function createCacheBuilders(deps: CacheBuilderDeps) {
     // Resolved ONCE and passed to every redis.packed read/write below. Keeping a single object
     // (rather than re-spelling `{ compress }` per call site) makes the symmetry contract in
     // CachedLookupOptions.compress mechanically obvious: one binding, nine consumers.
-    const packedOptions = { compress } as const;
+    // `cacheName` rides along on the same binding: it is the `cache_name` label on the codec
+    // duration histogram, and `key` is exactly the value this module already reports to
+    // metrics.hit/miss as cache_name — one scheme, not two. Bounded by construction (it is the
+    // cache prefix, not `${key}:${id}`), and observational only.
+    const packedOptions = { compress, cacheName: key } as const;
     // Holds the FINAL resolved per-id value — post-appendFn, cachedAt stripped — so an L1 hit is
     // byte-identical to what the Redis path returns and needs no further decoration.
     // Driven with get/set rather than its wrapping .fetch — the access pattern here is a batch mGet,

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -691,7 +691,17 @@ function parseClusterNodes(fallbackUrl: string): { url: string }[] {
 // never drags prom-client's fs/cluster requires into the client bundle. Undefined until the
 // app's prom module has loaded server-side (always true by the time real commands run);
 // instrumentation simply no-ops until then (leak-free).
-type RedisMetricsBridge = {
+//
+// 🔴 EXPORTED SO THE PUBLISHER CAN BE CHECKED AGAINST IT — a type export only, erased at build, so
+// it adds nothing to any bundle. Every read below is optional-chained, so a handle THIS package
+// reads and the app never publishes is a metric that is silently dead: no throw, no warning, and a
+// permanently empty series that looks exactly like "the feature is off". No runtime test on either
+// side can see it — this package's own suite installs a FAKE bridge (rightly: it is testing the
+// client, not the app), and the app's bridge test compares the published object against a
+// hand-written ledger that the same person edits. So the app pins its published object against
+// this type at COMPILE time instead: see the `redisMetricsBridge` const in
+// `src/server/prom/client.ts`. Adding a field here without publishing it there is a type error.
+export type RedisMetricsBridge = {
   redisCommandsInflight: {
     inc: (labels: { client: string }) => void;
     dec: (labels: { client: string }) => void;
@@ -768,13 +778,18 @@ export const PACKED_CODEC_UNNAMED_CACHE = 'unknown';
  * an unthrottled line would be per-cache-read log spam).
  *
  * Two honest limits on that breadcrumb. It goes to `log()`, this module's GENERAL-PURPOSE debug
- * logger — the same one used for topology, deadline and fail-open lines, called with 35 distinct
- * messages in this file, so a distinct line here is unremarkable. (An earlier revision of this
- * comment claimed the opposite — that the logger on this path "reports corrupt entry" and so
+ * logger — the same one used for topology, deadline and fail-open lines, among many messages in
+ * this file, so a distinct line here is unremarkable. NO COUNT IS ASSERTED, deliberately: this
+ * sentence has carried a figure twice and been wrong both times ("~20", then "35", the second
+ * landing in a commit made solely to correct the first and not surviving its own head either). The
+ * only claim the number ever supported is that this logger already carries plenty of unrelated
+ * traffic, which needs no figure — while a count of log sites drifts on every edit and nothing
+ * checks it, so it is exactly the kind of fact a comment should not assert. (An earlier revision
+ * claimed the opposite thing too — that the logger on this path "reports corrupt entry" and so
  * could not be used. That was simply false: the corrupt-entry line is `Packed (compressed) unpack
- * failed, evicting bad cache entry` in `safeUnpackCompressed` below, one of that logger's 35
- * messages — not the logger's identity.) But `log()` defaults to a NO-OP and is only wired by the
- * app shim (`createLogger('redis')`), itself gated on the app's LOGGING config — so this is a
+ * failed, evicting bad cache entry` in `safeUnpackCompressed` below, one message among that
+ * logger's many — not the logger's identity.) But `log()` defaults to a NO-OP and is only wired by
+ * the app shim (`createLogger('redis')`), itself gated on the app's LOGGING config — so this is a
  * breadcrumb for whoever goes looking, not an alert. Nothing here pages anyone.
  */
 
@@ -793,14 +808,28 @@ function packedCodecTimer(cacheName?: string): PackedCodecTimer {
       // here would be a deleted cache entry (see above). So it is swallowed — but counted, and
       // reported at most once a minute so the gap is attributable instead of mysterious.
       packedCodecObserveFailures += 1;
-      const now = Date.now();
-      if (now - packedCodecObserveLastLoggedAt >= PACKED_CODEC_OBSERVE_LOG_INTERVAL_MS) {
-        packedCodecObserveLastLoggedAt = now;
-        log(
-          `packed codec metrics observe FAILED and was swallowed — packed_codec_duration_seconds is losing samples [op=${op}, cache_name=${cache_name}, failures=${packedCodecObserveFailures}]: ${
-            err instanceof Error ? err.message : String(err)
-          }`
-        );
+      // 🔴 THE BREADCRUMB IS ITSELF WRAPPED, so this catch stays TOTAL. Everything between here and
+      // the closing brace can throw: `log` is INJECTED BY THE APP and is therefore arbitrary code,
+      // and `String(err)` invokes a `toString`/`Symbol.toPrimitive` on a value we did not
+      // construct. A throw escaping from inside this handler escapes into `safeUnpackCompressed`'s
+      // catch exactly as the original would have, and that catch UNLINKS THE KEY — so an
+      // unprotected line in the REPORTING path reintroduces the whole observability-becomes-cache-
+      // eviction bug the outer catch exists to stop, one layer further in and on a rarer input.
+      // Low reachability is not totality; the nesting is what makes it total.
+      try {
+        const now = Date.now();
+        if (now - packedCodecObserveLastLoggedAt >= PACKED_CODEC_OBSERVE_LOG_INTERVAL_MS) {
+          packedCodecObserveLastLoggedAt = now;
+          log(
+            `packed codec metrics observe FAILED and was swallowed — packed_codec_duration_seconds is losing samples [op=${op}, cache_name=${cache_name}, failures=${packedCodecObserveFailures}]: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      } catch {
+        // Reporting the swallow must never be worse than the swallow itself, and there is nothing
+        // left to report TO — the reporter is what just failed. The failure count above is still
+        // incremented, so a later successful line carries it.
       }
     }
   };

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -21,7 +21,7 @@ import {
   recordClusterCommandSettle,
   resetClusterDeadlineHits,
 } from './cluster-deadline-hits';
-import { compressPacked, decompressPacked } from './packed-compression';
+import { compressPacked, decompressPacked, type PackedCodecTimer } from './packed-compression';
 import { applyCacheKeyPrefix } from './cache-key-prefix';
 
 export { CACHE_KEY_NAMESPACE, CACHE_KEY_PREFIX, prefixCacheKey } from './cache-key-prefix';
@@ -66,6 +66,17 @@ interface ClientCommandOptions extends QueueCommandOptions {
 // };
 // type CommandType = CommandOptions<ClientCommandOptions>;
 type CommandType = ClientCommandOptions;
+
+/**
+ * Per-call options for the `packed` codec (msgpack, plus opt-in brotli).
+ *
+ * `compress` is BEHAVIOURAL and must be symmetric across a cache's reads and writes (see the
+ * SENTINEL SCOPE note in ./packed-compression). `cacheName` is purely OBSERVATIONAL — it names
+ * the `cache_name` label on the codec duration histogram and changes no behaviour. Give it the
+ * cache PREFIX (`packed:caches:image-meta`), the same value the cache hit/miss counters carry —
+ * never a per-id key, which would be unbounded label cardinality.
+ */
+export type PackedOptions = { compress?: boolean; cacheName?: string };
 
 interface CustomRedisClient<K extends RedisKeyTemplates>
   extends Omit<
@@ -114,13 +125,16 @@ interface CustomRedisClient<K extends RedisKeyTemplates>
     // `packedOptions.compress` opts the READ into the compress-aware decode path
     // (sentinel-detect + brotli-decompress), SYMMETRIC with set's compress. Only enable
     // for keys written with compress — see the SENTINEL SCOPE note in packed-compression.
-    get<T>(key: K, packedOptions?: { compress?: boolean }): Promise<T | null>;
+    // `packedOptions.cacheName` is metrics-only: the `cache_name` label on the codec
+    // duration histogram. It must be the cache PREFIX (`packed:caches:image-meta`), never
+    // a per-id key, and it matches the `cache_name` the cache hit/miss counters carry.
+    get<T>(key: K, packedOptions?: PackedOptions): Promise<T | null>;
     // Wrapped to avoid CROSSSLOT errors - fetches keys individually with Promise.all.
     // `packedOptions.compress` opts the READ into the compress-aware decode path, exactly as
     // `get` does — REQUIRED for any caller whose writes compress, since mGet is the batched
     // read counterpart of set. Without it a compressed value decodes via the general msgpack
     // path, throws, and is EVICTED — a permanent miss+evict loop, not a soft failure.
-    mGet<T>(keys: K[], packedOptions?: { compress?: boolean }): Promise<(T | null)[]>;
+    mGet<T>(keys: K[], packedOptions?: PackedOptions): Promise<(T | null)[]>;
     // `packedOptions.compress` opts the value into brotli compression at rest (sentinel-
     // tagged; reads decode both compressed and legacy-uncompressed values transparently).
     // Only safe for callers that store wrapper objects, never bare scalars — see the
@@ -132,7 +146,7 @@ interface CustomRedisClient<K extends RedisKeyTemplates>
       key: K,
       value: T,
       setOptions?: SetOptions,
-      packedOptions?: { compress?: boolean }
+      packedOptions?: PackedOptions
     ): Promise<unknown>;
     // mSet still disabled - sets are more complex with different argument formats
     // mSet(records: Record<K, unknown>, setOptions?: SetOptions): Promise<void>;
@@ -676,7 +690,18 @@ type RedisMetricsBridge = {
     inc: (labels: { client: string }) => void;
     dec: (labels: { client: string }) => void;
   };
+  // NOTE ON SCOPE: this histogram closes when the redis ROUND TRIP closes — inside the command
+  // wrapper's done() below. It deliberately does NOT include the packed decode (msgpack unpack,
+  // and brotli-decompress on the compress-aware read paths), which runs afterwards in
+  // client.packed.get/mGet. Do not read it as a decode cost: a compressed value is SMALLER on
+  // the wire, so enabling compression makes this histogram look BETTER while adding codec work
+  // it cannot see. `packedCodecDuration` is the metric for that.
   redisCommandDuration: { observe: (labels: { client: string }, value: number) => void };
+  // Wall time of the brotli codec on the compress-aware packed paths, by `op` and `cache_name`.
+  // Optional (like the newer handles below) so an app that has not published it still works.
+  packedCodecDuration?: {
+    observe: (labels: { op: 'compress' | 'decompress'; cache_name: string }, value: number) => void;
+  };
   sysredisSentinelTopologyChangesCounter: {
     labels: (labels: Record<string, string>) => { inc: () => void };
   };
@@ -700,6 +725,25 @@ type RedisMetricsBridge = {
 function getRedisMetrics(): RedisMetricsBridge | undefined {
   return (globalThis as unknown as { __civitaiRedisMetrics?: RedisMetricsBridge })
     .__civitaiRedisMetrics;
+}
+
+/**
+ * Label value used when a compress-aware call site did not name its cache. Not every packed
+ * caller has a bounded name to give (an ad-hoc key would be unbounded cardinality), and prom
+ * needs the label present on every sample of the series, so it is spelled explicitly rather
+ * than left off.
+ */
+export const PACKED_CODEC_UNNAMED_CACHE = 'unknown';
+
+/**
+ * Build the codec timing callback handed to compressPacked/decompressPacked. The bridge is read
+ * PER CALL (not captured once) because it is published by the app's prom module after this
+ * module loads — capturing it at client-construction time would pin `undefined` forever.
+ */
+function packedCodecTimer(cacheName?: string): PackedCodecTimer {
+  const cache_name = cacheName ?? PACKED_CODEC_UNNAMED_CACHE;
+  return (op, seconds) =>
+    getRedisMetrics()?.packedCodecDuration?.observe({ op, cache_name }, seconds);
 }
 
 /**
@@ -830,6 +874,10 @@ export function instrumentCommands(
         dec = true;
       }
       metrics?.redisCommandsInflight.dec(labels);
+      // ROUND TRIP ONLY — this closes here, so it excludes the packed DECODE (msgpack unpack, and
+      // brotli-decompress on the compress-aware paths), which runs afterwards in
+      // client.packed.get/mGet. Not changed deliberately: the codec has its own histogram
+      // (packedCodecDuration). See the note on redisCommandDuration in RedisMetricsBridge.
       metrics?.redisCommandDuration.observe(labels, durationMs / 1000);
       // SELF-HEAL SIGNAL (cluster client only): record a wedge "hit" whenever a cluster command's
       // OBSERVED settle duration reaches the slow threshold — the SAME settle-time observation as
@@ -1314,10 +1362,11 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
   // throw is treated as a cache miss (null) and evicts the bad entry.
   const safeUnpackCompressed = async <T>(
     value: Buffer,
-    evict: () => Promise<unknown>
+    evict: () => Promise<unknown>,
+    cacheName?: string
   ): Promise<T | null> => {
     try {
-      return unpack(await decompressPacked(value)) as T;
+      return unpack(await decompressPacked(value, packedCodecTimer(cacheName))) as T;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log(`Packed (compressed) unpack failed, evicting bad cache entry: ${msg}`);
@@ -1329,20 +1378,20 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
   };
 
   client.packed = {
-    async get<T>(key: K, packedOptions?: { compress?: boolean }): Promise<T | null> {
+    async get<T>(key: K, packedOptions?: PackedOptions): Promise<T | null> {
       const result = await bufferClient.get<Buffer>(key);
       if (!result) return null;
       // Only the opt-in compress-aware read attempts sentinel-detect + brotli-decompress
       // (symmetric with `set(..., { compress: true })`). Non-compress callers use the
       // general decode path verbatim, so no decompression ever runs for them.
       if (packedOptions?.compress) {
-        return safeUnpackCompressed<T>(result, () => client.unlink(key));
+        return safeUnpackCompressed<T>(result, () => client.unlink(key), packedOptions.cacheName);
       }
       return safeUnpack<T>(result, () => client.unlink(key));
     },
 
     // Wrapped to avoid CROSSSLOT errors - fetches keys individually with Promise.all
-    async mGet<T>(keys: K[], packedOptions?: { compress?: boolean }): Promise<(T | null)[]> {
+    async mGet<T>(keys: K[], packedOptions?: PackedOptions): Promise<(T | null)[]> {
       const results = await Promise.all(keys.map((key) => bufferClient.get<Buffer>(key)));
       // SYMMETRIC with `set(..., { compress: true })`, same as the single-key `get` above.
       // The batched read is the one a per-id cache (createCachedArray) actually uses, so a
@@ -1350,7 +1399,13 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
       if (packedOptions?.compress) {
         return Promise.all(
           results.map((result, i) =>
-            result ? safeUnpackCompressed<T>(result, () => client.unlink(keys[i])) : null
+            result
+              ? safeUnpackCompressed<T>(
+                  result,
+                  () => client.unlink(keys[i]),
+                  packedOptions.cacheName
+                )
+              : null
           )
         );
       }
@@ -1366,12 +1421,14 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
       key: K,
       value: T,
       options?: SetOptions,
-      packedOptions?: { compress?: boolean }
+      packedOptions?: PackedOptions
     ): Promise<unknown> {
       const packed = pack(value);
       // Opt-in brotli (sentinel-tagged), async so the codec runs on the libuv threadpool
       // and never blocks the event loop. The symmetric read is get(key, { compress: true }).
-      const payload = packedOptions?.compress ? await compressPacked(packed) : packed;
+      const payload = packedOptions?.compress
+        ? await compressPacked(packed, packedCodecTimer(packedOptions.cacheName))
+        : packed;
       return client.set(key, payload, options);
     },
 

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -703,7 +703,9 @@ type RedisMetricsBridge = {
   // the wire, so enabling compression makes this histogram look BETTER while adding codec work
   // it cannot see. `packedCodecDuration` is the metric for that.
   redisCommandDuration: { observe: (labels: { client: string }, value: number) => void };
-  // Wall time of the brotli codec on the compress-aware packed paths, by `op` and `cache_name`.
+  // Duration of the brotli codec on the compress-aware packed paths, by `op` and `cache_name`.
+  // Wall clock as the caller sees it — threadpool queue wait and event-loop delay included, so
+  // wider than codec work; see PackedCodecTimer in ./packed-compression.
   // Optional (like the newer handles below) so an app that has not published it still works.
   packedCodecDuration?: {
     observe: (labels: { op: 'compress' | 'decompress'; cache_name: string }, value: number) => void;
@@ -757,18 +759,60 @@ export const PACKED_CODEC_UNNAMED_CACHE = 'unknown';
  *
  * Guarding here rather than at the three call sites is deliberate: one predicate, both ops, every
  * caller — a second copy is how the two drift apart.
+ *
+ * 🔴 AND IT LEAVES A BREADCRUMB, because swallowing silently is its own failure. A bridge whose
+ * `observe()` throws on every call produces a histogram that never has data — which is EXACTLY what
+ * "no cache opted into compress" looks like, on the one metric that exists to answer whether
+ * compression is worth its cost. A reassuring zero is indistinguishable from a probe wired to
+ * nothing, so the catch says so once, rate-limited (a throwing bridge throws on every codec call;
+ * an unthrottled line would be per-cache-read log spam).
+ *
+ * Two honest limits on that breadcrumb. It goes to `log()`, this module's GENERAL-PURPOSE debug
+ * logger — the same one used for topology, deadline and fail-open lines, called with ~20 distinct
+ * messages, so a distinct line here is unremarkable. (An earlier revision of this comment claimed
+ * the opposite — that the logger on this path "reports corrupt entry" and so could not be used.
+ * That was simply false: the corrupt-entry line is one of this logger's many messages, not the
+ * logger's identity.) But `log()` defaults to a NO-OP and is only wired by the app shim
+ * (`createLogger('redis')`), which is itself gated on the app's LOGGING config — so this is a
+ * breadcrumb for whoever goes looking, not an alert. Nothing here pages anyone.
  */
+
+/** At most one observe-failure line per this many ms, per process. */
+const PACKED_CODEC_OBSERVE_LOG_INTERVAL_MS = 60_000;
+let packedCodecObserveFailures = 0;
+let packedCodecObserveLastLoggedAt = 0;
+
 function packedCodecTimer(cacheName?: string): PackedCodecTimer {
   const cache_name = cacheName ?? PACKED_CODEC_UNNAMED_CACHE;
   return (op, seconds) => {
     try {
       getRedisMetrics()?.packedCodecDuration?.observe({ op, cache_name }, seconds);
-    } catch {
+    } catch (err) {
       // Metrics must never fail a read or a write. A lost sample is a gap in a graph; a throw
-      // here would be a deleted cache entry (see above). Deliberately silent — the logger on this
-      // path is the one that reports "corrupt entry", which is precisely the wrong claim.
+      // here would be a deleted cache entry (see above). So it is swallowed — but counted, and
+      // reported at most once a minute so the gap is attributable instead of mysterious.
+      packedCodecObserveFailures += 1;
+      const now = Date.now();
+      if (now - packedCodecObserveLastLoggedAt >= PACKED_CODEC_OBSERVE_LOG_INTERVAL_MS) {
+        packedCodecObserveLastLoggedAt = now;
+        log(
+          `packed codec metrics observe FAILED and was swallowed — packed_codec_duration_seconds is losing samples [op=${op}, cache_name=${cache_name}, failures=${packedCodecObserveFailures}]: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
     }
   };
+}
+
+/**
+ * Test seam for the rate-limited observe-failure breadcrumb above: the throttle state is
+ * module-scoped and per-process, so a suite that exercises the catch twice cannot otherwise tell
+ * "throttled" from "never logged". Not used by production code.
+ */
+export function __resetPackedCodecObserveFailureState() {
+  packedCodecObserveFailures = 0;
+  packedCodecObserveLastLoggedAt = 0;
 }
 
 /**

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -768,12 +768,13 @@ export const PACKED_CODEC_UNNAMED_CACHE = 'unknown';
  * an unthrottled line would be per-cache-read log spam).
  *
  * Two honest limits on that breadcrumb. It goes to `log()`, this module's GENERAL-PURPOSE debug
- * logger — the same one used for topology, deadline and fail-open lines, called with ~20 distinct
- * messages, so a distinct line here is unremarkable. (An earlier revision of this comment claimed
- * the opposite — that the logger on this path "reports corrupt entry" and so could not be used.
- * That was simply false: the corrupt-entry line is one of this logger's many messages, not the
- * logger's identity.) But `log()` defaults to a NO-OP and is only wired by the app shim
- * (`createLogger('redis')`), which is itself gated on the app's LOGGING config — so this is a
+ * logger — the same one used for topology, deadline and fail-open lines, called with 35 distinct
+ * messages in this file, so a distinct line here is unremarkable. (An earlier revision of this
+ * comment claimed the opposite — that the logger on this path "reports corrupt entry" and so
+ * could not be used. That was simply false: the corrupt-entry line is `Packed (compressed) unpack
+ * failed, evicting bad cache entry` in `safeUnpackCompressed` below, one of that logger's 35
+ * messages — not the logger's identity.) But `log()` defaults to a NO-OP and is only wired by the
+ * app shim (`createLogger('redis')`), itself gated on the app's LOGGING config — so this is a
  * breadcrumb for whoever goes looking, not an alert. Nothing here pages anyone.
  */
 

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -73,8 +73,14 @@ type CommandType = ClientCommandOptions;
  * `compress` is BEHAVIOURAL and must be symmetric across a cache's reads and writes (see the
  * SENTINEL SCOPE note in ./packed-compression). `cacheName` is purely OBSERVATIONAL — it names
  * the `cache_name` label on the codec duration histogram and changes no behaviour. Give it the
- * cache PREFIX (`packed:caches:image-meta`), the same value the cache hit/miss counters carry —
- * never a per-id key, which would be unbounded label cardinality.
+ * cache PREFIX (`packed:caches:image-meta`) — never a per-id key, which would be unbounded label
+ * cardinality.
+ *
+ * Whether that label JOINS to a cache's hit/miss counters depends on the caller, and only one of
+ * the two consumers joins: createCachedArray/createCachedObject pass their `key` both here and as
+ * the `cache_name` on cacheHitCounter/cacheMissCounter, so the values match by construction;
+ * `fetchThroughCache` emits no hit/miss counters at all, so for those call sites the label
+ * separates caches from each other but joins to nothing.
  */
 export type PackedOptions = { compress?: boolean; cacheName?: string };
 
@@ -127,7 +133,7 @@ interface CustomRedisClient<K extends RedisKeyTemplates>
     // for keys written with compress — see the SENTINEL SCOPE note in packed-compression.
     // `packedOptions.cacheName` is metrics-only: the `cache_name` label on the codec
     // duration histogram. It must be the cache PREFIX (`packed:caches:image-meta`), never
-    // a per-id key, and it matches the `cache_name` the cache hit/miss counters carry.
+    // a per-id key. See PackedOptions for which callers it joins to the hit/miss counters.
     get<T>(key: K, packedOptions?: PackedOptions): Promise<T | null>;
     // Wrapped to avoid CROSSSLOT errors - fetches keys individually with Promise.all.
     // `packedOptions.compress` opts the READ into the compress-aware decode path, exactly as
@@ -739,11 +745,30 @@ export const PACKED_CODEC_UNNAMED_CACHE = 'unknown';
  * Build the codec timing callback handed to compressPacked/decompressPacked. The bridge is read
  * PER CALL (not captured once) because it is published by the app's prom module after this
  * module loads — capturing it at client-construction time would pin `undefined` forever.
+ *
+ * 🔴 THE try/catch IS LOAD-BEARING, not defensive habit. This callback runs INSIDE
+ * `decompressPacked`, which runs inside `safeUnpackCompressed`'s try — and that catch does not
+ * mean "something went wrong", it means "THE STORED BYTES ARE CORRUPT", so it logs, UNLINKS the
+ * key and returns null. Without this guard a prom fault (a duplicate-metric registration, a bad
+ * label value, an exhausted registry) would therefore turn a perfectly valid cache entry into a
+ * miss AND delete it, on every read, for as long as the fault lasted — an observability change
+ * silently becoming a cache-eviction bug. The compress side is milder but the same shape: a throw
+ * there escapes `packed.set` and fails the write.
+ *
+ * Guarding here rather than at the three call sites is deliberate: one predicate, both ops, every
+ * caller — a second copy is how the two drift apart.
  */
 function packedCodecTimer(cacheName?: string): PackedCodecTimer {
   const cache_name = cacheName ?? PACKED_CODEC_UNNAMED_CACHE;
-  return (op, seconds) =>
-    getRedisMetrics()?.packedCodecDuration?.observe({ op, cache_name }, seconds);
+  return (op, seconds) => {
+    try {
+      getRedisMetrics()?.packedCodecDuration?.observe({ op, cache_name }, seconds);
+    } catch {
+      // Metrics must never fail a read or a write. A lost sample is a gap in a graph; a throw
+      // here would be a deleted cache entry (see above). Deliberately silent — the logger on this
+      // path is the one that reports "corrupt entry", which is precisely the wrong claim.
+    }
+  };
 }
 
 /**

--- a/packages/civitai-redis/src/packed-compression.ts
+++ b/packages/civitai-redis/src/packed-compression.ts
@@ -46,14 +46,27 @@ const brotliDecompress = promisify(zlib.brotliDecompress);
 /**
  * Recorder for one codec call, in SECONDS (prom convention).
  *
- * 🔴 WHAT THE NUMBER ACTUALLY CONTAINS. The clock starts BEFORE the promisified call is enqueued
- * and stops when its callback resolves, so a sample is libuv threadpool QUEUE WAIT + codec work.
- * That is the right quantity for "what did compression cost this request", and it is deliberately
- * not CPU time: the value rises when the threadpool is busy with unrelated work (other brotli
- * calls, fs, dns, crypto) while the codec's own cost is unchanged. So read a rise as "the codec
- * PATH got slower", never as "brotli got more expensive", without a second signal to separate
- * them. Narrowing the window to the codec alone is not possible from JS — the enqueue and the
- * threadpool hand-off are both below the promisified boundary.
+ * 🔴 WHAT THE NUMBER ACTUALLY CONTAINS, and it is wider than "codec" in TWO directions. The clock
+ * starts BEFORE the promisified call is enqueued and stops at the `await` CONTINUATION on the JS
+ * thread — not when the threadpool finishes. So a sample is:
+ *   threadpool QUEUE WAIT + codec work + EVENT-LOOP DELAY before the continuation is delivered.
+ * Both of the non-codec terms are real and neither is small:
+ *   - queue wait rises when the threadpool is busy with unrelated work (other brotli calls, fs,
+ *     dns, crypto) while the codec's own cost is unchanged;
+ *   - event-loop delay is absorbed roughly 1:1, because the completion cannot be delivered while
+ *     the JS thread is busy. Measured: a 50 ms main-thread block held while a decompress was in
+ *     flight produced a 50.79 ms sample for a call that normally takes ~0.02 ms. A rise in this
+ *     histogram is therefore just as likely to be event-loop pressure as codec cost.
+ * And the FLOOR is dispatch, not codec: a 1-byte payload, with no real codec work to do,
+ * round-trips in ~11 µs p50 on one machine and ~22 µs on another, against a typical decompress of
+ * ~25-36 µs. So roughly half or more of a typical sample is the promise/threadpool hand-off. Do
+ * not read the low buckets as "what brotli cost"; they are mostly the cost of asking.
+ *
+ * That is still the right quantity for "what did compression cost this request", and it is
+ * deliberately not CPU time — but read a rise as "the codec PATH got slower", never as "brotli got
+ * more expensive", without a second signal (event-loop lag, threadpool depth) to separate them.
+ * Narrowing the window to the codec alone is not possible from JS: the enqueue, the threadpool
+ * hand-off and the continuation scheduling are all below the promisified boundary.
  *
  * WHY THE TIMING LIVES IN THIS MODULE rather than at the call sites: the codec is ASYNC, so
  * it runs on the libuv threadpool and never appears on the JS stack. A V8 CPU profile
@@ -74,7 +87,8 @@ export type PackedCodecTimer = (op: 'compress' | 'decompress', seconds: number) 
  * Brotli-compress an already-msgpack-packed Buffer and prepend the sentinel byte.
  *
  * `onTiming` (optional) receives the elapsed time of the compress call as this caller sees it —
- * threadpool queue wait included, so not CPU time; see PackedCodecTimer — labelled `compress`.
+ * threadpool queue wait AND event-loop delay included, so not CPU time and not codec-only; see
+ * PackedCodecTimer — labelled `compress`.
  */
 export async function compressPacked(packed: Buffer, onTiming?: PackedCodecTimer): Promise<Buffer> {
   const startedAt = performance.now();
@@ -96,7 +110,8 @@ export async function compressPacked(packed: Buffer, onTiming?: PackedCodecTimer
  * why the first-byte sentinel check is collision-free there.
  *
  * `onTiming` (optional) is called ONLY when a brotli-decompress actually ran, and records elapsed
- * time as this caller sees it — threadpool queue wait included; see PackedCodecTimer. The legacy
+ * time as this caller sees it — threadpool queue wait AND event-loop delay included; see
+ * PackedCodecTimer. The legacy
  * raw-msgpack passthrough deliberately records NOTHING: it is a sentinel check and a return,
  * not a codec call, and mixing those near-zero samples into the `decompress` histogram would
  * drag the quantiles toward "the cost of not decompressing" — a number that answers no

--- a/packages/civitai-redis/src/packed-compression.ts
+++ b/packages/civitai-redis/src/packed-compression.ts
@@ -44,7 +44,16 @@ const brotliCompress = promisify(zlib.brotliCompress);
 const brotliDecompress = promisify(zlib.brotliDecompress);
 
 /**
- * Wall-clock recorder for one codec call, in SECONDS (prom convention).
+ * Recorder for one codec call, in SECONDS (prom convention).
+ *
+ * 🔴 WHAT THE NUMBER ACTUALLY CONTAINS. The clock starts BEFORE the promisified call is enqueued
+ * and stops when its callback resolves, so a sample is libuv threadpool QUEUE WAIT + codec work.
+ * That is the right quantity for "what did compression cost this request", and it is deliberately
+ * not CPU time: the value rises when the threadpool is busy with unrelated work (other brotli
+ * calls, fs, dns, crypto) while the codec's own cost is unchanged. So read a rise as "the codec
+ * PATH got slower", never as "brotli got more expensive", without a second signal to separate
+ * them. Narrowing the window to the codec alone is not possible from JS — the enqueue and the
+ * threadpool hand-off are both below the promisified boundary.
  *
  * WHY THE TIMING LIVES IN THIS MODULE rather than at the call sites: the codec is ASYNC, so
  * it runs on the libuv threadpool and never appears on the JS stack. A V8 CPU profile
@@ -64,8 +73,8 @@ export type PackedCodecTimer = (op: 'compress' | 'decompress', seconds: number) 
 /**
  * Brotli-compress an already-msgpack-packed Buffer and prepend the sentinel byte.
  *
- * `onTiming` (optional) receives the wall time of the compress call itself, labelled
- * `compress`.
+ * `onTiming` (optional) receives the elapsed time of the compress call as this caller sees it —
+ * threadpool queue wait included, so not CPU time; see PackedCodecTimer — labelled `compress`.
  */
 export async function compressPacked(packed: Buffer, onTiming?: PackedCodecTimer): Promise<Buffer> {
   const startedAt = performance.now();
@@ -86,7 +95,8 @@ export async function compressPacked(packed: Buffer, onTiming?: PackedCodecTimer
  * Only the compress-aware read path calls this — see the SENTINEL SCOPE note above for
  * why the first-byte sentinel check is collision-free there.
  *
- * `onTiming` (optional) is called ONLY when a brotli-decompress actually ran. The legacy
+ * `onTiming` (optional) is called ONLY when a brotli-decompress actually ran, and records elapsed
+ * time as this caller sees it — threadpool queue wait included; see PackedCodecTimer. The legacy
  * raw-msgpack passthrough deliberately records NOTHING: it is a sentinel check and a return,
  * not a codec call, and mixing those near-zero samples into the `decompress` histogram would
  * drag the quantiles toward "the cost of not decompressing" — a number that answers no

--- a/packages/civitai-redis/src/packed-compression.ts
+++ b/packages/civitai-redis/src/packed-compression.ts
@@ -43,14 +43,39 @@ const PACKED_BROTLI_QUALITY = 6;
 const brotliCompress = promisify(zlib.brotliCompress);
 const brotliDecompress = promisify(zlib.brotliDecompress);
 
-/** Brotli-compress an already-msgpack-packed Buffer and prepend the sentinel byte. */
-export async function compressPacked(packed: Buffer): Promise<Buffer> {
+/**
+ * Wall-clock recorder for one codec call, in SECONDS (prom convention).
+ *
+ * WHY THE TIMING LIVES IN THIS MODULE rather than at the call sites: the codec is ASYNC, so
+ * it runs on the libuv threadpool and never appears on the JS stack. A V8 CPU profile
+ * therefore contains no `brotli*` frame at all — searching one for the codec returns zero,
+ * which reads as "free" rather than "unobservable". And the redis command histogram cannot
+ * stand in for it: that observation closes when the round trip does, while decode happens
+ * strictly after — plus a compressed payload is SMALLER, so the command histogram actually
+ * IMPROVES when the codec gets more expensive. This callback is the only signal that can
+ * answer "what does the codec cost".
+ *
+ * Injected rather than imported so this module (reachable from the client bundle via
+ * ./client) stays free of a static prom-client import; ./client passes a closure over the
+ * globalThis metrics bridge. Undefined = no-op, so nothing here depends on prom being loaded.
+ */
+export type PackedCodecTimer = (op: 'compress' | 'decompress', seconds: number) => void;
+
+/**
+ * Brotli-compress an already-msgpack-packed Buffer and prepend the sentinel byte.
+ *
+ * `onTiming` (optional) receives the wall time of the compress call itself, labelled
+ * `compress`.
+ */
+export async function compressPacked(packed: Buffer, onTiming?: PackedCodecTimer): Promise<Buffer> {
+  const startedAt = performance.now();
   const compressed = await brotliCompress(packed, {
     params: {
       [zlib.constants.BROTLI_PARAM_QUALITY]: PACKED_BROTLI_QUALITY,
       [zlib.constants.BROTLI_PARAM_SIZE_HINT]: packed.length,
     },
   });
+  onTiming?.('compress', (performance.now() - startedAt) / 1000);
   return Buffer.concat([Buffer.from([PACKED_BROTLI_SENTINEL]), compressed]);
 }
 
@@ -60,10 +85,23 @@ export async function compressPacked(packed: Buffer): Promise<Buffer> {
  *
  * Only the compress-aware read path calls this — see the SENTINEL SCOPE note above for
  * why the first-byte sentinel check is collision-free there.
+ *
+ * `onTiming` (optional) is called ONLY when a brotli-decompress actually ran. The legacy
+ * raw-msgpack passthrough deliberately records NOTHING: it is a sentinel check and a return,
+ * not a codec call, and mixing those near-zero samples into the `decompress` histogram would
+ * drag the quantiles toward "the cost of not decompressing" — a number that answers no
+ * question. The sentinel discrimination therefore stays in this ONE function; the caller
+ * never re-derives it (a second copy of that predicate is how the two drift apart).
  */
-export async function decompressPacked(value: Buffer): Promise<Buffer> {
+export async function decompressPacked(
+  value: Buffer,
+  onTiming?: PackedCodecTimer
+): Promise<Buffer> {
   if (value.length > 0 && value[0] === PACKED_BROTLI_SENTINEL) {
-    return brotliDecompress(value.subarray(1));
+    const startedAt = performance.now();
+    const inflated = await brotliDecompress(value.subarray(1));
+    onTiming?.('decompress', (performance.now() - startedAt) / 1000);
+    return inflated;
   }
   return value;
 }

--- a/packages/civitai-telemetry/src/__tests__/packed-codec-buckets.test.ts
+++ b/packages/civitai-telemetry/src/__tests__/packed-codec-buckets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { PACKED_CODEC_DURATION_BUCKETS } from '../client';
+import { PACKED_CODEC_DURATION_BUCKETS, packedCodecDuration } from '../client';
 
 /**
  * Resolution guard for `packed_codec_duration_seconds`.
@@ -10,6 +10,16 @@ import { PACKED_CODEC_DURATION_BUCKETS } from '../client';
  * moves only for enormous changes, and which nothing else in the suite can notice. And the cost of
  * discovering it late is asymmetric: re-cutting the edges resets every series' history, so this has
  * to be right before the metric ships rather than after someone distrusts the graph.
+ *
+ * 🔴 WHY IT READS THE REGISTERED HISTOGRAM AND NOT THE EXPORTED CONSTANT. The constant is an input
+ * to `registerHistogram`, not the thing scraped. An earlier version of this file imported only the
+ * constant, and two mutants walked straight past it: (N1) leave the constant correct and set
+ * `buckets:` on `packedCodecDuration` to the pre-fix literal — the exact histogram this guard
+ * exists to prevent, shipped with the whole suite green; (N2) coarsen the constant to
+ * `[0.00002, 0.00005, 0.0001, 0.00025, 1]`, which satisfies a last-edge-only tail check while
+ * being one 0.25 ms → 1 s bucket, i.e. unable to resolve the ~36 ms tail at all. So the verdict
+ * comes from `packedCodecDuration.get()` — prom-client's own view of the registered metric, after
+ * an observation — and the constant is checked separately for agreement with it.
  *
  * The measurements the edges are cut against, both from the compress-aware caches that exist today:
  *   - the SMALL end: imageMetaCache values are ~0.5-4 KB and decompress in ~0.026 ms. This is the
@@ -25,10 +35,18 @@ import { PACKED_CODEC_DURATION_BUCKETS } from '../client';
 const TYPICAL_SMALL_SECONDS = 0.000026;
 /** Measured worst-case compress time for the large tensor-metadata blob (~36 ms), in seconds. */
 const LARGE_BLOB_TAIL_SECONDS = 0.036;
+/**
+ * The coarsest any adjacent pair of edges is allowed to be. A histogram's resolution is exactly
+ * its widest bucket: `histogram_quantile` interpolates linearly inside one, so a pair 4x apart
+ * already means a quantile that can be off by most of a bucket's width. The shipped list's widest
+ * pair is 2.5x, so 4 leaves real headroom rather than pinning today's number — and it is not a
+ * multiple of any step in the list, so it cannot be satisfied by accident.
+ */
+const MAX_EDGE_RATIO = 4;
 
 /**
- * The two properties that make a quantile readable, as a function of an arbitrary edge list — so
- * they can be run against a KNOWN-BAD list as a negative control, not only against the shipped one.
+ * The three properties that make a quantile readable, as functions of an arbitrary edge list — so
+ * they can be run against KNOWN-BAD lists as negative controls, not only against the shipped one.
  */
 function resolvesTypicalCase(buckets: readonly number[]) {
   // The common case must be above the first edge (otherwise it is inside the unresolvable
@@ -42,29 +60,86 @@ function coversLargeTail(buckets: readonly number[]) {
   return buckets[buckets.length - 1] >= LARGE_BLOB_TAIL_SECONDS;
 }
 
+/** The widest adjacent edge ratio in the list — the histogram's worst-case resolution. */
+function widestEdgeRatio(buckets: readonly number[]) {
+  let widest = 1;
+  for (let i = 1; i < buckets.length; i += 1)
+    widest = Math.max(widest, buckets[i] / buckets[i - 1]);
+  return widest;
+}
+
+function resolutionIsUniform(buckets: readonly number[]) {
+  return widestEdgeRatio(buckets) <= MAX_EDGE_RATIO;
+}
+
+/**
+ * The `le` edges prom-client is actually holding for the registered histogram, in order and
+ * without the implicit `+Inf`. A labelled histogram emits no series until something is observed,
+ * so a sample is recorded first; the label values are arbitrary (this asserts on edges, not counts)
+ * but are spelled as a real op/cache pair so the observe cannot be rejected for a bad label.
+ */
+async function registeredBuckets(): Promise<number[]> {
+  packedCodecDuration.observe(
+    { op: 'decompress', cache_name: 'packed:caches:bucket-guard' },
+    0.001
+  );
+  // `le` is not in the declared label union, so prom-client's own types cannot express it.
+  const values = (await packedCodecDuration.get()).values as unknown as Array<{
+    metricName?: string;
+    labels: Record<string, string | number | undefined>;
+  }>;
+  const edges = values
+    .filter((v) => v.metricName?.endsWith('_bucket') && v.labels.le !== '+Inf')
+    .map((v) => Number(v.labels.le));
+  return [...new Set(edges)].sort((a, b) => a - b);
+}
+
 describe('packed_codec_duration_seconds buckets', () => {
+  it('the REGISTERED histogram carries the exported edge set (the seam the constant alone cannot see)', async () => {
+    const registered = await registeredBuckets();
+
+    // Positive control first: a bucketless or unobserved metric would give an empty list, and
+    // every equality below would then be a claim about nothing.
+    expect(registered.length, 'prom-client reported bucket edges for the registered metric').toBe(
+      PACKED_CODEC_DURATION_BUCKETS.length
+    );
+    expect(registered).toEqual([...PACKED_CODEC_DURATION_BUCKETS]);
+  });
+
   it('is strictly ascending (prom requires it; an out-of-order edge is silently accepted here)', () => {
     const sorted = [...PACKED_CODEC_DURATION_BUCKETS].sort((a, b) => a - b);
     expect(PACKED_CODEC_DURATION_BUCKETS).toEqual(sorted);
     expect(new Set(PACKED_CODEC_DURATION_BUCKETS).size).toBe(PACKED_CODEC_DURATION_BUCKETS.length);
   });
 
-  it('resolves the measured common case rather than swallowing it in the first bucket', () => {
+  it('resolves the measured common case rather than swallowing it in the first bucket', async () => {
+    const registered = await registeredBuckets();
+
     expect(
-      PACKED_CODEC_DURATION_BUCKETS[0],
-      'the first edge sits BELOW the measured typical decompress, so a typical sample is resolvable'
+      registered[0],
+      'the first REGISTERED edge sits BELOW the measured typical decompress, so a typical sample is resolvable'
     ).toBeLessThan(TYPICAL_SMALL_SECONDS);
     expect(
-      resolvesTypicalCase(PACKED_CODEC_DURATION_BUCKETS),
-      'the edges give the common case a first edge below it and >=3 edges within 10x'
+      resolvesTypicalCase(registered),
+      'the registered edges give the common case a first edge below it and >=3 edges within 10x'
     ).toBe(true);
   });
 
-  it('still covers the large-blob tail the metric exists to show', () => {
-    expect(coversLargeTail(PACKED_CODEC_DURATION_BUCKETS)).toBe(true);
+  it('has no bucket coarser than the allowed ratio anywhere in its range', async () => {
+    const registered = await registeredBuckets();
+
+    expect(
+      widestEdgeRatio(registered),
+      `the widest adjacent edge ratio must stay at or under ${MAX_EDGE_RATIO}x, or one bucket spans the range it is supposed to resolve`
+    ).toBeLessThanOrEqual(MAX_EDGE_RATIO);
   });
 
-  // 🔴 NEGATIVE CONTROL. Without this the predicate above could be one that returns `true` for
+  it('still covers the large-blob tail the metric exists to show', async () => {
+    const registered = await registeredBuckets();
+    expect(coversLargeTail(registered)).toBe(true);
+  });
+
+  // 🔴 NEGATIVE CONTROL #1. Without this the predicates above could be ones that return `true` for
   // anything — including the edge set this PR replaced, which is exactly the failure the guard is
   // supposed to catch. The pre-fix list is checked here and must be REJECTED.
   it('rejects the pre-fix edge set, whose 0.5ms floor swallowed the common case', () => {
@@ -75,8 +150,26 @@ describe('packed_codec_duration_seconds buckets', () => {
       'the old floor of 0.0005 is ~19x the measured typical value, so it must not pass'
     ).toBe(false);
     // …and the discrimination really is about the FLOOR, not about the tail: the old list covered
-    // the large end perfectly well. A guard that failed the old list for the wrong reason would
-    // pass this line too, which is why it is asserted separately.
+    // the large end perfectly well, and its resolution was uniform. A guard that failed the old
+    // list for either of those reasons would pass these lines too, which is why they are asserted
+    // separately.
     expect(coversLargeTail(preFix), 'the old list was fine at the LARGE end').toBe(true);
+    expect(resolutionIsUniform(preFix), 'the old list was fine on RESOLUTION too').toBe(true);
+  });
+
+  // 🔴 NEGATIVE CONTROL #2, and it is the one that motivates `resolutionIsUniform`. This list has a
+  // correct floor and a last edge above the tail, so both of the other predicates accept it — while
+  // being a single 0.25 ms → 1 s bucket that cannot resolve the ~36 ms tail at all. Asserting the
+  // other two ACCEPT it is the point: it isolates which predicate is doing the rejecting.
+  it('rejects a list that reaches the tail in one enormous bucket', () => {
+    const coarseTail = [0.00002, 0.00005, 0.0001, 0.00025, 1];
+
+    expect(resolutionIsUniform(coarseTail), 'a 4000x bucket is not resolution').toBe(false);
+    expect(resolvesTypicalCase(coarseTail), 'its FLOOR is fine — that is not what is wrong').toBe(
+      true
+    );
+    expect(coversLargeTail(coarseTail), 'its last edge is fine — that is not what is wrong').toBe(
+      true
+    );
   });
 });

--- a/packages/civitai-telemetry/src/__tests__/packed-codec-buckets.test.ts
+++ b/packages/civitai-telemetry/src/__tests__/packed-codec-buckets.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { PACKED_CODEC_DURATION_BUCKETS } from '../client';
+
+/**
+ * Resolution guard for `packed_codec_duration_seconds`.
+ *
+ * WHY A TEST FOR A LIST OF NUMBERS. Bad histogram edges do not fail — they report. A first edge
+ * above the values actually being measured puts (almost) every sample in bucket one, and
+ * `histogram_quantile` then answers with that edge forever: a plausible, stable, wrong number that
+ * moves only for enormous changes, and which nothing else in the suite can notice. And the cost of
+ * discovering it late is asymmetric: re-cutting the edges resets every series' history, so this has
+ * to be right before the metric ships rather than after someone distrusts the graph.
+ *
+ * The measurements the edges are cut against, both from the compress-aware caches that exist today:
+ *   - the SMALL end: imageMetaCache values are ~0.5-4 KB and decompress in ~0.026 ms. This is the
+ *     overwhelming majority of samples by count, so it is what the quantiles will be made of.
+ *   - the LARGE end: the tensor-metadata blob is ~335 KB, ~36 ms to compress in the worst case
+ *     measured. Rare, but it is the tail the metric exists to show.
+ *
+ * These are inputs to the design, so they are spelled here as constants and the predicates below
+ * are derived from them — not the other way round.
+ */
+
+/** Measured decompress time for a typical imageMetaCache value (~0.026 ms), in seconds. */
+const TYPICAL_SMALL_SECONDS = 0.000026;
+/** Measured worst-case compress time for the large tensor-metadata blob (~36 ms), in seconds. */
+const LARGE_BLOB_TAIL_SECONDS = 0.036;
+
+/**
+ * The two properties that make a quantile readable, as a function of an arbitrary edge list — so
+ * they can be run against a KNOWN-BAD list as a negative control, not only against the shipped one.
+ */
+function resolvesTypicalCase(buckets: readonly number[]) {
+  // The common case must be above the first edge (otherwise it is inside the unresolvable
+  // "0 → first edge" bucket) and must have real resolution around it rather than one giant bucket:
+  // at least three edges at or below 10x it.
+  const edgesAroundTypical = buckets.filter((b) => b <= TYPICAL_SMALL_SECONDS * 10).length;
+  return buckets[0] < TYPICAL_SMALL_SECONDS && edgesAroundTypical >= 3;
+}
+
+function coversLargeTail(buckets: readonly number[]) {
+  return buckets[buckets.length - 1] >= LARGE_BLOB_TAIL_SECONDS;
+}
+
+describe('packed_codec_duration_seconds buckets', () => {
+  it('is strictly ascending (prom requires it; an out-of-order edge is silently accepted here)', () => {
+    const sorted = [...PACKED_CODEC_DURATION_BUCKETS].sort((a, b) => a - b);
+    expect(PACKED_CODEC_DURATION_BUCKETS).toEqual(sorted);
+    expect(new Set(PACKED_CODEC_DURATION_BUCKETS).size).toBe(PACKED_CODEC_DURATION_BUCKETS.length);
+  });
+
+  it('resolves the measured common case rather than swallowing it in the first bucket', () => {
+    expect(
+      PACKED_CODEC_DURATION_BUCKETS[0],
+      'the first edge sits BELOW the measured typical decompress, so a typical sample is resolvable'
+    ).toBeLessThan(TYPICAL_SMALL_SECONDS);
+    expect(
+      resolvesTypicalCase(PACKED_CODEC_DURATION_BUCKETS),
+      'the edges give the common case a first edge below it and >=3 edges within 10x'
+    ).toBe(true);
+  });
+
+  it('still covers the large-blob tail the metric exists to show', () => {
+    expect(coversLargeTail(PACKED_CODEC_DURATION_BUCKETS)).toBe(true);
+  });
+
+  // 🔴 NEGATIVE CONTROL. Without this the predicate above could be one that returns `true` for
+  // anything — including the edge set this PR replaced, which is exactly the failure the guard is
+  // supposed to catch. The pre-fix list is checked here and must be REJECTED.
+  it('rejects the pre-fix edge set, whose 0.5ms floor swallowed the common case', () => {
+    const preFix = [0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1];
+
+    expect(
+      resolvesTypicalCase(preFix),
+      'the old floor of 0.0005 is ~19x the measured typical value, so it must not pass'
+    ).toBe(false);
+    // …and the discrimination really is about the FLOOR, not about the tail: the old list covered
+    // the large end perfectly well. A guard that failed the old list for the wrong reason would
+    // pass this line too, which is why it is asserted separately.
+    expect(coversLargeTail(preFix), 'the old list was fine at the LARGE end').toBe(true);
+  });
+});

--- a/packages/civitai-telemetry/src/__tests__/packed-codec-buckets.test.ts
+++ b/packages/civitai-telemetry/src/__tests__/packed-codec-buckets.test.ts
@@ -21,9 +21,13 @@ import { PACKED_CODEC_DURATION_BUCKETS, packedCodecDuration } from '../client';
  * comes from `packedCodecDuration.get()` — prom-client's own view of the registered metric, after
  * an observation — and the constant is checked separately for agreement with it.
  *
- * The measurements the edges are cut against, both from the compress-aware caches that exist today:
- *   - the SMALL end: imageMetaCache values are ~0.5-4 KB and decompress in ~0.026 ms. This is the
- *     overwhelming majority of samples by count, so it is what the quantiles will be made of.
+ * The measurements the edges are cut against, all from the compress-aware caches that exist today
+ * and all taken through the same `promisify(zlib.brotli*)` shape the codec actually uses:
+ *   - the DISPATCH FLOOR: a 1-byte payload costs p50 17.7 us. That is threadpool round trip, not
+ *     codec work, so nothing this metric ever samples can be meaningfully faster than it.
+ *   - the SMALL end: 48 real image-meta values off the live cache decompress at p50 21.9-30.2 us,
+ *     p90 41.9-66.2 us. This is the overwhelming majority of samples by count, so it is what the
+ *     quantiles will be made of. Compress at q6 is p50 111.6 us, p90 216.3 us, p99 3.8 ms.
  *   - the LARGE end: the tensor-metadata blob is ~335 KB, ~36 ms to compress in the worst case
  *     measured. Rare, but it is the tail the metric exists to show.
  *
@@ -31,18 +35,57 @@ import { PACKED_CODEC_DURATION_BUCKETS, packedCodecDuration } from '../client';
  * are derived from them — not the other way round.
  */
 
+/**
+ * Measured p50 of the async threadpool round trip for a 1-BYTE payload, in seconds — i.e. pure
+ * dispatch overhead with no codec work in it. The first edge has to sit BELOW this, so that
+ * bucket one means "impossibly fast, suspect the instrument" rather than "typical". (Tracked
+ * separately as civitai#4656: making the codec sync for small values would remove most of it.)
+ */
+const DISPATCH_FLOOR_SECONDS = 0.0000177;
 /** Measured decompress time for a typical imageMetaCache value (~0.026 ms), in seconds. */
 const TYPICAL_SMALL_SECONDS = 0.000026;
 /** Measured worst-case compress time for the large tensor-metadata blob (~36 ms), in seconds. */
 const LARGE_BLOB_TAIL_SECONDS = 0.036;
 /**
- * The coarsest any adjacent pair of edges is allowed to be. A histogram's resolution is exactly
- * its widest bucket: `histogram_quantile` interpolates linearly inside one, so a pair 4x apart
- * already means a quantile that can be off by most of a bucket's width. The shipped list's widest
- * pair is 2.5x, so 4 leaves real headroom rather than pinning today's number — and it is not a
- * multiple of any step in the list, so it cannot be satisfied by accident.
+ * 🔴 THE SHIPPED LIST'S RESOLUTION IS PINNED AS AN EXACT ORDERED SEQUENCE OF ADJACENT RATIOS, NOT
+ * AS A BOUND, and that is the whole point of this constant. A bound on the widest adjacent ratio
+ * is the obvious guard and it has a hole that this file walked into: deleting an edge does not
+ * invent a new ratio, it MULTIPLIES the two steps either side of it, so a list built from 2x and
+ * 2.5x steps composes to 4x, 5x and 6.25x. The previous revision bounded the widest ratio at 4x
+ * inclusive and asserted in a comment that 4 "is not a multiple of any step in the list, so it
+ * cannot be satisfied by accident" — false, and demonstrably so: deleting any one of 0.0005,
+ * 0.005, 0.05 or 0.5 left neighbours exactly 4x apart and all 35 tests in this package stayed
+ * green. Raising the bound to 3 would have closed that particular hole and left the same shape of
+ * guard in place for the next re-cut to reopen.
+ *
+ * An equality has no hole to reason about. Deleting ANY edge shortens this sequence, changing ANY
+ * edge changes at least one entry, and inserting one lengthens it — each is a plain `toEqual`
+ * failure with the before/after visible in the diff. The cost is that a deliberate re-cut of the
+ * edges has to update this list too. That is the intended price: these edges reset every series'
+ * history when they change, so a change here should be loud.
+ *
+ * Rounded to 3 decimals because the list's 1.5x and 1.667x steps are not exact in IEEE754
+ * (0.00003/0.00002 is 1.4999999999999998). 3 decimals is ~0.05% resolution — far finer than any
+ * step the list uses, so no real edge change survives the rounding.
  */
-const MAX_EDGE_RATIO = 4;
+const EXPECTED_EDGE_RATIOS = [
+  // 5 -> 10 -> 15 -> 20 -> 30 -> 50 -> 75 -> 100 -> 150 -> 250 us: the dispatch floor and the
+  // decompress/compress bulk, deliberately the finest part of the list.
+  2, 1.5, 1.333, 1.5, 1.667, 1.5, 1.333, 1.5, 1.667,
+  // 250us -> 1s: the usual 1-2-5 decade steps over the ms tail and the ~36 ms large-blob tail.
+  2, 2, 2.5, 2, 2, 2.5, 2, 2, 2.5, 2, 2,
+];
+/**
+ * A coarse "is this list uniform at all" threshold, used ONLY to discriminate the known-bad
+ * control lists at the bottom of this file — never as the verdict on the shipped list, which is
+ * pinned by EXPECTED_EDGE_RATIOS above.
+ *
+ * No claim is made that this value is unreachable by composing the list's own steps. It is not:
+ * two consecutive 2x steps compose to exactly 4x, which is what made it useless as the real
+ * guard. It survives here because the control lists it has to separate are nowhere near it (the
+ * pre-fix list's widest pair is 2.5x; the coarse-tail control's is 4000x).
+ */
+const CONTROL_MAX_EDGE_RATIO = 4;
 
 /**
  * The three properties that make a quantile readable, as functions of an arbitrary edge list — so
@@ -56,8 +99,25 @@ function resolvesTypicalCase(buckets: readonly number[]) {
   return buckets[0] < TYPICAL_SMALL_SECONDS && edgesAroundTypical >= 3;
 }
 
+/**
+ * Strictly stronger than `resolvesTypicalCase`'s first clause, and separate from it on purpose:
+ * "below the typical sample" still allows a floor sitting inside the population, which is exactly
+ * the mistake both previous edge sets made. "Below the dispatch floor" does not.
+ */
+function floorIsBelowDispatchFloor(buckets: readonly number[]) {
+  return buckets[0] < DISPATCH_FLOOR_SECONDS;
+}
+
 function coversLargeTail(buckets: readonly number[]) {
   return buckets[buckets.length - 1] >= LARGE_BLOB_TAIL_SECONDS;
+}
+
+/** Every adjacent edge ratio in order, rounded — the histogram's resolution profile. */
+function edgeRatios(buckets: readonly number[]) {
+  const ratios: number[] = [];
+  for (let i = 1; i < buckets.length; i += 1)
+    ratios.push(Math.round((buckets[i] / buckets[i - 1]) * 1000) / 1000);
+  return ratios;
 }
 
 /** The widest adjacent edge ratio in the list — the histogram's worst-case resolution. */
@@ -69,7 +129,7 @@ function widestEdgeRatio(buckets: readonly number[]) {
 }
 
 function resolutionIsUniform(buckets: readonly number[]) {
-  return widestEdgeRatio(buckets) <= MAX_EDGE_RATIO;
+  return widestEdgeRatio(buckets) <= CONTROL_MAX_EDGE_RATIO;
 }
 
 /**
@@ -125,13 +185,25 @@ describe('packed_codec_duration_seconds buckets', () => {
     ).toBe(true);
   });
 
-  it('has no bucket coarser than the allowed ratio anywhere in its range', async () => {
+  it('puts its floor below the measured dispatch floor, so bucket one means "impossibly fast"', async () => {
     const registered = await registeredBuckets();
 
     expect(
-      widestEdgeRatio(registered),
-      `the widest adjacent edge ratio must stay at or under ${MAX_EDGE_RATIO}x, or one bucket spans the range it is supposed to resolve`
-    ).toBeLessThanOrEqual(MAX_EDGE_RATIO);
+      registered[0],
+      `the first REGISTERED edge must sit below the ${DISPATCH_FLOOR_SECONDS}s threadpool dispatch floor — a floor inside the sample population cannot be resolved past, and the previous 0.00002 floor swallowed 38.5% of measured decompress samples`
+    ).toBeLessThan(DISPATCH_FLOOR_SECONDS);
+  });
+
+  it('carries exactly the resolution profile it was cut for, edge for edge', async () => {
+    const registered = await registeredBuckets();
+
+    // An EQUALITY, not a bound. A bound on the widest adjacent ratio is satisfiable by deleting an
+    // edge — the two neighbouring steps compose — which is the regression this must catch; see
+    // EXPECTED_EDGE_RATIOS. Deleting any edge shortens this array; changing one moves an entry.
+    expect(
+      edgeRatios(registered),
+      'the registered edges have exactly the adjacent-ratio sequence this list was designed with — an edge was added, removed or moved'
+    ).toEqual(EXPECTED_EDGE_RATIOS);
   });
 
   it('still covers the large-blob tail the metric exists to show', async () => {
@@ -157,10 +229,45 @@ describe('packed_codec_duration_seconds buckets', () => {
     expect(resolutionIsUniform(preFix), 'the old list was fine on RESOLUTION too').toBe(true);
   });
 
-  // 🔴 NEGATIVE CONTROL #2, and it is the one that motivates `resolutionIsUniform`. This list has a
-  // correct floor and a last edge above the tail, so both of the other predicates accept it — while
-  // being a single 0.25 ms → 1 s bucket that cannot resolve the ~36 ms tail at all. Asserting the
-  // other two ACCEPT it is the point: it isolates which predicate is doing the rejecting.
+  // 🔴 NEGATIVE CONTROL #1b, and it is the one that motivates `floorIsBelowDispatchFloor`. This is
+  // the edge set the FIRST revision of this PR shipped — the one that replaced the 0.5 ms floor
+  // above and was itself wrong, in the same direction and by much less. Its floor of 20 us is
+  // below the 26 us typical, so `resolvesTypicalCase` accepts it; measured against 48 real
+  // image-meta values it still swallowed 38.5% of decompress samples in bucket one. Asserting
+  // that the other three predicates ACCEPT it is the point — it isolates which predicate rejects.
+  it('rejects the 20us floor, which was under the typical value and still inside the population', () => {
+    const twentyMicroFloor = [
+      0.00002, 0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25,
+      0.5, 1,
+    ];
+
+    expect(
+      floorIsBelowDispatchFloor(twentyMicroFloor),
+      'a 20us floor sits ABOVE the 17.7us dispatch floor, i.e. inside the sample population'
+    ).toBe(false);
+    expect(
+      resolvesTypicalCase(twentyMicroFloor),
+      'it passes the weaker floor test — which is exactly why that test was not enough'
+    ).toBe(true);
+    expect(coversLargeTail(twentyMicroFloor), 'its tail was fine — not what is wrong').toBe(true);
+    expect(
+      resolutionIsUniform(twentyMicroFloor),
+      'its resolution was fine — not what is wrong'
+    ).toBe(true);
+  });
+
+  // 🔴 POSITIVE CONTROL for `floorIsBelowDispatchFloor`: it must be capable of returning true, or
+  // the assertion above is a claim about a predicate that always rejects.
+  it('accepts the shipped floor (positive control for the dispatch-floor predicate)', async () => {
+    expect(floorIsBelowDispatchFloor(await registeredBuckets())).toBe(true);
+  });
+
+  // 🔴 NEGATIVE CONTROL #2: resolution, independent of both ends. This list has a floor under the
+  // typical value and a last edge above the tail, so both of the other predicates accept it —
+  // while being a single 0.25 ms → 1 s bucket that cannot resolve the ~36 ms tail at all.
+  // Asserting the other two ACCEPT it is the point: it isolates which predicate is rejecting.
+  // (`resolutionIsUniform` is a control-only predicate — the shipped list's resolution is pinned
+  // by the exact ratio sequence above, not by this threshold. See CONTROL_MAX_EDGE_RATIO.)
   it('rejects a list that reaches the tail in one enormous bucket', () => {
     const coarseTail = [0.00002, 0.00005, 0.0001, 0.00025, 1];
 

--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -360,8 +360,17 @@ export const redisCommandDuration = registerHistogram({
   buckets: [0.001, 0.005, 0.025, 0.1, 0.5, 1, 2, 5, 10, 30],
 });
 
-// Wall time of the brotli codec on the opt-in compressed `redis.packed` paths, by `op`
+// Duration of the brotli codec on the opt-in compressed `redis.packed` paths, by `op`
 // (compress | decompress) and `cache_name`.
+//
+// 🔴 WHAT A SAMPLE CONTAINS, because the name says "codec" and the number is wider than that. The
+// clock starts before the promisified call is enqueued and stops at the `await` CONTINUATION on the
+// JS thread, so a sample is threadpool queue wait + codec work + whatever event-loop delay sits
+// between the completion landing and the continuation running. Measured: a 50 ms main-thread block
+// held while a decompress is in flight yields a 50.79 ms sample — event-loop delay is absorbed ~1:1.
+// And the floor is dispatch, not codec: a 1-byte payload (no real codec work) round-trips in ~11 µs
+// p50 on one machine and ~22 µs on another, against a typical ~25-36 µs decompress — i.e. roughly
+// half or more of a typical sample is the hand-off, not brotli. Read the low buckets accordingly.
 //
 // WHY A SEPARATE HISTOGRAM. Two existing signals both LOOK like they cover this and neither does:
 //   - CPU profiles: the codec is `promisify(zlib.brotli*)`, i.e. it runs on the libuv threadpool.
@@ -398,9 +407,12 @@ export const redisCommandDuration = registerHistogram({
 // is resolvable at all rather than reported as "somewhere under half a millisecond".
 // ⚠️ Changing these edges resets every series' history — settle them before this ships.
 //
-// Exported so the resolution invariant can be checked mechanically rather than by eye: see
-// ./__tests__/packed-codec-buckets.test.ts, which pins that the measured common case is not
-// swallowed by the first bucket and that the large-blob tail is still covered.
+// Exported so the resolution invariant can be checked mechanically rather than by eye. The guard
+// in ./__tests__/packed-codec-buckets.test.ts does NOT read this constant for its verdict — it
+// observes a sample and reads the `le` set back off the REGISTERED histogram, so editing `buckets:`
+// below without editing this list (or the reverse) fails. It pins three properties: the measured
+// common case is not swallowed by the first bucket, no adjacent pair of edges is more than 4x
+// apart (so no single bucket can span the resolvable range), and the large-blob tail is covered.
 export const PACKED_CODEC_DURATION_BUCKETS = [
   0.00002, 0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25,
   0.5, 1,
@@ -408,7 +420,7 @@ export const PACKED_CODEC_DURATION_BUCKETS = [
 
 export const packedCodecDuration = registerHistogram({
   name: 'packed_codec_duration_seconds',
-  help: 'Brotli codec duration for compressed redis.packed values, by op and cache_name. Wall clock as seen by the caller, so it includes libuv threadpool QUEUE WAIT as well as codec work: it is what the codec cost the request, NOT CPU time, and it rises under unrelated threadpool load with no change in codec cost. Invisible to CPU profiles (the codec runs off the JS stack) and not covered by redis_command_duration_seconds, which stops at the round trip.',
+  help: 'Brotli codec duration for compressed redis.packed values, by op and cache_name. Wall clock as the CALLER sees it, NOT CPU time: the clock stops at the await continuation on the JS thread, so a sample is libuv threadpool QUEUE WAIT + codec work + EVENT-LOOP DELAY before the completion is delivered (a blocked JS thread inflates it ~1:1 — a 50ms block measured 50.79ms). The threadpool round-trip floor is ~10-25us even for a byte-sized payload, so the lowest buckets are dispatch overhead rather than codec time. A rise means the codec PATH got slower; it does NOT on its own mean brotli got more expensive. Invisible to CPU profiles (the codec runs off the JS stack) and not covered by redis_command_duration_seconds, which stops at the round trip.',
   labelNames: ['op', 'cache_name'] as const,
   buckets: [...PACKED_CODEC_DURATION_BUCKETS],
 });

--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -360,6 +360,32 @@ export const redisCommandDuration = registerHistogram({
   buckets: [0.001, 0.005, 0.025, 0.1, 0.5, 1, 2, 5, 10, 30],
 });
 
+// Wall time of the brotli codec on the opt-in compressed `redis.packed` paths, by `op`
+// (compress | decompress) and `cache_name`.
+//
+// WHY A SEPARATE HISTOGRAM. Two existing signals both LOOK like they cover this and neither does:
+//   - CPU profiles: the codec is `promisify(zlib.brotli*)`, i.e. it runs on the libuv threadpool.
+//     Threadpool work carries no JS stack, so no `brotli*` frame is ever sampled — a profile search
+//     returns zero, which reads as "the codec is free" rather than "the profiler cannot see it".
+//   - redis_command_duration_seconds: that observation closes when the redis round trip closes,
+//     while compress happens before the write and decompress after the read. Worse, it moves the
+//     WRONG WAY — a compressed payload is smaller on the wire, so turning compression on makes that
+//     histogram improve while adding codec cost it structurally cannot observe.
+// So this is the only signal that can answer "what does compression cost us".
+//
+// `cache_name` matches the label the cache hit/miss counters carry (the cache PREFIX, e.g.
+// `packed:caches:image-meta`), so codec cost joins to cache traffic. Cardinality is bounded by the
+// small set of caches that opt into `compress`. Callers with no bounded name report 'unknown'.
+//
+// Buckets are milliseconds-scaled, not the redis command scale: the values here are sub-ms for a
+// typical cached record, with a tail into tens of ms for a large blob.
+export const packedCodecDuration = registerHistogram({
+  name: 'packed_codec_duration_seconds',
+  help: 'Brotli codec wall-clock duration for compressed redis.packed values, by op and cache_name (invisible to CPU profiles — the codec runs on the libuv threadpool — and not covered by redis_command_duration_seconds, which stops at the round trip)',
+  labelNames: ['op', 'cache_name'] as const,
+  buckets: [0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1],
+});
+
 // SELF-HEAL reconnect counter. Incremented once each time an inflight-leak self-heal watchdog forces
 // a full client reconnect. Healthy pods never touch this; a nonzero rate flags a pod that hit the
 // binary-wedge state and was auto-recovered (vs needing a human rolling-restart). `client`

--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -398,29 +398,51 @@ export const redisCommandDuration = registerHistogram({
 //     its place there by separating one cache's codec cost from another's; it is simply not a join
 //     key today.
 //
-// BUCKETS — seconds, and the floor has to be tens of MICROseconds. "Sub-ms for a typical record"
-// is true and was still the wrong floor: the two live compress-aware caches sit at opposite ends.
-// imageMetaCache values are ~0.5-4 KB and decompress in ~0.026 ms, so against a 0.0005 first edge
-// the overwhelming majority of all samples land in the first bucket and histogram_quantile is
-// pinned to that edge no matter what the codec does. tensor-metadata's ~335 KB blob is the
-// tens-of-ms tail. The edge set below spans both, and the four smallest exist so the common case
-// is resolvable at all rather than reported as "somewhere under half a millisecond".
+// BUCKETS — seconds, and the floor has to be MICROseconds, cut against measured values rather
+// than against a guess at the order of magnitude. Two earlier floors were both wrong, in the same
+// direction, for the same reason: they were placed at or just under where typical samples land,
+// which is precisely where a first edge must NOT be. Everything at or below the first edge is
+// indistinguishable — `histogram_quantile` cannot see inside bucket one — so a floor sitting in
+// the middle of the population reports a stable, plausible number that barely moves whatever the
+// codec does. 0.0005 was ~19x the typical decompress. 0.00002 (20us) looked far safer and was
+// still inside the population: measured over 48 real image-meta values pulled off the live cache
+// and timed through this exact `promisify(zlib.brotli*)` shape, 38.5% of decompress samples landed
+// AT OR BELOW 20us.
+//
+// What the measurements say, and what each end of the list is cut to:
+//   - DISPATCH FLOOR. A 1-byte payload through the same async shape costs p50 17.7us / p90 38.6us
+//     / p99 140.9us. That is threadpool round trip, not codec work, and nothing can be faster than
+//     it. So the first edge belongs BELOW it: 5us, chosen so bucket one means "impossibly fast —
+//     something is wrong with the instrument", not "typical".
+//   - DECOMPRESS, the overwhelming majority of samples by count: p50 21.9-30.2us, p90 41.9-66.2us,
+//     p99 182.7us. The 10-70us band therefore carries the readable quantiles and gets the finest
+//     edges in the list (1.33x-1.67x steps).
+//   - COMPRESS at q6: p50 111.6us, p90 216.3us, p99 3.8ms. The 100-250us band gets the same
+//     treatment; the ms decade covers its p99.
+//   - LARGE VALUES. tensor-metadata's ~335 KB blob is ~36 ms to compress in the worst case
+//     measured. Rare, but it is the tail the metric exists to show, so the list runs past it.
+// (Those are per-value codec timings and nothing else — no rate, no volume, is implied by them.)
 // ⚠️ Changing these edges resets every series' history — settle them before this ships.
 //
 // Exported so the resolution invariant can be checked mechanically rather than by eye. The guard
 // in ./__tests__/packed-codec-buckets.test.ts does NOT read this constant for its verdict — it
 // observes a sample and reads the `le` set back off the REGISTERED histogram, so editing `buckets:`
-// below without editing this list (or the reverse) fails. It pins three properties: the measured
-// common case is not swallowed by the first bucket, no adjacent pair of edges is more than 4x
-// apart (so no single bucket can span the resolvable range), and the large-blob tail is covered.
+// below without editing this list (or the reverse) fails. It pins four properties: the first edge
+// is below the measured dispatch floor, the measured common case is not swallowed by the first
+// bucket, the large-blob tail is covered, and the ORDERED SEQUENCE OF ADJACENT RATIOS is exactly
+// the one written out here. That last one is deliberately an equality and not a bound — see the
+// comment on EXPECTED_EDGE_RATIOS in that file for why a bound is the wrong shape of guard.
 export const PACKED_CODEC_DURATION_BUCKETS = [
-  0.00002, 0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25,
-  0.5, 1,
+  // 5us -> 250us: the dispatch floor and the decompress/compress bulk, at 1.33x-2x.
+  0.000005, 0.00001, 0.000015, 0.00002, 0.00003, 0.00005, 0.000075, 0.0001, 0.00015, 0.00025,
+  // 0.5ms -> 1s: the compress p99 (~3.8ms), the ~36ms large-blob tail, and headroom above it,
+  // at the usual 1-2-5 decade steps.
+  0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
 ] as const;
 
 export const packedCodecDuration = registerHistogram({
   name: 'packed_codec_duration_seconds',
-  help: 'Brotli codec duration for compressed redis.packed values, by op and cache_name. Wall clock as the CALLER sees it, NOT CPU time: the clock stops at the await continuation on the JS thread, so a sample is libuv threadpool QUEUE WAIT + codec work + EVENT-LOOP DELAY before the completion is delivered (a blocked JS thread inflates it ~1:1 — a 50ms block measured 50.79ms). The threadpool round-trip floor is ~10-25us even for a byte-sized payload, so the lowest buckets are dispatch overhead rather than codec time. A rise means the codec PATH got slower; it does NOT on its own mean brotli got more expensive. Invisible to CPU profiles (the codec runs off the JS stack) and not covered by redis_command_duration_seconds, which stops at the round trip.',
+  help: 'Brotli codec duration for compressed redis.packed values, by op and cache_name. Wall clock as the CALLER sees it, NOT CPU time: the clock stops at the await continuation on the JS thread, so a sample is libuv threadpool QUEUE WAIT + codec work + EVENT-LOOP DELAY before the completion is delivered (a blocked JS thread inflates it ~1:1 — a 50ms block measured 50.79ms). The threadpool round-trip floor is p50 17.7us / p90 38.6us even for a 1-byte payload, so the lowest buckets are dispatch overhead rather than codec time and the first edge (5us) sits below that floor deliberately: a sample in bucket one means the instrument, not the codec. A rise means the codec PATH got slower; it does NOT on its own mean brotli got more expensive. Invisible to CPU profiles (the codec runs off the JS stack) and not covered by redis_command_duration_seconds, which stops at the round trip.',
   labelNames: ['op', 'cache_name'] as const,
   buckets: [...PACKED_CODEC_DURATION_BUCKETS],
 });

--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -373,17 +373,44 @@ export const redisCommandDuration = registerHistogram({
 //     histogram improve while adding codec cost it structurally cannot observe.
 // So this is the only signal that can answer "what does compression cost us".
 //
-// `cache_name` matches the label the cache hit/miss counters carry (the cache PREFIX, e.g.
-// `packed:caches:image-meta`), so codec cost joins to cache traffic. Cardinality is bounded by the
-// small set of caches that opt into `compress`. Callers with no bounded name report 'unknown'.
+// `cache_name` is the cache PREFIX (e.g. `packed:caches:image-meta`). It is chosen so cardinality
+// stays bounded by the small set of caches that opt into `compress`; callers with no bounded name
+// report 'unknown'.
 //
-// Buckets are milliseconds-scaled, not the redis command scale: the values here are sub-ms for a
-// typical cached record, with a tail into tens of ms for a large blob.
+// HOW FAR THE JOIN TO CACHE TRAFFIC GOES — it holds for ONE of the two consumers, so do not plan a
+// dashboard on it without checking which:
+//   - createCachedArray / createCachedObject DO join: the builder passes its `key` as this label
+//     AND passes the same `key` as `cache_name` to cacheHitCounter/cacheMissCounter, so the two
+//     label values are equal by construction.
+//   - fetchThroughCache does NOT join: it emits no hit/miss counters at all, so there is no
+//     cache-traffic series carrying this `cache_name` to join against. (The nearest counter a
+//     reader might reach for — the tensor-metadata in-process LRU — labels itself
+//     'tensor-metadata-full', a different value naming a different cache.) The label still earns
+//     its place there by separating one cache's codec cost from another's; it is simply not a join
+//     key today.
+//
+// BUCKETS — seconds, and the floor has to be tens of MICROseconds. "Sub-ms for a typical record"
+// is true and was still the wrong floor: the two live compress-aware caches sit at opposite ends.
+// imageMetaCache values are ~0.5-4 KB and decompress in ~0.026 ms, so against a 0.0005 first edge
+// the overwhelming majority of all samples land in the first bucket and histogram_quantile is
+// pinned to that edge no matter what the codec does. tensor-metadata's ~335 KB blob is the
+// tens-of-ms tail. The edge set below spans both, and the four smallest exist so the common case
+// is resolvable at all rather than reported as "somewhere under half a millisecond".
+// ⚠️ Changing these edges resets every series' history — settle them before this ships.
+//
+// Exported so the resolution invariant can be checked mechanically rather than by eye: see
+// ./__tests__/packed-codec-buckets.test.ts, which pins that the measured common case is not
+// swallowed by the first bucket and that the large-blob tail is still covered.
+export const PACKED_CODEC_DURATION_BUCKETS = [
+  0.00002, 0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25,
+  0.5, 1,
+] as const;
+
 export const packedCodecDuration = registerHistogram({
   name: 'packed_codec_duration_seconds',
-  help: 'Brotli codec wall-clock duration for compressed redis.packed values, by op and cache_name (invisible to CPU profiles — the codec runs on the libuv threadpool — and not covered by redis_command_duration_seconds, which stops at the round trip)',
+  help: 'Brotli codec duration for compressed redis.packed values, by op and cache_name. Wall clock as seen by the caller, so it includes libuv threadpool QUEUE WAIT as well as codec work: it is what the codec cost the request, NOT CPU time, and it rises under unrelated threadpool load with no change in codec cost. Invisible to CPU profiles (the codec runs off the JS stack) and not covered by redis_command_duration_seconds, which stops at the round trip.',
   labelNames: ['op', 'cache_name'] as const,
-  buckets: [0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1],
+  buckets: [...PACKED_CODEC_DURATION_BUCKETS],
 });
 
 // SELF-HEAL reconnect counter. Incremented once each time an inflight-leak self-heal watchdog forces

--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -137,7 +137,9 @@ export default MixedAuthEndpoint(async function handler(
               fileSizeBytes: file.sizeKB * 1024,
               estimateVram,
             }),
-          { ttl: CacheTTL.month, compress: true }
+          // `cacheName` is the PREFIX, not the `${prefix}:${id}` key above — the codec
+          // histogram's `cache_name` label has to stay bounded.
+          { ttl: CacheTTL.month, compress: true, cacheName: REDIS_KEYS.CACHES.TENSOR_METADATA }
         )
       );
 

--- a/src/server/prom/__tests__/redis-metrics-bridge.test.ts
+++ b/src/server/prom/__tests__/redis-metrics-bridge.test.ts
@@ -1,0 +1,114 @@
+import client from 'prom-client';
+import { describe, expect, it, vi } from 'vitest';
+import type * as PromClient from '~/server/prom/client';
+
+/**
+ * 🔴 THE SEAM THE WHOLE `packed_codec_duration_seconds` METRIC HANGS ON.
+ *
+ * `@civitai/redis` must not statically import prom-client (it is reachable from the client
+ * bundle), so it reads its metric handles off a `globalThis.__civitaiRedisMetrics` bag that THIS
+ * module publishes, and every read is optional-chained:
+ *
+ *     getRedisMetrics()?.packedCodecDuration?.observe(...)
+ *
+ * That `?.` is what makes the seam dangerous. Delete one line from the published object and every
+ * codec sample vanishes — no throw, no warning, no failing test anywhere in either package,
+ * because the package's own suite installs a FAKE bridge (correctly: it is testing the client, not
+ * the app). The observable result is a histogram with no series, which is exactly what "no cache
+ * opted into compress" looks like. So the publish itself needs a guard, and it has to be on the
+ * REAL module rather than a stub of it.
+ *
+ * Two halves, because either alone is walkable:
+ *   - a LEDGER of the published key set, asserted for equality so it fails when the set SHRINKS
+ *     (the deletion above) or GROWS (a handle added here but never consumed, or vice versa);
+ *   - a BEHAVIOURAL check that the published `packedCodecDuration` handle is a real registered
+ *     histogram whose observations reach the scraped exposition text. A structural check alone
+ *     passes against a key holding `undefined`, a stub, or a metric on a registry nobody serves.
+ */
+
+// `src/__tests__/setup.ts` replaces this module wholesale with call-recording stubs, to keep the
+// DB-pool glue it builds at module scope out of unrelated tests. A stub cannot answer either
+// question above — it has no globalThis publish and no registry — so the real module is loaded.
+// Same technique, and the same reason, as
+// src/server/__tests__/metrics-endpoint-prisma-failure.test.ts.
+vi.mock('~/server/prom/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof PromClient>()),
+}));
+
+/**
+ * Every handle `@civitai/redis` reads off the bridge (the `RedisMetricsBridge` type in
+ * packages/civitai-redis/src/client.ts). Asserted as a SET, both directions: a missing key is a
+ * silently dead metric, an extra key is a handle the consumer never reads.
+ */
+const PUBLISHED_HANDLES = [
+  'packedCodecDuration',
+  'redisCommandDuration',
+  'redisCommandsInflight',
+  'redisRoutingRetryCounter',
+  'redisSelfHealDeadlineHitsWindow',
+  'redisSelfHealReconnectCounter',
+  'sysredisSentinelClientErrorsCounter',
+  'sysredisSentinelTopologyChangesCounter',
+] as const;
+
+const CODEC_METRIC = 'civitai_app_packed_codec_duration_seconds';
+
+type Bridge = Record<string, unknown> | undefined;
+
+async function loadBridge(): Promise<Bridge> {
+  // Importing the module for its publish side effect is the point; it has no export for this.
+  await import('~/server/prom/client');
+  return (globalThis as unknown as { __civitaiRedisMetrics?: Record<string, unknown> })
+    .__civitaiRedisMetrics;
+}
+
+describe('the redis metrics bridge this app publishes on globalThis', () => {
+  it('publishes exactly the handle set @civitai/redis reads, with no undefined values', async () => {
+    const bridge = await loadBridge();
+
+    expect(bridge, 'the bridge object exists at all').toBeDefined();
+    expect(Object.keys(bridge as Record<string, unknown>).sort()).toEqual([...PUBLISHED_HANDLES]);
+
+    // A key present but holding `undefined` satisfies the key check and still short-circuits at
+    // the consumer's `?.` — the identical silent failure, one level down.
+    for (const handle of PUBLISHED_HANDLES) {
+      expect(
+        (bridge as Record<string, unknown>)[handle],
+        `${handle} is a live handle`
+      ).toBeDefined();
+    }
+  });
+
+  it('the published packedCodecDuration handle really writes to the scraped histogram', async () => {
+    const bridge = (await loadBridge()) as Record<string, unknown>;
+    const handle = bridge.packedCodecDuration as {
+      observe: (labels: { op: string; cache_name: string }, value: number) => void;
+    };
+
+    // Label values chosen so nothing else in the suite can have produced this series, and so the
+    // negative control below is a value the metric CANNOT already hold.
+    const cacheName = 'packed:caches:bridge-seam-probe';
+    const before = await client.register.metrics();
+    expect(
+      before,
+      'NEGATIVE CONTROL: the probe series does not exist before the observe'
+    ).not.toContain(`cache_name="${cacheName}"`);
+
+    handle.observe({ op: 'decompress', cache_name: cacheName }, 0.0125);
+
+    const after = await client.register.metrics();
+    // Pinned as whole lines: a check for the metric NAME alone would pass on a handle wired to a
+    // different metric, and a check for the label alone would pass on a counter.
+    expect(after).toContain(`${CODEC_METRIC}_count{op="decompress",cache_name="${cacheName}"} 1`);
+    expect(after).toContain(
+      `${CODEC_METRIC}_sum{op="decompress",cache_name="${cacheName}"} 0.0125`
+    );
+    // …and it landed in a bucket that can resolve it, rather than only in `+Inf`.
+    expect(after).toContain(
+      `${CODEC_METRIC}_bucket{le="0.025",op="decompress",cache_name="${cacheName}"} 1`
+    );
+    expect(after).toContain(
+      `${CODEC_METRIC}_bucket{le="0.01",op="decompress",cache_name="${cacheName}"} 0`
+    );
+  });
+});

--- a/src/server/prom/__tests__/redis-metrics-bridge.test.ts
+++ b/src/server/prom/__tests__/redis-metrics-bridge.test.ts
@@ -19,11 +19,30 @@ import type * as PromClient from '~/server/prom/client';
  * REAL module rather than a stub of it.
  *
  * Two halves, because either alone is walkable:
- *   - a LEDGER of the published key set, asserted for equality so it fails when the set SHRINKS
- *     (the deletion above) or GROWS (a handle added here but never consumed, or vice versa);
+ *   - a LEDGER of the PUBLISHED key set, asserted for equality so it fails when what
+ *     `src/server/prom/client.ts` publishes SHRINKS (the deletion above) or GROWS;
  *   - a BEHAVIOURAL check that the published `packedCodecDuration` handle is a real registered
  *     histogram whose observations reach the scraped exposition text. A structural check alone
  *     passes against a key holding `undefined`, a stub, or a metric on a registry nobody serves.
+ *
+ * 🔴 WHAT THIS FILE DOES *NOT* COVER, AND WHERE THAT LIVES INSTEAD. An earlier version of this
+ * comment claimed the ledger also caught "a handle added here but never consumed, or vice versa".
+ * The "vice versa" half was false. Both halves above only ever look at the PUBLISHER:
+ * `PUBLISHED_HANDLES` is a hand-written literal compared against the object
+ * `src/server/prom/client.ts` builds, and one person edits both, so this file cannot see the other
+ * direction at all — `@civitai/redis` growing a handle that nothing here publishes, which is the
+ * silently dead metric this whole seam exists to prevent. Measured: adding a ninth field to
+ * `RedisMetricsBridge` and reading it at the codec timer, while leaving the publish at eight, left
+ * this file 2/2 green and the package 193/193 green.
+ *
+ * That direction is enforced at COMPILE time instead, and deliberately not here: the consumer's
+ * type is the only independent statement of what is read, and `src/**\/__tests__/**` is excluded
+ * from `tsconfig.json`, so a type-level assertion written in THIS file would never be evaluated by
+ * `pnpm typecheck` — coverage that reads as coverage while providing none. The live check is the
+ * `satisfies RedisMetricsBridge & Record<keyof RedisMetricsBridge, unknown>` on the published
+ * object in `src/server/prom/client.ts`; growing the package's type without publishing the handle
+ * fails the typecheck there. The runtime equality below then fails too, as the second step, once
+ * the publish grows to satisfy it — which is what keeps the ledger in this file honest.
  */
 
 // `src/__tests__/setup.ts` replaces this module wholesale with call-recording stubs, to keep the
@@ -36,9 +55,10 @@ vi.mock('~/server/prom/client', async (importOriginal) => ({
 }));
 
 /**
- * Every handle `@civitai/redis` reads off the bridge (the `RedisMetricsBridge` type in
- * packages/civitai-redis/src/client.ts). Asserted as a SET, both directions: a missing key is a
- * silently dead metric, an extra key is a handle the consumer never reads.
+ * Every handle `src/server/prom/client.ts` publishes. Asserted as a SET, so it fails whether the
+ * publish loses a key or gains one — but note what that is and is not: this is a ledger of the
+ * PUBLISHER, kept by hand, not a reading of `RedisMetricsBridge`. It cannot tell you the consumer
+ * reads exactly these; see the second half of the block comment above for where that is checked.
  */
 const PUBLISHED_HANDLES = [
   'packedCodecDuration',

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -15,6 +15,9 @@ import {
   redisSelfHealDeadlineHitsWindow,
   redisRoutingRetryCounter,
 } from '@civitai/telemetry/client';
+// Type-only: the CONSUMER's view of the bridge object published below. A `import type` cannot pull
+// any of @civitai/redis's runtime into this module's graph — it is erased at build.
+import type { RedisMetricsBridge } from '@civitai/redis';
 import { datapacketDbRead } from '~/server/db/datapacketDb';
 import { pgDbRead, pgDbReadLong, pgDbWrite } from '~/server/db/pgDb';
 // request-bulkhead is a pure leaf module (no imports), so this edge cannot form a cycle.
@@ -28,7 +31,26 @@ export * from '@civitai/telemetry/client';
 // Publishing here — where prom-client is already loaded — captures them directly. No eager
 // reader exists; consumed only from @civitai/redis client function bodies (self-heal watchdog +
 // routing-retry path).
-(globalThis as unknown as { __civitaiRedisMetrics?: unknown }).__civitaiRedisMetrics = {
+//
+// 🔴 THE `satisfies` IS THE GUARD, AND IT IS THE ONLY THING THAT COVERS THE "@civitai/redis GREW A
+// HANDLE" DIRECTION. Every consumer read over there is optional-chained
+// (`getRedisMetrics()?.packedCodecDuration?.observe(...)`), so a handle the package reads and this
+// object does not publish is a metric that is silently dead: no throw, no warning, and an
+// eternally-empty series indistinguishable from "nothing opted in". No runtime test can see it —
+// the package's own suite installs a fake bridge, and this app's bridge test compares this object
+// only against its own hand-written ledger, so both sides move together whenever one person edits
+// them. Comparing against the CONSUMER'S type is the only check with an independent side.
+//
+// `Record<keyof RedisMetricsBridge, unknown>` is deliberately not just `RedisMetricsBridge`: most
+// handles are declared OPTIONAL over there (so an older app publishing fewer still typechecks), and
+// a plain `satisfies RedisMetricsBridge` therefore accepts every one of them being missing — i.e.
+// it would accept exactly the defect. `Record<…>` makes each key REQUIRED here, and intersecting
+// the real type back in keeps the value SHAPES checked. Excess-property checking on the literal
+// covers the other direction (publishing a handle nothing reads).
+//
+// So: add a field to `RedisMetricsBridge` in @civitai/redis without adding it here and this file
+// stops compiling. That is the intended failure — wire the handle, do not widen the type below.
+const redisMetricsBridge = {
   redisCommandsInflight,
   redisCommandDuration,
   packedCodecDuration,
@@ -37,7 +59,10 @@ export * from '@civitai/telemetry/client';
   redisSelfHealReconnectCounter,
   redisSelfHealDeadlineHitsWindow,
   redisRoutingRetryCounter,
-};
+} satisfies RedisMetricsBridge & Record<keyof RedisMetricsBridge, unknown>;
+
+(globalThis as unknown as { __civitaiRedisMetrics?: unknown }).__civitaiRedisMetrics =
+  redisMetricsBridge;
 
 // pgPoolAcquireHistogram is registered in @civitai/db's db-helpers, not here, to avoid
 // a module-init cycle (this module imports pgDb → db-helpers, which would import the

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -8,6 +8,7 @@ import {
   registerInstrumentationMetric,
   redisCommandsInflight,
   redisCommandDuration,
+  packedCodecDuration,
   sysredisSentinelTopologyChangesCounter,
   sysredisSentinelClientErrorsCounter,
   redisSelfHealReconnectCounter,
@@ -30,6 +31,7 @@ export * from '@civitai/telemetry/client';
 (globalThis as unknown as { __civitaiRedisMetrics?: unknown }).__civitaiRedisMetrics = {
   redisCommandsInflight,
   redisCommandDuration,
+  packedCodecDuration,
   sysredisSentinelTopologyChangesCounter,
   sysredisSentinelClientErrorsCounter,
   redisSelfHealReconnectCounter,

--- a/src/server/utils/__tests__/cache-helpers-cache-name.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-cache-name.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Coverage for `fetchThroughCache`'s `cacheName` option — the value that becomes the
+ * `cache_name` label on the packed codec duration histogram.
+ *
+ * WHY THIS FILE EXISTS. `cacheName` is purely OBSERVATIONAL: no cached value, hit/miss decision
+ * or return shape changes when it goes missing, so every behavioural test in this directory
+ * stays green with the option silently dropped. The createCachedArray/createCachedObject half of
+ * the same seam is guarded by driving the real builder (see
+ * packages/civitai-redis/src/__tests__/packed-codec-metrics.test.ts); `fetchThroughCache` has no
+ * builder to drive — each call site passes its own name — so the threading is pinned here
+ * directly, against the real `fetchThroughCache` with redis mocked.
+ *
+ * Four things a mutant can break, one test each:
+ *   1. the READ carries it,
+ *   2. the WRITE carries it,
+ *   3. the LOCK-LOSER'S RETRY carries it — the recursion re-spells the options object by hand, so
+ *      it is the one path where the label can be dropped while the first attempt still looks
+ *      correct, and the samples then land under the fallback label instead of the caller's cache,
+ *   4. a caller that names no cache gets `undefined` here — the 'unknown' fallback belongs to the
+ *      redis client (PACKED_CODEC_UNNAMED_CACHE); spelling it a second time in this module is how
+ *      the two copies drift.
+ */
+
+const getMock = redisMock.redis.packed.get;
+const setMock = redisMock.redis.packed.set;
+const setNxMock = redisMock.redis.setNxKeepTtlWithEx;
+const delMock = redisMock.redis.del;
+
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+
+vi.mock('~/server/prom/client', () => ({
+  cacheHitCounter: { inc: vi.fn() },
+  cacheMissCounter: { inc: vi.fn() },
+  cacheRevalidateCounter: { inc: vi.fn() },
+  cacheFailOpenDegradedCounter: { inc: vi.fn() },
+  cacheFailOpenOriginFetchCounter: { inc: vi.fn() },
+}));
+
+import { fetchThroughCache } from '~/server/utils/cache-helpers';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+// CACHE_NAME is deliberately NOT a prefix of nothing and NOT equal to KEY: `key` is routinely
+// `${prefix}:${id}`, and labelling with the key would make `cache_name` unbounded. A mutant that
+// passes `key` where `cacheName` belongs is visible because the two literals differ.
+const CACHE_NAME = 'packed:caches:cache-name-probe';
+const KEY = `${CACHE_NAME}:4242` as Parameters<typeof fetchThroughCache>[0];
+const TTL = 300;
+const ORIGIN = { id: 4242, value: 'origin' };
+
+type PackedOpts = { compress?: boolean; cacheName?: string } | undefined;
+const readOpts = (call: number) => getMock.mock.calls[call]?.[1] as PackedOpts;
+const writeOpts = (call: number) => setMock.mock.calls[call]?.[3] as PackedOpts;
+
+beforeEach(() => {
+  getMock.mockReset().mockResolvedValue(null);
+  setMock.mockReset().mockResolvedValue(undefined);
+  setNxMock.mockReset().mockResolvedValue(true);
+  delMock.mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('fetchThroughCache — cacheName threading', () => {
+  it('threads cacheName to the packed READ', async () => {
+    await fetchThroughCache(KEY, async () => ORIGIN, {
+      ttl: TTL,
+      compress: true,
+      cacheName: CACHE_NAME,
+    });
+
+    expect(readOpts(0)?.cacheName, 'the packed READ carries the caller cacheName').toBe(CACHE_NAME);
+    expect(readOpts(0)?.compress).toBe(true);
+  });
+
+  it('threads cacheName to the packed WRITE', async () => {
+    await fetchThroughCache(KEY, async () => ORIGIN, {
+      ttl: TTL,
+      compress: true,
+      cacheName: CACHE_NAME,
+    });
+
+    expect(writeOpts(0)?.cacheName, 'the packed WRITE carries the caller cacheName').toBe(
+      CACHE_NAME
+    );
+    expect(writeOpts(0)?.compress).toBe(true);
+  });
+
+  it('never substitutes the per-id key for the cache name', async () => {
+    await fetchThroughCache(KEY, async () => ORIGIN, {
+      ttl: TTL,
+      compress: true,
+      cacheName: CACHE_NAME,
+    });
+
+    expect(readOpts(0)?.cacheName, 'cache_name must be the PREFIX, not the per-id key').not.toBe(
+      KEY
+    );
+    expect(writeOpts(0)?.cacheName, 'cache_name must be the PREFIX, not the per-id key').not.toBe(
+      KEY
+    );
+  });
+
+  it('passes cacheName undefined when the caller names no cache (no second fallback literal)', async () => {
+    await fetchThroughCache(KEY, async () => ORIGIN, { ttl: TTL, compress: true });
+
+    expect(
+      readOpts(0)?.cacheName,
+      'an unnamed caller reaches the client as undefined; the client owns the fallback label'
+    ).toBeUndefined();
+    expect(writeOpts(0)?.cacheName).toBeUndefined();
+  });
+
+  // 🔴 THE RETRY. A lock loser with no stale value to serve sleeps and RE-ENTERS
+  // fetchThroughCache with a hand-respelled options object. Every other path reads
+  // `options.cacheName` once; this one rebuilds the object from locals, so it is the only place
+  // the label can go missing while the first attempt still looks perfectly correct.
+  it('preserves cacheName across the lock-loser retry', async () => {
+    // First attempt: cache empty AND lock lost → sleep → recurse. Second attempt wins the lock,
+    // runs the origin fetch, and writes.
+    setNxMock.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+    await fetchThroughCache(KEY, async () => ORIGIN, {
+      ttl: TTL,
+      lockTTL: 0.01, // keeps the retry's sleep((lockTTL*1000)/2) at ~5ms
+      compress: true,
+      cacheName: CACHE_NAME,
+    });
+
+    // Positive control: the retry really happened, so the assertion below is reachable.
+    expect(
+      getMock.mock.calls.length,
+      'the lock-loser actually retried (a second packed read happened)'
+    ).toBeGreaterThanOrEqual(2);
+
+    expect(readOpts(1)?.cacheName, 'the RETRY read still carries cacheName').toBe(CACHE_NAME);
+    expect(readOpts(1)?.compress, 'the RETRY read still carries compress').toBe(true);
+    expect(writeOpts(0)?.cacheName, 'the write after the retry still carries cacheName').toBe(
+      CACHE_NAME
+    );
+  });
+});

--- a/src/server/utils/__tests__/cache-helpers-update.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-update.test.ts
@@ -81,10 +81,14 @@ describe('createCachedArray.update — the write-through path', () => {
     // (#4588). This cache does not opt in, so it must be `false` here — asserted rather than
     // loosened to `expect.anything()`, since a read that silently flipped to compress:true
     // against uncompressed writes is exactly the asymmetry that flag has to avoid.
-    expect(mGetMock).toHaveBeenCalledWith([ENTRY_KEY], { compress: false });
+    // `cacheName` rides on the same object (metrics-only: the `cache_name` label on the codec
+    // duration histogram). Asserted as the cache PREFIX, NOT `ENTRY_KEY` — the two differ by
+    // exactly the per-id suffix, and labelling with the per-id key would make that label
+    // unbounded (one prom series per cached id).
+    expect(mGetMock).toHaveBeenCalledWith([ENTRY_KEY], { compress: false, cacheName: KEY });
     const [key, value, options, packedOptions] = setMock.mock.calls[0];
     expect(key).toBe(ENTRY_KEY);
-    expect(packedOptions).toEqual({ compress: false });
+    expect(packedOptions).toEqual({ compress: false, cacheName: KEY });
     // `cachedAt` carried over, not reset: the entry stays as fresh as it was and no
     // fresher, so its revalidation clock is unchanged.
     expect(value).toEqual({ id: 1, members: [7, 9], cachedAt });

--- a/src/server/utils/__tests__/tensor-metadata-cache-split.test.ts
+++ b/src/server/utils/__tests__/tensor-metadata-cache-split.test.ts
@@ -17,12 +17,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  *      never contains `tensors`).
  *   3. The full path returns the full analysis INCLUDING `tensors`.
  *   4. The full cache write opts into `compress: true`; the summary write does not.
+ *   5. The full cache write names itself (`cacheName`, the codec histogram's `cache_name` label);
+ *      the summary write does not, because no codec runs there.
+ *
+ * ⚠️ `makeFetchers` below MIRRORS the endpoint's composition, so it is a model, not the thing.
+ * That the real call site passes these options is pinned separately, against the real handler
+ * module, in src/tests/api/v1/model-files/tensor-metadata-cache-name.test.ts — keep both in step.
  */
 
-// In-memory packed store keyed by redis key. `compress` is recorded per-set so we can
-// assert the full cache opts in and the summary does not.
+// In-memory packed store keyed by redis key. `compress` and `cacheName` are recorded per-set so we
+// can assert the full cache opts in / names itself and the summary does neither.
 const store = new Map<string, unknown>();
 const setCompressFlags = new Map<string, boolean | undefined>();
+const setCacheNames = new Map<string, string | undefined>();
 
 const packedGet = redisMock.redis.packed.get;
 const packedSet = redisMock.redis.packed.set;
@@ -41,15 +48,28 @@ vi.mock('~/server/prom/client', () => ({
 import { CacheTTL } from '~/server/common/constants';
 import { bustFetchThroughCache, fetchThroughCache } from '~/server/utils/cache-helpers';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
-redisMock.redis.packed.get.mockImplementation(async (key: string) => (store.has(key) ? store.get(key) : null));
-redisMock.redis.packed.set.mockImplementation(async (key: string, value: unknown, _opts?: unknown, packedOptions?: { compress?: boolean }) => {
+redisMock.redis.packed.get.mockImplementation(async (key: string) =>
+  store.has(key) ? store.get(key) : null
+);
+redisMock.redis.packed.set.mockImplementation(
+  async (
+    key: string,
+    value: unknown,
+    _opts?: unknown,
+    packedOptions?: { compress?: boolean; cacheName?: string }
+  ) => {
     store.set(key, value);
     setCompressFlags.set(key, packedOptions?.compress);
-  });
+    setCacheNames.set(key, packedOptions?.cacheName);
+  }
+);
 redisMock.redis.setNxKeepTtlWithEx.mockResolvedValue(true);
 redisMock.redis.del.mockResolvedValue(undefined);
 
-const FULL_KEY = 'packed:caches:tensor-metadata:42';
+// The PREFIX is the codec histogram's `cache_name`; the KEY it reads is `${prefix}:${id}`. They
+// are deliberately different values — labelling with the key would be one series per cached file.
+const FULL_CACHE_NAME = 'packed:caches:tensor-metadata';
+const FULL_KEY = `${FULL_CACHE_NAME}:42`;
 const SUMMARY_KEY = 'packed:caches:tensor-metadata-summary:42';
 
 const makeAnalysis = () => ({
@@ -68,7 +88,11 @@ const makeAnalysis = () => ({
 // Mirrors the endpoint's composition exactly.
 function makeFetchers(parse: () => Promise<ReturnType<typeof makeAnalysis>>) {
   const fetchFull = () =>
-    fetchThroughCache(FULL_KEY as never, parse, { ttl: CacheTTL.month, compress: true });
+    fetchThroughCache(FULL_KEY as never, parse, {
+      ttl: CacheTTL.month,
+      compress: true,
+      cacheName: FULL_CACHE_NAME,
+    });
   const fetchSummary = () =>
     fetchThroughCache(
       SUMMARY_KEY as never,
@@ -85,6 +109,7 @@ function makeFetchers(parse: () => Promise<ReturnType<typeof makeAnalysis>>) {
 beforeEach(() => {
   store.clear();
   setCompressFlags.clear();
+  setCacheNames.clear();
   packedGet.mockClear();
   packedSet.mockClear();
   setNxMock.mockClear().mockResolvedValue(true);
@@ -108,6 +133,10 @@ describe('tensor-metadata summary/full cache split', () => {
     expect(store.has(FULL_KEY)).toBe(true);
     expect(setCompressFlags.get(FULL_KEY)).toBe(true);
     expect(setCompressFlags.get(SUMMARY_KEY)).toBeFalsy();
+    // …and the compressed one names itself for the codec histogram, with the PREFIX not the key.
+    expect(setCacheNames.get(FULL_KEY)).toBe(FULL_CACHE_NAME);
+    expect(setCacheNames.get(FULL_KEY)).not.toBe(FULL_KEY);
+    expect(setCacheNames.get(SUMMARY_KEY)).toBeUndefined();
   });
 
   it('summary HIT does NOT invoke the full fetcher / parse (never touches the big blob)', async () => {
@@ -160,6 +189,7 @@ describe('bustFetchThroughCache compress threading', () => {
   it('threads compress=true to the get AND the set when busting a compressed key', async () => {
     store.set(FULL_KEY, { data: { x: 1 }, cachedAt: 999 });
     setCompressFlags.clear();
+    setCacheNames.clear();
     packedGet.mockClear();
 
     await bustFetchThroughCache(FULL_KEY as never, { compress: true });
@@ -173,6 +203,7 @@ describe('bustFetchThroughCache compress threading', () => {
   it('defaults to compress=false (general path) for uncompressed callers', async () => {
     store.set(SUMMARY_KEY, { data: { y: 2 }, cachedAt: 999 });
     setCompressFlags.clear();
+    setCacheNames.clear();
     packedGet.mockClear();
 
     await bustFetchThroughCache(SUMMARY_KEY as never);

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -254,6 +254,11 @@ type FetchThroughCacheOptions = {
   // fetchThroughCache always stores the `{ data, cachedAt }` wrapper object (never a
   // bare scalar) — see the SENTINEL SAFETY note in redis/client.ts.
   compress?: boolean;
+  // Metrics-only: the `cache_name` label put on the codec duration histogram for this key's
+  // compress/decompress calls. Pass the cache PREFIX, never the full per-id key — `key` here is
+  // routinely `${prefix}:${id}`, so using it directly would be unbounded label cardinality.
+  // Ignored entirely unless `compress` is on (nothing else records codec time).
+  cacheName?: string;
 };
 type FetchThroughCacheEntity<T> = { data: T; cachedAt: number };
 
@@ -304,6 +309,7 @@ export async function fetchThroughCache<T>(
   const lockTTL = options.lockTTL ?? 10;
   const retryCount = options.retryCount ?? 3;
   const compress = options.compress ?? false;
+  const cacheName = options.cacheName;
   const lockKey = `${REDIS_KEYS.CACHE_LOCKS}:${key}` as const;
 
   // --- Redis READ (cache lookup) -------------------------------------------------
@@ -318,7 +324,7 @@ export async function fetchThroughCache<T>(
     // Thread `compress` to the READ so it's symmetric with the compressed write below:
     // only a compressed caller's get attempts brotli-decompress, and only that path
     // carries the sentinel invariant. Non-compress callers read via the general path.
-    cachedData = await redis.packed.get<FetchThroughCacheEntity<T>>(key, { compress });
+    cachedData = await redis.packed.get<FetchThroughCacheEntity<T>>(key, { compress, cacheName });
   } catch (err) {
     logSysRedisFailOpen('read-degraded', 'fetchThroughCache get (cache cluster)', err, { key });
     return fetchThroughCacheFailOpen(key, fetchFn);
@@ -377,7 +383,7 @@ export async function fetchThroughCache<T>(
     const data = await fetchFn();
     const toCache: FetchThroughCacheEntity<T> = { data, cachedAt: Date.now() };
     try {
-      await redis.packed.set(key, toCache, { EX: ttl * 2 }, { compress });
+      await redis.packed.set(key, toCache, { EX: ttl * 2 }, { compress, cacheName });
     } catch (err) {
       logSysRedisFailOpen('write-degraded', 'fetchThroughCache set (cache cluster)', err, { key });
     }

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -365,11 +365,17 @@ export async function fetchThroughCache<T>(
 
       // Wait for the fetcher to do their thing...
       await sleep((lockTTL * 1000) / 2);
+      // Every option the caller gave must survive the recursion — this is the ONE path that
+      // re-spells them by hand rather than passing `options` through, so anything omitted here
+      // silently reverts to its default on a retry only. `cacheName` is the easy one to miss
+      // because nothing observable changes: the retry's codec samples just move to the client's
+      // 'unknown' label while the first attempt still looked correct.
       return fetchThroughCache(key, fetchFn, {
         ttl,
         lockTTL,
         retryCount: retryCount - 1,
         compress,
+        cacheName,
       });
     }
   } else if (cachedData) return cachedData.data;

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -365,18 +365,19 @@ export async function fetchThroughCache<T>(
 
       // Wait for the fetcher to do their thing...
       await sleep((lockTTL * 1000) / 2);
-      // Every option the caller gave must survive the recursion — this is the ONE path that
-      // re-spells them by hand rather than passing `options` through, so anything omitted here
-      // silently reverts to its default on a retry only. `cacheName` is the easy one to miss
-      // because nothing observable changes: the retry's codec samples just move to the client's
-      // 'unknown' label while the first attempt still looked correct.
-      return fetchThroughCache(key, fetchFn, {
-        ttl,
-        lockTTL,
-        retryCount: retryCount - 1,
-        compress,
-        cacheName,
-      });
+      // 🔴 SPREAD `options`, never re-spell the fields. Every option the caller gave has to
+      // survive the recursion, and this used to list all five by hand — which is correct only
+      // until a sixth is added, and the omission is invisible: the retry silently falls back to
+      // that option's default while the first attempt still looked right. (`cacheName` was the
+      // worst of them — a missed one just moves the retry's codec samples to the 'unknown'
+      // label.) Spreading makes the whole class impossible rather than pinning it with a comment.
+      //
+      // Behaviour-identical to the hand-listed version: every default above is a CONSTANT
+      // (`CacheTTL.sm`, 10, 3, false, undefined), applied with `??`, so passing an option through
+      // as `undefined` re-derives exactly the same value the resolved local held. `retryCount` is
+      // the one field that must NOT be passed through, hence the explicit override after the
+      // spread — order matters here.
+      return fetchThroughCache(key, fetchFn, { ...options, retryCount: retryCount - 1 });
     }
   } else if (cachedData) return cachedData.data;
 

--- a/src/tests/api/v1/model-files/tensor-metadata-cache-name.test.ts
+++ b/src/tests/api/v1/model-files/tensor-metadata-cache-name.test.ts
@@ -1,0 +1,189 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * Seam coverage for the tensor-metadata endpoint's CALL SITE of `fetchThroughCache`.
+ *
+ * `cacheName` is observational — it only decides the `cache_name` label on the packed codec
+ * duration histogram — so deleting it here changes no response, no cached value and no status
+ * code. Every other test of this endpoint (cache headers, cache split) therefore stays green with
+ * the option gone, while the histogram quietly collapses this cache's samples into the redis
+ * client's 'unknown' fallback alongside every other unnamed compressed caller.
+ *
+ * A test that re-declared the options itself would only pin its own copy, so this drives the REAL
+ * handler module and reads the options the endpoint actually passes.
+ *
+ * The label literals are written out rather than imported from REDIS_KEYS on purpose: the claim is
+ * about what the metric's label will BE, and deriving the expectation from the same constant the
+ * implementation reads would make a rename invisible on both sides at once.
+ */
+
+const FULL_CACHE_NAME = 'packed:caches:tensor-metadata';
+const SUMMARY_CACHE_PREFIX = 'packed:caches:tensor-metadata-summary';
+const FILE_ID = 3057178;
+
+const analysis = {
+  format: 'SafeTensor',
+  tensorCount: 1,
+  totalTensorBytes: 8,
+  dtypeCounts: [],
+  largestTensor: null,
+  vramEstimate: null,
+  tensors: [{ name: 'weight', shape: [2, 2], dtype: 'F16', sizeBytes: 8 }],
+};
+
+const {
+  mockGetFileForModelVersion,
+  mockGetFullTensorAnalysisCached,
+  mockParseModelTensorMetadata,
+  fetchThroughCacheCalls,
+} = vi.hoisted(() => ({
+  mockGetFileForModelVersion: vi.fn(),
+  mockGetFullTensorAnalysisCached: vi.fn(),
+  mockParseModelTensorMetadata: vi.fn(),
+  fetchThroughCacheCalls: [] as { key: string; options: Record<string, unknown> | undefined }[],
+}));
+
+const mockFindUnique = dbMock.dbRead.modelFile.findUnique;
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  MixedAuthEndpoint: (handler: any) => (req: any, res: any) => handler(req, res, undefined),
+}));
+
+vi.mock('~/server/services/file.service', () => ({
+  getFileForModelVersion: (...args: any[]) => mockGetFileForModelVersion(...args),
+}));
+
+// The real parser issues an upstream byte-range HTTP fetch; this file is about cache options.
+vi.mock('~/utils/model-tensor-metadata', () => ({
+  inferTensorMetadataFormat: () => 'SafeTensor',
+  supportsTensorVramEstimate: () => false,
+  parseModelTensorMetadata: (...args: any[]) => mockParseModelTensorMetadata(...args),
+}));
+
+// Pass-through in beforeEach, so the FULL `fetchThroughCache` the endpoint composes INSIDE it
+// actually runs. (The sibling header test stubs this with a resolved value, which short-circuits
+// the composition — which is exactly why that file cannot see this defect.)
+vi.mock('~/server/services/tensor-metadata.service', () => ({
+  getFullTensorAnalysisCached: (...args: any[]) => mockGetFullTensorAnalysisCached(...args),
+}));
+
+// Records (key, options) and then runs the fetcher, so both caches resolve normally.
+vi.mock('~/server/utils/cache-helpers', () => ({
+  fetchThroughCache: (
+    key: string,
+    fetcher: () => Promise<unknown>,
+    options?: Record<string, unknown>
+  ) => {
+    fetchThroughCacheCalls.push({ key, options });
+    return fetcher();
+  },
+}));
+
+let handler: (req: NextApiRequest, res: NextApiResponse) => Promise<void> | void;
+
+beforeAll(async () => {
+  const mod = await import('~/pages/api/v1/model-files/[id]/tensor-metadata');
+  handler = mod.default as any;
+}, 120000);
+
+function fakeRes() {
+  const res: any = {
+    setHeader() {
+      return this;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+  };
+  return res as NextApiResponse & { statusCode?: number; body?: any };
+}
+
+async function invoke(query: Record<string, unknown>) {
+  const res = fakeRes();
+  await handler({ method: 'GET', query } as unknown as NextApiRequest, res);
+  return res;
+}
+
+const fullCall = () =>
+  fetchThroughCacheCalls.find((c) => c.key === `${FULL_CACHE_NAME}:${FILE_ID}`);
+const summaryCall = () =>
+  fetchThroughCacheCalls.find((c) => c.key === `${SUMMARY_CACHE_PREFIX}:${FILE_ID}`);
+
+describe('/api/v1/model-files/[id]/tensor-metadata — codec cache_name at the call site', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchThroughCacheCalls.length = 0;
+    mockFindUnique.mockResolvedValue({
+      id: FILE_ID,
+      modelVersionId: 3176604,
+      name: 'a-model.safetensors',
+      type: 'Model',
+      sizeKB: 24_000_000,
+      metadata: { format: 'SafeTensor' },
+      modelVersion: { model: { type: 'Checkpoint' } },
+    });
+    mockGetFileForModelVersion.mockResolvedValue({
+      status: 'success',
+      url: 'https://delivery.example/file.safetensors',
+    });
+    mockParseModelTensorMetadata.mockResolvedValue(analysis);
+    // Pass-through: invoke the factory the endpoint hands it, so its inner fetchThroughCache runs.
+    mockGetFullTensorAnalysisCached.mockImplementation(
+      async (_id: number, factory: () => Promise<unknown>) => factory()
+    );
+  });
+
+  it('names the FULL compressed cache so its codec samples are attributable', async () => {
+    const res = await invoke({ id: String(FILE_ID) });
+    expect(res.statusCode).toBe(200);
+
+    // Positive control: the full cache was reached at all, so the assertions below are reachable.
+    expect(fullCall(), 'the endpoint fetched the FULL tensor-metadata cache').toBeDefined();
+
+    expect(
+      fullCall()!.options?.compress,
+      'the FULL cache still opts into compression (nothing records codec time without it)'
+    ).toBe(true);
+    expect(
+      fullCall()!.options?.cacheName,
+      'the FULL cache is named, so its codec samples do not fall into the client "unknown" bucket'
+    ).toBe(FULL_CACHE_NAME);
+  });
+
+  it('labels with the cache PREFIX, never the per-id key it reads', async () => {
+    await invoke({ id: String(FILE_ID) });
+
+    const call = fullCall()!;
+    expect(call.key, 'the key really is the per-id one').toBe(`${FULL_CACHE_NAME}:${FILE_ID}`);
+    expect(
+      call.options?.cacheName,
+      'cache_name must not be the per-id key — that is one histogram series per cached file'
+    ).not.toBe(call.key);
+  });
+
+  it('the summary cache stays uncompressed and unnamed (no codec runs there)', async () => {
+    const res = await invoke({ id: String(FILE_ID), summaryOnly: 'true' });
+    expect(res.statusCode).toBe(200);
+
+    expect(summaryCall(), 'the endpoint fetched the SUMMARY cache').toBeDefined();
+    expect(summaryCall()!.options?.compress).toBeFalsy();
+    expect(
+      summaryCall()!.options?.cacheName,
+      'an uncompressed cache records no codec samples, so a label there would name nothing'
+    ).toBeUndefined();
+  });
+
+  it('reaches the FULL cache (still named) on a summary MISS', async () => {
+    await invoke({ id: String(FILE_ID), summaryOnly: 'true' });
+
+    expect(fullCall(), 'a summary miss falls through to the full fetch').toBeDefined();
+    expect(fullCall()!.options?.cacheName).toBe(FULL_CACHE_NAME);
+  });
+});


### PR DESCRIPTION
## Problem

The opt-in brotli codec on `redis.packed` values (`compressPacked` /
`decompressPacked`) has **no cost signal at all**. That is not for lack of
metrics nearby — it is that the two signals which look like they cover it both
give a confidently wrong answer:

**CPU profiles cannot see it.** The codec is
`util.promisify(zlib.brotliCompress / zlib.brotliDecompress)`, so it runs on the
libuv threadpool. Threadpool work carries no JS stack, so no `brotli*` frame is
ever sampled. Searching a profile for the codec returns **zero**, which reads as
"the codec is free" rather than "the profiler is structurally blind to it".

**`civitai_app_redis_command_duration_seconds` does not cover it either.** That
observation is made inside the redis command wrapper and closes when the round
trip closes. Compression happens before the write, and decompression strictly
*after* the read — in `client.packed.get` / `client.packed.mGet`, past the point
where the command histogram has already been observed. And it fails in the worse
direction: a compressed payload is **smaller on the wire**, so enabling
compression makes that histogram *improve* while adding codec work it cannot
observe. Reading it as a codec cost gives you the answer backwards.

So today the question "what does compression cost us?" cannot be answered from
any existing signal.

## Change

Adds `civitai_app_packed_codec_duration_seconds` — a histogram of the codec's
elapsed time.

| label | values |
|---|---|
| `op` | `compress` \| `decompress` |
| `cache_name` | the cache **prefix**, e.g. `packed:caches:image-meta` |

### What the number is, precisely

**Elapsed time as the caller sees it, not CPU time.** `performance.now()` starts
*before* the promisified call is enqueued and stops when its callback resolves,
so a sample is libuv threadpool **queue wait + codec work**. That is the right
quantity for "what did compression cost this request", and it is the only window
reachable from JS — the enqueue and the threadpool hand-off are both below the
promisified boundary. But it means the value rises when the threadpool is busy
with unrelated work (other brotli calls, fs, dns, crypto) at unchanged codec
cost. The help string and the `PackedCodecTimer` doc comment both say this
outright, so a rise is read as "the codec **path** got slower", not "brotli got
more expensive".

### What `cache_name` does and does not join to

`cache_name` is the cache **prefix**, chosen so cardinality stays bounded by the
small set of caches that opt into `compress` (two today). Whether it *joins* to
cache-traffic counters depends on the caller, and it holds for only one of the
two consumers — stated here because an earlier revision of this description
claimed it held for both:

* **`createCachedArray` / `createCachedObject` — joins.** The builder passes its
  own `key` as this label *and* passes the same `key` as `cache_name` to
  `civitai_app_cache_hit_total` / `civitai_app_cache_miss_total`, so the two label
  values are equal by construction.
* **`fetchThroughCache` — does not join.** It emits no hit/miss counters at all,
  so there is no cache-traffic series carrying this `cache_name` to join against.
  The nearest counter a reader might reach for is the tensor-metadata in-process
  LRU in `tensor-metadata.service`, which labels itself `tensor-metadata-full` — a
  different value naming a different cache. The label still earns its place on
  this consumer by separating one cache's codec cost from another's; it is simply
  not a join key today, and no dashboard should be built as though it were.

`fetchThroughCache` takes an explicit `cacheName` option rather than reusing its
`key`, because that key is routinely `${prefix}:${id}` — labelling with it would
be unbounded prom cardinality. A compress-aware call site that supplies no name
reports the explicit literal `unknown`, so the label is present on every sample.

### Buckets are cut for the values actually measured

The first draft of this metric put the floor at `0.0005` (0.5 ms) on a "sub-ms
for a typical record" intuition. Review measured that as the wrong floor by more
than an order of magnitude, and it would have shipped a permanently-misleading
quantile: `imageMetaCache` — the compressed cache that carries the sample volume —
holds ~0.5–4 KB values that decompress in **~0.026 ms**, putting **99.4% of
samples at or below the old first edge** (measured in review; p50 error 9.6×), so
`histogram_quantile` would have answered with that edge no matter what the codec
did.

> ⚠️ **Superseded by Round 3 (B1/B2).** This section's fix — a floor of
> `0.00002` with three more edges below the old one — was measured against
> production values in round 3 and found to be *the same mistake one order of
> magnitude smaller*: 38.5% of real decompress samples land at or below 20 µs.
> The shipped edge list, the measurements it is cut against, and the guard that
> pins it are in **Round 3 → B1 and B2**. Kept here because the reasoning error
> it describes is the one round 3 repeats at finer scale.

### A metrics fault must never destroy a cache entry

The timer call sits inside `decompressPacked`, which sits inside
`safeUnpackCompressed`'s `try` — and that `catch` does not mean "something went
wrong", it means **"the stored bytes are corrupt"**, so it logs, `unlink`s the key
and returns `null`. So a bridge whose `observe()` throws (duplicate metric
registration, a rejected label value, an exhausted registry) would not merely
lose a sample: a **valid entry is reported as a miss and deleted**, on every read,
for as long as the fault lasted — an observability change silently becoming a
cache-eviction bug that presents as a cache with a mysterious 0% hit rate.

`packedCodecTimer`'s body is now wrapped in `try { … } catch {}` — one place,
both ops, all three call sites. Three tests drive a **throwing** bridge (the
pre-existing test only covered bridge *absence*, which short-circuits at `?.` and
is a strictly weaker claim) and assert that no key is unlinked and no value is
lost, with a call counter as the positive control that the throwing path was
really entered.

### The legacy path is deliberately not recorded

`decompressPacked` returns a pre-compression (raw msgpack, no sentinel byte)
value untouched after a single byte comparison. Those are **not** recorded as
`decompress` observations. Counting them would fill the histogram with near-zero
samples measuring the cost of *not* decompressing; the p50 would then answer "how
much of this cache is still legacy", which is not the question the metric exists
for.

I chose *skip* over *a separate outcome label* because the passthrough is not a
codec call at all — it is a branch and a return, and giving it a bucket invites
someone to aggregate across the label and get the diluted number back. The
sentinel discrimination stays inside `decompressPacked`, the one function that
already makes it; the caller never re-derives that predicate, so the two cannot
drift apart.

### Wiring

Follows the existing plumbing exactly, with no parallel registry:

* the metric is declared in `@civitai/telemetry`,
* published on the `__civitaiRedisMetrics` globalThis bridge by the app's prom
  shim, alongside `redisCommandDuration` and friends,
* read **per call** by `@civitai/redis` — that package must not statically import
  `prom-client`, since it is reachable from the client bundle, and the bridge is
  published after it loads, so a captured-once handle would pin `undefined`
  forever.

Instrumentation no-ops entirely when the bridge is absent, and swallows a bridge
that throws (both covered by tests).

The timing itself lives in `packed-compression.ts` behind an optional injected
callback, rather than being wrapped at the call sites — that keeps the
codec/legacy discrimination in one place and lets it be unit-tested without a
redis client.

### `fetchThroughCache`'s retry no longer drops the label

The lock-loser retry path re-enters `fetchThroughCache` with a **hand-respelled**
options object rather than passing `options` through, and it threaded `compress`
but not `cacheName`. So a lock loser's retry recorded its samples under
`cache_name="unknown"` even though the caller had named the cache — invisible,
because nothing about the returned value changes. Fixed, and pinned by a test
that drives the real retry.

### Also

`redisCommandDuration`'s round-trip-only scope is now stated in a comment at both
its declaration and its observe site, so the next reader does not mistake it for
a decode cost. **Its semantics are unchanged** — no behaviour, buckets or labels
were touched.

## Tests

`packages/civitai-redis/src/__tests__/packed-codec-timing.test.ts` — 6 tests on
the codec's own timing contract:

* `compressPacked records exactly one compress sample`
* `decompressPacked records exactly one decompress sample when brotli actually ran`
* `decompressPacked records NOTHING for a legacy raw-msgpack value (no sentinel)`
* `decompressPacked records NOTHING for an empty buffer`
* `records SECONDS: 0 < sample <= the caller-observed elapsed time, both ops`
* `is optional: both functions still work with no timer passed`

The seconds assertion is bounded against the caller's *own* wall clock rather
than a fixed threshold, so it is load-independent — a millisecond value overshoots
the elapsed-seconds bound by ~1000x on any machine.

`packages/civitai-redis/src/__tests__/packed-codec-metrics.test.ts` — 12 tests, a
**seam** test rather than a component test. It drives the real client, the real
codec, the real cache builders and the real bridge lookup against an in-memory
transport (same approach as the existing `cached-array-compress.test.ts`). A test
that mocked `redis.packed` would pass against a client that instruments nothing,
which is exactly the defect worth catching:

* `a compressed set observes exactly one compress sample under the given cache_name`
* `an UNCOMPRESSED set observes nothing (no codec ran)`
* `a compressed get observes exactly one decompress sample under the given cache_name`
* `a LEGACY (uncompressed) value read through the compress-aware get observes nothing`
* `a compressed mGet observes one decompress per COMPRESSED value only`
* `an UNCOMPRESSED get observes nothing`
* `falls back to the explicit unnamed-cache label when no cacheName is given`
* `does not throw when the app has published no metrics bridge`
* `createCachedObject labels with the cache PREFIX, never the per-id key`
* `a throwing observe() neither loses the value nor unlinks the key on a compressed get` *(new)*
* `a throwing observe() does not fail a compressed set` *(new)*
* `a throwing observe() leaves a whole compressed mGet batch intact` *(new)*

`packages/civitai-telemetry/src/__tests__/packed-codec-buckets.test.ts` — 4 tests
(new file) on the bucket-resolution invariant, including the negative control
described above.

`src/server/utils/__tests__/cache-helpers-cache-name.test.ts` — 5 tests (new
file) against the **real** `fetchThroughCache` with redis mocked. `cacheName` is
observational, so nothing else in that directory can see it go missing:

* `threads cacheName to the packed READ`
* `threads cacheName to the packed WRITE`
* `never substitutes the per-id key for the cache name`
* `passes cacheName undefined when the caller names no cache (no second fallback literal)`
* `preserves cacheName across the lock-loser retry`

`src/tests/api/v1/model-files/tensor-metadata-cache-name.test.ts` — 4 tests (new
file) driving the **real handler module**, so the assertion is about the
production call site rather than a copy of it. The sibling
`tensor-metadata-cache-headers.test.ts` stubs `getFullTensorAnalysisCached` with a
resolved value, which short-circuits the composition — which is precisely why that
file cannot see a dropped option here.

`src/server/utils/__tests__/tensor-metadata-cache-split.test.ts` — its
`makeFetchers` model of the endpoint had drifted (it omitted `cacheName` while
production passes it). Re-synced, and it now records and asserts the label
alongside `compress`. Its header notes that it is a *model* and points at the
handler-driving test above as the thing that pins the real call site.

Two existing structural assertions were widened rather than loosened:
`cached-array-compress.test.ts`'s packedOptions ledger now pins the full new
binding, and `cache-helpers-update.test.ts` now asserts `cacheName` equals the
cache **prefix**, not the entry key — so a regression to per-id labelling fails
there too.

## Mutation table

Every mutant was applied to the committed code, run, and killed by a **named**
assertion (not merely "a test failed"). M1–M7 are from the original round; M8–M12
cover the fixes above.

| # | Mutant | Killed by | Failing assertion |
|---|---|---|---|
| M1 | delete the bridge `observe` call — timer becomes a no-op | 5 tests | `expected [] to deeply equal [ { op: 'compress', … } ]` |
| M2a | `compress` records the label `decompress` | 4 tests | `expected [ 'decompress' ] to deeply equal [ 'compress' ]` |
| M2b | `decompress` records the label `compress` | 5 tests | `expected [ 'compress' ] to deeply equal [ 'decompress' ]` |
| M3 | record the legacy early return as `decompress` | 4 tests | `expected [ { op: 'decompress', seconds: +0 } ] to deeply equal []` |
| M4 | cache builders stop passing `cacheName` | 2 tests | `expected Set{ 'unknown' } to deeply equal Set{ 'packed:caches:test-codec-builder' }` |
| M5 | report milliseconds instead of seconds | 1 test | `expected 1.8352319999999906 to be less than or equal to 0.0018524749999999984` |
| M6 | write path stops passing a timer | 3 tests | `expected [] to deeply equal [ { op: 'compress', … } ]` |
| M7 | read path stops passing a timer | 3 tests | `expected [] to deeply equal [ { op: 'decompress', … } ]` |
| M8 | `cache-helpers.ts` `const cacheName = options.cacheName` → `= undefined` | 4 tests, 2 files | `the packed READ carries the caller cacheName: expected undefined to be 'packed:caches:cache-name-probe'` |
| M9 | drop `cacheName: REDIS_KEYS.CACHES.TENSOR_METADATA` at the endpoint call site | 2 tests, 1 file | `the FULL cache is named, so its codec samples do not fall into the client "unknown" bucket: expected undefined to be 'packed:caches:tensor-metadata'` |
| M10 | remove the `try/catch` from `packedCodecTimer` | 3 tests | `the healthy entry was NOT unlinked by a metrics fault: expected false to be true` |
| M11 | drop `cacheName` from the lock-loser retry recursion **only** | 1 test | `the RETRY read still carries cacheName: expected undefined to be 'packed:caches:cache-name-probe'` |
| M12 | revert the bucket list to the pre-fix edges | 1 test | `the first edge sits BELOW the measured typical decompress, so a typical sample is resolvable: expected 0.0005 to be less than 0.000026` |

M8 and M9 are the two mutants that previously survived the entire green
`unit*` tier byte-identically. M10's assertion reproduces the defect exactly: the
key really is deleted (`expected false to be true` on `store.has(key)`), and the
same run also shows the read returning `null` for a valid entry. M11 is isolated
to the single line — it kills exactly one test and leaves the other 20 green, so
it cannot be dying for another guard's reason.

## Known open — deliberately not fixed here

Recorded so they read as open rather than absent:

* **`bustFetchThroughCache` has no `cacheName` option**
  (`src/server/utils/cache-helpers.ts`). Latent only: the comment at its
  `compress` parameter records that no current caller busts a compressed key, so
  no codec runs on that path and there is nothing to label. It becomes real the
  moment a compressed cache gains a bust call site.
* **`cacheName?: string` is unvalidated** (`packages/civitai-redis/src/client.ts`).
  `fetchThroughCache` takes a free-form string right next to a `key` that is
  routinely `${prefix}:${id}` — a confusable pair, and passing the key would be
  unbounded prom cardinality. The defences today are doc comments plus the tests
  above that assert the label is *not* the key at each call site; nothing
  structurally prevents it. A branded type or a registry of permitted names would,
  at the cost of touching every packed call signature.
* **The codec's dispatch overhead is tracked as civitai#4656 and is explicitly out
  of scope for this PR.** The codec is `promisify(zlib.brotli*)` unconditionally,
  so every call pays a libuv threadpool round trip: measured at p50 17.7 µs for a
  1-byte payload against a p50 21.9–30.2 µs real decompress, i.e. **~63% of an
  async decompress is dispatch, not brotli**. Making the choice size-conditional
  (sync below a threshold, async above it) would remove most of that, but it is a
  change to the codec's execution model — a different review, with its own
  event-loop-blocking argument to make. This PR only *measures* the path; the new
  bucket floor at 5 µs sits below the dispatch floor precisely so that overhead is
  visible as its own band rather than hidden in bucket one.

## Verification

> **The numbers that were here have been deleted rather than maintained.** This
> section carried a round-1 snapshot (`1645/38249`, `1203/8`, `@civitai/redis`
> 191, `@civitai/telemetry` 32) that every later round then contradicted in a
> table below it — two copies of the same claim, one of them always stale. There
> is now **one** authoritative set of counts, at the head of the branch:
> **Round 3 → Round-3 verification**. Round 2's table is kept as history and is
> labelled with the ref it was measured at.

---

# Round 2 — delta-audit fixes (`1243de2f7b`, `f098314ea5`)

A second adversarial pass over the round-1 delta found three guards that claimed
more than they delivered and one shipped help string that gives a wrong
diagnosis instruction. All five are fixed here, plus a guard on the seam the
whole metric hangs on.

## R1 — the bucket guard pinned a constant, not the histogram (2 surviving mutants)

`packed-codec-buckets.test.ts` imported `PACKED_CODEC_DURATION_BUCKETS` and never
read the **registered** metric. Two mutants shipped past the full package tier
(223/223 at the time) and past all four affected `unit*` files:

* **N1** — leave the constant correct, set `buckets:` on `packedCodecDuration` to
  the pre-fix literal `[0.0005, …, 1]`. That ships the exact histogram this guard
  exists to prevent, with nothing red anywhere.
* **N2** — coarsen the constant to `[0.00002, 0.00005, 0.0001, 0.00025, 1]`. The
  old `coversLargeTail` only asserted `last >= 0.036`, so a single 0.25 ms → 1 s
  bucket passed both predicates while being unable to resolve the ~36 ms tail at
  all.

The guard now **observes a sample and reads the `le` set back off prom-client**
(`packedCodecDuration.get()`), so the verdict comes from the registered metric and
the constant is checked separately for agreement with it. The last-edge-only tail
check is replaced by a **max adjacent edge ratio** predicate (`4x`; the shipped
list's widest pair is `2.5x`, so the bound is not pinning today's number). Both
mutants now die — each on its own assertion, with the other predicates still
passing, so neither is dying for a neighbour's reason.

> ⚠️ **Superseded by Round 3 (B2).** The parenthetical above is the second half of
> a claim whose first half — that 4 "is not a multiple of any step in the list, so
> it cannot be satisfied by accident" — is **false**: two consecutive 2× steps
> compose to exactly 4×, so deleting a single interior edge satisfies the bound.
> The bound is replaced in round 3 by an equality on the ordered ratio sequence.

The comment above the export ("Exported so the resolution invariant can be checked
mechanically rather than by eye") now describes what the test actually does.

## R2 — the observe-failure catch was permanently silent, and its stated reason was false

`packedCodecTimer`'s `catch` is correct and stays. But it swallowed with no log,
no counter and no breadcrumb — so a bridge that throws on every `observe` yields a
histogram that never has data, which is byte-for-byte what *"no cache opted into
compress"* looks like. On the one metric that exists to answer whether compression
pays, a reassuring zero is indistinguishable from a probe wired to nothing.

It now **counts every swallowed failure and reports at most one line per minute**,
naming the op, the cache and the underlying error. Rate-limited rather than
one-shot: a throwing bridge throws on every codec call (unthrottled = per-read log
spam), while a strict one-shot goes quiet for the life of the process however long
the fault lasts.

The old comment asserted that the logger on this path *"is the one that reports
'corrupt entry', which is precisely the wrong claim"* — and therefore that no log
line was possible. **That was false.** `log()` in this module is general-purpose,
called with ~20 distinct messages; the corrupt-entry line is one of its messages,
not its identity. The comment is corrected to what is true, and the breadcrumb's
two real limits are stated instead of a new invented reason: `log()` defaults to a
**no-op** and is only wired by the app shim (`createLogger('redis')`), itself gated
on the app's `LOGGING` config. It is a breadcrumb for whoever goes looking, not an
alert.

## R3 — the shipped `help` string gave a wrong diagnosis instruction

Both the doc block and the `help` said a sample was *"threadpool queue wait + codec
work"* and enumerated inflation causes as threadpool-side only. But the clock stops
at the **`await` continuation on the JS thread**, so the sample also absorbs
**event-loop delay**, and it does so at roughly 1:1.

Measured on this tree:

| what | measurement |
|---|---|
| decompress sample while the JS thread was blocked 50 ms | **50.79 ms** (same call is ~0.02 ms unblocked) |
| threadpool round-trip floor, 1-byte payload, no real codec work | **~11 µs p50** on one machine, **~22 µs p50** on another |
| typical `imageMetaCache`-shaped decompress | **~25–36 µs p50** |

So roughly **half or more of a typical sample is the promise/threadpool hand-off,
not brotli**. Both facts — event-loop delay, and the ~10–25 µs dispatch floor — are
now named in `packed-compression.ts`, in the `RedisMetricsBridge` field doc, and in
the shipped `help` string, so nobody reads the low buckets as codec time or a rise
as "brotli got more expensive".

## R4 — a prose guard replaced with a structural one

`fetchThroughCache`'s lock-loser retry re-spelled all five options by hand, with a
comment warning that a sixth would be silently dropped. It now spreads:

```ts
return fetchThroughCache(key, fetchFn, { ...options, retryCount: retryCount - 1 });
```

Behaviour-identical — every default is a **constant** (`CacheTTL.sm`, `10`, `3`,
`false`, `undefined`) applied with `??`, so an option passed through as `undefined`
re-derives exactly the value the resolved local held — and it makes the whole class
impossible rather than pinning it with prose.

## R5 — swept the sibling the round-1 reword missed

`packages/civitai-telemetry/src/client.ts` still opened with *"Wall time of the
brotli codec…"*, the exact framing rewritten 48 lines below and in
`packed-compression.ts`. Same file, same commit. The `RedisMetricsBridge` field doc
in `packages/civitai-redis/src/client.ts` carried the same phrasing and is swept
too.

## R6 — a guard on the seam the metric hangs on

`src/server/prom/client.ts` publishes `packedCodecDuration` onto the globalThis
bridge. **Delete that one line and every codec sample vanishes with no error
anywhere** — the consumer reads it through `?.`, and the package's own suite
installs a *fake* bridge (correctly: it is testing the client, not the app), so
nothing in either package can see it. The observable result is a histogram with no
series: the same reassuring zero as R2.

New `src/server/prom/__tests__/redis-metrics-bridge.test.ts` loads the **real** app
shim and asserts two things, because either alone is walkable:

* a **ledger** of the published handle set, asserted for equality so it fails when
  the set shrinks (the deletion) *or* grows, plus that no key holds `undefined`
  (which satisfies a key check and still short-circuits at the consumer's `?.`);
* a **behavioural** check that the published handle really writes to the scraped
  exposition text, pinned as whole `_count` / `_sum` / `_bucket` lines with a
  negative control first (the probe series must not exist before the observe).

## Round-2 mutation table

Applied to the committed code, run, restored, and re-verified green after each.

| # | Mutant | Killed by | Failing assertion |
|---|---|---|---|
| N1 | constant correct, `buckets:` on the histogram reverted to the pre-fix literal | 2 tests | `prom-client reported bucket edges for the registered metric: expected 11 to be 15` and `the first REGISTERED edge sits BELOW the measured typical decompress: expected 0.0005 to be less than 0.000026` |
| N2 | constant coarsened to `[0.00002, 0.00005, 0.0001, 0.00025, 1]` | 1 test | `the widest adjacent edge ratio must stay at or under 4x…: expected 4000 to be less than or equal to 4` |
| N3 | delete `packedCodecDuration` from the globalThis publish | 2 tests | `expected [ 'redisCommandDuration', …(6) ] to deeply equal [ 'packedCodecDuration', …(7) ]` |
| N3b | publish the key but wire it to `redisCommandDuration` | 1 test (ledger half correctly passes) | the scraped-exposition assertion on `…_count{op="decompress",cache_name="packed:caches:bridge-seam-probe"} 1` |
| N4 | breadcrumb never logs (`if (false)`) | 1 test | `the FIRST swallowed failure is reported: expected [] to have a length of 1 but got +0` |
| N5 | breadcrumb unthrottled (`if (true)`) | 1 test | `a second failure inside the window is throttled, not logged: expected […(2)] to have a length of 1 but got 2` |
| N6 | breadcrumb one-shot forever (`lastLoggedAt === 0`) | 1 test | `the breadcrumb returns after the throttle window: expected [Array(1)] to have a length of 2 but got 1` |
| N7 | count only the failures that were logged (increment moved inside the throttle) | 1 test | `the throttled failures are still counted, so the line reports 3 rather than 1: expected '…failures=2…' to contain 'failures=3'` |
| N8 | drop the `...options` spread from the retry recursion | 1 test | `the RETRY read still carries cacheName: expected undefined to be 'packed:caches:cache-name-probe'` |

N1 and N2 are the two mutants that previously survived a fully green tier. N3b is
the isolation control for R6: it leaves the ledger half green and kills only the
behavioural half, so the two halves are covering different things.

## Round-2 verification (corrected numbers)

The earlier "1206 passed / 8 failed" figure in this PR body was wrong. Re-measured
from a clean run of each ref:

| ref | `pnpm test:packages:run` | files |
|---|---|---|
| merge base `e695de5aae` | 1189 total / **1181 passed** / 8 failed | 84 of 87 |
| round-1 head `f81267c702` | 1211 total / **1203 passed** / 8 failed | 87 of 90 |
| this head `1243de2f7b` (`f098314ea5` is comment-only) | 1216 total / **1208 passed** / 8 failed | 87 of 90 |

head − base = **+27 tests / +3 files**: the three package test files this PR adds
(6 + 12 + 4 at round 1) plus the 5 tests round 2 adds to two of them. The 8
failures are identical at every ref — the `@civitai/db-queries` DB-backed EXPLAIN
suites, all from a single `connect ECONNREFUSED …:15432` because no local Postgres
is running. Connection refusals, not assertions.

Also at `1243de2f7b` (unchanged by the comment-only `f098314ea5`):

* `pnpm typecheck` — **0 type errors** (via `scripts/typecheck.mjs`, which sets the
  8 GB heap cap; a bare `tsc --noEmit` OOMs at exit 134 on this tree).
* `pnpm test:unit:run` — **1646 files / 38251 tests passed**, 3 files + 33 tests
  skipped, **0 failures**.
* `@civitai/redis` **20 files / 193 tests**, `@civitai/telemetry` **3 files / 35
  tests** (191 and 32 at the round-1 head).
* `prettier --check` clean and `eslint` **0 errors** on all 7 changed files; the 2
  remaining `no-explicit-any` warnings in `cache-helpers.ts` are pre-existing and
  untouched by this change.

---

# Round 3 — final audit round (`d3bf7ba68a`)

Four fixes. Two of them are guards from round 2 that were **satisfiable while the
defect they name is present**; the other two close a hole opened by round 2's own
breadcrumb and pin a constant that was bounded from only one side.

## B1 — the bucket edges are re-cut against production measurements

48 **real** `image-meta` values were pulled off the live cache and timed through
the same `promisify(zlib.brotli*)` shape the codec uses (100% brotli-sentinelled;
compressed p50 883 B, uncompressed p50 1,671 B). Per-value codec timings, in
microseconds:

| | p50 | p90 | p99 |
|---|---|---|---|
| dispatch floor (1-byte payload — threadpool round trip, no codec work) | 17.7 | 38.6 | 140.9 |
| decompress (async, the shape that ships) | 21.9–30.2 | 41.9–66.2 | 182.7 |
| compress q6 | 111.6 | 216.3 | 3,803 |

Against those, the round-1 floor of `0.00002` (20 µs) was **still inside the
sample population**: **38.5% of decompress samples land at or below it**. That is
the same mistake the original `0.0005` floor made — a first edge placed where
typical samples land — one order of magnitude smaller and therefore much easier to
call settled. Everything at or below the first edge is indistinguishable, so a
floor inside the population reports a stable, plausible number that barely moves
whatever the codec does.

**The new list is 21 edges:**

```
5, 10, 15, 20, 30, 50, 75, 100, 150, 250 µs,
0.5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500 ms, 1 s
```

* the floor is **below the measured 17.7 µs dispatch floor**, so bucket one means
  *"impossibly fast — suspect the instrument"* rather than *"typical"*;
* the decompress bulk (10–70 µs) and the compress bulk (100–250 µs) get the finest
  steps in the list, 1.33×–1.67×, because that is where the readable quantiles
  live;
* the ms decade covers compress p99 (~3.8 ms) and the ~36 ms large-blob tail at
  the usual 1-2-5 steps, widest adjacent pair 2.5×.

Cost: 21 edges instead of 15, i.e. **+6 edges × 2 ops × the small set of
compress-aware caches**. Settled before merge, as before — re-cutting resets every
series' history.

## B2 — the bucket guard's bound was satisfiable by deleting an edge, and said it was not

Round 2 replaced a last-edge-only tail check with a bound on the widest adjacent
edge ratio (`<= 4`), and its comment asserted that 4 *"is not a multiple of any
step in the list, so it cannot be satisfied by accident"*.

**That sentence is false.** Deleting an edge does not invent a new ratio — it
**multiplies the two steps either side of it**. A list built from 2× and 2.5×
steps therefore composes to 4×, 5× and 6.25×, and the smallest of those is exactly
the bound. Demonstrated on the round-2 list: deleting any one of `0.0005`,
`0.005`, `0.05` or `0.5` leaves its neighbours at a ratio of **exactly 4**, and
**all 35 tests in the package stay green** — a histogram with half the resolution
across a whole decade, shipped past the guard written to prevent it.

Raising the bound to 3 would close that particular hole and leave the same shape
of guard for the next re-cut to reopen. So the bound is **replaced by an equality
on the ordered sequence of adjacent ratios**, which has no composition hole:
deleting any edge shortens the sequence, changing one moves an entry, inserting
one lengthens it. The comparison is rounded to 3 decimals because 1.5× and 1.667×
are not exact in IEEE754 — ~0.05% resolution, far finer than any step the list
uses.

The old `MAX_EDGE_RATIO` survives, renamed `CONTROL_MAX_EDGE_RATIO` and demoted to
what it can honestly do: discriminating the known-bad **control** lists at the
bottom of the file, which are nowhere near it (2.5× and 4000×). Its comment now
states plainly that no claim is made about it being unreachable by composition —
**it is reachable, and that is why it is no longer the guard.**

A separate test pins the floor below the measured dispatch floor, with a **negative
control** (the round-1 20 µs list, which passes the weaker "below the typical
value" test and fails this one) and a **positive control** (the shipped list must
be accepted, or the assertion is a claim about a predicate that always rejects).

## B3 — the bridge ledger covered only the publisher, and its docstring said otherwise

`redis-metrics-bridge.test.ts` claimed its ledger caught drift *"or vice versa"* —
a handle added to `@civitai/redis` that the app never publishes, which is the
silently-dead-metric case the whole seam exists to prevent. **It cannot.**
`PUBLISHED_HANDLES` is a hand-written literal compared only against
`Object.keys(globalThis.__civitaiRedisMetrics)`, and one person edits both, so
both sides move together.

Demonstrated: add a ninth field to `RedisMetricsBridge` and a real read of it at
the codec timer, leave the publish at eight — **bridge test 2/2 green,
`@civitai/redis` 194/194 green**. Every consumer read is optional-chained, so the
result is a permanently empty series indistinguishable from "the feature is off".

`RedisMetricsBridge` is now **exported** (a type export, erased at build — it adds
nothing to any bundle) and the published object is pinned to it at compile time:

```ts
const redisMetricsBridge = { … } satisfies RedisMetricsBridge &
  Record<keyof RedisMetricsBridge, unknown>;
```

The `Record` half is load-bearing. Most handles are declared **optional** over
there, so a plain `satisfies RedisMetricsBridge` accepts every one of them being
missing — i.e. it accepts exactly the defect. `Record<keyof …, unknown>` makes each
key required at the publish site; intersecting the real type back in keeps the
value shapes checked; and excess-property checking on the literal covers the other
direction.

The check lives in `src/server/prom/client.ts` and **deliberately not** in the test
file: `src/**/__tests__/**` is excluded in `tsconfig.json`, so a type-level
assertion written there would never be evaluated by `pnpm typecheck` — coverage
that reads as coverage while providing none. The docstring now says what the file
covers, what it does not, and where the other direction is enforced.

## B4 — round 2's breadcrumb put unprotected code inside the load-bearing catch

The `catch` in `packedCodecTimer` is documented as 🔴 load-bearing because a throw
escaping it lands in `safeUnpackCompressed`'s catch, **which unlinks the key**.
Round 2 added the breadcrumb *inside* it — an unprotected `log(...)` plus
`err instanceof Error ? err.message : String(err)`. `log` is **injected by the
app** and is therefore arbitrary code, and `String(err)` invokes a
`toString`/`Symbol.toPrimitive` on a value we did not construct. Either throwing
reintroduces the whole observability-becomes-cache-eviction bug the catch exists
to stop, one layer further in, by the very line that reports the swallow.

Now a nested `try { … } catch {}`. The failure counter is still incremented outside
it, so a later successful line carries the count. Low reachability is not totality;
the nesting is what makes the catch total.

## B5 — the throttle constant was pinned only from above

The round-2 test crossed the throttle window and asserted the line returns. That
pins the interval from **above** only — "no larger than the advance" — which every
value down to 1 ms satisfies. Measured: setting
`PACKED_CODEC_OBSERVE_LOG_INTERVAL_MS` to `1` left `@civitai/redis` **193/193
green**, so a `60_000 → 60` unit slip would restore near-per-call log spam under a
sustained fault with nothing red anywhere.

A `+59_999` advance that must **still be throttled** now pins it from below. The
two together bracket the constant into `(59_999, 60_001]`.

## B6 — the message count is deleted rather than corrected a fourth time

The observe-failure comment's claim about how many distinct messages this module's
`log()` carries has been wrong three times: `~20` in round 2, then `35` in a commit
made **solely** to correct it (stating "Counted: 35"); measured at the round-2 head
it is neither — 49 call sites, 47 distinct texts.

**The figure is removed, not re-corrected.** The only claim it ever supported is
that this logger already carries plenty of unrelated traffic, which needs no
number; a count of log sites drifts on every edit and nothing checks it. The
comment now says outright that no count is asserted, and why. Its **other** claim —
that the corrupt-entry line is `Packed (compressed) unpack failed, evicting bad
cache entry` in `safeUnpackCompressed`, not this logger's identity — is correct and
is kept.

## Round-3 mutation table

Applied to the committed code, run, restored, and re-verified green after each.
Bucket mutants were applied by a harness that edits **code lines only** — the first
version of it matched inside the constant's block and silently deleted the `0.5` in
a **comment**, leaving the array untouched and scoring that mutant SURVIVED. The
harness now parses the edge list from non-comment lines and asserts the count drops
by exactly one.

| # | Mutant | Killed by | Failing assertion |
|---|---|---|---|
| P1 | delete edge `0.00003` | 1 test | `the registered edges have exactly the adjacent-ratio sequence this list was designed with…: expected [ 2, 1.5, 1.333, 2.5, 1.5, …(14) ] to deeply equal [ 2, 1.5, 1.333, 1.5, 1.667, …(15) ]` |
| P2 | delete edge `0.000075` | 1 test | same assertion — `expected [ 2, 1.5, 1.333, 1.5, 1.667, 2, …(13) ]` |
| P3 | delete edge `0.00015` | 1 test | same assertion — 20 ratios where 20 are expected but one entry composed |
| P4 | delete edge `0.0005` | 1 test | same assertion |
| P5 | delete edge `0.005` | 1 test | same assertion |
| P6 | delete edge `0.05` | 1 test | same assertion |
| P7 | delete edge `0.5` | 1 test | same assertion |
| P8 | revert the whole list to the round-1 20 µs edge set | 3 tests | `the first REGISTERED edge must sit below the 0.0000177s threadpool dispatch floor…: expected 0.00002 to be less than 0.0000177`, plus the ratio-sequence assertion and the dispatch-floor **positive control** |
| P9 | add a 9th handle to `RedisMetricsBridge` + a real read of it, publish left at 8 | `pnpm typecheck` | `src/server/prom/client.ts(62,3): error TS1360: Type '{ … }' does not satisfy the expected type 'RedisMetricsBridge & Record<keyof RedisMetricsBridge, unknown>'` |
| P10 | remove the nested `try/catch` from `packedCodecTimer` (body kept in a bare block) | 1 test | `the healthy entry survived a throwing LOGGER, not merely a throwing observe(): expected false to be true` |
| P11 | `PACKED_CODEC_OBSERVE_LOG_INTERVAL_MS = 1` | 1 test | `a failure just BELOW the throttle window is still throttled — the window is ~60s, not milliseconds: expected […(2)] to have a length of 1 but got 2` |

**P1–P7 are the mutants the round-2 bound could not see.** Four of them
(`0.0005`, `0.005`, `0.05`, `0.5`) left the round-2 list at a widest adjacent ratio
of exactly 4 and passed a `<= 4` bound.

**P9 has a control, because a red arm alone does not attribute.** With the
`satisfies` clause removed and the mutant otherwise identical, `pnpm typecheck`
returns **0 errors** — so the `satisfies` is what kills it, not something else in
the tree. And under P9 the runtime suites stay green (`@civitai/redis` 194/194, the
bridge test 2/2), which is the point: no runtime test on either side can observe
this defect.

**P10's two positive controls run before the killing assertion** — the throwing
`observe()` was reached, and the throttle then admitted the breadcrumb line and the
injected logger actually threw. Without the second, the test would also pass
against a build where the breadcrumb never fires at all.

## Round-3 verification

Measured at `d3bf7ba68a` in a clean worktree off this branch.

| | before (`f098314ea5`) | after (`d3bf7ba68a`) |
|---|---|---|
| `@civitai/telemetry` | 3 files / **35** tests | 3 files / **38** tests |
| `@civitai/redis` | 20 files / **193** tests | 20 files / **194** tests |
| `src/server/prom/__tests__/redis-metrics-bridge.test.ts` | 1 file / **2** tests | 1 file / **2** tests |
| `pnpm test:packages:run` | 1216 total / 1208 passed / 8 failed *(derived)* | **1220 total / 1212 passed / 8 failed** *(measured)* |
| `pnpm typecheck` | 0 errors | **0 errors** (77 s, 8 GB heap cap) |

The first four rows' "before" figures were measured directly at the pristine
`f098314ea5` worktree. The `test:packages:run` "before" is marked *derived*: it is
the measured 1220 minus the 4 tests this round adds, all of which are in the two
projects measured directly on both sides. It agrees with round 2's independently
measured 1216, which is the cross-check.

The 8 failures are identical before and after: the `@civitai/db-queries` DB-backed
EXPLAIN suites, all from a single `connect ECONNREFUSED …:15432` because no local
Postgres is running. Connection refusals, not assertions.

`prettier --check` clean and `eslint` **0 errors** on all 6 changed files. The
eslint run was positive-controlled — the same invocation on a deliberately bad file
reports `1 problem`, so the clean verdict is about the code and not about a
zero-file glob.

### CI is the authoritative verdict, and it is green on this head

`gh run view 34046090182` at `headSha=d3bf7ba68a`: **20 checks, 19 SUCCESS + 1
SKIPPED, every one terminal** — including *App unit tests + typecheck*, *Package
unit tests*, *ESLint + Prettier (changed files)*, all four *Unit tests* shards,
`tekton / typecheck`, and the preview deploy + smoke suite (66 passed, 0 flaky).
That matters for the section below: CI runs in a checkout that has none of the two
local environment faults, and it agrees.

### `pnpm test:unit:run`, and the two environment faults in it

**1649 files / 38269 tests — 38222 passed, 45 skipped, 2 failed.** Neither failure
is attributable to this change; both were run down to a cause rather than re-run
until green:

* **4 of the 5 failing files** fail on
  `TSConfckParseError: failed to resolve "extends":"./.svelte-kit/tsconfig.json"`
  in `apps/moderator/tsconfig.json` and `apps/auth/tsconfig.json`. `.svelte-kit/`
  is a **generated** SvelteKit artifact and is gitignored
  (`apps/moderator/.gitignore:8`), so it is present in a long-lived clone and
  absent in a fresh checkout. `moderator-restriction-vocabulary.test.ts` passes
  **21/21** in a clone that has it. This is a property of the checkout, identical
  on `main`.
* **`eventloop-watchdog.capture.test.ts > 🔴 classifies an idle wedge as starved`**
  took **12,045 ms** in the full-suite run and **passes in isolation** — a
  wall-time load flake, not an assertion failure.

A first attempt at this tier is discarded and not quoted: the worktree shares the
base clone's `node_modules` by symlink, hence also `node_modules/.vite` and
`.experimental-vitest-cache`, and a concurrent run in the base clone rewrote that
cache mid-run. 814 of 1649 files then failed to **collect**
(`Cannot find module …/deps_ssr/prom-client.js`, `ENOENT …/.experimental-vitest-cache/…`)
— roughly 8,000 tests never executed, while the summary still printed a pass count
for the rest. The run above was re-taken with nothing concurrent.

The one app file this round touches — `src/server/prom/client.ts` — is covered by
`redis-metrics-bridge.test.ts`, 2/2, against the real module, and the change there
is a named `const` plus a `satisfies` clause: runtime-identical to what it replaced,
and `pnpm typecheck` is the only gate that can see the guard it adds.

### Diff shape

6 files, **+332 / −59**. Of the added lines, **114 are executable and 218 are
comment or blank**:

| file | added exec | added comment/blank | kind |
|---|---|---|---|
| `packages/civitai-telemetry/src/client.ts` | 3 | 32 | payload |
| `packages/civitai-redis/src/client.ts` | 12 | 32 | payload |
| `src/server/prom/client.ts` | 5 | 22 | payload |
| `packages/civitai-telemetry/src/__tests__/packed-codec-buckets.test.ts` | 49 | 76 | scaffolding |
| `packages/civitai-redis/src/__tests__/packed-codec-metrics.test.ts` | 45 | 31 | scaffolding |
| `src/server/prom/__tests__/redis-metrics-bridge.test.ts` | 0 | 25 | scaffolding |

Payload total: **20 executable / 86 comment**. The ratio is deliberate — three of
the four fixes are corrections to *claims* a previous round made, and the
correction has to be the sentence as much as the code, or the next reader
re-derives the same wrong justification.
