### PR TITLE
feat(moderation): read-through cache for external prompt-moderation verdicts (off by default)

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2007,8 +2007,9 @@ export const REDIS_SYS_KEYS = {
      * segment after THAT is a truncated SHA-256 of the exact string sent to the classifier; the
      * prompt itself is never stored. Every key carries an EX.
      *
-     * Written only while EXTERNAL_MODERATION_CACHE_TTL_SECONDS is a positive integer — that TTL is
-     * the arming switch, and there is deliberately no separate boolean to disagree with it.
+     * Written only while BOTH EXTERNAL_MODERATION_CACHE_TTL_SECONDS is a positive integer AND
+     * EXTERNAL_MODERATION_CACHE_NAMESPACE names an allowlisted deployment — two inputs, because one
+     * says how long entries live and the other says where; neither is inferable from the other.
      * See src/server/integrations/moderation-verdict-cache.ts.
      */
     MODERATION_VERDICT: 'generation:moderation-verdict',

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1999,7 +1999,9 @@ export const REDIS_SYS_KEYS = {
      * Read-through cache of external prompt-moderation VERDICTS — unlike MODERATION_CACHE_PROBE
      * above, this one IS read back, and a hit skips the classifier call entirely.
      *
-     * The segment after this prefix is a digest of the POLICY that produced the verdict (model,
+     * The segment after this prefix is the DEPLOYMENT namespace — several deployments share one
+     * sysRedis and sys keys carry no environment segment, so without it a preview could serve a
+     * verdict to production. The segment after THAT is a digest of the POLICY (model,
      * score threshold, category map), not a deployment label: changing any of them changes every
      * key, so a policy change invalidates the whole cache atomically with no flush step. The
      * segment after THAT is a truncated SHA-256 of the exact string sent to the classifier; the

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1995,6 +1995,21 @@ export const REDIS_SYS_KEYS = {
      * See src/server/integrations/moderation-cache-probe.ts.
      */
     MODERATION_CACHE_PROBE: 'generation:moderation-cache-probe',
+    /**
+     * Read-through cache of external prompt-moderation VERDICTS — unlike MODERATION_CACHE_PROBE
+     * above, this one IS read back, and a hit skips the classifier call entirely.
+     *
+     * The segment after this prefix is a digest of the POLICY that produced the verdict (model,
+     * score threshold, category map), not a deployment label: changing any of them changes every
+     * key, so a policy change invalidates the whole cache atomically with no flush step. The
+     * segment after THAT is a truncated SHA-256 of the exact string sent to the classifier; the
+     * prompt itself is never stored. Every key carries an EX.
+     *
+     * Written only while EXTERNAL_MODERATION_CACHE_TTL_SECONDS is a positive integer — that TTL is
+     * the arming switch, and there is deliberately no separate boolean to disagree with it.
+     * See src/server/integrations/moderation-verdict-cache.ts.
+     */
+    MODERATION_VERDICT: 'generation:moderation-verdict',
   },
   TRAINING: {
     STATUS: 'training:status',

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -656,7 +656,20 @@ export const serverSchema = z
     // bound on a classifier whose model can change behind a stable name; the measured value of a
     // longer window is small anyway (12x the TTL bought ~7 points of hit rate).
     // See src/server/integrations/moderation-verdict-cache.ts.
-    EXTERNAL_MODERATION_CACHE_TTL_SECONDS: z.coerce.number().int().min(0).max(3600).default(0),
+    // The deployment this cache writes under. REQUIRED to arm it — several civitai-web deployments
+    // share one sysRedis and sys keys carry no environment segment, and the PR-preview task copies
+    // civitai-cfg WHOLESALE, so the TTL below is inherited by every open preview. A closed
+    // allowlist lives in moderation-verdict-cache.ts (one rule, one place); anything outside it is
+    // OFF and logged once. See that module for why the policy digest cannot substitute for this.
+    EXTERNAL_MODERATION_CACHE_NAMESPACE: z.string().trim().optional().default(''),
+    // 🔴 `.catch(0)`, NOT `.default(0)` — the same rule TRPC_MAX_BATCH_SIZE and
+    // EXTERNAL_MODERATION_TIMEOUT_MS carry above. `src/env/server.ts` THROWS on any invalid field,
+    // and env is parsed only at container start, so a typo here (`=off`, `=false`, `=3600s`,
+    // `=7200` over the cap) does nothing visible at the time and then CrashLoops the whole fleet at
+    // the next rollout, hours detached from the change — during the very incident this lever exists
+    // to end. `.catch(0)` degrades an unparseable value to OFF, which is the safe direction for a
+    // cache in front of a moderation gate.
+    EXTERNAL_MODERATION_CACHE_TTL_SECONDS: z.coerce.number().int().min(0).max(3600).catch(0),
     BLOCKED_IMAGE_HASH_CHECK: zc.booleanString.optional().default(false),
     MODERATION_KNIGHT_TAGS: commaDelimitedStringArray().default([]),
 

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -647,6 +647,16 @@ export const serverSchema = z
     // as perfectly good namespaces, so the likeliest spelling of "turn this off" would ARM the
     // probe. See src/server/integrations/moderation-cache-probe.ts.
     EXTERNAL_MODERATION_CACHE_PROBE: z.string().trim().optional().default(''),
+    //
+    // Seconds to hold a cached external-moderation verdict. THIS IS THE ARMING SWITCH for the
+    // verdict cache: absent or 0 means the cache is inert and emits no metric series at all.
+    // There is deliberately no separate boolean — a second on/off input is a second thing that can
+    // disagree with the first, which is the trap the probe's namespace allowlist above exists to
+    // avoid. Capped at 3600 because a cached verdict is a STALE verdict and the TTL is the only
+    // bound on a classifier whose model can change behind a stable name; the measured value of a
+    // longer window is small anyway (12x the TTL bought ~7 points of hit rate).
+    // See src/server/integrations/moderation-verdict-cache.ts.
+    EXTERNAL_MODERATION_CACHE_TTL_SECONDS: z.coerce.number().int().min(0).max(3600).default(0),
     BLOCKED_IMAGE_HASH_CHECK: zc.booleanString.optional().default(false),
     MODERATION_KNIGHT_TAGS: commaDelimitedStringArray().default([]),
 

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -648,20 +648,33 @@ export const serverSchema = z
     // probe. See src/server/integrations/moderation-cache-probe.ts.
     EXTERNAL_MODERATION_CACHE_PROBE: z.string().trim().optional().default(''),
     //
-    // Seconds to hold a cached external-moderation verdict. THIS IS THE ARMING SWITCH for the
-    // verdict cache: absent or 0 means the cache is inert and emits no metric series at all.
-    // There is deliberately no separate boolean — a second on/off input is a second thing that can
-    // disagree with the first, which is the trap the probe's namespace allowlist above exists to
-    // avoid. Capped at 3600 because a cached verdict is a STALE verdict and the TTL is the only
-    // bound on a classifier whose model can change behind a stable name; the measured value of a
-    // longer window is small anyway (12x the TTL bought ~7 points of hit rate).
-    // See src/server/integrations/moderation-verdict-cache.ts.
-    // The deployment this cache writes under. REQUIRED to arm it — several civitai-web deployments
-    // share one sysRedis and sys keys carry no environment segment, and the PR-preview task copies
-    // civitai-cfg WHOLESALE, so the TTL below is inherited by every open preview. A closed
-    // allowlist lives in moderation-verdict-cache.ts (one rule, one place); anything outside it is
-    // OFF and logged once. See that module for why the policy digest cannot substitute for this.
+    // 🔴 THE VERDICT CACHE NEEDS BOTH OF THE NEXT TWO VARIABLES. Neither alone arms it: this one
+    // says WHERE entries live, the TTL below says HOW LONG. Setting only one leaves the cache inert
+    // and emitting no metric series, which looks identical to "not configured" — so if you set a
+    // TTL and see no `external_moderation_cache_total`, check this variable before concluding the
+    // metric is broken.
+    //
+    // ⚠️ An earlier revision of this block said the TTL was "THE ARMING SWITCH" with "deliberately
+    // no separate boolean". That was retracted across the module, the counter help text, the redis
+    // key registry and the PR body — and survived HERE, five lines above the comment contradicting
+    // it, which is the surface an operator actually reads. Stated once, in full, at both fields.
+    //
+    // The deployment this cache writes under. Several civitai-web deployments share one sysRedis
+    // and sys keys carry no environment segment, and the PR-preview task copies civitai-cfg
+    // WHOLESALE, so the TTL below is inherited by every open preview. A closed allowlist lives in
+    // moderation-verdict-cache.ts (one rule, one place); anything outside it is OFF and logged
+    // once. See that module for why the policy digest cannot substitute for this.
     EXTERNAL_MODERATION_CACHE_NAMESPACE: z.string().trim().optional().default(''),
+    // Seconds to hold a cached external-moderation verdict — the second of the two required inputs
+    // described above. Capped at 3600 because a cached verdict is a STALE verdict and the TTL is
+    // the only bound on a classifier whose model can change behind a stable name; the measured
+    // value of a longer window is small anyway (12x the TTL bought ~7 points of hit rate).
+    // See src/server/integrations/moderation-verdict-cache.ts.
+    //
+    // ⚠️ This descriptive comment was ORPHANED for two commits — it sat above the NAMESPACE
+    // declaration, so a reader of that field was told it is measured in seconds and capped at 3600.
+    // Introduced by inserting the namespace field between this text and the field it describes.
+    //
     // 🔴 `.catch(0)`, NOT `.default(0)` — the same rule TRPC_MAX_BATCH_SIZE and
     // EXTERNAL_MODERATION_TIMEOUT_MS carry above. `src/env/server.ts` THROWS on any invalid field,
     // and env is parsed only at container start, so a typo here (`=off`, `=false`, `=3600s`,

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -651,7 +651,9 @@ export const serverSchema = z
     // 🔴 THE VERDICT CACHE NEEDS BOTH OF THE NEXT TWO VARIABLES. Neither alone arms it: this one
     // says WHERE entries live, the TTL below says HOW LONG. Setting only one leaves the cache inert
     // and emitting no metric series, which looks identical to "not configured" — so if you set a
-    // TTL and see no `external_moderation_cache_total`, check this variable before concluding the
+    // TTL and see no `civitai_app_external_moderation_cache_total` (PROM_PREFIX is prepended at
+    // registration, so the bare name in the counter's help text is NOT queryable), check this
+    // variable before concluding the
     // metric is broken.
     //
     // ⚠️ An earlier revision of this block said the TTL was "THE ARMING SWITCH" with "deliberately

--- a/src/server/integrations/__tests__/moderation-verdict-cache.test.ts
+++ b/src/server/integrations/__tests__/moderation-verdict-cache.test.ts
@@ -29,6 +29,7 @@ const env = vi.hoisted(() => ({
   EXTERNAL_MODERATION_CATEGORIES: undefined as Record<string, string> | undefined,
   EXTERNAL_MODERATION_CACHE_PROBE: '' as string,
   EXTERNAL_MODERATION_CACHE_TTL_SECONDS: 300,
+  EXTERNAL_MODERATION_CACHE_NAMESPACE: 'prod' as string,
 }));
 vi.mock('~/env/server', () => ({ env }));
 
@@ -37,6 +38,7 @@ import { serverSchema } from '~/env/server-schema';
 import { extModeration } from '~/server/integrations/moderation';
 import {
   buildVerdictKey,
+  CACHE_NAMESPACES,
   moderationCacheEnabled,
   policyDigest,
 } from '~/server/integrations/moderation-verdict-cache';
@@ -105,6 +107,7 @@ beforeEach(() => {
   promClient.register.getSingleMetric(CACHE)?.reset();
   promClient.register.getSingleMetric(HIST)?.reset();
   env.EXTERNAL_MODERATION_CACHE_TTL_SECONDS = 300;
+  env.EXTERNAL_MODERATION_CACHE_NAMESPACE = 'prod';
   env.EXTERNAL_MODERATION_THRESHOLD = 0.5;
   env.EXTERNAL_MODERATION_CATEGORIES = undefined;
   // `resetSharedMocks()` runs once PER FILE, not per test, so call history accumulates across
@@ -156,14 +159,13 @@ describe('the TTL is the arming switch', () => {
     expect(serverSchema.shape.EXTERNAL_MODERATION_CACHE_TTL_SECONDS.safeParse(300).success).toBe(
       true
     );
-    expect(serverSchema.shape.EXTERNAL_MODERATION_CACHE_TTL_SECONDS.safeParse('nope').success).toBe(
-      false
-    );
-    // Capped: a cached verdict is a stale verdict, and the TTL is the only bound on a classifier
-    // whose model can move behind a stable name.
-    expect(serverSchema.shape.EXTERNAL_MODERATION_CACHE_TTL_SECONDS.safeParse(3601).success).toBe(
-      false
-    );
+    // 🔴 `.catch(0)`, so an operator typo degrades to OFF instead of throwing. An earlier revision
+    // pinned `success === false` — i.e. it asserted the fleet-CrashLooping behaviour AS INTENDED,
+    // because env.ts throws on any invalid field and env parses only at container start.
+    const typo = serverSchema.shape.EXTERNAL_MODERATION_CACHE_TTL_SECONDS.safeParse('off');
+    expect(typo.success && typo.data).toBe(0);
+    const over = serverSchema.shape.EXTERNAL_MODERATION_CACHE_TTL_SECONDS.safeParse(7200);
+    expect(over.success && over.data).toBe(0);
   });
 });
 
@@ -279,6 +281,22 @@ describe('what must NEVER be cached', () => {
     expect(result.flagged).toBe(false); // from the live call, not from the malformed entry
   });
 
+  it('🔴 a non-string CATEGORY element is an ERROR and re-calls (the other half of the strict guard)', async () => {
+    // This guard had NO test: deleting the `c.some(x => typeof x !== 'string')` clause left the
+    // suite fully green, because every other malformed case attacks `f` or the JSON parse. A stored
+    // `{"f":false,"c":[{"x":1}]}` would deserialize to categories:[{x:1}], and those values flow on
+    // to PromptTrigger `message`/`matchedWord` and into reportProhibitedRequest.
+    const store = installRedisStore();
+    const fetchSpy = stubFetchOk();
+    await extModeration.moderatePrompt('nonstring cats', 'generate');
+    await untilStored(store, 1);
+    store.set([...store.keys()][0], '{"f":false,"c":[1]}');
+
+    await extModeration.moderatePrompt('nonstring cats', 'generate');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(await cacheCount('error')).toBe(1);
+  });
+
   it('unparseable JSON is an error and re-calls', async () => {
     const store = installRedisStore();
     const fetchSpy = stubFetchOk();
@@ -302,6 +320,34 @@ describe('what must NEVER be cached', () => {
     expect(result).toEqual({ flagged: false, categories: [] });
     expect(await cacheCount('error')).toBe(1);
     expect(await cacheCount('hit')).toBe(0);
+  });
+
+  it('🔴 the awaited read is DEADLINE-WRAPPED — a hung sysRedis cannot park the submit path', async () => {
+    // 🔴 THE DEFECT THIS PINS IS A HANG, NOT A REJECTION, and the try/catch cannot see one. The sys
+    // client has no socketTimeout, so on a silent half-open a written command parks in node-redis's
+    // reply queue until OS TCP keepalive errors the socket — ~11 MINUTES on Linux defaults — on
+    // every authenticated request. This read is awaited on the generation submission path.
+    //
+    // Driven through the mock's `withSysReadDeadline` SEAM, whose default is the REAL wrapper. A
+    // never-settling `get` is only survivable if the call is routed through the deadline; an
+    // unwrapped `await sysRedis.get(...)` hangs this test instead of failing it.
+    installRedisStore();
+    redisMock.sysRedis.get.mockImplementation(() => new Promise(() => {})); // never settles
+    // 🔴 `Once`, NOT `mockImplementation`. `vi.restoreAllMocks()` in afterEach does NOT reset a
+    // SHARED-module mock's implementation, so a persistent override here leaks into every later
+    // case in this file: the first draft of this test made `withSysReadDeadline` throw forever,
+    // and the threshold-invalidation test three describes down failed with 2 fetch calls instead
+    // of 1. Same per-file persistence trap the beforeEach already clears `get`/`set` for.
+    redisMock.withSysReadDeadline.mockImplementationOnce(async () => {
+      throw new Error('sys read deadline exceeded');
+    });
+    const fetchSpy = stubFetchOk();
+
+    const result = await extModeration.moderatePrompt('hung redis', 'generate');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // fell through to the classifier
+    expect(result).toEqual({ flagged: false, categories: [] });
+    expect(await cacheCount('error')).toBe(1);
   });
 
   it('a Redis WRITE failure does not fail the request', async () => {
@@ -362,11 +408,63 @@ describe('the policy digest is the staleness answer', () => {
   });
 });
 
+describe('the deployment namespace is required to arm', () => {
+  it('🔴 an unknown namespace disables the cache — an unrecognised deployment must never share a keyspace', async () => {
+    const store = installRedisStore();
+    const fetchSpy = stubFetchOk();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    // Differential: the armed leg proves a read lands in this window.
+    env.EXTERNAL_MODERATION_CACHE_NAMESPACE = 'prod';
+    await extModeration.moderatePrompt('ns armed', 'generate');
+    await untilStored(store, 1);
+    expect(redisMock.sysRedis.get).toHaveBeenCalled();
+
+    redisMock.sysRedis.get.mockClear();
+    env.EXTERNAL_MODERATION_CACHE_NAMESPACE = 'preview';
+    await extModeration.moderatePrompt('ns armed', 'generate');
+
+    expect(redisMock.sysRedis.get).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(moderationCacheEnabled()).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('🔴 every on/off spelling an operator might reach for is OFF, not a namespace', () => {
+    // The charset-plus-denylist approach the probe's audit rejected accepted all of these.
+    for (const word of ['y', 'n', 'no', 'off', 'false', 'none', 'null', 'disable', '0', '2']) {
+      env.EXTERNAL_MODERATION_CACHE_NAMESPACE = word;
+      expect(moderationCacheEnabled()).toBe(false);
+    }
+  });
+
+  it('an empty namespace is the deliberately-unarmed case and logs nothing', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    env.EXTERNAL_MODERATION_CACHE_NAMESPACE = '';
+    expect(moderationCacheEnabled()).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('the allowlist is asserted as a LEDGER — it fails when the set grows OR shrinks', () => {
+    expect([...CACHE_NAMESPACES]).toEqual(['prod']);
+  });
+});
+
 describe('key shape', () => {
+  it('🔴 separates two DEPLOYMENTS for the same prompt and policy', () => {
+    // 🔴 THE ONLY PLACE THIS IS REACHABLE. `CACHE_NAMESPACES` has one member, so no test driven
+    // through the public surface can distinguish a key that carries the namespace from one that
+    // hardcodes it — the same blind spot the probe documented when its allowlist narrowed to one.
+    // Passing the namespace as an ARGUMENT is what makes the segment testable at all.
+    const prod = buildVerdictKey('generation:moderation-verdict', 'prod', 'p', 'd');
+    const preview = buildVerdictKey('generation:moderation-verdict', 'preview', 'p', 'd');
+    expect(prod).not.toBe(preview);
+  });
+
   it('separates two policies for the same prompt', () => {
-    const a = buildVerdictKey('generation:moderation-verdict', 'policyA', 'deadbeef');
-    const b = buildVerdictKey('generation:moderation-verdict', 'policyB', 'deadbeef');
-    expect(a).toBe('generation:moderation-verdict:policyA:deadbeef');
+    const a = buildVerdictKey('generation:moderation-verdict', 'prod', 'policyA', 'deadbeef');
+    const b = buildVerdictKey('generation:moderation-verdict', 'prod', 'policyB', 'deadbeef');
+    expect(a).toBe('generation:moderation-verdict:prod:policyA:deadbeef');
     expect(a).not.toBe(b);
   });
 
@@ -380,7 +478,7 @@ describe('key shape', () => {
     const key = [...store.keys()][0];
     expect(key).not.toContain(secret);
     expect(key).not.toContain('distinctive');
-    expect(key).toMatch(/^generation:moderation-verdict:[0-9a-f]{16}:[0-9a-f]{32}$/);
+    expect(key).toMatch(/^generation:moderation-verdict:prod:[0-9a-f]{16}:[0-9a-f]{32}$/);
     // The stored VALUE carries the verdict only, never the prompt.
     expect(store.get(key)).not.toContain('distinctive');
   });

--- a/src/server/integrations/__tests__/moderation-verdict-cache.test.ts
+++ b/src/server/integrations/__tests__/moderation-verdict-cache.test.ts
@@ -333,7 +333,9 @@ describe('what must NEVER be cached', () => {
     // never-settling `get` is only survivable if the call is routed through the deadline; an
     // unwrapped `await sysRedis.get(...)` hangs this test instead of failing it.
     installRedisStore();
-    redisMock.sysRedis.get.mockImplementation(() => new Promise(() => {})); // never settles
+    // `() => undefined` rather than `() => {}` — the latter trips
+    // @typescript-eslint/no-empty-function, which is a CI tier I had not run locally.
+    redisMock.sysRedis.get.mockImplementation(() => new Promise(() => undefined));
     // 🔴 `Once`, NOT `mockImplementation`. `vi.restoreAllMocks()` in afterEach does NOT reset a
     // SHARED-module mock's implementation, so a persistent override here leaks into every later
     // case in this file: the first draft of this test made `withSysReadDeadline` throw forever,

--- a/src/server/integrations/__tests__/moderation-verdict-cache.test.ts
+++ b/src/server/integrations/__tests__/moderation-verdict-cache.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Contract for the external-moderation VERDICT CACHE.
+ *
+ * WHAT IT IS. A read-through cache that lets an identical prompt skip the classifier call entirely.
+ * Unlike the dark probe it replaces, this one CHANGES BEHAVIOUR: on a hit no request is issued and
+ * the stored verdict is returned. It sits on a moderation gate, so most of these cases are negative
+ * constraints — what it must never do — rather than happy-path coverage.
+ *
+ * 🔴 WHY THE TESTS LOOK LIKE THIS. The dangerous failure of a moderation cache is not "it misses
+ * too often" (that costs latency, which we already pay). It is serving a PERMISSIVE verdict that
+ * was never computed: a malformed entry read as `flagged:false`, a failure cached as a pass, or a
+ * verdict computed under a policy that no longer exists. Every case below is written so that the
+ * lenient direction fails, and the absence assertions are structured as DIFFERENTIALS — the probe's
+ * own test suite learned that the hard way, when a bare "asserted zero" passed with the arming
+ * guard deleted because the first lazy `import()` simply hadn't resolved inside the sleep.
+ *
+ * These read back the REAL prom-client registry rather than asserting we called our own wrapper.
+ */
+import promClient from 'prom-client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mutable env mock, overriding the global stub in src/__tests__/setup.ts, so each case can flip the
+// TTL. `vi.hoisted` so it exists before the hoisted `vi.mock` factory references it.
+const env = vi.hoisted(() => ({
+  EXTERNAL_MODERATION_ENDPOINT: 'https://moderation.example/v1/moderations' as string,
+  EXTERNAL_MODERATION_TOKEN: 'tok' as string,
+  EXTERNAL_MODERATION_THRESHOLD: 0.5,
+  EXTERNAL_MODERATION_TIMEOUT_MS: 5000,
+  EXTERNAL_MODERATION_CATEGORIES: undefined as Record<string, string> | undefined,
+  EXTERNAL_MODERATION_CACHE_PROBE: '' as string,
+  EXTERNAL_MODERATION_CACHE_TTL_SECONDS: 300,
+}));
+vi.mock('~/env/server', () => ({ env }));
+
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { serverSchema } from '~/env/server-schema';
+import { extModeration } from '~/server/integrations/moderation';
+import {
+  buildVerdictKey,
+  moderationCacheEnabled,
+  policyDigest,
+} from '~/server/integrations/moderation-verdict-cache';
+
+const CACHE = 'civitai_app_external_moderation_cache_total';
+const HIST = 'civitai_app_external_moderation_duration_seconds';
+
+type Sample = { labels: Record<string, string | number>; value: number };
+
+async function samples(name: string): Promise<Sample[]> {
+  const metric = promClient.register.getSingleMetric(name);
+  if (!metric) throw new Error(`metric ${name} is not registered`);
+  return (await metric.get()).values as Sample[];
+}
+
+async function cacheCount(result: string, source = 'generate') {
+  const vals = await samples(CACHE);
+  return vals.find((v) => v.labels.source === source && v.labels.result === result)?.value ?? 0;
+}
+
+/** Every histogram `_count` summed — used to prove a cache hit records NO latency sample. */
+async function histCount() {
+  return (await samples(HIST))
+    .filter((v) =>
+      String((v as unknown as { metricName?: string }).metricName ?? '').endsWith('_count')
+    )
+    .reduce((acc, v) => acc + v.value, 0);
+}
+
+/**
+ * A real in-memory key/value store behind `sysRedis.get`/`set`.
+ *
+ * 🔴 THE DEFAULT MOCK CANNOT TEST THIS. `get` defaults to null (always a miss) and `set` to 'OK',
+ * so a cache that never actually reads Redis would pass every miss case vacuously and could never
+ * produce a hit at all. The store is what makes a hit reachable, which is the point.
+ */
+function installRedisStore() {
+  const store = new Map<string, string>();
+  redisMock.sysRedis.get.mockImplementation(async (key: string) => store.get(key) ?? null);
+  redisMock.sysRedis.set.mockImplementation(async (key: string, value: string) => {
+    store.set(key, value);
+    return 'OK';
+  });
+  return store;
+}
+
+const okResponse = (flagged = false, categories: Record<string, boolean> = {}) => ({
+  ok: true,
+  json: async () => ({
+    results: [{ flagged, category_scores: {}, categories }],
+  }),
+});
+
+function stubFetchOk(flagged = false) {
+  const spy = vi.fn(async () => okResponse(flagged));
+  vi.stubGlobal('fetch', spy);
+  return spy;
+}
+
+/** The store write is fire-and-forget; poll rather than sleep. A fixed sleep is the classic flake. */
+async function untilStored(store: Map<string, string>, n: number) {
+  await vi.waitFor(() => expect(store.size).toBe(n));
+}
+
+beforeEach(() => {
+  promClient.register.getSingleMetric(CACHE)?.reset();
+  promClient.register.getSingleMetric(HIST)?.reset();
+  env.EXTERNAL_MODERATION_CACHE_TTL_SECONDS = 300;
+  env.EXTERNAL_MODERATION_THRESHOLD = 0.5;
+  env.EXTERNAL_MODERATION_CATEGORIES = undefined;
+  // `resetSharedMocks()` runs once PER FILE, not per test, so call history accumulates across
+  // cases — the same trap documented in the probe's suite.
+  redisMock.sysRedis.get.mockClear();
+  redisMock.sysRedis.set.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('the TTL is the arming switch', () => {
+  it('is OFF with no TTL: Redis untouched, no series, classifier still called', async () => {
+    // Structured as a DIFFERENTIAL. The armed leg proves a read DOES land in this window, so the
+    // unarmed leg finding none is evidence rather than a slow lazy import.
+    const store = installRedisStore();
+    const fetchSpy = stubFetchOk();
+
+    env.EXTERNAL_MODERATION_CACHE_TTL_SECONDS = 300;
+    await extModeration.moderatePrompt('armed leg', 'generate');
+    await untilStored(store, 1);
+    expect(redisMock.sysRedis.get).toHaveBeenCalled();
+
+    redisMock.sysRedis.get.mockClear();
+    env.EXTERNAL_MODERATION_CACHE_TTL_SECONDS = 0;
+    await extModeration.moderatePrompt('unarmed leg', 'generate');
+
+    expect(redisMock.sysRedis.get).not.toHaveBeenCalled();
+    expect(store.size).toBe(1); // nothing new written
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // the classifier is called either way
+    expect(moderationCacheEnabled()).toBe(false);
+  });
+
+  it('treats a negative or fractional TTL as OFF rather than coercing it', async () => {
+    env.EXTERNAL_MODERATION_CACHE_TTL_SECONDS = -1;
+    expect(moderationCacheEnabled()).toBe(false);
+    env.EXTERNAL_MODERATION_CACHE_TTL_SECONDS = 0;
+    expect(moderationCacheEnabled()).toBe(false);
+    env.EXTERNAL_MODERATION_CACHE_TTL_SECONDS = 0.4;
+    // 0.4 floors to 0 -> off. The env schema rejects non-integers anyway; this is defence in depth.
+    expect(moderationCacheEnabled()).toBe(false);
+  });
+
+  it('the env schema accepts an integer TTL, rejects a non-number, and defaults to 0 (OFF)', () => {
+    const parsed = serverSchema.shape.EXTERNAL_MODERATION_CACHE_TTL_SECONDS.safeParse(undefined);
+    expect(parsed.success && parsed.data).toBe(0);
+    expect(serverSchema.shape.EXTERNAL_MODERATION_CACHE_TTL_SECONDS.safeParse(300).success).toBe(
+      true
+    );
+    expect(serverSchema.shape.EXTERNAL_MODERATION_CACHE_TTL_SECONDS.safeParse('nope').success).toBe(
+      false
+    );
+    // Capped: a cached verdict is a stale verdict, and the TTL is the only bound on a classifier
+    // whose model can move behind a stable name.
+    expect(serverSchema.shape.EXTERNAL_MODERATION_CACHE_TTL_SECONDS.safeParse(3601).success).toBe(
+      false
+    );
+  });
+});
+
+describe('a hit skips the classifier', () => {
+  it('second identical prompt returns the stored verdict and issues NO request', async () => {
+    const store = installRedisStore();
+    const fetchSpy = stubFetchOk();
+
+    const first = await extModeration.moderatePrompt('same prompt', 'generate');
+    await untilStored(store, 1);
+    const second = await extModeration.moderatePrompt('same prompt', 'generate');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // the whole point
+    expect(second).toEqual(first);
+    expect(await cacheCount('miss')).toBe(1);
+    expect(await cacheCount('hit')).toBe(1);
+  });
+
+  it('🔴 a hit records NO latency sample — the histogram keeps meaning "cost of a real call"', async () => {
+    const store = installRedisStore();
+    stubFetchOk();
+
+    await extModeration.moderatePrompt('histogram prompt', 'generate');
+    await untilStored(store, 1);
+    const afterMiss = await histCount();
+    await extModeration.moderatePrompt('histogram prompt', 'generate');
+    const afterHit = await histCount();
+
+    // If a hit were observed, the count would rise and the p50 would collapse toward zero —
+    // destroying the one instrument that measures what a classifier call costs.
+    expect(afterMiss).toBe(1);
+    expect(afterHit).toBe(1);
+  });
+
+  it('🔴 a FLAGGED verdict round-trips as flagged — a cached block stays blocked', async () => {
+    const store = installRedisStore();
+    const fetchSpy = stubFetchOk(true);
+
+    const first = await extModeration.moderatePrompt('bad prompt', 'generate');
+    await untilStored(store, 1);
+    const second = await extModeration.moderatePrompt('bad prompt', 'generate');
+
+    expect(first.flagged).toBe(true);
+    // The lenient direction is the dangerous one: a serialization that lost `true` would let a
+    // previously-blocked prompt through for the whole TTL, and nothing else would notice.
+    expect(second.flagged).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('a DIFFERENT prompt is a miss and does call the classifier', async () => {
+    const store = installRedisStore();
+    const fetchSpy = stubFetchOk();
+
+    await extModeration.moderatePrompt('prompt one', 'generate');
+    await untilStored(store, 1);
+    await extModeration.moderatePrompt('prompt two', 'generate');
+    await untilStored(store, 2);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(await cacheCount('hit')).toBe(0);
+  });
+
+  it('keys on the PREPARED prompt, so a false-positive rewrite collapses to one call', async () => {
+    // `removeFalsePositiveTriggers` maps 'girl' -> 'woman', so these two produce an IDENTICAL
+    // classifier request. Keying the raw prompt would issue two calls and silently halve the
+    // benefit, with a plausible-looking hit rate and nothing to contradict it.
+    const store = installRedisStore();
+    const fetchSpy = stubFetchOk();
+
+    await extModeration.moderatePrompt('a girl in a field', 'generate');
+    await untilStored(store, 1);
+    await extModeration.moderatePrompt('a woman in a field', 'generate');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(await cacheCount('hit')).toBe(1);
+  });
+});
+
+describe('what must NEVER be cached', () => {
+  it('🔴 a failed call is not stored — a failure must cost a retry every time', async () => {
+    const store = installRedisStore();
+    const failing = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      text: async () => 'down',
+    }));
+    vi.stubGlobal('fetch', failing);
+
+    await expect(extModeration.moderatePrompt('failing prompt', 'generate')).rejects.toThrow();
+    // Caching a failure would convert one transient gateway error into TTL-long silent
+    // under-moderation of this exact prompt, because the caller is fail-soft on error.
+    expect(store.size).toBe(0);
+
+    // And the next attempt really does call again rather than answering from a poisoned entry.
+    const ok = stubFetchOk();
+    await extModeration.moderatePrompt('failing prompt', 'generate');
+    expect(ok).toHaveBeenCalledTimes(1);
+  });
+
+  it('🔴 a malformed stored value is an ERROR and re-calls — never a permissive verdict', async () => {
+    const store = installRedisStore();
+    const fetchSpy = stubFetchOk();
+
+    await extModeration.moderatePrompt('poisoned', 'generate');
+    await untilStored(store, 1);
+    const key = [...store.keys()][0];
+    store.set(key, '{"f":0,"c":[]}'); // `0`, not `false` — truthiness would read this as "not flagged"
+
+    const result = await extModeration.moderatePrompt('poisoned', 'generate');
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // re-called, not trusted
+    expect(await cacheCount('error')).toBe(1);
+    expect(result.flagged).toBe(false); // from the live call, not from the malformed entry
+  });
+
+  it('unparseable JSON is an error and re-calls', async () => {
+    const store = installRedisStore();
+    const fetchSpy = stubFetchOk();
+    await extModeration.moderatePrompt('badjson', 'generate');
+    await untilStored(store, 1);
+    store.set([...store.keys()][0], 'not json at all');
+
+    await extModeration.moderatePrompt('badjson', 'generate');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(await cacheCount('error')).toBe(1);
+  });
+
+  it('🔴 a Redis read failure falls through to the classifier, never to a weaker verdict', async () => {
+    installRedisStore();
+    redisMock.sysRedis.get.mockRejectedValue(new Error('redis is down'));
+    const fetchSpy = stubFetchOk();
+
+    const result = await extModeration.moderatePrompt('redis down', 'generate');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ flagged: false, categories: [] });
+    expect(await cacheCount('error')).toBe(1);
+    expect(await cacheCount('hit')).toBe(0);
+  });
+
+  it('a Redis WRITE failure does not fail the request', async () => {
+    installRedisStore();
+    redisMock.sysRedis.set.mockRejectedValue(new Error('redis is down'));
+    stubFetchOk();
+    await expect(extModeration.moderatePrompt('write fails', 'generate')).resolves.toEqual({
+      flagged: false,
+      categories: [],
+    });
+  });
+});
+
+describe('the policy digest is the staleness answer', () => {
+  const D = () => policyDigest('omni-moderation-latest', 0.5, undefined);
+
+  it('changes when the THRESHOLD changes', () => {
+    expect(policyDigest('omni-moderation-latest', 0.6, undefined)).not.toBe(D());
+  });
+
+  it('changes when the MODEL changes', () => {
+    expect(policyDigest('text-moderation-007', 0.5, undefined)).not.toBe(D());
+  });
+
+  it('changes when the CATEGORY MAP changes', () => {
+    expect(policyDigest('omni-moderation-latest', 0.5, { violence: 'v' })).not.toBe(D());
+    expect(policyDigest('omni-moderation-latest', 0.5, { violence: 'v' })).not.toBe(
+      policyDigest('omni-moderation-latest', 0.5, { violence: 'w' })
+    );
+  });
+
+  it('is STABLE under a category key reorder — a reshuffle must not flush the cache', () => {
+    expect(policyDigest('m', 0.5, { a: '1', b: '2' })).toBe(
+      policyDigest('m', 0.5, { b: '2', a: '1' })
+    );
+  });
+
+  it('🔴 a threshold change makes previously-cached verdicts unreachable, with no flush step', async () => {
+    const store = installRedisStore();
+    const fetchSpy = stubFetchOk();
+
+    await extModeration.moderatePrompt('policy prompt', 'generate');
+    await untilStored(store, 1);
+    await extModeration.moderatePrompt('policy prompt', 'generate');
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // hit under the original policy
+
+    env.EXTERNAL_MODERATION_THRESHOLD = 0.9; // policy changed
+    await extModeration.moderatePrompt('policy prompt', 'generate');
+
+    // The old entry is still IN Redis — it simply cannot be addressed any more, and ages out on its
+    // own EX. That is the whole design: invalidation with nothing for an operator to remember.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    // The store write is fire-and-forget, so POLL for it. Asserting `store.size` straight after the
+    // call read 1 and failed — the classifier had already been re-called (which is the behaviour
+    // under test) but the new entry had not landed yet.
+    await untilStored(store, 2);
+    expect(store.size).toBe(2);
+  });
+});
+
+describe('key shape', () => {
+  it('separates two policies for the same prompt', () => {
+    const a = buildVerdictKey('generation:moderation-verdict', 'policyA', 'deadbeef');
+    const b = buildVerdictKey('generation:moderation-verdict', 'policyB', 'deadbeef');
+    expect(a).toBe('generation:moderation-verdict:policyA:deadbeef');
+    expect(a).not.toBe(b);
+  });
+
+  it('🔴 the prompt itself never reaches Redis — only digests', async () => {
+    const store = installRedisStore();
+    stubFetchOk();
+    const secret = 'a very distinctive prompt string';
+    await extModeration.moderatePrompt(secret, 'generate');
+    await untilStored(store, 1);
+
+    const key = [...store.keys()][0];
+    expect(key).not.toContain(secret);
+    expect(key).not.toContain('distinctive');
+    expect(key).toMatch(/^generation:moderation-verdict:[0-9a-f]{16}:[0-9a-f]{32}$/);
+    // The stored VALUE carries the verdict only, never the prompt.
+    expect(store.get(key)).not.toContain('distinctive');
+  });
+
+  it('stores with the configured EX', async () => {
+    const store = installRedisStore();
+    stubFetchOk();
+    env.EXTERNAL_MODERATION_CACHE_TTL_SECONDS = 300;
+    await extModeration.moderatePrompt('ttl prompt', 'generate');
+    await untilStored(store, 1);
+    expect(redisMock.sysRedis.set).toHaveBeenCalledWith(
+      expect.stringContaining('generation:moderation-verdict:'),
+      expect.any(String),
+      { EX: 300 }
+    );
+  });
+});

--- a/src/server/integrations/__tests__/moderation-verdict-cache.test.ts
+++ b/src/server/integrations/__tests__/moderation-verdict-cache.test.ts
@@ -121,7 +121,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe('the TTL is the arming switch', () => {
+describe('arming needs BOTH an allowlisted namespace and a positive TTL', () => {
   it('is OFF with no TTL: Redis untouched, no series, classifier still called', async () => {
     // Structured as a DIFFERENTIAL. The armed leg proves a read DOES land in this window, so the
     // unarmed leg finding none is evidence rather than a slow lazy import.
@@ -149,11 +149,12 @@ describe('the TTL is the arming switch', () => {
     env.EXTERNAL_MODERATION_CACHE_TTL_SECONDS = 0;
     expect(moderationCacheEnabled()).toBe(false);
     env.EXTERNAL_MODERATION_CACHE_TTL_SECONDS = 0.4;
-    // 0.4 floors to 0 -> off. The env schema rejects non-integers anyway; this is defence in depth.
+    // 0.4 floors to 0 -> off. The schema degrades a non-integer to 0 via `.catch(0)`; this is
+    // defence in depth, not a restatement of a rejection the schema no longer performs.
     expect(moderationCacheEnabled()).toBe(false);
   });
 
-  it('the env schema accepts an integer TTL, rejects a non-number, and defaults to 0 (OFF)', () => {
+  it('the env schema accepts an integer TTL and DEGRADES anything else to 0 (OFF), never throwing', () => {
     const parsed = serverSchema.shape.EXTERNAL_MODERATION_CACHE_TTL_SECONDS.safeParse(undefined);
     expect(parsed.success && parsed.data).toBe(0);
     expect(serverSchema.shape.EXTERNAL_MODERATION_CACHE_TTL_SECONDS.safeParse(300).success).toBe(
@@ -425,13 +426,34 @@ describe('the deployment namespace is required to arm', () => {
     await extModeration.moderatePrompt('ns armed', 'generate');
 
     expect(redisMock.sysRedis.get).not.toHaveBeenCalled();
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(moderationCacheEnabled()).toBe(false);
     expect(errorSpy).toHaveBeenCalled();
+
+    // 🔴 THE WRITE SIDE TOO — AND IT CANNOT BE ASSERTED IMMEDIATELY. Asserting only the READ left
+    // the write-side arming guard unpinned and it SURVIVED mutation on a green 28/28 suite: a
+    // rejected namespace stopped being inert and wrote `…:null:<policy>:<digest>` into one shared
+    // un-namespaced keyspace.
+    //
+    // 🔴 The obvious fix is ALSO vacuous, and was tried first: `expect(sysRedis.set).not
+    // .toHaveBeenCalled()` right here passes whether or not the guard exists, because
+    // `writeCachedVerdict` is fire-and-forget behind a lazy `import()` — the write has not happened
+    // YET either way. An absence you did not wait for is not an absence.
+    //
+    // So ORDER it. Issue a third call that IS armed, wait for ITS write to land, and only then
+    // assert the keyspace. The rejected call was issued first through the same import-then-set
+    // path, so if it were going to write it would have written by now.
+    env.EXTERNAL_MODERATION_CACHE_NAMESPACE = 'prod';
+    await extModeration.moderatePrompt('ns armed again', 'generate');
+    await untilStored(store, 2);
+
+    expect(store.size).toBe(2); // the two ARMED entries only — the rejected call wrote nothing
+    for (const key of store.keys()) expect(key).toContain(':prod:');
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
 
   it('🔴 every on/off spelling an operator might reach for is OFF, not a namespace', () => {
     // The charset-plus-denylist approach the probe's audit rejected accepted all of these.
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
     for (const word of ['y', 'n', 'no', 'off', 'false', 'none', 'null', 'disable', '0', '2']) {
       env.EXTERNAL_MODERATION_CACHE_NAMESPACE = word;
       expect(moderationCacheEnabled()).toBe(false);

--- a/src/server/integrations/moderation-verdict-cache.ts
+++ b/src/server/integrations/moderation-verdict-cache.ts
@@ -33,8 +33,9 @@
 //     caching a failure would convert one transient gateway error into TTL-long silent
 //     under-moderation of that exact prompt. A failure must cost a retry, every time.
 //   * CACHE ERRORS. A Redis failure resolves to a MISS and the classifier is called. There is no
-//     path from a cache problem to a weaker verdict; the worst case is the latency we already pay
-//     today.
+//     path from a cache problem to a weaker verdict. The added latency is bounded by
+//     `withSysReadDeadline` (`REDIS_SYS_READ_TIMEOUT_MS`, default 2000 ms) — NOT by the Redis
+//     client, which has no socket timeout, and NOT by the try/catch, which cannot see a hang.
 import { createHash } from 'node:crypto';
 
 import { registerCounterWithLabels } from '@civitai/telemetry/client';
@@ -92,6 +93,58 @@ function record(source: ExternalModerationSource, result: CacheResult): void {
 }
 
 /**
+ * The deployment this cache may write under, or `null` when it is not armed.
+ *
+ * 🔴 WITHOUT THIS SEGMENT THE CACHE IS CROSS-DEPLOYMENT, AND THAT IS A MODERATION BUG, NOT A
+ * TIDINESS ONE. Several civitai-web deployments share ONE sysRedis, and sys keys — unlike cache
+ * keys — carry no environment segment. Worse, the PR-preview Tekton task copies civitai-next's
+ * `civitai-cfg` ConfigMap WHOLESALE into every `civitai-pr-<N>` namespace, overriding only an
+ * explicit key list, so a NEW variable like the TTL below is inherited by every open PR's preview,
+ * and ~10 of those share one `civitai-pr-sysredis`.
+ *
+ * The policy digest cannot close this. It covers the model, threshold and category map — but not
+ * `EXTERNAL_MODERATION_ENDPOINT`, not the token, and above all not the CODE in `moderation.ts` that
+ * derives `flagged` from the scores. A preview branch that changes that derivation, or points the
+ * endpoint at a stub, writes `{"f":false,"c":[]}` under a policy digest IDENTICAL to production's,
+ * and any other armed deployment reads it as an authoritative "not flagged".
+ *
+ * 🔴 SO ARMING AND NAMESPACING ARE ONE ACTION — the rule the dark probe already established for a
+ * WRITE-ONLY instrument whose worst outcome was a biased number. This one SERVES VERDICTS ON A
+ * MODERATION GATE, so it inherits that rule a fortiori.
+ *
+ * ⚠️ THIS IS A SECOND REQUIRED INPUT, AND AN EARLIER REVISION OF THIS MODULE ARGUED AGAINST ONE
+ * ("a second on/off input is a second thing that can disagree with the first"). That argument was
+ * wrong here: these are not two on/off switches. One names WHERE the entries live and one says HOW
+ * LONG they live; neither can be inferred from the other, and both are necessary by construction.
+ *
+ * A CLOSED ALLOWLIST, not a charset plus a denylist — the probe's audit enumerated the survivors of
+ * the charset approach (`y`, `n`, `none`, `null`, `disable`, `2`), and `y`/`n` are exactly how an
+ * operator spells "off", which would ARM the cache under a namespace called `n`.
+ *
+ * Duplicated from the probe rather than imported: the probe is a temporary instrument scheduled for
+ * removal, and a cache on a moderation gate must not acquire a dependency that is expected to be
+ * deleted.
+ */
+export const CACHE_NAMESPACES: readonly string[] = Object.freeze(['prod']);
+
+let warnedNamespace: string | null = null;
+
+function cacheNamespace(): string | null {
+  const raw = env.EXTERNAL_MODERATION_CACHE_NAMESPACE?.trim() ?? '';
+  if (raw === '') return null;
+  if (CACHE_NAMESPACES.includes(raw)) return raw;
+  if (warnedNamespace !== raw) {
+    warnedNamespace = raw;
+    console.error(
+      `[moderation-verdict-cache] EXTERNAL_MODERATION_CACHE_NAMESPACE=${JSON.stringify(raw)} is ` +
+        `not a known deployment (${CACHE_NAMESPACES.join(', ')}). The cache is DISABLED. This is ` +
+        `the safe direction: an unrecognised deployment must never share a verdict keyspace.`
+    );
+  }
+  return null;
+}
+
+/**
  * Seconds to hold a verdict, or 0 when the cache is OFF.
  *
  * 🔴 THE TTL IS THE ARMING SWITCH — there is no separate boolean, for the reason the probe's
@@ -99,9 +152,20 @@ function record(source: ExternalModerationSource, result: CacheResult): void {
  * first. Absent or 0 means the cache is inert and emits no series at all, which is the state every
  * deployment starts in. A non-numeric value is rejected by the env schema, not silently coerced.
  *
- * The value is read per call rather than captured at module load so a config change takes effect on
- * the next request instead of the next deploy — this is the kill switch, and a kill switch that
- * needs a rollout is not one.
+ * ⚠️ IT IS NOT A HOT KILL SWITCH, AND AN EARLIER REVISION OF THIS COMMENT CLAIMED IT WAS. It said
+ * the per-call read meant "a config change takes effect on the next request instead of the next
+ * deploy". That is FALSE: `src/env/server.ts` runs `serverSchema.safeParse(process.env)` ONCE at
+ * import and exports `env` as a plain object spread, so reading it per call re-reads a frozen
+ * snapshot for the life of the process. DISABLING THIS REQUIRES A ROLLOUT, exactly as much as a
+ * module-level `const` would.
+ *
+ * 🔴 The suite could not have caught that, and still cannot: it mocks `~/env/server` with a MUTABLE
+ * hoisted object and flips it mid-test, so the fixture makes the false claim true. The claim is
+ * corrected here rather than pinned by a test, because pinning it would need a test that imports
+ * the real env module.
+ *
+ * The per-call read is kept anyway — it costs nothing and keeps this function honest about where
+ * the value comes from — but do not read it as a rollout-free lever.
  */
 function ttlSeconds(): number {
   const raw = env.EXTERNAL_MODERATION_CACHE_TTL_SECONDS;
@@ -109,7 +173,7 @@ function ttlSeconds(): number {
 }
 
 export function moderationCacheEnabled(): boolean {
-  return ttlSeconds() > 0;
+  return cacheNamespace() !== null && ttlSeconds() > 0;
 }
 
 /**
@@ -172,10 +236,11 @@ function promptDigest(preparedPrompt: string): string {
  */
 export function buildVerdictKey<P extends string>(
   prefix: P,
+  namespace: string,
   policy: string,
   digest: string
 ): `${P}:${string}` {
-  return `${prefix}:${policy}:${digest}`;
+  return `${prefix}:${namespace}:${policy}:${digest}`;
 }
 
 /**
@@ -216,16 +281,29 @@ export async function readCachedVerdict(
   preparedPrompt: string,
   policy: string
 ): Promise<ModerationVerdict | null> {
-  if (!moderationCacheEnabled()) return null;
+  const namespace = cacheNamespace();
+  if (namespace === null || ttlSeconds() <= 0) return null;
   const metricSource = clampExternalModerationSource(source);
   try {
-    const { sysRedis, REDIS_SYS_KEYS } = await import('~/server/redis/client');
+    const { sysRedis, REDIS_SYS_KEYS, withSysReadDeadline } = await import('~/server/redis/client');
     const key = buildVerdictKey(
       REDIS_SYS_KEYS.GENERATION.MODERATION_VERDICT,
+      namespace,
       policy,
       promptDigest(preparedPrompt)
     );
-    const raw = await sysRedis.get(key);
+    // 🔴 DEADLINE-WRAPPED, AND THE UNWRAPPED VERSION WAS A DEPLOY-BLOCKER. The sys client carries
+    // NO socketTimeout (`REDIS_SYS_SOCKET_TIMEOUT_MS` defaults to 0, to avoid a reconnect-storm
+    // wedge on the single-replica backend), so on a SILENT half-open a written command parks in
+    // node-redis's reply queue until OS TCP keepalive errors the socket — Linux default ~11 MINUTES
+    // — on every authenticated request. The `try/catch` below catches REJECTIONS, not HANGS.
+    //
+    // This read is awaited on the generation submission path, so unwrapped it would park the whole
+    // tRPC handler off-CPU. That is the exact failure `moderation.ts` added `AbortSignal.timeout`
+    // for after an observed ~194 s api-primary tail — putting an UNBOUNDED wait in front of that
+    // bounded call would have reinstated it. `promptAuditing.ts`, the immediate caller, wraps all
+    // four of its own sys reads the same way; this is the convention, not a precaution.
+    const raw = await withSysReadDeadline(sysRedis.get(key));
     if (raw == null) {
       record(metricSource, 'miss');
       return null;
@@ -257,13 +335,15 @@ export function writeCachedVerdict(
   policy: string,
   verdict: ModerationVerdict
 ): void {
+  const namespace = cacheNamespace();
   const ttl = ttlSeconds();
-  if (ttl <= 0) return;
+  if (namespace === null || ttl <= 0) return;
   void (async () => {
     try {
       const { sysRedis, REDIS_SYS_KEYS } = await import('~/server/redis/client');
       const key = buildVerdictKey(
         REDIS_SYS_KEYS.GENERATION.MODERATION_VERDICT,
+        namespace,
         policy,
         promptDigest(preparedPrompt)
       );

--- a/src/server/integrations/moderation-verdict-cache.ts
+++ b/src/server/integrations/moderation-verdict-cache.ts
@@ -76,8 +76,12 @@ const cacheCounter = registerCounterWithLabels({
     'outage would read as "prompts stopped repeating", the reassuring direction and therefore the ' +
     'dangerous one. 🔴 A hit is NOT observed on external_moderation_duration_seconds, so once this ' +
     'is armed that histogram counts CLASSIFIER CALLS and this counter counts moderation CHECKS; ' +
-    'the two diverge by exactly the hit count. Unarmed (no EXTERNAL_MODERATION_CACHE_TTL_SECONDS) ' +
-    'there are no series at all, which is what makes the arming instant readable. The dark probe ' +
+    'the two diverge by exactly the hit count. Unarmed there are no series at all, which is what ' +
+    'makes the arming instant readable — but arming needs BOTH a positive ' +
+    'EXTERNAL_MODERATION_CACHE_TTL_SECONDS and an allowlisted EXTERNAL_MODERATION_CACHE_NAMESPACE, ' +
+    'so an absence of series does NOT mean "no TTL configured": a set TTL with a rejected namespace ' +
+    'looks identical here, and the two are told apart only by the one-off error the namespace ' +
+    'resolver logs. The dark probe ' +
     'this replaces measured 34.3% repeats at a 5m window over 224,989 observations; expect a hit ' +
     'rate at or BELOW that, because the probe claimed its slot when a request STARTED whereas this ' +
     'cache cannot store a verdict until the classifier answers ~200 ms later.',
@@ -124,6 +128,18 @@ function record(source: ExternalModerationSource, result: CacheResult): void {
  * Duplicated from the probe rather than imported: the probe is a temporary instrument scheduled for
  * removal, and a cache on a moderation gate must not acquire a dependency that is expected to be
  * deleted.
+ *
+ * 🔴 BEFORE ADDING A MEMBER, CHECK BOTH — the rule had to come with the value, because the probe's
+ * copy is the one going away and this is the higher-stakes surface. A member must name ONE running
+ * population, not a template other namespaces inherit: `preview` is a CLASS (~10 concurrent
+ * `civitai-pr-*` namespaces on one sysRedis), and `next` looks like a single deployment but is not,
+ * because the PR-preview task copies civitai-next's `civitai-cfg` wholesale into every preview.
+ * Adding either re-opens the cross-deployment hazard this list exists to close.
+ *
+ * A FROZEN ARRAY, not a `ReadonlySet` — that type is erased at runtime, so any importer could
+ * `.add()` to the object this module reads. And ONE object, not an array plus a lookup Set: the
+ * ledger test asserts the array, so a second copy is how that assertion goes false while staying
+ * green.
  */
 export const CACHE_NAMESPACES: readonly string[] = Object.freeze(['prod']);
 
@@ -145,12 +161,17 @@ function cacheNamespace(): string | null {
 }
 
 /**
- * Seconds to hold a verdict, or 0 when the cache is OFF.
+ * Seconds to hold a verdict, or 0 when that half of the arming is absent.
  *
- * 🔴 THE TTL IS THE ARMING SWITCH — there is no separate boolean, for the reason the probe's
- * namespace allowlist exists: a second on/off input is a second thing that can disagree with the
- * first. Absent or 0 means the cache is inert and emits no series at all, which is the state every
- * deployment starts in. A non-numeric value is rejected by the env schema, not silently coerced.
+ * ⚠️ THIS IS ONE OF TWO REQUIRED INPUTS, NOT "THE ARMING SWITCH". An earlier revision of this
+ * docstring said it was, and repeated the "a second on/off input is a second thing that can
+ * disagree with the first" argument that `cacheNamespace` — 35 lines above, in the same file —
+ * had already retracted. The two sentences contradicted each other. {@link armedCache} is the
+ * predicate that actually gates the cache.
+ *
+ * A non-numeric value degrades to 0 (OFF) via `.catch(0)` on the schema; it is NOT rejected, and an
+ * earlier revision of this line said it was. Rejecting would CrashLoop the fleet on an operator
+ * typo, because `src/env/server.ts` throws on any invalid field.
  *
  * ⚠️ IT IS NOT A HOT KILL SWITCH, AND AN EARLIER REVISION OF THIS COMMENT CLAIMED IT WAS. It said
  * the per-call read meant "a config change takes effect on the next request instead of the next
@@ -172,8 +193,27 @@ function ttlSeconds(): number {
   return typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 0;
 }
 
+/**
+ * The single arming predicate: the namespace and TTL to use, or `null` when the cache is off.
+ *
+ * 🔴 ONE RULE, ONE PLACE — and the previous revision had it in THREE. It open-coded
+ * `namespace === null || ttl <= 0` at both live call sites and left `moderationCacheEnabled()` with
+ * ZERO production callers, so seven test assertions were aiming at a function nothing executed
+ * while the two predicates that actually gate the cache were unasserted. That is how the write-side
+ * guard came to survive mutation: the tests were pointed at the copy, not at the original.
+ *
+ * Returning the VALUES rather than a boolean is what makes one predicate sufficient — the call
+ * sites need the namespace and the TTL, which is why they open-coded it in the first place.
+ */
+function armedCache(): { namespace: string; ttl: number } | null {
+  const namespace = cacheNamespace();
+  const ttl = ttlSeconds();
+  return namespace !== null && ttl > 0 ? { namespace, ttl } : null;
+}
+
+/** Derived view of {@link armedCache}, for tests and for readability at a glance. */
 export function moderationCacheEnabled(): boolean {
-  return cacheNamespace() !== null && ttlSeconds() > 0;
+  return armedCache() !== null;
 }
 
 /**
@@ -227,7 +267,8 @@ function promptDigest(preparedPrompt: string): string {
 }
 
 /**
- * `<prefix>:<policyDigest>:<promptDigest>`.
+ * `<prefix>:<namespace>:<policyDigest>:<promptDigest>` — FOUR segments. Anyone reasoning about key
+ * shape (a SCAN, a flush, a capacity estimate) reads this line; the key-shape test pins it.
  *
  * Exported as a pure function taking the policy digest as an ARGUMENT for the reason the probe's
  * `buildProbeKey` was extracted: with one live configuration, a mutant that hardcodes the policy
@@ -281,8 +322,9 @@ export async function readCachedVerdict(
   preparedPrompt: string,
   policy: string
 ): Promise<ModerationVerdict | null> {
-  const namespace = cacheNamespace();
-  if (namespace === null || ttlSeconds() <= 0) return null;
+  const armed = armedCache();
+  if (armed === null) return null;
+  const { namespace } = armed;
   const metricSource = clampExternalModerationSource(source);
   try {
     const { sysRedis, REDIS_SYS_KEYS, withSysReadDeadline } = await import('~/server/redis/client');
@@ -335,9 +377,9 @@ export function writeCachedVerdict(
   policy: string,
   verdict: ModerationVerdict
 ): void {
-  const namespace = cacheNamespace();
-  const ttl = ttlSeconds();
-  if (namespace === null || ttl <= 0) return;
+  const armed = armedCache();
+  if (armed === null) return;
+  const { namespace, ttl } = armed;
   void (async () => {
     try {
       const { sysRedis, REDIS_SYS_KEYS } = await import('~/server/redis/client');

--- a/src/server/integrations/moderation-verdict-cache.ts
+++ b/src/server/integrations/moderation-verdict-cache.ts
@@ -19,7 +19,8 @@
 // trust-and-safety trade, not a performance detail, and it was accepted deliberately rather than
 // arrived at. Two things bound it:
 //
-//   1. The TTL is short and operator-set, and the cache is OFF unless a TTL is configured.
+//   1. The TTL is short and operator-set, and the cache is OFF unless BOTH an allowlisted
+//      EXTERNAL_MODERATION_CACHE_NAMESPACE and a positive TTL are set — see `armedCache`.
 //   2. 🔴 THE KEY CARRIES A DIGEST OF THE POLICY THAT PRODUCED THE VERDICT — see `policyDigest`.
 //      A change to the model, the score threshold or the category map changes the key, so every
 //      previously-cached verdict becomes unreachable AT ONCE, without a flush and without anyone
@@ -79,9 +80,12 @@ const cacheCounter = registerCounterWithLabels({
     'the two diverge by exactly the hit count. Unarmed there are no series at all, which is what ' +
     'makes the arming instant readable — but arming needs BOTH a positive ' +
     'EXTERNAL_MODERATION_CACHE_TTL_SECONDS and an allowlisted EXTERNAL_MODERATION_CACHE_NAMESPACE, ' +
-    'so an absence of series does NOT mean "no TTL configured": a set TTL with a rejected namespace ' +
-    'looks identical here, and the two are told apart only by the one-off error the namespace ' +
-    'resolver logs. The dark probe ' +
+    'so an absence of series does NOT mean "no TTL configured" — a set TTL with a rejected ' +
+    'namespace looks identical, and so does an ARMED deployment nothing scrapes. A rejected ' +
+    'namespace logs one error line (which separates it from the other two, NOT the pair of them ' +
+    'from each other, because the namespace is resolved whether or not a TTL is set); an unscraped ' +
+    'deployment is invisible from here by construction and has to be ruled out at the ' +
+    'ServiceMonitor. The dark probe ' +
     'this replaces measured 34.3% repeats at a 5m window over 224,989 observations; expect a hit ' +
     'rate at or BELOW that, because the probe claimed its slot when a request STARTED whereas this ' +
     'cache cannot store a verdict until the classifier answers ~200 ms later.',
@@ -135,6 +139,14 @@ function record(source: ExternalModerationSource, result: CacheResult): void {
  * `civitai-pr-*` namespaces on one sysRedis), and `next` looks like a single deployment but is not,
  * because the PR-preview task copies civitai-next's `civitai-cfg` wholesale into every preview.
  * Adding either re-opens the cross-deployment hazard this list exists to close.
+ *
+ * ...AND (2) that something actually SCRAPES it. This is the half an earlier revision dropped while
+ * keeping the words "CHECK BOTH" — a heading promising two checks and supplying one is what stops
+ * the next person looking for the missing half. It is the criterion that removed `next-stage` from
+ * the probe's list: no ServiceMonitor or PodMonitor, so an armed deployment emits no series at all.
+ * For the PROBE that meant a measurement nobody could read. For THIS cache it is worse: it changes
+ * moderation behaviour, so an unscraped deployment would serve cached verdicts on a moderation gate
+ * with zero observability.
  *
  * A FROZEN ARRAY, not a `ReadonlySet` — that type is erased at runtime, so any importer could
  * `.add()` to the object this module reads. And ONE object, not an array plus a lookup Set: the

--- a/src/server/integrations/moderation-verdict-cache.ts
+++ b/src/server/integrations/moderation-verdict-cache.ts
@@ -1,0 +1,277 @@
+// A read-through cache for external prompt-moderation verdicts.
+//
+// WHY. `extModeration.moderatePrompt` is an outbound HTTPS call that runs inline and serially on the
+// generation submission path, costing ~205 ms at p50 ~188 ms and accounting for 78-88% of the
+// app-side time of `orchestrator.generateFromGraph`. Three ways to make the CALL cheaper were tested
+// against production and all three are dead: the latency distribution is a FLOOR not a tail (zero
+// calls under 50 ms), connection reuse is worth ~7-24 ms because the classifier answers from a
+// nearby edge, and the audit cannot be overlapped with the workflow submit because a flagged prompt
+// must never reach `submitWorkflow`. What is left is to NOT MAKE THE CALL.
+//
+// The dark probe that preceded this module measured whether that is worth doing: over 224,989
+// observations spanning the quietest overnight hours through the weekly peak, 34.3% of prepared
+// prompts had been seen before inside 5 minutes, and the rate is LOAD-INVARIANT (+1.63 points across
+// a ~33% swing in call volume). At ~205 ms a call that is ~70 ms per invocation, roughly 7x the best
+// infra lever. The probe is retired; this replaces it.
+//
+// 🔴 WHAT THIS CHANGES ABOUT MODERATION, STATED PLAINLY. A cached verdict is a STALE verdict: within
+// the TTL, an identical prompt gets the previous answer without consulting the classifier. That is a
+// trust-and-safety trade, not a performance detail, and it was accepted deliberately rather than
+// arrived at. Two things bound it:
+//
+//   1. The TTL is short and operator-set, and the cache is OFF unless a TTL is configured.
+//   2. 🔴 THE KEY CARRIES A DIGEST OF THE POLICY THAT PRODUCED THE VERDICT — see `policyDigest`.
+//      A change to the model, the score threshold or the category map changes the key, so every
+//      previously-cached verdict becomes unreachable AT ONCE, without a flush and without anyone
+//      remembering to bump anything. This is the mechanical half of the staleness answer: the
+//      remaining exposure is a policy change that happens OUTSIDE this app (the classifier's own
+//      model being retrained behind a stable name), which the TTL bounds and nothing here can see.
+//
+// 🔴 WHAT IS NOT CACHED, AND WHY EACH OMISSION IS LOAD-BEARING:
+//   * FAILURES. Only an `ok` outcome is stored. `moderatePrompt` is fail-SOFT on error — the caller
+//     catches and proceeds with `flagged:false`, with the local regex audit still gating — so
+//     caching a failure would convert one transient gateway error into TTL-long silent
+//     under-moderation of that exact prompt. A failure must cost a retry, every time.
+//   * CACHE ERRORS. A Redis failure resolves to a MISS and the classifier is called. There is no
+//     path from a cache problem to a weaker verdict; the worst case is the latency we already pay
+//     today.
+import { createHash } from 'node:crypto';
+
+import { registerCounterWithLabels } from '@civitai/telemetry/client';
+import { env } from '~/env/server';
+import {
+  clampExternalModerationSource,
+  type ExternalModerationSource,
+} from '~/server/prom/external-moderation.metrics';
+
+/** The verdict shape `moderatePrompt` returns and this module round-trips. */
+export interface ModerationVerdict {
+  flagged: boolean;
+  categories: string[];
+}
+
+/**
+ * `hit` = a stored verdict was returned and the classifier was NOT called. `miss` = nothing stored,
+ * the classifier was called. `error` = the cache itself failed (Redis unreachable, malformed stored
+ * value); the classifier was called, so an `error` costs latency but never correctness.
+ *
+ * 🔴 SEPARATE FROM THE DURATION HISTOGRAM, DELIBERATELY. A cache hit is NOT observed on
+ * `civitai_app_external_moderation_duration_seconds`. If hits were recorded there as ~0 ms samples
+ * they would drag the p50 down and destroy the one instrument that measures what a classifier call
+ * actually costs — the same instrument that has to grade any future decision about the model. So
+ * after this ships, that histogram's `_count` is CLASSIFIER CALLS, not moderation checks; the
+ * check count is `hit + miss` here. Anyone comparing a before/after on that histogram must know
+ * this, because the denominator changed meaning on the day the cache armed.
+ */
+type CacheResult = 'hit' | 'miss' | 'error';
+
+const cacheCounter = registerCounterWithLabels({
+  name: 'external_moderation_cache_total',
+  help:
+    'Read-through cache for external prompt-moderation verdicts. Labeled by source (same population ' +
+    'split as external_moderation_duration_seconds) and result (hit|miss|error). A hit means the ' +
+    'classifier was NOT called. COMPUTE THE HIT RATE AS sum(rate(...{result="hit"}[..])) / ' +
+    'sum(rate(...{result=~"hit|miss"}[..])) — dividing over the TOTAL folds in `error`, so a Redis ' +
+    'outage would read as "prompts stopped repeating", the reassuring direction and therefore the ' +
+    'dangerous one. 🔴 A hit is NOT observed on external_moderation_duration_seconds, so once this ' +
+    'is armed that histogram counts CLASSIFIER CALLS and this counter counts moderation CHECKS; ' +
+    'the two diverge by exactly the hit count. Unarmed (no EXTERNAL_MODERATION_CACHE_TTL_SECONDS) ' +
+    'there are no series at all, which is what makes the arming instant readable. The dark probe ' +
+    'this replaces measured 34.3% repeats at a 5m window over 224,989 observations; expect a hit ' +
+    'rate at or BELOW that, because the probe claimed its slot when a request STARTED whereas this ' +
+    'cache cannot store a verdict until the classifier answers ~200 ms later.',
+  labelNames: ['source', 'result'] as const,
+});
+
+function record(source: ExternalModerationSource, result: CacheResult): void {
+  try {
+    cacheCounter.inc({ source, result });
+  } catch {
+    // Observability must never break the moderation path.
+  }
+}
+
+/**
+ * Seconds to hold a verdict, or 0 when the cache is OFF.
+ *
+ * 🔴 THE TTL IS THE ARMING SWITCH — there is no separate boolean, for the reason the probe's
+ * namespace allowlist exists: a second on/off input is a second thing that can disagree with the
+ * first. Absent or 0 means the cache is inert and emits no series at all, which is the state every
+ * deployment starts in. A non-numeric value is rejected by the env schema, not silently coerced.
+ *
+ * The value is read per call rather than captured at module load so a config change takes effect on
+ * the next request instead of the next deploy — this is the kill switch, and a kill switch that
+ * needs a rollout is not one.
+ */
+function ttlSeconds(): number {
+  const raw = env.EXTERNAL_MODERATION_CACHE_TTL_SECONDS;
+  return typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 0;
+}
+
+export function moderationCacheEnabled(): boolean {
+  return ttlSeconds() > 0;
+}
+
+/**
+ * A digest of everything OTHER than the prompt that determines the verdict.
+ *
+ * 🔴 THIS IS THE STALENESS ANSWER, AND IT IS MECHANICAL RATHER THAN PROCEDURAL. `moderatePrompt`
+ * does not return the classifier's raw response: it derives `flagged` and `categories` from the
+ * scores using `EXTERNAL_MODERATION_THRESHOLD` and, when set, `EXTERNAL_MODERATION_CATEGORIES` —
+ * and it asks a specific `model`. A cached verdict is therefore a function of FOUR inputs, not one.
+ * Keying on the prompt alone would serve verdicts computed under a policy that no longer exists, and
+ * the failure would be silent and indefinite: lower the threshold to catch more, and every prompt
+ * already in the cache keeps its old lenient answer until its TTL expires.
+ *
+ * Folding the policy into the KEY makes a policy change invalidate the entire cache atomically, with
+ * no flush step and nothing for an operator to remember. The old entries are simply unreachable and
+ * age out on their own EX.
+ *
+ * ⚠️ WHAT IT CANNOT SEE: a change to the classifier BEHIND a stable model name. `omni-moderation-latest`
+ * is a moving target by construction, so its retraining is invisible here and is bounded only by the
+ * TTL. That is the residual exposure, and it is the reason the TTL should stay short.
+ *
+ * Sorted `JSON.stringify` of the category map, because object key ORDER is not part of the policy and
+ * must not change the digest — otherwise an unrelated config reshuffle silently flushes the cache.
+ */
+export function policyDigest(
+  model: string,
+  threshold: number,
+  categories: Record<string, string | undefined> | undefined
+): string {
+  const normalizedCategories = categories
+    ? Object.keys(categories)
+        .sort()
+        .map((k) => [k, categories[k] ?? null] as const)
+    : null;
+  const material = JSON.stringify({ model, threshold, categories: normalizedCategories });
+  return createHash('sha256').update(material).digest('hex').slice(0, 16);
+}
+
+/**
+ * Hash of the exact string handed to the classifier.
+ *
+ * 🔴 THE PROMPT ITSELF IS NEVER STORED. Only this digest reaches Redis. Truncated to 32 hex chars
+ * (128 bits) because the only operation performed on it is equality inside one bounded window.
+ *
+ * 🔴 A COLLISION HERE RETURNS ANOTHER PROMPT'S VERDICT, which is why this is 128 bits and not the
+ * 64 that would comfortably fit the keyspace. At ~17k live keys the birthday probability is on the
+ * order of 1e-30; the cost of the extra 16 characters is nothing.
+ */
+function promptDigest(preparedPrompt: string): string {
+  return createHash('sha256').update(preparedPrompt).digest('hex').slice(0, 32);
+}
+
+/**
+ * `<prefix>:<policyDigest>:<promptDigest>`.
+ *
+ * Exported as a pure function taking the policy digest as an ARGUMENT for the reason the probe's
+ * `buildProbeKey` was extracted: with one live configuration, a mutant that hardcodes the policy
+ * segment is indistinguishable from the real thing at runtime, so a test must be able to drive it
+ * with two different policies without config being able to produce them.
+ */
+export function buildVerdictKey<P extends string>(
+  prefix: P,
+  policy: string,
+  digest: string
+): `${P}:${string}` {
+  return `${prefix}:${policy}:${digest}`;
+}
+
+/**
+ * Serialized form. Deliberately terse and versioned by SHAPE rather than a version field: a stored
+ * value that does not parse to this exact shape is treated as a MISS, so a future change to the
+ * serialization cannot serve a half-understood verdict — the worst case is one extra classifier call.
+ */
+function serialize(v: ModerationVerdict): string {
+  return JSON.stringify({ f: v.flagged, c: v.categories });
+}
+
+function deserialize(raw: string): ModerationVerdict | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const { f, c } = parsed as { f?: unknown; c?: unknown };
+    // 🔴 STRICT. `flagged` must be a real boolean and `categories` an array of strings. A truthy
+    // coercion here is how a malformed entry becomes a permissive verdict: `f: 0` from some future
+    // encoder would read as "not flagged" under `!!f`, and that is the direction that lets a
+    // flagged prompt through.
+    if (typeof f !== 'boolean') return null;
+    if (!Array.isArray(c) || c.some((x) => typeof x !== 'string')) return null;
+    return { flagged: f, categories: c as string[] };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Look up a stored verdict. Returns `null` on miss, on cache error, and when the cache is off.
+ *
+ * Awaited, unlike the probe it replaces — this one is on the critical path BY DESIGN, because its
+ * whole purpose is to answer before the classifier is called. The Redis round trip it costs is
+ * single-digit milliseconds against the ~205 ms it avoids.
+ */
+export async function readCachedVerdict(
+  source: ExternalModerationSource,
+  preparedPrompt: string,
+  policy: string
+): Promise<ModerationVerdict | null> {
+  if (!moderationCacheEnabled()) return null;
+  const metricSource = clampExternalModerationSource(source);
+  try {
+    const { sysRedis, REDIS_SYS_KEYS } = await import('~/server/redis/client');
+    const key = buildVerdictKey(
+      REDIS_SYS_KEYS.GENERATION.MODERATION_VERDICT,
+      policy,
+      promptDigest(preparedPrompt)
+    );
+    const raw = await sysRedis.get(key);
+    if (raw == null) {
+      record(metricSource, 'miss');
+      return null;
+    }
+    const verdict = deserialize(raw);
+    if (!verdict) {
+      // Stored but unreadable. Counted as an ERROR rather than a miss: a miss is a normal, expected
+      // outcome and would hide a serialization fault in the noise, whereas this should be visible.
+      record(metricSource, 'error');
+      return null;
+    }
+    record(metricSource, 'hit');
+    return verdict;
+  } catch {
+    record(metricSource, 'error');
+    return null;
+  }
+}
+
+/**
+ * Store a verdict. Fire-and-forget: nothing downstream waits on it, so a slow or broken Redis cannot
+ * add latency to the request that produced the verdict, and cannot fail it.
+ *
+ * 🔴 CALL THIS ONLY ON AN `ok` OUTCOME. See the module header — caching a failure would turn one
+ * transient error into TTL-long under-moderation of that prompt.
+ */
+export function writeCachedVerdict(
+  preparedPrompt: string,
+  policy: string,
+  verdict: ModerationVerdict
+): void {
+  const ttl = ttlSeconds();
+  if (ttl <= 0) return;
+  void (async () => {
+    try {
+      const { sysRedis, REDIS_SYS_KEYS } = await import('~/server/redis/client');
+      const key = buildVerdictKey(
+        REDIS_SYS_KEYS.GENERATION.MODERATION_VERDICT,
+        policy,
+        promptDigest(preparedPrompt)
+      );
+      await sysRedis.set(key, serialize(verdict), { EX: ttl });
+    } catch {
+      // A write failure costs a future classifier call, nothing more. Not counted on the cache
+      // counter: that counter's denominator is READ outcomes, and mixing a write failure into it
+      // would make the hit rate uninterpretable.
+    }
+  })();
+}

--- a/src/server/integrations/moderation-verdict-cache.ts
+++ b/src/server/integrations/moderation-verdict-cache.ts
@@ -81,11 +81,12 @@ const cacheCounter = registerCounterWithLabels({
     'makes the arming instant readable — but arming needs BOTH a positive ' +
     'EXTERNAL_MODERATION_CACHE_TTL_SECONDS and an allowlisted EXTERNAL_MODERATION_CACHE_NAMESPACE, ' +
     'so an absence of series does NOT mean "no TTL configured" — a set TTL with a rejected ' +
-    'namespace looks identical, and so does an ARMED deployment nothing scrapes. A rejected ' +
-    'namespace logs one error line (which separates it from the other two, NOT the pair of them ' +
-    'from each other, because the namespace is resolved whether or not a TTL is set); an unscraped ' +
-    'deployment is invisible from here by construction and has to be ruled out at the ' +
-    'ServiceMonitor. The dark probe ' +
+    'namespace looks identical, and so does an ARMED deployment nothing scrapes. What the one-off ' +
+    'error line tells you is narrow and worth stating exactly: it fires when the namespace is set ' +
+    'but unrecognised, regardless of the TTL, so it identifies a REJECTED namespace and nothing ' +
+    'else — it is silent when the namespace is simply unset, and it says nothing about whether a ' +
+    'TTL is configured. An unscraped deployment is invisible from here by construction and has to ' +
+    'be ruled out at the ServiceMonitor. The dark probe ' +
     'this replaces measured 34.3% repeats at a 5m window over 224,989 observations; expect a hit ' +
     'rate at or BELOW that, because the probe claimed its slot when a request STARTED whereas this ' +
     'cache cannot store a verdict until the classifier answers ~200 ms later.',
@@ -101,7 +102,13 @@ function record(source: ExternalModerationSource, result: CacheResult): void {
 }
 
 /**
- * The deployment this cache may write under, or `null` when it is not armed.
+ * The deployment this cache may write under, or `null` when no allowlisted deployment is named.
+ *
+ * ⚠️ A NON-NULL RESULT DOES NOT MEAN THE CACHE IS ARMED — an earlier revision of this line said
+ * "or `null` when it is not armed", which asserts an equivalence that holds in only one direction:
+ * with `NAMESPACE=prod` and `TTL=0` this returns `'prod'` while the cache is off. It is the mirror
+ * of the TTL-only claim retracted elsewhere in this file, written for the other half. {@link
+ * armedCache} is the only function whose null means "not armed".
  *
  * 🔴 WITHOUT THIS SEGMENT THE CACHE IS CROSS-DEPLOYMENT, AND THAT IS A MODERATION BUG, NOT A
  * TIDINESS ONE. Several civitai-web deployments share ONE sysRedis, and sys keys — unlike cache

--- a/src/server/integrations/moderation.ts
+++ b/src/server/integrations/moderation.ts
@@ -1,6 +1,12 @@
 import { env } from '~/env/server';
 import { probeModerationCacheRepeat } from '~/server/integrations/moderation-cache-probe';
 import {
+  type ModerationVerdict,
+  policyDigest,
+  readCachedVerdict,
+  writeCachedVerdict,
+} from '~/server/integrations/moderation-verdict-cache';
+import {
   clampExternalModerationSource,
   isAbortDeadlineError,
   observeExternalModeration,
@@ -8,6 +14,15 @@ import {
   type ExternalModerationSource,
 } from '~/server/prom/external-moderation.metrics';
 import { setActiveSpanAttributes, withSpan } from '~/server/utils/otel-helpers';
+
+/**
+ * The classifier model, named ONCE.
+ *
+ * 🔴 It is both sent in the request body and folded into the verdict cache's policy digest. Two
+ * spellings would let a cache key claim a policy the request did not actually use, which is the
+ * one way a policy-digested key can still serve a stale verdict.
+ */
+const MODERATION_MODEL = 'omni-moderation-latest';
 
 const falsePositiveTriggers = Object.entries({
   '\\d*girl': 'woman',
@@ -27,6 +42,12 @@ function removeFalsePositiveTriggers(prompt: string) {
 /**
  * Call the external prompt classifier.
  *
+ * 🔴 THE RETURN TYPE WAS WIDENED FROM `{ flagged: false }` TO `boolean` (`ModerationVerdict`), and
+ * that was a latent BUG, not a loosening. This function returns `flagged: true` whenever the
+ * classifier flags — the literal `false` only ever type-checked because `results[0].flagged` comes
+ * off an untyped `res.json()`, so `any` flowed straight past the annotation. Any consumer TS had
+ * narrowed to "never flagged" was being told something false about a moderation gate.
+ *
  * `source` is OBSERVABILITY ONLY — it selects the `source` label on
  * `civitai_app_external_moderation_duration_seconds` and changes nothing about the request, the
  * deadline or the verdict. It is optional and defaults to `other` so an undeclared caller can never
@@ -35,7 +56,7 @@ function removeFalsePositiveTriggers(prompt: string) {
 async function moderatePrompt(
   prompt: string,
   source: ExternalModerationSource = 'other'
-): Promise<{ flagged: false; categories: string[] }> {
+): Promise<ModerationVerdict> {
   // Clamp once, here, so every instrument below shares one bounded value.
   //
   // 🔴 NOT because callers build these options by spread — none do, and that rationale was fiction;
@@ -84,6 +105,30 @@ async function moderatePrompt(
   // there rather than carrying a direction away from here.
   probeModerationCacheRepeat(metricSource, preparedPrompt);
 
+  // Read-through verdict cache. OFF unless EXTERNAL_MODERATION_CACHE_TTL_SECONDS is set.
+  //
+  // 🔴 PLACED AFTER THE PROBE ON PURPOSE. The probe measures how often this exact string RECURS, and
+  // that is a property of the traffic, not of whether we happened to answer from cache. Returning
+  // before it would make the probe count only cache misses and silently understate the very rate it
+  // exists to report — so if the probe is ever re-armed alongside the cache, the two measure
+  // different things and both stay honest.
+  //
+  // 🔴 THE POLICY DIGEST IS COMPUTED FROM THE SAME VALUES THE VERDICT IS DERIVED FROM BELOW, and
+  // the model literal is shared with the request body via MODERATION_MODEL rather than written
+  // twice — two spellings of the model would let the key claim a policy the request did not use.
+  const policy = policyDigest(
+    MODERATION_MODEL,
+    env.EXTERNAL_MODERATION_THRESHOLD,
+    env.EXTERNAL_MODERATION_CATEGORIES
+  );
+  const cached = await readCachedVerdict(metricSource, preparedPrompt, policy);
+  if (cached) {
+    // No histogram observation and no span: this call did not happen. Recording it would drag down
+    // the p50 of the one instrument that measures what a classifier call costs. The cache counter
+    // already recorded the hit.
+    return cached;
+  }
+
   // Wall-clock timing of the whole classifier call — the interval the generation submission actually
   // parks on. Started before the span so the observation cannot be biased by span setup, and read
   // exactly once per exit path below (resolve XOR throw), never in a `finally`, which could not see
@@ -113,7 +158,7 @@ async function moderatePrompt(
           },
           body: JSON.stringify({
             input: preparedPrompt,
-            model: 'omni-moderation-latest',
+            model: MODERATION_MODEL,
           }),
           signal: AbortSignal.timeout(env.EXTERNAL_MODERATION_TIMEOUT_MS),
         });
@@ -143,6 +188,10 @@ async function moderatePrompt(
         }
 
         recordOutcome(metricSource, 'ok', elapsedSeconds());
+        // Store ONLY here, on the `ok` path. A failure must cost a retry every time — see the
+        // module header on why caching one transient error would be TTL-long under-moderation.
+        // Fire-and-forget: nothing waits on the write.
+        writeCachedVerdict(preparedPrompt, policy, { flagged, categories });
         return { flagged, categories };
       } catch (e) {
         // Exactly one observation per call — here on the throw path, XOR on the resolve path above.

--- a/src/server/integrations/moderation.ts
+++ b/src/server/integrations/moderation.ts
@@ -105,7 +105,8 @@ async function moderatePrompt(
   // there rather than carrying a direction away from here.
   probeModerationCacheRepeat(metricSource, preparedPrompt);
 
-  // Read-through verdict cache. OFF unless EXTERNAL_MODERATION_CACHE_TTL_SECONDS is set.
+  // Read-through verdict cache. OFF unless BOTH EXTERNAL_MODERATION_CACHE_NAMESPACE names an
+  // allowlisted deployment AND EXTERNAL_MODERATION_CACHE_TTL_SECONDS is positive.
   //
   // 🔴 PLACED AFTER THE PROBE ON PURPOSE. The probe measures how often this exact string RECURS, and
   // that is a property of the traffic, not of whether we happened to answer from cache. Returning


### PR DESCRIPTION
Ships the verdict cache the dark probe was built to size. **Off by default** — it does nothing until an allowlisted namespace *and* a positive TTL are both configured.

The probe's own source said this had to be its own change with its own review, because caching a moderation verdict is a **trust-and-safety** decision rather than a performance one. That decision was taken deliberately, not arrived at.

## Why

`moderatePrompt` is an inline, serial outbound call on the generation submit path — **~205 ms at p50 ~188 ms**, and **78–88 %** of the app-side time of `generateFromGraph`. Three ways to make the *call* cheaper were tested in production and all three are dead:

| lever | why it's dead |
|---|---|
| clamp the slow tail | the distribution is a **floor**, not a tail — zero calls under 50 ms, 0.46 % under 100 ms |
| reuse the connection | the classifier answers from a nearby edge; the whole handshake is ~7–24 ms |
| overlap with the submit | impossible — a flagged prompt must never reach `submitWorkflow` |

Best infra lever: ~10 ms. Not making the call: **~70 ms**. The probe measured **34.3 %** repeats at a 5m window over **224,989 observations**, load-invariant across the full weekly range (+1.63 points over a ~33 % swing in volume).

## The staleness answer is mechanical, not procedural

The verdict is **not a function of the prompt alone**. `moderatePrompt` derives `flagged`/`categories` from the raw scores using `EXTERNAL_MODERATION_THRESHOLD` and, when set, `EXTERNAL_MODERATION_CATEGORIES`, and asks a specific `model`. So the key carries a digest of all four:

```
generation:moderation-verdict:<namespace>:<policyDigest>:<promptDigest>
```

Change the threshold, the category map or the model and **every previously-cached verdict becomes unreachable at once** — no flush step, nothing for an operator to remember; old entries age out on their own `EX`. The digest is stable under a category-key *reorder*, so an unrelated config reshuffle doesn't flush the cache.

The residual exposure is a classifier that changes behind a stable model name (`omni-moderation-latest` is a moving target by construction). Only the TTL bounds that — hence the 3600 s cap.

## Deliberately not cached

- **Failures.** Only an `ok` outcome is stored. The caller is fail-**soft** on error — it proceeds with `flagged:false` and the local regex audit still gates — so caching one transient gateway error would be TTL-long silent under-moderation of that exact prompt.
- **Cache errors.** A Redis failure resolves to a miss and the classifier is called. There is no path from a cache problem to a weaker verdict; worst case is the latency we already pay.

## Arming

Arming takes **two** inputs, both required: `EXTERNAL_MODERATION_CACHE_NAMESPACE=prod` (a closed allowlist) **and** a positive `EXTERNAL_MODERATION_CACHE_TTL_SECONDS`. Unarmed there are **no metric series at all**.

⚠️ **This section originally said the opposite** — that the TTL was the sole switch, that a second input would be a thing that could disagree with the first, and that reading it per call made it "a real kill switch rather than one needing a rollout." Audit rounds 1 and 2 retracted all three. Deployments share one sysRedis and the PR-preview task copies `civitai-cfg` wholesale, so a namespace segment is mandatory; and `env` is a module-load snapshot, so **disabling requires a rollout**. Corrected here as well as in the code, because this is the first thing a reviewer reads.

## ⚠️ One thing to know about the metrics

**A hit is not observed on `external_moderation_duration_seconds`.** Recording hits as ~0 ms samples would drag down the p50 of the one instrument that measures what a classifier call costs — the same instrument any future decision about the model has to be graded on.

Consequence: once armed, that histogram's `_count` is **classifier calls**, while the new `external_moderation_cache_total` counts moderation **checks**. The two diverge by exactly the hit count. Anyone comparing a before/after on that histogram needs to know the denominator changed meaning on the day the cache armed.

## Also: a latent type bug

Widens `moderatePrompt`'s return from `{ flagged: false }` to `boolean`. That literal was a **bug, not a safety property** — the function returns `flagged: true` whenever the classifier flags, and only type-checked because `results[0].flagged` comes off an untyped `res.json()`, so `any` flowed past the annotation. Any consumer TS had narrowed to "never flagged" was being told something false about a moderation gate. Typecheck is clean after the widening.

## Verification

- **68/68** across all four moderation suites (28 in the new one)
- **Typecheck OK, 0 errors in 103 s** — content read, not an exit code
- **Prettier clean**, confirmed against a positive control first, since "All matched files use Prettier code style!" is also what it prints when the glob matched nothing

Mutation-tested, each mutant the narrowest expression that can be wrong so it dies for its own guard's reason:

| mutation | result |
|---|---|
| policy digest → a hex constant (`policyDigest`'s body) | 4 tests fail |
| namespace segment dropped from the key | 4 tests fail, incl. the two-deployment case |
| namespace allowlist widened to any non-empty string | 2 tests fail |
| **write-side** arming guard removed | fails alone with `expected '…:null:2c…' to contain ':prod:'` |
| the sys-read deadline wrapper removed | hangs its test to a vitest timeout |
| a failed call is cached | "failure must cost a retry" fails, alone |
| deserialization loosened to truthiness | malformed-value test fails, alone — `f: 0` must not read as "not flagged" |
| a hit observed on the histogram | no-latency-sample test fails, alone |
| TTL arming guard removed | 2 tests fail (both TTL cases) |

**Every row above was re-measured at the current head.** Two of them had drifted since they were written — the segment row gained a fourth kill from the new keyspace assertion, and the TTL row stopped being "alone" once `moderationCacheEnabled()` began routing through `armedCache()`. Both drifted in the understating direction, and both were caused by the very commit that claimed to have corrected this table.

🔴 Two mutation-testing mistakes of mine, both caught by re-running rather than assuming. The first policy mutation hit the **read path alone**, desynchronising the keys and taking out 7 tests — proving the *key* matters, not the *policy segment*. And in round 2 the **write-side arming guard survived** a green 28/28 suite; the obvious fix (`expect(set).not.toHaveBeenCalled()`) was *also* vacuous, because the write is fire-and-forget behind a lazy `import()` and had not happened yet either way. An absence you did not wait for is not an absence.

## Rollout

Merge is inert. To arm, set **both** `EXTERNAL_MODERATION_CACHE_NAMESPACE=prod` and a positive TTL on one deployment, then read `external_moderation_cache_total`; the hit rate should land at or **below** 34.3 %, because the probe claimed its slot when a request *started* whereas this cache cannot store a verdict until the classifier answers ~200 ms later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsSvftTXXvxBixDoMq7FTM
