### PR TITLE
perf(blocks): drop unplayable collections from discovery via a bounded, order-pinned sample

### DIFF
--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -45,8 +45,20 @@ import {
  * can't surface a mature collection in discovery. (Per-item maturity is enforced
  * on the detail endpoint where the media is actually read.)
  *
+ * 🔴 THE COLLECTION-LEVEL `nsfwLevel` CANNOT SEPARATE A MOSTLY-SAFE COLLECTION
+ * FROM A MOSTLY-MATURE ONE, which is why the clamped count below exists. It is a
+ * bitmask OR-ed over the collection's items, so a contest collection that is 97%
+ * safe and a mature collection that is 1% safe both carry the same value (29 =
+ * PG|R|X|XXX) and both INTERSECT a SFW ceiling. Gating harder on that value is not
+ * an option: strict containment (`nsfwLevel & ~browsingLevel === 0`) was measured
+ * against the live population and drops 87.5% of the first discovery page,
+ * including the large contest collections that are the best content on a SFW
+ * domain. The separating signal is the CLAMPED ITEM COUNT — see
+ * `MIN_PLAYABLE_FRACTION`.
+ *
  * Response: `{ items: [{ id, name, description, coverImageUrl, itemCount,
- *   curator:{ userId, username }, isPublic, followed }], nextCursor }`.
+ *   curator:{ userId, username }, isPublic, followed }], nextCursor }`, where
+ * `itemCount` is CLAMPED to the token's ceiling in BOTH modes.
  */
 
 export const config = { api: { responseLimit: false } };
@@ -60,6 +72,38 @@ const SORT_ALIAS: Record<string, CollectionSort> = {
   newest: CollectionSort.Newest,
   popular: CollectionSort.MostContributors,
 };
+
+/**
+ * The PLAYABLE-FRACTION FLOOR: the share of a collection's advertised (accepted)
+ * items that must survive the viewer's maturity ceiling for that collection to be
+ * worth surfacing in PUBLIC discovery.
+ *
+ * A collection at 1% is not a collection the viewer can browse; it is a card
+ * promising 2,080 items that opens onto 19. Twenty percent is the point measured
+ * to separate the two live populations — the mostly-safe contest collections sit
+ * far above it and the mature ones far below — without needing a second signal.
+ *
+ * 🔴 DISCOVERY ONLY. It is deliberately NOT applied in `mode=mine`; see the drop
+ * comment on the public branch and the note above the `mine` branch.
+ */
+export const MIN_PLAYABLE_FRACTION = 0.2;
+
+/**
+ * Does `playable` of `advertised` items clear {@link MIN_PLAYABLE_FRACTION}?
+ *
+ * 🔴 THE ZERO CASE IS AN EXPLICIT BRANCH, NOT A DIVISION. An empty collection
+ * gives `0 / 0 = NaN`, and every comparison against NaN is false — so without
+ * this guard an empty collection would be silently DROPPED by a filter that has
+ * nothing to say about it. This filter exists to catch a MATURITY MISMATCH
+ * between what a card advertises and what it can serve, and a collection
+ * advertising nothing has no mismatch to detect. Whether an empty collection
+ * belongs in discovery at all is a separate product question this must not decide
+ * as a side effect.
+ */
+export function meetsPlayableFloor(advertised: number, playable: number): boolean {
+  if (advertised <= 0) return true;
+  return playable / advertised >= MIN_PLAYABLE_FRACTION;
+}
 
 const querySchema = z.object({
   mode: z.enum(['public', 'mine']).default('public'),
@@ -160,6 +204,33 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
         },
       });
 
+      // The playable-fraction floor needs BOTH counts, and it decides which rows
+      // the walk below consumes — so the counts have to be resolved BEFORE the
+      // walk, over every row that could still appear, not after the page is
+      // chosen. Only rows that already clear the collection-level ceiling can
+      // appear, so those are the only ids worth counting.
+      //
+      // COST: two grouped counts over up to `OVERFETCH` ids instead of one over
+      // `limit`. Both are the same indexed GROUP BY the page already ran.
+      const ceilingOk = (c: (typeof rows)[number]) =>
+        collectionWithinCeiling(c.nsfwLevel ?? 0, browsingLevel);
+      const candidateIds = rows.filter(ceilingOk).map((c) => c.id);
+      const [advertisedRows, playableRows] = await Promise.all([
+        getCollectionItemCount({
+          collectionIds: candidateIds,
+          status: CollectionItemStatus.ACCEPTED,
+        }),
+        // The SAME count, clamped to this token's ceiling — what the player will
+        // actually serve.
+        getCollectionItemCount({
+          collectionIds: candidateIds,
+          status: CollectionItemStatus.ACCEPTED,
+          browsingLevel,
+        }),
+      ]);
+      const advertisedMap = new Map(advertisedRows.map((c) => [c.id, Number(c.count)]));
+      const playableMap = new Map(playableRows.map((c) => [c.id, Number(c.count)]));
+
       const items: typeof rows = [];
       let firstUnconsumedId: number | undefined;
       for (let i = 0; i < rows.length; i++) {
@@ -167,7 +238,19 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
           firstUnconsumedId = rows[i].id;
           break;
         }
-        if (collectionWithinCeiling(rows[i].nsfwLevel ?? 0, browsingLevel)) items.push(rows[i]);
+        if (!ceilingOk(rows[i])) continue;
+        // 🔴 THE DROP, AND WHY IT IS INSIDE THIS WALK RATHER THAN AFTER IT. Both
+        // count maps are absent-means-zero (GROUP BY emits no row for a collection
+        // with no accepted items), which `meetsPlayableFloor` reads as "empty, keep".
+        // Filtering here means a dropped row is walked PAST like a clamped-out one,
+        // so the page still fills to `limit` and `firstUnconsumedId` still advances
+        // — filtering the sliced page afterwards would return short pages and, on a
+        // page that filtered to empty, emit no cursor at all and TERMINATE the feed
+        // while qualifying collections remained.
+        const advertised = advertisedMap.get(rows[i].id) ?? 0;
+        const playable = playableMap.get(rows[i].id) ?? 0;
+        if (!meetsPlayableFloor(advertised, playable)) continue;
+        items.push(rows[i]);
       }
 
       let nextCursor: number | undefined;
@@ -178,7 +261,10 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
         // Consumed the ENTIRE over-fetch without filling `limit` (a very heavy
         // clamp) yet the source returned a full batch → more may remain. Resume
         // from the last fetched row (inclusive → re-fetched next page; the client
-        // dedups by id). Rare (needs the clamp to drop most of 4×limit+1 rows).
+        // dedups by id). No longer rare: the playable floor drops far more rows
+        // than the ceiling alone did, so a page CAN come back short — but it comes
+        // back with a cursor that advanced by OVERFETCH-1 rows, which is what
+        // keeps the rest of the feed reachable. Short page, live feed.
         nextCursor = rows[rows.length - 1]?.id;
       }
       // else: rows.length < OVERFETCH and the page wasn't over-consumed → the
@@ -195,12 +281,13 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       const primaryCoverUsable = (c: (typeof items)[number]) =>
         !!c.image?.url && collectionWithinCeiling(c.image.nsfwLevel ?? 0, browsingLevel);
       const missingCoverIds = items.filter((c) => !primaryCoverUsable(c)).map((c) => c.id);
-      const [countRows, followed, fallbackCovers] = await Promise.all([
-        getCollectionItemCount({ collectionIds: ids, status: CollectionItemStatus.ACCEPTED }),
+      const [followed, fallbackCovers] = await Promise.all([
         getFollowedCollectionIds(subjectUserId, ids),
         getFallbackCoverImages(missingCoverIds, browsingLevel),
       ]);
-      const countMap = new Map(countRows.map((c) => [c.id, Number(c.count)]));
+      // No third count query here: `playableMap` was already resolved above for the
+      // floor, over a SUPERSET of `ids`, and it is the clamped number the card must
+      // advertise.
 
       res.status(200).json({
         items: items.map((c) => ({
@@ -208,7 +295,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
           name: c.name,
           description: c.description ?? null,
           coverImageUrl: toCoverImageUrl(primaryCoverUsable(c) ? c.image : fallbackCovers.get(c.id)),
-          itemCount: countMap.get(c.id) ?? 0,
+          itemCount: playableMap.get(c.id) ?? 0,
           curator: { userId: c.userId, username: c.user?.username ?? null },
           isPublic: c.read === CollectionReadConfiguration.Public,
           followed: followed.has(c.id),
@@ -254,7 +341,21 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       !!c.image?.url && collectionWithinCeiling(c.image.nsfwLevel ?? 0, browsingLevel);
     const missingCoverIds = items.filter((c) => !primaryCoverUsable(c)).map((c) => c.id);
     const [countRows, followed, fallbackCovers] = await Promise.all([
-      getCollectionItemCount({ collectionIds: ids, status: CollectionItemStatus.ACCEPTED }),
+      // CLAMPED here too — the count must agree with what the player serves in
+      // every mode, or a viewer's own card promises items their ceiling hides.
+      //
+      // 🔴 BUT NO PLAYABLE-FRACTION FLOOR ON THIS BRANCH, DELIBERATELY. These are
+      // the SUBJECT'S OWN collections: they created or bookmarked every one of
+      // them and know it is in this list. Dropping one for being mostly mature
+      // makes it look deleted, which is the defect class the detail surface
+      // already settled the other way — an empty own-collection is shown DISABLED
+      // WITH A REASON, never hidden. The floor is a DISCOVERY ranking filter, and
+      // there is nothing to discover in a list the viewer assembled.
+      getCollectionItemCount({
+        collectionIds: ids,
+        status: CollectionItemStatus.ACCEPTED,
+        browsingLevel,
+      }),
       getFollowedCollectionIds(subjectUserId, ids),
       getFallbackCoverImages(missingCoverIds, browsingLevel),
     ]);

--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -234,10 +234,12 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       // the ~85 ms this endpoint takes without it — a ~31× regression on the
       // discovery front door — because the clamp's join to "Image" forfeits the
       // covering index the unclamped count scans. Narrowing OVERFETCH does not
-      // rescue it (~27%). One bounded, order-pinned LATERAL sample costs ~257 ms
-      // and agreed with the exact count on this floor for 97 of 97 live
-      // collections. Measurements, and the order-sensitivity that forces the
-      // ORDER BY, are on `PLAYABLE_SAMPLE_SIZE`.
+      // rescue it (~27%). One bounded, order-pinned LATERAL sample costs ~400 ms
+      // as shipped and agreed with the exact count on this floor for 97 of 97 live
+      // collections. Measurements, the order-sensitivity that forces the ORDER BY,
+      // and why that pin costs ~4x an unordered LIMIT are on
+      // `PLAYABLE_SAMPLE_SIZE` — including the retraction of an earlier 257 ms
+      // figure that had been measured WITHOUT the ordering.
       const ceilingOk = (c: (typeof rows)[number]) =>
         collectionWithinCeiling(c.nsfwLevel ?? 0, browsingLevel);
       const candidateIds = rows.filter(ceilingOk).map((c) => c.id);

--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -14,6 +14,7 @@ import {
 } from '~/server/services/collection.service';
 import {
   collectionWithinCeiling,
+  getCollectionPlayableSample,
   getFallbackCoverImages,
   getFollowedCollectionIds,
   hydrateBlockSubject,
@@ -53,12 +54,21 @@ import {
  * an option: strict containment (`nsfwLevel & ~browsingLevel === 0`) was measured
  * against the live population and drops 87.5% of the first discovery page,
  * including the large contest collections that are the best content on a SFW
- * domain. The separating signal is the CLAMPED ITEM COUNT — see
- * `MIN_PLAYABLE_FRACTION`.
+ * domain. The separating signal is HOW MUCH OF THE COLLECTION SURVIVES THE
+ * CEILING, sampled — see `MIN_PLAYABLE_FRACTION` and `PLAYABLE_SAMPLE_SIZE`.
  *
  * Response: `{ items: [{ id, name, description, coverImageUrl, itemCount,
- *   curator:{ userId, username }, isPublic, followed }], nextCursor }`, where
- * `itemCount` is CLAMPED to the token's ceiling in BOTH modes.
+ *   curator:{ userId, username }, isPublic, followed }], nextCursor }`.
+ *
+ * 🔴 `itemCount` DIFFERS BY MODE, DELIBERATELY. In `mode=mine` it is CLAMPED to
+ * the token's ceiling — that branch counts only the subject's own collections, a
+ * bounded set with no over-fetch window, so the exact clamped count is affordable
+ * there. In `mode=public` it is the collection's ADVERTISED (unclamped) size: the
+ * exact clamped count over the discovery over-fetch window is a ~31× regression
+ * on this endpoint (measured; see `PLAYABLE_SAMPLE_SIZE`), and the sampled
+ * fraction that replaces it is an ESTIMATE, which a field that reads as exact
+ * must not carry. The advertised number is not a lie — it is the collection's
+ * real size — and the playable floor now guarantees that most of it is playable.
  */
 
 export const config = { api: { responseLimit: false } };
@@ -74,14 +84,23 @@ const SORT_ALIAS: Record<string, CollectionSort> = {
 };
 
 /**
- * The PLAYABLE-FRACTION FLOOR: the share of a collection's advertised (accepted)
- * items that must survive the viewer's maturity ceiling for that collection to be
- * worth surfacing in PUBLIC discovery.
+ * The PLAYABLE-FRACTION FLOOR: the share of a collection's SAMPLED accepted items
+ * that must survive the viewer's maturity ceiling for that collection to be worth
+ * surfacing in PUBLIC discovery.
  *
  * A collection at 1% is not a collection the viewer can browse; it is a card
  * promising 2,080 items that opens onto 19. Twenty percent is the point measured
  * to separate the two live populations — the mostly-safe contest collections sit
  * far above it and the mature ones far below — without needing a second signal.
+ *
+ * 🔴 A RANKING HEURISTIC, NOT A SAFETY GATE, AND IT IS FED BY A SAMPLE. The
+ * fraction is computed over the newest `PLAYABLE_SAMPLE_SIZE` items, not over the
+ * whole collection (the exact clamped count is unaffordable here — the cost,
+ * accuracy and order-sensitivity measurements live on that constant). Nothing on
+ * this path protects a viewer from mature media: per-item maturity is enforced on
+ * the DETAIL endpoint where the media is read, and on the cover via
+ * `getFallbackCoverImages`. A collection kept by this floor can still be 79%
+ * mature.
  *
  * 🔴 DISCOVERY ONLY. It is deliberately NOT applied in `mode=mine`; see the drop
  * comment on the public branch and the note above the `mine` branch.
@@ -89,20 +108,20 @@ const SORT_ALIAS: Record<string, CollectionSort> = {
 export const MIN_PLAYABLE_FRACTION = 0.2;
 
 /**
- * Does `playable` of `advertised` items clear {@link MIN_PLAYABLE_FRACTION}?
+ * Does `playable` of `sampled` items clear {@link MIN_PLAYABLE_FRACTION}?
  *
- * 🔴 THE ZERO CASE IS AN EXPLICIT BRANCH, NOT A DIVISION. An empty collection
- * gives `0 / 0 = NaN`, and every comparison against NaN is false — so without
- * this guard an empty collection would be silently DROPPED by a filter that has
+ * 🔴 THE ZERO CASE IS AN EXPLICIT BRANCH, NOT A DIVISION. A collection with
+ * nothing sampled gives `0 / 0 = NaN`, and every comparison against NaN is false
+ * — so without this guard it would be silently DROPPED by a filter that has
  * nothing to say about it. This filter exists to catch a MATURITY MISMATCH
- * between what a card advertises and what it can serve, and a collection
- * advertising nothing has no mismatch to detect. Whether an empty collection
- * belongs in discovery at all is a separate product question this must not decide
- * as a side effect.
+ * between what a card advertises and what it can serve, and a collection with no
+ * items has no mismatch to detect. Whether an empty collection belongs in
+ * discovery at all is a separate product question this must not decide as a side
+ * effect.
  */
-export function meetsPlayableFloor(advertised: number, playable: number): boolean {
-  if (advertised <= 0) return true;
-  return playable / advertised >= MIN_PLAYABLE_FRACTION;
+export function meetsPlayableFloor(sampled: number, playable: number): boolean {
+  if (sampled <= 0) return true;
+  return playable / sampled >= MIN_PLAYABLE_FRACTION;
 }
 
 const querySchema = z.object({
@@ -204,32 +223,25 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
         },
       });
 
-      // The playable-fraction floor needs BOTH counts, and it decides which rows
-      // the walk below consumes — so the counts have to be resolved BEFORE the
-      // walk, over every row that could still appear, not after the page is
-      // chosen. Only rows that already clear the collection-level ceiling can
-      // appear, so those are the only ids worth counting.
+      // The playable-fraction floor decides which rows the walk below consumes, so
+      // it has to be resolved BEFORE the walk, over every row that could still
+      // appear — not after the page is chosen. Only rows that already clear the
+      // collection-level ceiling can appear, so those are the only ids worth
+      // sampling.
       //
-      // COST: two grouped counts over up to `OVERFETCH` ids instead of one over
-      // `limit`. Both are the same indexed GROUP BY the page already ran.
+      // 🔴 SAMPLED, NOT COUNTED, AND THAT IS THE WHOLE COST STORY. Computing the
+      // EXACT clamped count over this over-fetch window costs ~2.6-2.8 s against
+      // the ~85 ms this endpoint takes without it — a ~31× regression on the
+      // discovery front door — because the clamp's join to "Image" forfeits the
+      // covering index the unclamped count scans. Narrowing OVERFETCH does not
+      // rescue it (~27%). One bounded, order-pinned LATERAL sample costs ~257 ms
+      // and agreed with the exact count on this floor for 97 of 97 live
+      // collections. Measurements, and the order-sensitivity that forces the
+      // ORDER BY, are on `PLAYABLE_SAMPLE_SIZE`.
       const ceilingOk = (c: (typeof rows)[number]) =>
         collectionWithinCeiling(c.nsfwLevel ?? 0, browsingLevel);
       const candidateIds = rows.filter(ceilingOk).map((c) => c.id);
-      const [advertisedRows, playableRows] = await Promise.all([
-        getCollectionItemCount({
-          collectionIds: candidateIds,
-          status: CollectionItemStatus.ACCEPTED,
-        }),
-        // The SAME count, clamped to this token's ceiling — what the player will
-        // actually serve.
-        getCollectionItemCount({
-          collectionIds: candidateIds,
-          status: CollectionItemStatus.ACCEPTED,
-          browsingLevel,
-        }),
-      ]);
-      const advertisedMap = new Map(advertisedRows.map((c) => [c.id, Number(c.count)]));
-      const playableMap = new Map(playableRows.map((c) => [c.id, Number(c.count)]));
+      const playableSample = await getCollectionPlayableSample(candidateIds, browsingLevel);
 
       const items: typeof rows = [];
       let firstUnconsumedId: number | undefined;
@@ -239,17 +251,17 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
           break;
         }
         if (!ceilingOk(rows[i])) continue;
-        // 🔴 THE DROP, AND WHY IT IS INSIDE THIS WALK RATHER THAN AFTER IT. Both
-        // count maps are absent-means-zero (GROUP BY emits no row for a collection
-        // with no accepted items), which `meetsPlayableFloor` reads as "empty, keep".
-        // Filtering here means a dropped row is walked PAST like a clamped-out one,
-        // so the page still fills to `limit` and `firstUnconsumedId` still advances
-        // — filtering the sliced page afterwards would return short pages and, on a
-        // page that filtered to empty, emit no cursor at all and TERMINATE the feed
-        // while qualifying collections remained.
-        const advertised = advertisedMap.get(rows[i].id) ?? 0;
-        const playable = playableMap.get(rows[i].id) ?? 0;
-        if (!meetsPlayableFloor(advertised, playable)) continue;
+        // 🔴 THE DROP, AND WHY IT IS INSIDE THIS WALK RATHER THAN AFTER IT. The
+        // sample map is absent-means-nothing-sampled (the lateral emits no row for
+        // a collection with no accepted items), which `meetsPlayableFloor` reads as
+        // "nothing to judge, keep". Filtering here means a dropped row is walked
+        // PAST like a clamped-out one, so the page still fills to `limit` and
+        // `firstUnconsumedId` still advances — filtering the sliced page afterwards
+        // would return short pages and, on a page that filtered to empty, emit no
+        // cursor at all and TERMINATE the feed while qualifying collections
+        // remained.
+        const sample = playableSample.get(rows[i].id);
+        if (!meetsPlayableFloor(sample?.sampled ?? 0, sample?.playable ?? 0)) continue;
         items.push(rows[i]);
       }
 
@@ -281,13 +293,19 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       const primaryCoverUsable = (c: (typeof items)[number]) =>
         !!c.image?.url && collectionWithinCeiling(c.image.nsfwLevel ?? 0, browsingLevel);
       const missingCoverIds = items.filter((c) => !primaryCoverUsable(c)).map((c) => c.id);
-      const [followed, fallbackCovers] = await Promise.all([
+      const [countRows, followed, fallbackCovers] = await Promise.all([
+        // 🔴 THE ADVERTISED (UNCLAMPED) COUNT — the same query, over the same
+        // `limit`-sized id list, that this endpoint has always run. It is not a
+        // lie: it is the collection's real size, and the floor above now
+        // guarantees most of it is playable. It is deliberately NOT the sampled
+        // fraction extrapolated to a total — `itemCount` reads as an exact number
+        // and must not carry an estimate — and it is deliberately not the exact
+        // clamped count, which is the ~31× regression this design exists to avoid.
+        getCollectionItemCount({ collectionIds: ids, status: CollectionItemStatus.ACCEPTED }),
         getFollowedCollectionIds(subjectUserId, ids),
         getFallbackCoverImages(missingCoverIds, browsingLevel),
       ]);
-      // No third count query here: `playableMap` was already resolved above for the
-      // floor, over a SUPERSET of `ids`, and it is the clamped number the card must
-      // advertise.
+      const countMap = new Map(countRows.map((c) => [c.id, Number(c.count)]));
 
       res.status(200).json({
         items: items.map((c) => ({
@@ -295,7 +313,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
           name: c.name,
           description: c.description ?? null,
           coverImageUrl: toCoverImageUrl(primaryCoverUsable(c) ? c.image : fallbackCovers.get(c.id)),
-          itemCount: playableMap.get(c.id) ?? 0,
+          itemCount: countMap.get(c.id) ?? 0,
           curator: { userId: c.userId, username: c.user?.username ?? null },
           isPublic: c.read === CollectionReadConfiguration.Public,
           followed: followed.has(c.id),
@@ -341,10 +359,18 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       !!c.image?.url && collectionWithinCeiling(c.image.nsfwLevel ?? 0, browsingLevel);
     const missingCoverIds = items.filter((c) => !primaryCoverUsable(c)).map((c) => c.id);
     const [countRows, followed, fallbackCovers] = await Promise.all([
-      // CLAMPED here too — the count must agree with what the player serves in
-      // every mode, or a viewer's own card promises items their ceiling hides.
+      // 🔴 THE EXACT CLAMPED COUNT, WHICH THIS BRANCH CAN AFFORD AND PUBLIC
+      // DISCOVERY CANNOT. `itemCount` here is the number the player will serve, so
+      // a viewer's own card never promises items their ceiling hides. The reason
+      // the same choice is impossible on the public branch is not the query — it
+      // is the POPULATION. This branch counts only the subject's own collections:
+      // a bounded set, already sliced to `limit`, with no over-fetch window and no
+      // 34,577-item contest collection dragged in by a popularity sort. Public
+      // discovery counts up to `limit * 4 + 1` candidates chosen precisely because
+      // the sort ranks the biggest ones first, which is what turns the same clamp
+      // into a ~2.6 s query (see `PLAYABLE_SAMPLE_SIZE`).
       //
-      // 🔴 BUT NO PLAYABLE-FRACTION FLOOR ON THIS BRANCH, DELIBERATELY. These are
+      // 🔴 AND NO PLAYABLE-FRACTION FLOOR ON THIS BRANCH, DELIBERATELY. These are
       // the SUBJECT'S OWN collections: they created or bookmarked every one of
       // them and know it is in this list. Dropping one for being mostly mature
       // makes it look deleted, which is the defect class the detail surface

--- a/src/server/services/__tests__/collection-item-count-clamp-wiring.test.ts
+++ b/src/server/services/__tests__/collection-item-count-clamp-wiring.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'fs';
+import path from 'path';
+import ts from 'typescript';
+
+/**
+ * 🔴 CALL-SITE LEDGER for `getCollectionItemCount`'s `browsingLevel` clamp.
+ *
+ * The parameter is OPTIONAL, which is what makes every existing caller safe — and
+ * is also exactly why nothing else can see a caller that should have passed it and
+ * did not. There is no compile error, no runtime error, and no failing assertion:
+ * the call simply returns the UNCLAMPED total, and a discovery card goes back to
+ * advertising thousands of items the player will not serve. That is the original
+ * defect, restored silently, by a caller written months from now.
+ *
+ * So the population is pinned here: every call site in `src/`, enumerated from the
+ * TREE rather than from a list someone maintains, keyed by
+ * `file::enclosingFunction`, with — in source order — whether each one clamps.
+ * Adding, removing or re-clamping a call site is then a REVIEWABLE EDIT to this
+ * table rather than an invisible change.
+ *
+ * 🔴 THE PIN IS A LIST, NOT A COUNT, BECAUSE ONE KEY COVERS SEVERAL CALLS. The
+ * blocks discovery handler issues THREE: an unclamped "advertised" count, a
+ * clamped "playable" one on the public branch, and a clamped one on `mine`. A
+ * per-key boolean could not distinguish "the advertised call lost its clamp"
+ * (correct) from "the playable call lost its clamp" (the bug), because both keys
+ * would still read "mixed". A per-key COUNT could not see a clamped call being
+ * swapped for an unclamped one at all. The ordered list sees both.
+ *
+ * MECHANISM: the TypeScript AST, not a regex. Call sites are matched by
+ * IDENTIFIER (so a `mockGetCollectionItemCount(...)` is not a call to
+ * `getCollectionItemCount`, which a substring needle cannot distinguish) and the
+ * clamp is read as a PROPERTY of the argument object, so a prettier reflow, a
+ * renamed local or a comment mentioning the parameter cannot change the answer.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+const NEEDLE = 'getCollectionItemCount';
+
+/** The declaration itself — not a call site. */
+const DEFINITION_FILE = 'src/server/services/collection.service.ts';
+/**
+ * This guard's own source. It mentions the needle only in comments and string
+ * literals, which the AST walk already ignores, but it is excluded by path as
+ * well so the enumeration can never depend on that.
+ */
+const GUARD_FILE = 'src/server/services/__tests__/collection-item-count-clamp-wiring.test.ts';
+
+/** The optional parameter whose presence at a call site this ledger tracks. */
+const CLAMP_PARAM = 'browsingLevel';
+
+/**
+ * What a call site does with {@link CLAMP_PARAM}.
+ *
+ * `unreadable` is the deliberately conservative bucket: an argument that is not a
+ * plain object literal (a spread, a variable, a helper's return value) cannot be
+ * read statically, so it fails every pin rather than being guessed at. If a future
+ * caller legitimately needs that shape, the fix is to make the clamp visible at the
+ * call site — not to loosen this.
+ */
+type ClampState = 'clamped' | 'unclamped' | 'unreadable';
+
+interface CallSite {
+  /** Repo-relative path. */
+  file: string;
+  /** Nearest named enclosing function / method / `const fn = () =>`. */
+  fn: string;
+  /** 1-based line of the call, for a failure message a human can act on. */
+  line: number;
+  clamp: ClampState;
+}
+
+/** `file::enclosingFunction` — the key the expectation table is written in. */
+type CallSiteKey = string;
+
+interface ExpectedCallSite {
+  /**
+   * Every call under this key, IN SOURCE ORDER, and whether it clamps.
+   *
+   * 🔴 CHANGING AN ENTRY IS THE REVIEWABLE ACT. Flipping a `'clamped'` to
+   * `'unclamped'` is asserting that this particular count is meant to be the
+   * ADVERTISED total — the denominator of the playable fraction — and not a number
+   * anything renders. Adding an entry is asserting the same for a new call.
+   */
+  clamps: readonly ClampState[];
+  /** What those calls ARE, so a mismatch message can name the one that moved. */
+  siteNote: string;
+}
+
+/**
+ * Every PRODUCTION call site of `getCollectionItemCount`.
+ *
+ * 🔴 THE THREE UNCLAMPED ROWS ARE NOT OVERSIGHTS. They are the surfaces that
+ * predate the clamp and must keep their present behaviour byte for byte: the
+ * public REST collections list, the on-site infinite-scroll controller, and the
+ * model showcase card. Each renders a count to a viewer whose maturity ceiling is
+ * enforced elsewhere in that surface's own pipeline; changing what they count is a
+ * separate, deliberate change to those surfaces, not a side effect of this one.
+ */
+const EXPECTED_BY_CALL_SITE: Record<CallSiteKey, ExpectedCallSite> = {
+  'src/pages/api/v1/blocks/collections/index.ts::handler': {
+    // Source order: the two public-branch counts inside one `Promise.all`, then
+    // the `mine`-branch count.
+    clamps: ['unclamped', 'clamped', 'clamped'],
+    siteNote:
+      "public branch: (1) the ADVERTISED count — the floor's denominator, deliberately unclamped; " +
+      "(2) the PLAYABLE count, clamped, which is both the floor's numerator and the rendered " +
+      'itemCount; then (3) the `mine` branch count, clamped because the number must agree with ' +
+      'the player in every mode (only the DROP is discovery-only)',
+  },
+  'src/pages/api/v1/collections/index.ts::handler': {
+    clamps: ['unclamped'],
+    siteNote: 'the public REST collections list — pre-existing surface, behaviour unchanged',
+  },
+  'src/server/controllers/collection.controller.ts::getAllCollectionsInfiniteHandler': {
+    clamps: ['unclamped'],
+    siteNote: 'the on-site infinite collection feed — pre-existing surface, behaviour unchanged',
+  },
+  'src/server/controllers/model.controller.ts::getModelCollectionShowcaseHandler': {
+    clamps: ['unclamped'],
+    siteNote:
+      "the model page's showcase-collection card — pre-existing surface, behaviour unchanged",
+  },
+};
+
+/** Total pinned call sites — the floor the enumeration guard must clear. */
+const EXPECTED_TOTAL_SITES = Object.values(EXPECTED_BY_CALL_SITE).reduce(
+  (n, pin) => n + pin.clamps.length,
+  0
+);
+
+/**
+ * Candidate files, enumerated from the TREE rather than from a hand-kept list.
+ *
+ * The needle is the BARE identifier: it only has to over-approximate, because the
+ * AST walk below decides what is really a call. That removes every formatting
+ * dependency from the enumeration.
+ */
+function candidateFiles(): string[] {
+  const found: string[] = [];
+  const walk = (rel: string) => {
+    for (const entry of readdirSync(path.join(REPO_ROOT, rel), { withFileTypes: true })) {
+      const child = `${rel}/${entry.name}`;
+      if (entry.isDirectory()) walk(child);
+      else if (
+        /\.tsx?$/.test(entry.name) &&
+        readFileSync(path.join(REPO_ROOT, child), 'utf8').includes(NEEDLE)
+      )
+        found.push(child);
+    }
+  };
+  walk('src');
+  return found
+    .filter((f) => f !== DEFINITION_FILE && f !== GUARD_FILE)
+    .filter((f) => !(f.includes('__tests__') || /\.test\.tsx?$/.test(f)));
+}
+
+/**
+ * The nearest NAMED enclosing scope of `node`, walking up the parent chain.
+ *
+ * Handles the shapes this repo uses at these call sites:
+ *   - `async function handler(req, res) {}` passed to a wrapper → FunctionExpression
+ *   - `export const getAllCollectionsInfiniteHandler = async () => {}` → VariableDeclaration
+ *   - `export async function getModelCollectionShowcaseHandler() {}` → FunctionDeclaration
+ *
+ * A name is only accepted from a variable/property once a function boundary has
+ * been crossed, so a call sitting directly in an object literal is not mislabelled
+ * as "inside" it.
+ */
+function enclosingFunctionName(node: ts.Node): string {
+  let sawFunctionBoundary = false;
+  let cur: ts.Node | undefined = node.parent;
+  while (cur) {
+    if (ts.isFunctionDeclaration(cur)) {
+      if (cur.name) return cur.name.text;
+      sawFunctionBoundary = true;
+    } else if (ts.isMethodDeclaration(cur) && ts.isIdentifier(cur.name)) {
+      return cur.name.text;
+    } else if (ts.isFunctionExpression(cur)) {
+      if (cur.name) return cur.name.text;
+      sawFunctionBoundary = true;
+    } else if (ts.isArrowFunction(cur)) {
+      sawFunctionBoundary = true;
+    } else if (sawFunctionBoundary && ts.isVariableDeclaration(cur) && ts.isIdentifier(cur.name)) {
+      return cur.name.text;
+    } else if (sawFunctionBoundary && ts.isPropertyAssignment(cur) && ts.isIdentifier(cur.name)) {
+      return cur.name.text;
+    }
+    cur = cur.parent;
+  }
+  return '<module scope>';
+}
+
+/** Does the call's single object-literal argument carry a `browsingLevel` key? */
+function clampStateOf(arg: ts.Expression | undefined): ClampState {
+  if (!arg || !ts.isObjectLiteralExpression(arg)) return 'unreadable';
+  for (const prop of arg.properties) {
+    // A spread could carry the key invisibly — refuse to guess.
+    if (ts.isSpreadAssignment(prop)) return 'unreadable';
+    const name = prop.name;
+    if (!name) continue;
+    // A computed key could also be `browsingLevel` at runtime — refuse to guess.
+    if (ts.isComputedPropertyName(name)) return 'unreadable';
+    if ((ts.isIdentifier(name) || ts.isStringLiteral(name)) && name.text === CLAMP_PARAM)
+      return 'clamped';
+  }
+  return 'unclamped';
+}
+
+/** Every real `getCollectionItemCount(...)` call in `file`, in source order. */
+function callSitesIn(file: string): CallSite[] {
+  const text = readFileSync(path.join(REPO_ROOT, file), 'utf8');
+  const source = ts.createSourceFile(
+    file,
+    text,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+  const found: CallSite[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      // Identifier equality — NOT a substring match.
+      const callee = node.expression;
+      const calleeName = ts.isIdentifier(callee)
+        ? callee.text
+        : ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.name)
+        ? callee.name.text
+        : null;
+      if (calleeName === NEEDLE) {
+        found.push({
+          file,
+          fn: enclosingFunctionName(node),
+          line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+          clamp: clampStateOf(node.arguments[0]),
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  // `forEachChild` is a pre-order walk, so `found` is already in source order
+  // within a file; sorting by line makes that independent of the traversal.
+  return found.sort((a, b) => a.line - b.line);
+}
+
+const keyOf = (c: CallSite): CallSiteKey => `${c.file}::${c.fn}`;
+
+describe('getCollectionItemCount — browsingLevel call-site ledger', () => {
+  // A throw in the describe BODY happens during registration, so no `it` below
+  // would be declared and the file would collect zero tests while READING GREEN.
+  // Catching it keeps registration total, so the guard below reports the breakage.
+  let sites: CallSite[] = [];
+  let enumerationError: unknown;
+  try {
+    sites = candidateFiles().flatMap(callSitesIn);
+  } catch (e) {
+    enumerationError = e;
+  }
+
+  it('finds the call sites at all (guard the guard)', () => {
+    if (enumerationError) throw enumerationError;
+    // Without this, a broken enumeration would make every assertion below pass
+    // vacuously over an empty list.
+    expect(sites.length).toBeGreaterThanOrEqual(EXPECTED_TOTAL_SITES);
+    // And no call site may resolve to an unnamed scope — that would collapse
+    // distinct handlers onto one key.
+    expect(sites.filter((c) => c.fn === '<module scope>')).toEqual([]);
+  });
+
+  it('🔴 no UNEXPECTED call site — a new caller must declare whether it clamps', () => {
+    const unexpected = sites
+      .filter((c) => !(keyOf(c) in EXPECTED_BY_CALL_SITE))
+      .map((c) => `${c.file}:${c.line} inside ${c.fn}() [${c.clamp}]`);
+    expect(unexpected).toEqual([]);
+  });
+
+  it('🔴 every pinned key has EXACTLY the calls it claims, clamped exactly as it claims', () => {
+    const liveByKey = new Map<CallSiteKey, CallSite[]>();
+    for (const c of sites) {
+      const bucket = liveByKey.get(keyOf(c));
+      if (bucket) bucket.push(c);
+      else liveByKey.set(keyOf(c), [c]);
+    }
+
+    const wrong = Object.entries(EXPECTED_BY_CALL_SITE)
+      .map(([key, pin]) => {
+        const live = liveByKey.get(key) ?? [];
+        const actual = live.map((c) => c.clamp);
+        if (
+          actual.length === pin.clamps.length &&
+          actual.every((state, i) => state === pin.clamps[i])
+        )
+          return null;
+        return (
+          `${key}\n  expected [${pin.clamps.join(', ')}]\n  found    [${actual.join(', ')}]` +
+          `${
+            live.length ? ` at line(s) ${live.map((c) => c.line).join(', ')}` : ' (no calls found)'
+          }` +
+          `\n  the pinned calls are: ${pin.siteNote}`
+        );
+      })
+      .filter((m): m is string => m !== null);
+
+    expect(wrong).toEqual([]);
+  });
+
+  it('no call site passes an argument this guard cannot read', () => {
+    // `unreadable` means the clamp is invisible to review. It fails the pin above
+    // anyway; this reports it in its own terms rather than as a confusing
+    // "expected clamped, found unreadable".
+    const opaque = sites
+      .filter((c) => c.clamp === 'unreadable')
+      .map(
+        (c) =>
+          `${c.file}:${c.line} inside ${c.fn}() passes a non-literal argument — ` +
+          `pass a plain object literal so the '${CLAMP_PARAM}' decision is visible at the call site`
+      );
+    expect(opaque).toEqual([]);
+  });
+});

--- a/src/server/services/__tests__/collection-item-count-clamp-wiring.test.ts
+++ b/src/server/services/__tests__/collection-item-count-clamp-wiring.test.ts
@@ -96,12 +96,23 @@ interface ExpectedCallSite {
 /**
  * Every PRODUCTION call site of `getCollectionItemCount`.
  *
- * 🔴 THE THREE UNCLAMPED ROWS ARE NOT OVERSIGHTS. They are the surfaces that
- * predate the clamp and must keep their present behaviour byte for byte: the
- * public REST collections list, the on-site infinite-scroll controller, and the
- * model showcase card. Each renders a count to a viewer whose maturity ceiling is
- * enforced elsewhere in that surface's own pipeline; changing what they count is a
- * separate, deliberate change to those surfaces, not a side effect of this one.
+ * 🔴 NONE OF THE FOUR UNCLAMPED ENTRIES IS AN OVERSIGHT, AND THEY ARE UNCLAMPED
+ * FOR TWO DIFFERENT REASONS.
+ *
+ * Three are surfaces that predate the clamp and must keep their present behaviour
+ * byte for byte: the public REST collections list, the on-site infinite-scroll
+ * controller, and the model showcase card. Each renders a count to a viewer whose
+ * maturity ceiling is enforced elsewhere in that surface's own pipeline; changing
+ * what they count is a separate, deliberate change to those surfaces, not a side
+ * effect of this one.
+ *
+ * The fourth — the blocks PUBLIC discovery branch — is unclamped for COST. The
+ * clamped form of this query is exact and cheap only over a bounded population;
+ * over the discovery over-fetch window it measured 2829 ms against 85 ms, so that
+ * branch advertises the collection's real (unclamped) size and gets its playable
+ * FRACTION from a bounded sample instead. Flipping that entry to 'clamped' is
+ * reintroducing the regression, which is exactly what this ledger is here to make
+ * visible.
  */
 const EXPECTED_BY_CALL_SITE: Record<CallSiteKey, ExpectedCallSite> = {
   'src/pages/api/v1/blocks/collections/index.ts::handler': {

--- a/src/server/services/__tests__/collection-item-count-clamp-wiring.test.ts
+++ b/src/server/services/__tests__/collection-item-count-clamp-wiring.test.ts
@@ -6,12 +6,17 @@ import ts from 'typescript';
 /**
  * 🔴 CALL-SITE LEDGER for `getCollectionItemCount`'s `browsingLevel` clamp.
  *
- * The parameter is OPTIONAL, which is what makes every existing caller safe — and
- * is also exactly why nothing else can see a caller that should have passed it and
- * did not. There is no compile error, no runtime error, and no failing assertion:
- * the call simply returns the UNCLAMPED total, and a discovery card goes back to
- * advertising thousands of items the player will not serve. That is the original
- * defect, restored silently, by a caller written months from now.
+ * The parameter is OPTIONAL, and it moves the query between two wildly different
+ * cost classes with no compile error, no runtime error and no failing assertion.
+ * It is silent in BOTH directions:
+ *
+ *   - Adding it where it does not belong restores a ~31× latency regression on
+ *     App Blocks discovery. Unclamped, the query is an Index Only Scan on the
+ *     covering (collectionId, status) index; the clamp joins "Image", forfeits
+ *     that index, and measured 2829 ms against 85 ms over one live over-fetch
+ *     window. Nothing about the response changes shape — it just gets slow.
+ *   - Dropping it where it does belong sends a viewer's own card back to
+ *     advertising items their ceiling hides.
  *
  * So the population is pinned here: every call site in `src/`, enumerated from the
  * TREE rather than from a list someone maintains, keyed by
@@ -19,13 +24,13 @@ import ts from 'typescript';
  * Adding, removing or re-clamping a call site is then a REVIEWABLE EDIT to this
  * table rather than an invisible change.
  *
- * 🔴 THE PIN IS A LIST, NOT A COUNT, BECAUSE ONE KEY COVERS SEVERAL CALLS. The
- * blocks discovery handler issues THREE: an unclamped "advertised" count, a
- * clamped "playable" one on the public branch, and a clamped one on `mine`. A
- * per-key boolean could not distinguish "the advertised call lost its clamp"
- * (correct) from "the playable call lost its clamp" (the bug), because both keys
- * would still read "mixed". A per-key COUNT could not see a clamped call being
- * swapped for an unclamped one at all. The ordered list sees both.
+ * 🔴 THE PIN IS A LIST, NOT A COUNT, BECAUSE ONE KEY CAN COVER SEVERAL CALLS. The
+ * blocks discovery handler issues two: an unclamped one on the public branch and a
+ * clamped one on `mine`. A per-key boolean could not distinguish "the public call
+ * gained a clamp" (the cost regression) from "the `mine` call lost one" (the
+ * correctness one), because the key would read "mixed" either way. A per-key COUNT
+ * could not see a clamped call swapped for an unclamped one at all. The ordered
+ * list sees both.
  *
  * MECHANISM: the TypeScript AST, not a regex. Call sites are matched by
  * IDENTIFIER (so a `mockGetCollectionItemCount(...)` is not a call to
@@ -100,14 +105,14 @@ interface ExpectedCallSite {
  */
 const EXPECTED_BY_CALL_SITE: Record<CallSiteKey, ExpectedCallSite> = {
   'src/pages/api/v1/blocks/collections/index.ts::handler': {
-    // Source order: the two public-branch counts inside one `Promise.all`, then
-    // the `mine`-branch count.
-    clamps: ['unclamped', 'clamped', 'clamped'],
+    // Source order: the public-branch count, then the `mine`-branch count.
+    clamps: ['unclamped', 'clamped'],
     siteNote:
-      "public branch: (1) the ADVERTISED count — the floor's denominator, deliberately unclamped; " +
-      "(2) the PLAYABLE count, clamped, which is both the floor's numerator and the rendered " +
-      'itemCount; then (3) the `mine` branch count, clamped because the number must agree with ' +
-      'the player in every mode (only the DROP is discovery-only)',
+      '(1) PUBLIC discovery: the ADVERTISED size, deliberately UNCLAMPED — clamping it over the ' +
+      'discovery over-fetch window is the ~31x regression this endpoint was redesigned to avoid, ' +
+      'and the playable FLOOR is fed by a bounded sample (getCollectionPlayableSample) instead; ' +
+      "(2) `mine`: CLAMPED, because that branch counts only the subject's own already-sliced " +
+      'collections — a bounded population where the exact clamped count is affordable',
   },
   'src/pages/api/v1/collections/index.ts::handler': {
     clamps: ['unclamped'],

--- a/src/server/services/__tests__/collection-item-count-clamp.behavior.test.ts
+++ b/src/server/services/__tests__/collection-item-count-clamp.behavior.test.ts
@@ -1,0 +1,288 @@
+import { PGlite } from '@electric-sql/pglite';
+import { Prisma } from '@prisma/client';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { CollectionItemStatus } from '~/shared/utils/prisma/enums';
+
+// Booting PGlite (WASM Postgres) can exceed the default 10s hook timeout on a
+// contended runner. Relaxing it can only help a slow box, never mask a failure.
+vi.setConfig({ hookTimeout: 60_000, testTimeout: 60_000 });
+
+/**
+ * What `getCollectionItemCount`'s maturity clamp counts against REAL ROWS, as
+ * opposed to what its SQL text says.
+ *
+ * 🔴 WHY THIS IS EXECUTED AND NOT STRING-ASSERTED. The defect this file exists to
+ * prevent is a one-word difference — `JOIN "Image"` where the code needs `LEFT
+ * JOIN "Image"`. An assertion that the statement "contains `Image`" and
+ * "contains `nsfwLevel &`" passes on BOTH, and so does one that pins the fragment
+ * order, because both spellings contain the same fragments in the same order. The
+ * inner-join version silently returns ZERO for every model / post / article
+ * collection — `nsfwLevel` lives on `Image`, and those items have no image row to
+ * join to. Only running the query on rows of each shape can tell the two apart,
+ * so that is what this does: the service's own SQL, unmodified, on an in-process
+ * Postgres.
+ *
+ * The clamped count is what a discovery card advertises, so a collection reading
+ * 0 is a collection that disappears behind the playable-fraction floor. An
+ * inner-join regression here would empty every non-image collection out of the
+ * catalog while every mocked test stayed green.
+ */
+
+// `beforeAll` builds the instance, so everything below reaches it through this
+// holder rather than capturing a value that does not exist yet.
+const holder = { db: null as unknown as PGlite };
+
+/**
+ * Run the service's tagged-template statement on PGlite.
+ *
+ * 🔴 THE FLATTEN IS LOAD-BEARING. `getCollectionItemCount` interpolates NESTED
+ * `Prisma.sql` fragments (the join clause and the composed WHERE), so the naive
+ * `$${i + 1}` stitch used by sibling harnesses would substitute a bind parameter
+ * where a whole SQL clause belongs and produce a syntactically valid statement
+ * that tests nothing. `Prisma.sql(strings, ...values)` performs exactly the
+ * flattening Prisma itself does before sending, and `.text` / `.values` are the
+ * statement and binds the database would have received.
+ */
+dbMock.dbRead.$queryRaw.mockImplementation(
+  (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const flat = Prisma.sql(strings, ...(values as never[]));
+    return holder.db.query(flat.text, flat.values as unknown[]).then((r) => r.rows);
+  }
+);
+
+const { getCollectionItemCount } = await import('~/server/services/collection.service');
+
+// nsfwLevel buckets, as the app's Flags enum lays them out.
+const PG = 1;
+const PG13 = 2;
+const R = 4;
+const X = 8;
+/** A SFW-domain ceiling: PG | PG13. */
+const SFW_CEILING = PG | PG13;
+
+// One collection per item shape, so a clamp that only works for one of them
+// cannot hide behind the others' totals.
+const MIXED = 7001; // images at several maturities + one of every non-image shape
+const IMAGES_ONLY = 7002;
+const MODELS_ONLY = 7003; // 🔴 the inner-join canary
+const ARTICLES_ONLY = 7004;
+const POSTS_ONLY = 7005;
+const EMPTY = 7006; // no accepted items at all
+const ORPHAN_IMAGE = 7007; // an item pointing at an Image row that no longer exists
+
+beforeAll(async () => {
+  holder.db = new PGlite();
+  // The real `status` column is the `CollectionItemStatus` enum, not text. A text
+  // stand-in accepts casts Postgres rejects on the enum, so the statement's
+  // `::"CollectionItemStatus"` would prove nothing against it.
+  await holder.db.exec(`
+    CREATE TYPE "CollectionItemStatus" AS ENUM (${Object.values(CollectionItemStatus)
+      .map((s) => `'${s}'`)
+      .join(', ')});
+    CREATE TABLE "Image" (
+      "id"        integer PRIMARY KEY,
+      "nsfwLevel" integer NOT NULL DEFAULT 0
+    );
+    CREATE TABLE "CollectionItem" (
+      "id"           integer PRIMARY KEY,
+      "collectionId" integer NOT NULL,
+      "imageId"      integer,
+      "modelId"      integer,
+      "postId"       integer,
+      "articleId"    integer,
+      "status"       "CollectionItemStatus" NOT NULL DEFAULT 'ACCEPTED'
+    );
+    INSERT INTO "Image" ("id", "nsfwLevel") VALUES
+      (1, ${PG}), (2, ${PG13}), (3, ${R}), (4, ${X}), (5, 0),
+      (6, ${PG}), (7, ${X}),
+      (8, ${R});
+    INSERT INTO "CollectionItem" ("id","collectionId","imageId","modelId","postId","articleId","status") VALUES
+      -- MIXED: 2 permitted images (PG, PG13), 1 unrated image (always permitted),
+      -- 2 over-ceiling images (R, X), and one item of every NON-IMAGE shape.
+      (101, ${MIXED},        1,    NULL, NULL, NULL, 'ACCEPTED'),
+      (102, ${MIXED},        2,    NULL, NULL, NULL, 'ACCEPTED'),
+      (103, ${MIXED},        5,    NULL, NULL, NULL, 'ACCEPTED'),
+      (104, ${MIXED},        3,    NULL, NULL, NULL, 'ACCEPTED'),
+      (105, ${MIXED},        4,    NULL, NULL, NULL, 'ACCEPTED'),
+      (106, ${MIXED},        NULL, 900,  NULL, NULL, 'ACCEPTED'),
+      (107, ${MIXED},        NULL, NULL, 901,  NULL, 'ACCEPTED'),
+      (108, ${MIXED},        NULL, NULL, NULL, 902,  'ACCEPTED'),
+      -- A REJECTED row that would be permitted by the ceiling: proves the status
+      -- filter still composes with the clamp rather than being replaced by it.
+      (109, ${MIXED},        6,    NULL, NULL, NULL, 'REJECTED'),
+      -- IMAGES_ONLY: 1 permitted, 1 over the ceiling.
+      (201, ${IMAGES_ONLY},  1,    NULL, NULL, NULL, 'ACCEPTED'),
+      (202, ${IMAGES_ONLY},  7,    NULL, NULL, NULL, 'ACCEPTED'),
+      -- MODELS_ONLY / ARTICLES_ONLY / POSTS_ONLY: no image rows anywhere.
+      (301, ${MODELS_ONLY},  NULL, 910,  NULL, NULL, 'ACCEPTED'),
+      (302, ${MODELS_ONLY},  NULL, 911,  NULL, NULL, 'ACCEPTED'),
+      (303, ${MODELS_ONLY},  NULL, 912,  NULL, NULL, 'ACCEPTED'),
+      (401, ${ARTICLES_ONLY},NULL, NULL, NULL, 920,  'ACCEPTED'),
+      (402, ${ARTICLES_ONLY},NULL, NULL, NULL, 921,  'ACCEPTED'),
+      (501, ${POSTS_ONLY},   NULL, NULL, 930,  NULL, 'ACCEPTED'),
+      -- EMPTY: an item with no subject at all (the row filter drops it), so this
+      -- collection produces no GROUP BY row in either mode.
+      (601, ${EMPTY},        NULL, NULL, NULL, NULL, 'ACCEPTED'),
+      -- ORPHAN_IMAGE: imageId 99999 has no "Image" row.
+      (701, ${ORPHAN_IMAGE}, 99999,NULL, NULL, NULL, 'ACCEPTED'),
+      (702, ${ORPHAN_IMAGE}, 1,    NULL, NULL, NULL, 'ACCEPTED');
+  `);
+});
+
+/** `[{id,count}]` → a plain id→number map; a collection with no row reads 0. */
+async function counts(args: Parameters<typeof getCollectionItemCount>[0]) {
+  const rows = await getCollectionItemCount(args);
+  const map = new Map<number, number>(rows.map((r) => [Number(r.id), Number(r.count)]));
+  return (id: number) => map.get(id) ?? 0;
+}
+
+const ALL = [MIXED, IMAGES_ONLY, MODELS_ONLY, ARTICLES_ONLY, POSTS_ONLY, EMPTY, ORPHAN_IMAGE];
+
+describe("getCollectionItemCount — UNCLAMPED (today's behaviour, must not move)", () => {
+  it('counts every accepted item with a subject, of any type, at any maturity', async () => {
+    const at = await counts({ collectionIds: ALL, status: CollectionItemStatus.ACCEPTED });
+    // 5 images (incl. the R and X ones) + model + post + article = 8. The REJECTED
+    // row is excluded by the status filter, the subject-less row by the row filter.
+    expect(at(MIXED)).toBe(8);
+    expect(at(IMAGES_ONLY)).toBe(2);
+    expect(at(MODELS_ONLY)).toBe(3);
+    expect(at(ARTICLES_ONLY)).toBe(2);
+    expect(at(POSTS_ONLY)).toBe(1);
+    // GROUP BY emits no row for a collection with nothing to count.
+    expect(at(EMPTY)).toBe(0);
+    // An item whose Image is gone is still an item as far as the unclamped count
+    // is concerned — it never looks at "Image".
+    expect(at(ORPHAN_IMAGE)).toBe(2);
+  });
+
+  it('omitting `status` counts REVIEW/REJECTED rows too', async () => {
+    const at = await counts({ collectionIds: [MIXED] });
+    expect(at(MIXED)).toBe(9);
+  });
+
+  it('an empty id list short-circuits without touching the database', async () => {
+    dbMock.dbRead.$queryRaw.mockClear();
+    // Note: the short-circuit returns the array SYNCHRONOUSLY while the query path
+    // returns a promise. That union is pre-existing and every caller `await`s the
+    // result, so both work; asserted as-is rather than tidied, since changing it
+    // is a change to five call sites' return type.
+    expect(await getCollectionItemCount({ collectionIds: [] })).toEqual([]);
+    expect(dbMock.dbRead.$queryRaw).not.toHaveBeenCalled();
+  });
+});
+
+describe('getCollectionItemCount — CLAMPED to a browsingLevel', () => {
+  it('🔴 keeps NON-IMAGE items unconditionally (the LEFT JOIN guarantee)', async () => {
+    // THE regression this file exists for. `nsfwLevel` lives on "Image"; an inner
+    // join here returns 0 for all three of these, which is not a smaller number —
+    // it is the whole collection vanishing from discovery.
+    const at = await counts({
+      collectionIds: ALL,
+      status: CollectionItemStatus.ACCEPTED,
+      browsingLevel: SFW_CEILING,
+    });
+    expect(at(MODELS_ONLY)).toBe(3);
+    expect(at(ARTICLES_ONLY)).toBe(2);
+    expect(at(POSTS_ONLY)).toBe(1);
+    // …and their unclamped counts are identical, i.e. a ceiling cannot move a
+    // number that no image contributes to.
+    const unclamped = await counts({ collectionIds: ALL, status: CollectionItemStatus.ACCEPTED });
+    for (const id of [MODELS_ONLY, ARTICLES_ONLY, POSTS_ONLY]) expect(at(id)).toBe(unclamped(id));
+  });
+
+  it('🔴 a MIXED collection keeps permitted images AND every non-image row, and drops only the over-ceiling images', async () => {
+    const at = await counts({
+      collectionIds: [MIXED],
+      status: CollectionItemStatus.ACCEPTED,
+      browsingLevel: SFW_CEILING,
+    });
+    // PG + PG13 + unrated + model + post + article = 6. The R and X images go.
+    // Distinct from both 8 (no clamp at all) and 3 (image-only clamp that dropped
+    // the non-image rows), so neither mistake can produce this number.
+    expect(at(MIXED)).toBe(6);
+  });
+
+  it('images-only: the clamp is the bitwise intersection, not a threshold', async () => {
+    const at = await counts({
+      collectionIds: [IMAGES_ONLY],
+      status: CollectionItemStatus.ACCEPTED,
+      browsingLevel: SFW_CEILING,
+    });
+    expect(at(IMAGES_ONLY)).toBe(1);
+
+    // A ceiling of exactly R admits the R image and REFUSES the PG one — which a
+    // `nsfwLevel <= browsingLevel` comparison could never produce (PG=1 <= R=4).
+    const atR = await counts({
+      collectionIds: [MIXED],
+      status: CollectionItemStatus.ACCEPTED,
+      browsingLevel: R,
+    });
+    // The R image + the unrated one + the three non-image rows = 5; the PG, PG13
+    // and X images are all excluded.
+    expect(atR(MIXED)).toBe(5);
+  });
+
+  it('the status filter still composes with the clamp', async () => {
+    // Item 109 is a PG image (permitted) but REJECTED. Counting REJECTED alone at
+    // a SFW ceiling must find exactly it — proving the clamp did not replace the
+    // status predicate, and that a permitted-but-wrong-status row is still excluded
+    // from the ACCEPTED count above.
+    const at = await counts({
+      collectionIds: [MIXED],
+      status: CollectionItemStatus.REJECTED,
+      browsingLevel: SFW_CEILING,
+    });
+    expect(at(MIXED)).toBe(1);
+  });
+
+  it('🔴 `browsingLevel: 0` clamps to unrated-only — it is NOT read as "no clamp"', async () => {
+    // The mutation this pins: `if (browsingLevel)` instead of `if (browsingLevel
+    // != null)`. Under truthiness a ceiling of 0 — the most restrictive viewer
+    // there is — silently returns the FULL unclamped count.
+    const at = await counts({
+      collectionIds: [MIXED],
+      status: CollectionItemStatus.ACCEPTED,
+      browsingLevel: 0,
+    });
+    // Only the unrated image + the three non-image rows survive.
+    expect(at(MIXED)).toBe(4);
+    // Emphatically not the unclamped 8.
+    expect(at(MIXED)).not.toBe(8);
+  });
+
+  it('an item whose Image row is gone is NOT counted as playable (fail closed)', async () => {
+    const at = await counts({
+      collectionIds: [ORPHAN_IMAGE],
+      status: CollectionItemStatus.ACCEPTED,
+      browsingLevel: SFW_CEILING,
+    });
+    // Only the item with a real, permitted Image. An image we cannot rate is one
+    // we cannot promise is playable — and `getFallbackCoverImages` drops it too.
+    expect(at(ORPHAN_IMAGE)).toBe(1);
+  });
+
+  it('a collection with nothing to count stays absent (no phantom zero row)', async () => {
+    const rows = await getCollectionItemCount({
+      collectionIds: [EMPTY],
+      status: CollectionItemStatus.ACCEPTED,
+      browsingLevel: SFW_CEILING,
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('a ceiling that permits everything reproduces the unclamped count exactly', async () => {
+    // Positive control on the harness: if the clamped path were wired to nothing —
+    // or to a predicate that can only ever exclude — this would not be able to
+    // reach the unclamped totals.
+    const everything = PG | PG13 | R | X;
+    const at = await counts({
+      collectionIds: ALL,
+      status: CollectionItemStatus.ACCEPTED,
+      browsingLevel: everything,
+    });
+    expect(at(MIXED)).toBe(8);
+    expect(at(IMAGES_ONLY)).toBe(2);
+    expect(at(MODELS_ONLY)).toBe(3);
+  });
+});

--- a/src/server/services/blocks/__tests__/collection-playable-sample.behavior.test.ts
+++ b/src/server/services/blocks/__tests__/collection-playable-sample.behavior.test.ts
@@ -1,0 +1,352 @@
+import { PGlite } from '@electric-sql/pglite';
+import { Prisma } from '@prisma/client';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { CollectionItemStatus } from '~/shared/utils/prisma/enums';
+
+// Booting PGlite (WASM Postgres) can exceed the default 10s hook timeout on a
+// contended runner. Relaxing it can only help a slow box, never mask a failure.
+vi.setConfig({ hookTimeout: 60_000, testTimeout: 60_000 });
+
+/**
+ * What `getCollectionPlayableSample` actually reads, against REAL ROWS.
+ *
+ * 🔴 WHY THIS IS EXECUTED AND NOT STRING-ASSERTED. Every defect this file exists
+ * to catch is a query that still parses and still returns plausible numbers:
+ *
+ *   - `JOIN "Image"` instead of `LEFT JOIN` scores every model / post / article
+ *     item as unplayable and empties those collections out of discovery.
+ *   - A bare `LIMIT` with no `ORDER BY` samples PHYSICAL row order — which is
+ *     neither stable nor reviewable, and which flips a real collection's verdict
+ *     (measured: 1 disagreement in 84, worst-case gap 0.800 between the two ends
+ *     of the same collection).
+ *   - `ORDER BY ci."id" ASC` samples the OLDEST items, the exact opposite window.
+ *   - One shared `LIMIT` instead of a per-collection LATERAL samples the first
+ *     collection and starves the rest.
+ *
+ * A text assertion passes on all four. Only running the statement on rows shaped
+ * like the live ones can tell them apart, so that is what this does: the
+ * service's own SQL, unmodified, on an in-process Postgres.
+ */
+
+// `beforeAll` builds the instance, so everything below reaches it through this
+// holder rather than capturing a value that does not exist yet.
+const holder = { db: null as unknown as PGlite };
+
+/**
+ * Run the service's tagged-template statement on PGlite.
+ *
+ * 🔴 THE FLATTEN IS LOAD-BEARING. The statement interpolates a NESTED
+ * `Prisma.sql` fragment (the cast id list), so the naive `$${i + 1}` stitch used
+ * by sibling harnesses would substitute a single bind parameter where a whole
+ * comma-separated list belongs and produce a syntactically valid statement that
+ * tests nothing. `Prisma.sql(strings, ...values)` performs exactly the flattening
+ * Prisma itself does before sending, and `.text` / `.values` are the statement and
+ * binds the database would have received.
+ */
+dbMock.dbRead.$queryRaw.mockImplementation(
+  (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const flat = Prisma.sql(strings, ...(values as never[]));
+    return holder.db.query(flat.text, flat.values as unknown[]).then((r) => r.rows);
+  }
+);
+
+const { getCollectionPlayableSample, PLAYABLE_SAMPLE_SIZE } = await import(
+  '~/server/services/blocks/block-collections.service'
+);
+
+// nsfwLevel buckets, as the app's Flags enum lays them out.
+const PG = 1;
+const PG13 = 2;
+const R = 4;
+const X = 8;
+/** A SFW-domain ceiling: PG | PG13. */
+const SFW_CEILING = PG | PG13;
+
+/** Image ids with a fixed maturity, reused by every fixture below. */
+const IMG_PG = 1;
+const IMG_PG13 = 2;
+const IMG_R = 3;
+const IMG_X = 4;
+const IMG_UNRATED = 5;
+
+// One collection per property, so a bug that only affects one shape cannot hide
+// behind another's totals.
+const MIXED = 7001; // images at several maturities + one of every non-image shape
+const IMAGES_ONLY = 7002;
+const MODELS_ONLY = 7003; // 🔴 the inner-join canary
+const ARTICLES_ONLY = 7004;
+const POSTS_ONLY = 7005;
+const EMPTY = 7006; // no countable accepted items at all
+const ORPHAN_IMAGE = 7007; // an item pointing at an Image row that no longer exists
+const BIG_A = 7008; // >cap, used with BIG_B to prove the LIMIT is per-collection
+const BIG_B = 7009;
+
+/**
+ * 🔴 THE TWO ORDER FIXTURES. Both hold {@link ORDER_TOTAL} items — deliberately
+ * MORE than `PLAYABLE_SAMPLE_SIZE`, and not a multiple of it, so the sample window
+ * lands strictly inside the collection and the two ends genuinely disagree.
+ *
+ * `ORDER_NEWEST_SAFE` changes the COUNT: newest-200 is fully playable (200),
+ * oldest-200 is not (140).
+ *
+ * `ORDER_NEWEST_MATURE` changes the VERDICT, which is the measured 1-in-84 case
+ * turned into a guard: newest-200 is 10% playable (below the 20% floor → dropped),
+ * oldest-200 is 30% (above it → kept). A sample that reads the wrong end does not
+ * merely report a different number here, it surfaces a collection the floor exists
+ * to remove.
+ */
+const ORDER_NEWEST_SAFE = 7010;
+const ORDER_NEWEST_MATURE = 7011;
+/** Comfortably over the cap, and not a multiple of it. */
+const ORDER_TOTAL = 260;
+const ORDER_OLD_TAIL = ORDER_TOTAL - PLAYABLE_SAMPLE_SIZE; // 60 items older than the window
+
+/** Item-id allocator: ids ascend with insertion, exactly as the real serial does. */
+let nextItemId = 100_000;
+const rowsSql: string[] = [];
+function item(collectionId: number, cols: Partial<Record<string, number | string>> = {}) {
+  const id = nextItemId++;
+  const v = (k: string) => (cols[k] == null ? 'NULL' : String(cols[k]));
+  rowsSql.push(
+    `(${id}, ${collectionId}, ${v('imageId')}, ${v('modelId')}, ${v('postId')}, ${v(
+      'articleId'
+    )}, '${cols.status ?? 'ACCEPTED'}')`
+  );
+}
+
+// ---- MIXED: 2 permitted images, 1 unrated, 2 over-ceiling, one of each non-image
+item(MIXED, { imageId: IMG_PG });
+item(MIXED, { imageId: IMG_PG13 });
+item(MIXED, { imageId: IMG_UNRATED });
+item(MIXED, { imageId: IMG_R });
+item(MIXED, { imageId: IMG_X });
+item(MIXED, { modelId: 900 });
+item(MIXED, { postId: 901 });
+item(MIXED, { articleId: 902 });
+// A REJECTED row that the ceiling WOULD permit: proves the status filter still
+// applies inside the lateral rather than being replaced by the maturity test.
+item(MIXED, { imageId: IMG_PG, status: 'REJECTED' });
+
+// ---- IMAGES_ONLY: 1 permitted, 1 over the ceiling
+item(IMAGES_ONLY, { imageId: IMG_PG });
+item(IMAGES_ONLY, { imageId: IMG_X });
+
+// ---- non-image collections: no image rows anywhere
+for (let i = 0; i < 3; i++) item(MODELS_ONLY, { modelId: 910 + i });
+for (let i = 0; i < 2; i++) item(ARTICLES_ONLY, { articleId: 920 + i });
+item(POSTS_ONLY, { postId: 930 });
+
+// ---- EMPTY: an item with NO subject at all — the row filter drops it, so this
+// collection produces no lateral row and must be ABSENT from the map.
+item(EMPTY, {});
+
+// ---- ORPHAN_IMAGE: imageId 99999 has no "Image" row.
+item(ORPHAN_IMAGE, { imageId: 99999 });
+item(ORPHAN_IMAGE, { imageId: IMG_PG });
+
+// ---- BIG_A / BIG_B: 6 permitted items each, sampled at 3 in the same call.
+for (let i = 0; i < 6; i++) item(BIG_A, { imageId: IMG_PG });
+for (let i = 0; i < 6; i++) item(BIG_B, { imageId: IMG_PG });
+
+// ---- ORDER_NEWEST_SAFE: 60 mature, THEN 200 safe (so the newest 200 are safe).
+for (let i = 0; i < ORDER_OLD_TAIL; i++) item(ORDER_NEWEST_SAFE, { imageId: IMG_X });
+for (let i = 0; i < PLAYABLE_SAMPLE_SIZE; i++) item(ORDER_NEWEST_SAFE, { imageId: IMG_PG });
+
+// ---- ORDER_NEWEST_MATURE: 60 safe, THEN 180 mature, THEN 20 safe.
+// newest-200 → 20 safe (10%); oldest-200 → 60 safe (30%).
+const NEWEST_SAFE_TAIL = 20;
+for (let i = 0; i < ORDER_OLD_TAIL; i++) item(ORDER_NEWEST_MATURE, { imageId: IMG_PG });
+for (let i = 0; i < PLAYABLE_SAMPLE_SIZE - NEWEST_SAFE_TAIL; i++)
+  item(ORDER_NEWEST_MATURE, { imageId: IMG_X });
+for (let i = 0; i < NEWEST_SAFE_TAIL; i++) item(ORDER_NEWEST_MATURE, { imageId: IMG_PG });
+
+beforeAll(async () => {
+  holder.db = new PGlite();
+  // The real `status` column is the `CollectionItemStatus` enum, not text. A text
+  // stand-in accepts casts Postgres rejects on the enum, so the statement's
+  // `::"CollectionItemStatus"` would prove nothing against it.
+  await holder.db.exec(`
+    CREATE TYPE "CollectionItemStatus" AS ENUM (${Object.values(CollectionItemStatus)
+      .map((s) => `'${s}'`)
+      .join(', ')});
+    CREATE TABLE "Image" (
+      "id"        integer PRIMARY KEY,
+      "nsfwLevel" integer NOT NULL DEFAULT 0
+    );
+    CREATE TABLE "CollectionItem" (
+      "id"           integer PRIMARY KEY,
+      "collectionId" integer NOT NULL,
+      "imageId"      integer,
+      "modelId"      integer,
+      "postId"       integer,
+      "articleId"    integer,
+      "status"       "CollectionItemStatus" NOT NULL DEFAULT 'ACCEPTED'
+    );
+    INSERT INTO "Image" ("id", "nsfwLevel") VALUES
+      (${IMG_PG}, ${PG}), (${IMG_PG13}, ${PG13}), (${IMG_R}, ${R}),
+      (${IMG_X}, ${X}), (${IMG_UNRATED}, 0);
+    INSERT INTO "CollectionItem"
+      ("id","collectionId","imageId","modelId","postId","articleId","status")
+    VALUES ${rowsSql.join(',\n')};
+  `);
+});
+
+const ALL = [
+  MIXED,
+  IMAGES_ONLY,
+  MODELS_ONLY,
+  ARTICLES_ONLY,
+  POSTS_ONLY,
+  EMPTY,
+  ORPHAN_IMAGE,
+  BIG_A,
+  BIG_B,
+];
+
+describe('getCollectionPlayableSample — what it counts', () => {
+  it('🔴 keeps NON-IMAGE items unconditionally (the LEFT JOIN guarantee)', async () => {
+    // THE regression this file exists for. `nsfwLevel` lives on "Image"; an inner
+    // join drops these rows entirely — the collections do not merely score lower,
+    // they score `sampled: 0` and vanish from the map, which the endpoint reads as
+    // "nothing to judge" and the floor then silently stops filtering.
+    const map = await getCollectionPlayableSample(ALL, SFW_CEILING, 10);
+    expect(map.get(MODELS_ONLY)).toEqual({ sampled: 3, playable: 3 });
+    expect(map.get(ARTICLES_ONLY)).toEqual({ sampled: 2, playable: 2 });
+    expect(map.get(POSTS_ONLY)).toEqual({ sampled: 1, playable: 1 });
+  });
+
+  it('🔴 a MIXED collection keeps permitted images AND every non-image row, and scores only the over-ceiling images as unplayable', async () => {
+    const map = await getCollectionPlayableSample([MIXED], SFW_CEILING, 10);
+    // 8 countable ACCEPTED items (the REJECTED one is filtered out inside the
+    // lateral), of which PG + PG13 + unrated + model + post + article = 6 are
+    // playable. 6 is distinct from 8 (no clamp at all) and from 3 (an image-only
+    // clamp that dropped the non-image rows), so neither mistake produces it.
+    expect(map.get(MIXED)).toEqual({ sampled: 8, playable: 6 });
+  });
+
+  it('the maturity test is the BITWISE intersection, not a threshold', async () => {
+    const sfw = await getCollectionPlayableSample([IMAGES_ONLY], SFW_CEILING, 10);
+    expect(sfw.get(IMAGES_ONLY)).toEqual({ sampled: 2, playable: 1 });
+
+    // A ceiling of exactly R admits the R image and REFUSES the PG one — which a
+    // `nsfwLevel <= browsingLevel` comparison could never produce (PG=1 <= R=4).
+    const atR = await getCollectionPlayableSample([MIXED], R, 10);
+    // The R image + the unrated one + the three non-image rows = 5 playable; PG,
+    // PG13 and X are all excluded.
+    expect(atR.get(MIXED)).toEqual({ sampled: 8, playable: 5 });
+  });
+
+  it('🔴 a ceiling of 0 clamps to unrated-only — it is not read as "no clamp"', async () => {
+    const map = await getCollectionPlayableSample([MIXED], 0, 10);
+    // Only the unrated image + the three non-image rows survive.
+    expect(map.get(MIXED)).toEqual({ sampled: 8, playable: 4 });
+  });
+
+  it('an item whose Image row is gone is SAMPLED but NOT playable (fail closed)', async () => {
+    const map = await getCollectionPlayableSample([ORPHAN_IMAGE], SFW_CEILING, 10);
+    // An image we cannot rate is one we cannot promise is playable — and
+    // `getFallbackCoverImages` drops the same row.
+    expect(map.get(ORPHAN_IMAGE)).toEqual({ sampled: 2, playable: 1 });
+  });
+
+  it('a collection with nothing countable is ABSENT from the map (no phantom zero row)', async () => {
+    const map = await getCollectionPlayableSample([EMPTY], SFW_CEILING, 10);
+    // The endpoint reads an absent id as "nothing to judge, keep" — a phantom
+    // `{sampled: 0}` row would read the same, but a phantom `{sampled: 1,
+    // playable: 0}` would drop an empty collection for a mismatch it cannot have.
+    expect(map.has(EMPTY)).toBe(false);
+    expect(map.size).toBe(0);
+  });
+
+  it('an empty id list short-circuits without touching the database', async () => {
+    dbMock.dbRead.$queryRaw.mockClear();
+    expect(await getCollectionPlayableSample([], SFW_CEILING)).toEqual(new Map());
+    expect(dbMock.dbRead.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('a ceiling that permits everything makes playable equal sampled (positive control)', async () => {
+    // If the playable expression were wired to nothing — or to a predicate that
+    // can only ever exclude — it could not reach these totals.
+    const everything = PG | PG13 | R | X;
+    const map = await getCollectionPlayableSample(ALL, everything, 10);
+    for (const id of [MIXED, IMAGES_ONLY, MODELS_ONLY, ORPHAN_IMAGE]) {
+      const s = map.get(id);
+      expect(s).toBeTruthy();
+      // ORPHAN_IMAGE is the one exception and it is the fail-closed rule, not a
+      // ceiling effect: no "Image" row means no maturity to permit.
+      if (id === ORPHAN_IMAGE) expect(s).toEqual({ sampled: 2, playable: 1 });
+      else expect(s!.playable).toBe(s!.sampled);
+    }
+  });
+});
+
+describe('getCollectionPlayableSample — the BOUND', () => {
+  it('🔴 the cap is PER COLLECTION, not one LIMIT shared across the batch', async () => {
+    // Both collections hold 6 items and both are asked for 3 in ONE call. A single
+    // ordered query with one `LIMIT 3` returns 3 rows TOTAL — one collection gets
+    // 3 and the other gets 0 (or they split) — which reads as a real, dramatic
+    // maturity difference between two identical collections.
+    const map = await getCollectionPlayableSample([BIG_A, BIG_B], SFW_CEILING, 3);
+    expect(map.get(BIG_A)).toEqual({ sampled: 3, playable: 3 });
+    expect(map.get(BIG_B)).toEqual({ sampled: 3, playable: 3 });
+  });
+
+  it('a collection smaller than the cap is sampled whole (the cap is a ceiling, not a quota)', async () => {
+    const map = await getCollectionPlayableSample([POSTS_ONLY], SFW_CEILING, 50);
+    expect(map.get(POSTS_ONLY)).toEqual({ sampled: 1, playable: 1 });
+  });
+
+  it('🔴 the DEFAULT sample size is PLAYABLE_SAMPLE_SIZE, applied without being asked for', async () => {
+    // Called with no third argument, over a collection of 260 items.
+    const map = await getCollectionPlayableSample([ORDER_NEWEST_SAFE], SFW_CEILING);
+    expect(map.get(ORDER_NEWEST_SAFE)!.sampled).toBe(PLAYABLE_SAMPLE_SIZE);
+    // …and emphatically not the whole collection, which is what dropping the LIMIT
+    // would produce.
+    expect(map.get(ORDER_NEWEST_SAFE)!.sampled).not.toBe(ORDER_TOTAL);
+  });
+
+  it('🔴 PLAYABLE_SAMPLE_SIZE is 200 — the measured point, pinned absolutely', async () => {
+    // Every other assertion in this file derives its fixtures from the constant, so
+    // all of them would follow it anywhere. This one does not: 200 is the value
+    // measured to cost ~257 ms and to agree with the exact clamped count on the
+    // floor for 97 of 97 live collections, against ~354 ms for 500 (no measurable
+    // accuracy gain, wider worst case) and ~2.6 s for the exact count. Moving it is
+    // a cost/accuracy decision that must be re-measured, not a refactor.
+    expect(PLAYABLE_SAMPLE_SIZE).toBe(200);
+  });
+});
+
+describe('getCollectionPlayableSample — the ORDER (🔴 the finding that shapes this design)', () => {
+  it('🔴 samples the NEWEST items — an unordered LIMIT or an ASC order reads the wrong end', async () => {
+    // 260 items: the oldest 60 are mature, the newest 200 are safe.
+    //   ORDER BY id DESC (correct) → 200 sampled, 200 playable
+    //   ORDER BY id ASC            → 200 sampled, 140 playable
+    //   no ORDER BY                → physical (= insertion = oldest-first) order,
+    //                                so also 140 here
+    const map = await getCollectionPlayableSample([ORDER_NEWEST_SAFE], SFW_CEILING);
+    expect(map.get(ORDER_NEWEST_SAFE)).toEqual({
+      sampled: PLAYABLE_SAMPLE_SIZE,
+      playable: PLAYABLE_SAMPLE_SIZE,
+    });
+    // Named explicitly so the failure message says WHICH end was read.
+    expect(map.get(ORDER_NEWEST_SAFE)!.playable).not.toBe(PLAYABLE_SAMPLE_SIZE - ORDER_OLD_TAIL);
+  });
+
+  it('🔴 reading the wrong end FLIPS THE FLOOR VERDICT, not just the number', async () => {
+    // The measured 1-in-84 disagreement, reproduced. 260 items: the oldest 60 are
+    // safe, then 180 mature, then the newest 20 safe.
+    //   newest-200 (correct) → 20/200 = 10% → BELOW the 20% floor → dropped
+    //   oldest-200           → 60/200 = 30% → above it → kept
+    // A collection that recently went mature is exactly what the floor is for, and
+    // an oldest-first sample surfaces it anyway.
+    const map = await getCollectionPlayableSample([ORDER_NEWEST_MATURE], SFW_CEILING);
+    const s = map.get(ORDER_NEWEST_MATURE)!;
+    expect(s).toEqual({ sampled: PLAYABLE_SAMPLE_SIZE, playable: NEWEST_SAFE_TAIL });
+    // Stated as the verdict, since that is the consequence: 0.2 is
+    // MIN_PLAYABLE_FRACTION (pinned against the endpoint's constant there).
+    expect(s.playable / s.sampled).toBeLessThan(0.2);
+    // The oldest-first reading would have been 60/200 = 0.3, above the floor.
+    expect(s.playable).not.toBe(ORDER_OLD_TAIL);
+  });
+});

--- a/src/server/services/blocks/__tests__/collection-playable-sample.behavior.test.ts
+++ b/src/server/services/blocks/__tests__/collection-playable-sample.behavior.test.ts
@@ -309,10 +309,12 @@ describe('getCollectionPlayableSample — the BOUND', () => {
   it('🔴 PLAYABLE_SAMPLE_SIZE is 200 — the measured point, pinned absolutely', async () => {
     // Every other assertion in this file derives its fixtures from the constant, so
     // all of them would follow it anywhere. This one does not: 200 is the value
-    // measured to cost ~257 ms and to agree with the exact clamped count on the
-    // floor for 97 of 97 live collections, against ~354 ms for 500 (no measurable
-    // accuracy gain, wider worst case) and ~2.6 s for the exact count. Moving it is
-    // a cost/accuracy decision that must be re-measured, not a refactor.
+    // measured to agree with the exact clamped count on the floor for 97 of 97
+    // live collections, at ~400 ms as shipped against ~2.6 s for the exact count.
+    // 500 showed no measurable accuracy gain and a wider worst case. Moving it is
+    // a cost/accuracy decision that must be RE-MEASURED, not a refactor — and the
+    // re-measurement must use the shipped shape: the 257 ms once quoted here came
+    // from an unordered LIMIT, which is ~4x cheaper and not what runs.
     expect(PLAYABLE_SAMPLE_SIZE).toBe(200);
   });
 });

--- a/src/server/services/blocks/block-collections.service.ts
+++ b/src/server/services/blocks/block-collections.service.ts
@@ -153,8 +153,28 @@ export async function getFallbackCoverImages(
  *     unclamped, 97 ids                            84 ms / 78 ms
  *     EXACT CLAMPED count, 97 ids                2829 ms / 2563 ms
  *     exact clamped, 24 ids                      2076 ms / 2079 ms
- *     bounded sample, cap 200/collection          257 ms
- *     bounded sample, cap 500/collection          354 ms
+ *     THIS QUERY, as shipped (ORDER BY id DESC)   399 ms / 412 ms
+ *     ...same, but a bare LIMIT with no ORDER BY  102 ms / 107 ms
+ *     unordered sample, cap 500/collection        354 ms
+ *
+ * 🔴 THE LAST THREE ROWS ARE THE CORRECTION, AND THE REASON THEY ARE SPELLED OUT.
+ * An earlier revision of this block quoted 257 ms for "the bounded sample" and
+ * said it had been measured "with exactly this ordering". It had not: 257 ms was
+ * an UNORDERED `LIMIT 200`, and the order pin this design depends on was added
+ * afterwards. Re-measured on the shipped shape it is ~400 ms — still 7x cheaper
+ * than the exact clamp it replaces, but ~4x the unordered variant and ~4.7x the
+ * unclamped baseline, which is a different trade than the one the old number
+ * described. The figure was never asserted on by anything, which is exactly how
+ * it survived into a comment, a commit message and a PR body.
+ *
+ * WHERE THE ORDER PIN'S COST COMES FROM, since ~4x is more than it looks like it
+ * should be: there is no index giving (collectionId, status) rows in id order, so
+ * the LATERAL reads the WHOLE collection via the covering index — 3,077 rows on
+ * average, 34,577 at the tail — and quicksorts it before taking 200. The cap
+ * bounds what the JOIN and the count touch, NOT what the scan reads. An index on
+ * (collectionId, status, id DESC) would remove the sort; that is a migration, and
+ * migrations here are applied by hand per environment, so it is deliberately left
+ * as a follow-up rather than smuggled into this PR.
  *
  * The unclamped count is an Index Only Scan on the covering
  * (collectionId, status) index — no heap access at all. Joining "Image" forfeits
@@ -209,9 +229,10 @@ export type CollectionPlayableSample = {
  * collection sees first, and a collection that has recently gone mature should be
  * judged on what it is now rather than on what it was. `ci."id" DESC` is the
  * insertion-order surrogate for `createdAt` — a serial primary key, so ordering by
- * it needs no extra column on the row. (The 257 ms figure above was measured with
- * exactly this ordering; no claim is made here about which index the planner
- * picks, only that this shape is what was timed.)
+ * it needs no extra column on the row. (The ~400 ms figure on
+ * {@link PLAYABLE_SAMPLE_SIZE} was measured on THIS shape, ordering included —
+ * see the correction recorded there, because the number that preceded it was
+ * measured on the unordered variant and was ~4x too low.)
  *
  * Shape notes, each of which is load-bearing:
  *   - CROSS JOIN LATERAL, so the LIMIT applies PER COLLECTION. A single ordered

--- a/src/server/services/blocks/block-collections.service.ts
+++ b/src/server/services/blocks/block-collections.service.ts
@@ -208,8 +208,10 @@ export type CollectionPlayableSample = {
  * NEWEST-FIRST is the defensible end to look at: it is what a viewer opening the
  * collection sees first, and a collection that has recently gone mature should be
  * judged on what it is now rather than on what it was. `ci."id" DESC` is the
- * insertion-order surrogate for `createdAt` and is the column the per-collection
- * item index can walk directly.
+ * insertion-order surrogate for `createdAt` — a serial primary key, so ordering by
+ * it needs no extra column on the row. (The 257 ms figure above was measured with
+ * exactly this ordering; no claim is made here about which index the planner
+ * picks, only that this shape is what was timed.)
  *
  * Shape notes, each of which is load-bearing:
  *   - CROSS JOIN LATERAL, so the LIMIT applies PER COLLECTION. A single ordered

--- a/src/server/services/blocks/block-collections.service.ts
+++ b/src/server/services/blocks/block-collections.service.ts
@@ -137,6 +137,135 @@ export async function getFallbackCoverImages(
   return map;
 }
 
+/**
+ * How many of a collection's newest ACCEPTED items the playable-fraction sample
+ * reads. NOT a page size and NOT a display number — it is the width of the window
+ * the discovery ranking heuristic looks at, and nothing outside this module should
+ * need it.
+ *
+ * 🔴 WHY BOUNDED AT ALL, AND WHY 200. The exact clamped count — every accepted
+ * item of every candidate collection, LEFT JOINed to "Image" — cannot be afforded
+ * on this path. Measured on a production-scale replica over the real page-1
+ * over-fetch window under the endpoint's default sort (97 collections, 298,469
+ * accepted items, largest 34,577):
+ *
+ *     1 unclamped count, 24 ids (what main runs)   85 ms / 82 ms
+ *     unclamped, 97 ids                            84 ms / 78 ms
+ *     EXACT CLAMPED count, 97 ids                2829 ms / 2563 ms
+ *     exact clamped, 24 ids                      2076 ms / 2079 ms
+ *     bounded sample, cap 200/collection          257 ms
+ *     bounded sample, cap 500/collection          354 ms
+ *
+ * The unclamped count is an Index Only Scan on the covering
+ * (collectionId, status) index — no heap access at all. Joining "Image" forfeits
+ * that index and becomes a Nested Loop Left Join over ~300k rows
+ * (Buffers: shared hit=1713835). Narrowing the over-fetch is NOT the lever: the
+ * same exact count over 24 ids instead of 97 still costs 2076 ms (~27%), because
+ * the cost is concentrated in a handful of very large collections that are on
+ * page 1 *because* the sort ranks them there. 500 buys nothing measurable over
+ * 200 and widens the worst case, so 200 it is.
+ *
+ * ACCURACY, measured over those same 97 collections: a 200-item sample and the
+ * exact clamped count agree on the 20% floor for 97 of 97 (63 keeps either way,
+ * 0 disagreements).
+ *
+ * 🔴 BUT IT IS ORDER-SENSITIVE, which is why {@link getCollectionPlayableSample}
+ * pins the order and must never be "simplified" to a bare LIMIT. Over the 84 of
+ * those collections holding more than 200 items, an oldest-200 sample and a
+ * newest-200 sample disagree on the floor verdict for 1 collection, and the worst
+ * per-collection gap between the two ends is 0.800 — 80 percentage points, a
+ * collection whose character changed completely over its life. Mean gap 0.038.
+ * A bare `LIMIT 200` takes *physical* row order, which is neither stable nor
+ * reviewable, and would make that 1-in-84 verdict a coin flip.
+ */
+export const PLAYABLE_SAMPLE_SIZE = 200;
+
+export type CollectionPlayableSample = {
+  /** Items actually read — `min(accepted items, PLAYABLE_SAMPLE_SIZE)`. */
+  sampled: number;
+  /** How many of those the viewer's ceiling permits. */
+  playable: number;
+};
+
+/**
+ * A BOUNDED, ORDER-PINNED sample of how much of each collection survives the
+ * viewer's maturity ceiling: for every id, the newest
+ * {@link PLAYABLE_SAMPLE_SIZE} accepted items, and how many of them are playable.
+ *
+ * 🔴 THIS IS AN APPROXIMATION OF A RANKING HEURISTIC, NOT A SAFETY GATE. It
+ * decides whether a discovery card is worth *showing*, on the theory that a card
+ * promising 2,080 items and opening onto 19 is a bad card. It protects nobody
+ * from mature media and must never be described as if it did: per-item maturity
+ * is enforced on the DETAIL endpoint, where the media is actually read, and on
+ * the cover via `getFallbackCoverImages`. A collection this function keeps can
+ * still be 79% mature, and a collection it drops was never unsafe.
+ *
+ * The returned fraction is `playable / sampled` — both bounded by the cap — so it
+ * is the composition of the collection's RECENT items, not of the whole
+ * collection. Its cost, accuracy and order-sensitivity are recorded on
+ * {@link PLAYABLE_SAMPLE_SIZE}; read that before changing anything here.
+ *
+ * NEWEST-FIRST is the defensible end to look at: it is what a viewer opening the
+ * collection sees first, and a collection that has recently gone mature should be
+ * judged on what it is now rather than on what it was. `ci."id" DESC` is the
+ * insertion-order surrogate for `createdAt` and is the column the per-collection
+ * item index can walk directly.
+ *
+ * Shape notes, each of which is load-bearing:
+ *   - CROSS JOIN LATERAL, so the LIMIT applies PER COLLECTION. A single ordered
+ *     query with one LIMIT would sample the largest collection and nothing else.
+ *   - LEFT JOIN "Image" plus an explicit `imageId IS NULL` escape, because
+ *     `nsfwLevel` lives on "Image": an inner join would score every model / post /
+ *     article item as unplayable and empty those collections out of discovery.
+ *   - An item whose "Image" row is gone yields NULL on both halves of the bitwise
+ *     test and counts as NOT playable — fail closed, matching
+ *     `getFallbackCoverImages`, whose inner join drops the same row.
+ *   - The maturity test is BITWISE (`& != 0`, plus unrated 0), the identical
+ *     authority the detail path and the images service use. A `<=` would be
+ *     wrong: 29 is a mixed bucket that intersects a SFW ceiling.
+ *   - A collection with no countable accepted items produces NO ROW (the lateral
+ *     is an inner join), so it is ABSENT from the map — which callers read as
+ *     `sampled: 0`, i.e. "nothing to judge".
+ */
+export async function getCollectionPlayableSample(
+  collectionIds: number[],
+  browsingLevel: number,
+  sampleSize: number = PLAYABLE_SAMPLE_SIZE
+): Promise<Map<number, CollectionPlayableSample>> {
+  if (collectionIds.length === 0) return new Map();
+  // Cast each id so the array constructor's element type is unambiguous to the
+  // planner rather than depending on parameter-type inference.
+  const idList = Prisma.join(collectionIds.map((id) => Prisma.sql`${id}::int`));
+  const rows = await dbRead.$queryRaw<{ id: number; sampled: number; playable: number }[]>`
+    SELECT
+      c."id" as "id",
+      COUNT(*)::int as "sampled",
+      COUNT(*) FILTER (
+        WHERE s."imageId" IS NULL
+           OR (i."nsfwLevel" & ${browsingLevel}) != 0
+           OR i."nsfwLevel" = 0
+      )::int as "playable"
+    FROM unnest(ARRAY[${idList}]) AS c("id")
+    CROSS JOIN LATERAL (
+      SELECT ci."imageId" as "imageId"
+      FROM "CollectionItem" ci
+      WHERE ci."collectionId" = c."id"
+        AND ci."status" = ${CollectionItemStatus.ACCEPTED}::"CollectionItemStatus"
+        AND (ci."imageId" IS NOT NULL OR ci."modelId" IS NOT NULL OR ci."postId" IS NOT NULL OR ci."articleId" IS NOT NULL)
+      ORDER BY ci."id" DESC
+      LIMIT ${sampleSize}
+    ) s
+    LEFT JOIN "Image" i ON i."id" = s."imageId"
+    GROUP BY c."id"
+  `;
+  const map = new Map<number, CollectionPlayableSample>();
+  for (const r of rows) {
+    if (r.id == null) continue;
+    map.set(Number(r.id), { sampled: Number(r.sampled), playable: Number(r.playable) });
+  }
+  return map;
+}
+
 /** True iff the collection's own nsfwLevel is permitted by the clamped ceiling. */
 export function collectionWithinCeiling(nsfwLevel: number, browsingLevel: number): boolean {
   // A level of 0 (unrated) is always allowed; otherwise it must intersect the

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -2507,9 +2507,18 @@ export const updateCollectionItemsStatus = async ({
  * emitted SQL is the unclamped query this function has always run (only the table
  * alias is new), so every existing caller is unaffected. Supply it and the result
  * is the CLAMPED count: how many items a viewer at that maturity ceiling can
- * actually see. That is the number a discovery card should advertise, because it
- * is the number the player will serve — an unclamped count on a mixed-maturity
- * collection promises thousands of items and delivers dozens.
+ * actually see.
+ *
+ * 🔴 THE CLAMPED FORM IS EXACT AND EXPENSIVE — CHECK THE POPULATION BEFORE USING
+ * IT. Unclamped, this is an Index Only Scan on the covering (collectionId, status)
+ * index with no heap access; the clamp's join to "Image" forfeits that index and
+ * becomes a nested loop over every accepted item. Measured on a production-scale
+ * replica: 85 ms unclamped vs 2829 ms clamped over one App Blocks discovery
+ * over-fetch window (97 collections, 298,469 accepted items). Its one production
+ * caller is `mode=mine` of the blocks collections endpoint, whose population is
+ * the subject's own already-sliced collections — bounded, and nothing like the
+ * popularity-sorted discovery window. Public discovery deliberately does NOT use
+ * it; it samples instead (`getCollectionPlayableSample`).
  *
  * 🔴 THIS FUNCTION IS NOT IMAGE-ONLY, AND THE CLAMP MUST NOT MAKE IT SO. The row
  * filter keeps anything with an `imageId` OR `modelId` OR `postId` OR `articleId`,

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -2500,24 +2500,69 @@ export const updateCollectionItemsStatus = async ({
   return collection;
 };
 
+/**
+ * Accepted-item counts per collection.
+ *
+ * `browsingLevel` is OPTIONAL and defaults to today's behaviour — omit it and the
+ * emitted SQL is the unclamped query this function has always run (only the table
+ * alias is new), so every existing caller is unaffected. Supply it and the result
+ * is the CLAMPED count: how many items a viewer at that maturity ceiling can
+ * actually see. That is the number a discovery card should advertise, because it
+ * is the number the player will serve — an unclamped count on a mixed-maturity
+ * collection promises thousands of items and delivers dozens.
+ *
+ * 🔴 THIS FUNCTION IS NOT IMAGE-ONLY, AND THE CLAMP MUST NOT MAKE IT SO. The row
+ * filter keeps anything with an `imageId` OR `modelId` OR `postId` OR `articleId`,
+ * so model / post / article collections are counted here too. `nsfwLevel` lives on
+ * `Image`, so an INNER `JOIN "Image"` would silently return 0 for every one of
+ * those collections. Hence a LEFT JOIN plus an explicit `ci."imageId" IS NULL`
+ * escape: a non-image item has no image maturity to test and is kept
+ * unconditionally.
+ *
+ * An item whose `imageId` points at a row that no longer exists yields a NULL
+ * `nsfwLevel`, and both halves of the bitwise test are NULL → the item is NOT
+ * counted. That is deliberate and fail-closed: an image we cannot rate is one we
+ * cannot promise is playable, and it matches `getFallbackCoverImages`, whose
+ * inner join drops the same row.
+ *
+ * The maturity test itself is BITWISE (`nsfwLevel & browsingLevel != 0`, plus
+ * unrated 0) — the identical authority the images service, the collection detail
+ * path and `getFallbackCoverImages` use. A `<=` would be wrong: level 29 is a
+ * mixed bucket that intersects a SFW ceiling.
+ */
 export function getCollectionItemCount({
   collectionIds: ids,
   status,
+  browsingLevel,
 }: {
   collectionIds: number[];
   status?: CollectionItemStatus;
+  browsingLevel?: number;
 }) {
   if (ids.length === 0) return [] as { id: number; count: number }[];
 
-  const where = [Prisma.sql`"collectionId" IN (${Prisma.join(ids)})`];
-  if (status) where.push(Prisma.sql`"status" = ${status}::"CollectionItemStatus"`);
+  const where = [Prisma.sql`ci."collectionId" IN (${Prisma.join(ids)})`];
+  if (status) where.push(Prisma.sql`ci."status" = ${status}::"CollectionItemStatus"`);
+  // `!= null`, NOT truthiness: a ceiling of 0 is a real (if degenerate) ceiling
+  // that permits only unrated items, and `if (browsingLevel)` would silently read
+  // it as "no clamp" — i.e. return the FULL count for the most restrictive viewer.
+  if (browsingLevel != null)
+    where.push(
+      Prisma.sql`(ci."imageId" IS NULL OR (i."nsfwLevel" & ${browsingLevel}) != 0 OR i."nsfwLevel" = 0)`
+    );
+
+  // Joined only when clamping, so the unclamped plan every existing caller relies
+  // on is untouched.
+  const join =
+    browsingLevel != null ? Prisma.sql`LEFT JOIN "Image" i ON i."id" = ci."imageId"` : Prisma.empty;
 
   return dbRead.$queryRaw<{ id: number; count: number }[]>`
-    SELECT "collectionId" as "id", COUNT(*) as "count"
-    FROM "CollectionItem"
+    SELECT ci."collectionId" as "id", COUNT(*) as "count"
+    FROM "CollectionItem" ci
+    ${join}
     WHERE ${Prisma.sql`${Prisma.join(where, ' AND ')}`}
-      AND ("imageId" IS NOT NULL OR "modelId" IS NOT NULL OR "postId" IS NOT NULL OR "articleId" IS NOT NULL)
-    GROUP BY "collectionId"
+      AND (ci."imageId" IS NOT NULL OR ci."modelId" IS NOT NULL OR ci."postId" IS NOT NULL OR ci."articleId" IS NOT NULL)
+    GROUP BY ci."collectionId"
   `;
 }
 

--- a/src/tests/api/v1/blocks/collections-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/collections-endpoint.test.ts
@@ -109,7 +109,47 @@ vi.mock('~/server/utils/region-blocking', () => ({
   isRegionRestricted: () => false,
 }));
 
-import handler from '~/pages/api/v1/blocks/collections/index';
+import handler, {
+  MIN_PLAYABLE_FRACTION,
+  meetsPlayableFloor,
+} from '~/pages/api/v1/blocks/collections/index';
+
+/**
+ * Drive the TWO count queries the public branch issues — the ADVERTISED count
+ * (no `browsingLevel`) and the PLAYABLE one (clamped to the token's ceiling) —
+ * from two id→count tables.
+ *
+ * Dispatching on `browsingLevel` rather than on call order matters: the two are
+ * issued inside one `Promise.all`, so a `mockResolvedValueOnce` pair would pin
+ * the order they happen to be listed in and pass just as happily if the endpoint
+ * swapped which number it advertises.
+ *
+ * An id ABSENT from a table yields NO ROW, exactly as `GROUP BY` does for a
+ * collection with nothing to count — which is the shape the zero-advertised case
+ * below depends on.
+ */
+function itemCounts(advertised: Record<number, number>, playable: Record<number, number>) {
+  mockItemCount.mockImplementation(
+    ({ collectionIds, browsingLevel }: { collectionIds: number[]; browsingLevel?: number }) => {
+      const table = browsingLevel === undefined ? advertised : playable;
+      return Promise.resolve(
+        collectionIds.filter((id) => table[id] != null).map((id) => ({ id, count: table[id] }))
+      );
+    }
+  );
+}
+
+/** A discovery row at the given id; `nsfw` 29 is the live mixed-bucket shape. */
+const row = (id: number, nsfw = 29) => ({
+  id,
+  name: `C${id}`,
+  description: null,
+  read: 'Public',
+  nsfwLevel: nsfw,
+  userId: 1,
+  user: { id: 1, username: 'a' },
+  image: null,
+});
 
 function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
   return {
@@ -521,6 +561,143 @@ describe('GET /api/v1/blocks/collections', () => {
     expect(mockFallbackCovers).toHaveBeenCalledWith([], 3);
   });
 
+  // ---- playable-fraction floor + clamped itemCount ----
+  //
+  // The problem these cover: a collection's own `nsfwLevel` is a bitmask OR-ed
+  // over its items, so a 97%-safe contest collection and a 1%-safe mature one
+  // carry the identical value and both pass the bitwise ceiling. What separates
+  // them is how much of the collection SURVIVES the ceiling — which discovery did
+  // not compute, so a card advertised the unclamped total while the player served
+  // the clamped one.
+
+  it('mode=public: DROPS a collection below the playable floor and keeps one above it', async () => {
+    // Both are mixed-bucket (29) and both pass the ceiling — the whole point is
+    // that the collection-level level cannot tell them apart.
+    mockGetAll.mockResolvedValueOnce([row(10), row(11)]);
+    itemCounts(
+      { 10: 2078, 11: 34577 }, // advertised
+      { 10: 216, 11: 33500 } //   playable: 10.4% vs 96.9%
+    );
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items.map((i: any) => i.id)).toEqual([11]);
+    // …and the surviving card advertises the CLAMPED count, not the 34577 the
+    // player cannot serve.
+    expect(body.items[0].itemCount).toBe(33500);
+  });
+
+  it('mode=public: the boundary — EXACTLY at the floor is kept, one item below is dropped', async () => {
+    // 20/100 === MIN_PLAYABLE_FRACTION → kept (the test is `>=`, not `>`).
+    // 19/100 <  MIN_PLAYABLE_FRACTION → dropped.
+    // Derived from the constant so the pair moves with it rather than pinning 0.2.
+    const advertised = 100;
+    const atFloor = Math.round(advertised * MIN_PLAYABLE_FRACTION);
+    mockGetAll.mockResolvedValueOnce([row(10), row(11)]);
+    itemCounts({ 10: advertised, 11: advertised }, { 10: atFloor, 11: atFloor - 1 });
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items.map((i: any) => i.id)).toEqual([10]);
+  });
+
+  it('mode=public: a collection advertising ZERO items is NOT dropped (no 0/0 NaN drop)', async () => {
+    // Neither id appears in either table → both counts are 0, and `0 / 0` is NaN,
+    // which fails every comparison. Without the explicit zero branch this row is
+    // silently dropped by a filter that has nothing to say about it.
+    mockGetAll.mockResolvedValueOnce([row(10)]);
+    itemCounts({}, {});
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items.map((i: any) => i.id)).toEqual([10]);
+    expect(body.items[0].itemCount).toBe(0);
+  });
+
+  it('🔴 mode=public: a page where EVERY row is dropped by the floor still ADVANCES the cursor', async () => {
+    // limit 1 → OVERFETCH 5. Returning exactly 5 rows, all below the floor, is the
+    // "filtered to empty" page. Filtering AFTER the slice would emit no cursor here
+    // and terminate the feed while qualifying collections remained further down.
+    const rows = [row(10), row(9), row(8), row(7), row(6)];
+    mockGetAll.mockResolvedValueOnce(rows);
+    itemCounts(
+      { 10: 100, 9: 100, 8: 100, 7: 100, 6: 100 },
+      { 10: 1, 9: 1, 8: 1, 7: 1, 6: 1 } // 1% — every one below the floor
+    );
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '1' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    const body = res._json() as any;
+    // A short (here: empty) page is the accepted cost…
+    expect(body.items).toEqual([]);
+    // …but the feed MUST stay walkable. Resume from the last fetched row.
+    expect(body.nextCursor).toBe(6);
+  });
+
+  it('mode=public: counts are resolved over the CEILING-PASSING candidates, before the page is chosen', async () => {
+    // The floor decides which rows the page consumes, so both counts must cover
+    // every row that could still appear — not just the ones that survived. Id 9 is
+    // dropped by the floor yet must have been COUNTED, or the floor could not have
+    // dropped it; id 8 is over the ceiling (8 & 3 === 0) and must NOT be counted,
+    // since it can never appear.
+    mockGetAll.mockResolvedValueOnce([row(10), row(9), row(8, 8)]);
+    itemCounts({ 10: 100, 9: 100 }, { 10: 90, 9: 1 });
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items.map((i: any) => i.id)).toEqual([10]);
+
+    const calls = mockItemCount.mock.calls.map((c: any[]) => c[0]);
+    // Exactly two count queries: one advertised, one clamped to the token ceiling.
+    expect(calls).toHaveLength(2);
+    const advertisedCall = calls.find((a: any) => a.browsingLevel === undefined);
+    const playableCall = calls.find((a: any) => a.browsingLevel !== undefined);
+    expect(advertisedCall).toBeTruthy();
+    expect(playableCall.browsingLevel).toBe(3);
+    for (const call of calls) {
+      expect(call.collectionIds).toEqual([10, 9]);
+      expect(call.status).toBe('ACCEPTED');
+    }
+  });
+
+  it('🔴 mode=mine: a collection FAR below the floor is STILL RETURNED (the floor is discovery-only)', async () => {
+    // The subject put these in their own list. Hiding one for being mostly mature
+    // makes it look deleted — the defect class the detail surface already settled
+    // the other way (empty own-collection → disabled WITH A REASON, never hidden).
+    claimsBox.claims = fakeClaims({
+      scopes: ['collections:read:self', 'collections:read:private'],
+    });
+    mockUserCollections.mockResolvedValueOnce([
+      { id: 20, name: 'Mine, mostly mature', description: null, read: 'Private', userId: 42, image: null },
+      { id: 21, name: 'Mine, mostly safe', description: null, read: 'Public', userId: 42, image: null },
+    ]);
+    itemCounts({ 20: 2080, 21: 100 }, { 20: 19, 21: 90 }); // 0.9% and 90%
+    mockFollowed.mockResolvedValueOnce(new Set<number>());
+    const { req, res } = createMocks({ query: { mode: 'mine', limit: '24' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    const body = res._json() as any;
+    // BOTH, id DESC — the 0.9% one is not dropped.
+    expect(body.items.map((i: any) => i.id)).toEqual([21, 20]);
+  });
+
+  it('mode=mine: itemCount is CLAMPED (the count is wanted in both modes, only the DROP is not)', async () => {
+    mockUserCollections.mockResolvedValueOnce([
+      { id: 21, name: 'Mine', description: null, read: 'Public', userId: 42, image: null },
+    ]);
+    itemCounts({ 21: 2080 }, { 21: 19 });
+    mockFollowed.mockResolvedValueOnce(new Set<number>());
+    const { req, res } = createMocks({ query: { mode: 'mine', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    // 19, the number the player will serve — NOT the 2080 the card used to promise.
+    expect(body.items[0].itemCount).toBe(19);
+    // One count query on this branch, and it carries the ceiling.
+    const calls = mockItemCount.mock.calls.map((c: any[]) => c[0]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].browsingLevel).toBe(3);
+  });
+
   it('400 returns a STRING error message + flattened details (not a raw ZodError)', async () => {
     // limit 0 fails the .min(1) gate deterministically.
     const { req, res } = createMocks({ query: { mode: 'public', limit: '0' } });
@@ -532,5 +709,44 @@ describe('GET /api/v1/blocks/collections', () => {
     // flatten() shape: { formErrors, fieldErrors }.
     expect(body.details).toBeTruthy();
     expect(body.details).toHaveProperty('fieldErrors');
+  });
+});
+
+describe('meetsPlayableFloor', () => {
+  it('an empty collection is KEPT — the fraction is not computable, not "zero"', () => {
+    // `0 / 0` is NaN and every NaN comparison is false, so the absence of this
+    // branch is a silent drop rather than a visible error.
+    expect(meetsPlayableFloor(0, 0)).toBe(true);
+    // Defensive: a negative advertised count can only come from a corrupt read,
+    // and must not be treated as a mismatch either.
+    expect(meetsPlayableFloor(-1, 0)).toBe(true);
+  });
+
+  it('is inclusive at the floor and exclusive below it', () => {
+    expect(meetsPlayableFloor(100, Math.round(100 * MIN_PLAYABLE_FRACTION))).toBe(true);
+    expect(meetsPlayableFloor(100, Math.round(100 * MIN_PLAYABLE_FRACTION) - 1)).toBe(false);
+  });
+
+  it('is a FRACTION, not an absolute count', () => {
+    // The live shape the floor is aimed at: a huge collection with a large absolute
+    // playable count is still mostly unplayable. Any threshold on `playable` alone
+    // would keep this (216 items is plenty) and would be the wrong rule.
+    expect(meetsPlayableFloor(2078, 216)).toBe(false);
+    // …while a tiny collection that is entirely playable passes on 5 items.
+    expect(meetsPlayableFloor(5, 5)).toBe(true);
+  });
+
+  it('a fully playable collection always passes, at any size', () => {
+    expect(meetsPlayableFloor(1, 1)).toBe(true);
+    expect(meetsPlayableFloor(34577, 34577)).toBe(true);
+  });
+
+  it('MIN_PLAYABLE_FRACTION is a fraction in (0, 1]', () => {
+    // Pins the UNITS. A value expressed as a percentage (20) instead of a fraction
+    // (0.2) would make the floor unreachable and empty public discovery entirely,
+    // while every relative test above — which derives its fixtures from the
+    // constant — would keep passing.
+    expect(MIN_PLAYABLE_FRACTION).toBeGreaterThan(0);
+    expect(MIN_PLAYABLE_FRACTION).toBeLessThanOrEqual(1);
   });
 });

--- a/src/tests/api/v1/blocks/collections-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/collections-endpoint.test.ts
@@ -70,6 +70,7 @@ const {
   mockRate,
   mockMaturity,
   mockFallbackCovers,
+  mockPlayableSample,
 } = vi.hoisted(() => ({
   mockGetAll: vi.fn(),
   mockItemCount: vi.fn(),
@@ -79,6 +80,7 @@ const {
   mockRate: vi.fn(),
   mockMaturity: vi.fn(),
   mockFallbackCovers: vi.fn(),
+  mockPlayableSample: vi.fn(),
 }));
 
 vi.mock('~/server/services/collection.service', () => ({
@@ -90,6 +92,7 @@ vi.mock('~/server/services/blocks/block-collections.service', () => ({
   hydrateBlockSubject: mockHydrate,
   getFollowedCollectionIds: mockFollowed,
   getFallbackCoverImages: mockFallbackCovers,
+  getCollectionPlayableSample: mockPlayableSample,
   // Cover url helper: a video cover yields a poster (`poster:` prefix), a still
   // image yields `edge:`; null when there is no url — mirrors toCoverImageUrl.
   toCoverImageUrl: (img: any) =>
@@ -115,27 +118,42 @@ import handler, {
 } from '~/pages/api/v1/blocks/collections/index';
 
 /**
- * Drive the TWO count queries the public branch issues — the ADVERTISED count
- * (no `browsingLevel`) and the PLAYABLE one (clamped to the token's ceiling) —
- * from two id→count tables.
+ * Drive `getCollectionItemCount` from two id→count tables, dispatched on whether
+ * the call clamps: the UNCLAMPED (advertised) table is what `mode=public`
+ * renders, the CLAMPED one is what `mode=mine` renders.
  *
- * Dispatching on `browsingLevel` rather than on call order matters: the two are
- * issued inside one `Promise.all`, so a `mockResolvedValueOnce` pair would pin
- * the order they happen to be listed in and pass just as happily if the endpoint
- * swapped which number it advertises.
+ * Dispatching on `browsingLevel` rather than on call order matters: it makes a
+ * test that expects the advertised number fail if the endpoint starts clamping,
+ * instead of silently reading whichever value happened to be queued first.
  *
  * An id ABSENT from a table yields NO ROW, exactly as `GROUP BY` does for a
- * collection with nothing to count — which is the shape the zero-advertised case
- * below depends on.
+ * collection with nothing to count.
  */
-function itemCounts(advertised: Record<number, number>, playable: Record<number, number>) {
+function itemCounts(advertised: Record<number, number>, clamped: Record<number, number> = {}) {
   mockItemCount.mockImplementation(
     ({ collectionIds, browsingLevel }: { collectionIds: number[]; browsingLevel?: number }) => {
-      const table = browsingLevel === undefined ? advertised : playable;
+      const table = browsingLevel === undefined ? advertised : clamped;
       return Promise.resolve(
         collectionIds.filter((id) => table[id] != null).map((id) => ({ id, count: table[id] }))
       );
     }
+  );
+}
+
+/**
+ * Drive the BOUNDED SAMPLE the playable floor reads: id → `{sampled, playable}`.
+ *
+ * An id ABSENT from the table yields no map entry, exactly as the LATERAL does
+ * for a collection with no countable accepted items — which is the shape the
+ * "nothing sampled" case below depends on.
+ */
+function playableSample(table: Record<number, { sampled: number; playable: number }>) {
+  mockPlayableSample.mockImplementation((collectionIds: number[]) =>
+    Promise.resolve(
+      new Map(
+        collectionIds.filter((id) => table[id] != null).map((id) => [id, table[id]] as const)
+      )
+    )
   );
 }
 
@@ -178,6 +196,9 @@ beforeEach(() => {
   mockHydrate.mockResolvedValue({ id: 42, username: 'mod', isModerator: true });
   mockFollowed.mockResolvedValue(new Set<number>([10]));
   mockFallbackCovers.mockResolvedValue(new Map());
+  // Default: nothing sampled for any id → `meetsPlayableFloor` reads "nothing to
+  // judge, keep", so tests that are not about the floor see no drops.
+  mockPlayableSample.mockResolvedValue(new Map());
   mockItemCount.mockResolvedValue([
     { id: 10, count: 5 },
     { id: 11, count: 2 },
@@ -561,52 +582,84 @@ describe('GET /api/v1/blocks/collections', () => {
     expect(mockFallbackCovers).toHaveBeenCalledWith([], 3);
   });
 
-  // ---- playable-fraction floor + clamped itemCount ----
+  // ---- playable-fraction floor (sampled) + per-mode itemCount ----
   //
   // The problem these cover: a collection's own `nsfwLevel` is a bitmask OR-ed
   // over its items, so a 97%-safe contest collection and a 1%-safe mature one
   // carry the identical value and both pass the bitwise ceiling. What separates
   // them is how much of the collection SURVIVES the ceiling — which discovery did
-  // not compute, so a card advertised the unclamped total while the player served
-  // the clamped one.
+  // not compute.
+  //
+  // 🔴 It is computed here from a BOUNDED SAMPLE, not from an exact clamped count:
+  // the exact count over this over-fetch window is a ~31× regression (~2.6 s vs
+  // ~85 ms, measured on a production-scale replica). `itemCount` on the public
+  // branch therefore stays the ADVERTISED, unclamped size — real, and never a
+  // sample-derived estimate dressed as an exact number.
 
   it('mode=public: DROPS a collection below the playable floor and keeps one above it', async () => {
     // Both are mixed-bucket (29) and both pass the ceiling — the whole point is
     // that the collection-level level cannot tell them apart.
     mockGetAll.mockResolvedValueOnce([row(10), row(11)]);
-    itemCounts(
-      { 10: 2078, 11: 34577 }, // advertised
-      { 10: 216, 11: 33500 } //   playable: 10.4% vs 96.9%
-    );
+    playableSample({
+      10: { sampled: 200, playable: 21 }, // 10.5%
+      11: { sampled: 200, playable: 194 }, // 97%
+    });
+    itemCounts({ 10: 2078, 11: 34577 });
     const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
     await handler(req as never, res as never);
     const body = res._json() as any;
     expect(body.items.map((i: any) => i.id)).toEqual([11]);
-    // …and the surviving card advertises the CLAMPED count, not the 34577 the
-    // player cannot serve.
-    expect(body.items[0].itemCount).toBe(33500);
+    // 🔴 …and the surviving card advertises the collection's REAL SIZE. Not the
+    // sample (200), and not the sample extrapolated to a clamped estimate
+    // (34577 * 194/200 = 33540) — `itemCount` reads as exact, so it must be.
+    expect(body.items[0].itemCount).toBe(34577);
+  });
+
+  it('🔴 mode=public: the count query is NOT clamped, and covers only the FINAL page', async () => {
+    // The cost pin. Clamping this call is what made the endpoint ~31× slower; the
+    // clamp joins "Image" and forfeits the covering index the unclamped count
+    // scans. Id 9 is sampled (so the floor can judge it) but must not be counted —
+    // it never appears — and the one surviving call must carry no browsingLevel.
+    mockGetAll.mockResolvedValueOnce([row(10), row(9)]);
+    playableSample({ 10: { sampled: 200, playable: 180 }, 9: { sampled: 200, playable: 2 } });
+    itemCounts({ 10: 4242, 9: 999 });
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items.map((i: any) => i.id)).toEqual([10]);
+    expect(body.items[0].itemCount).toBe(4242);
+
+    const calls = mockItemCount.mock.calls.map((c: any[]) => c[0]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].browsingLevel).toBeUndefined();
+    expect(calls[0].collectionIds).toEqual([10]);
+    expect(calls[0].status).toBe('ACCEPTED');
   });
 
   it('mode=public: the boundary — EXACTLY at the floor is kept, one item below is dropped', async () => {
     // 20/100 === MIN_PLAYABLE_FRACTION → kept (the test is `>=`, not `>`).
     // 19/100 <  MIN_PLAYABLE_FRACTION → dropped.
     // Derived from the constant so the pair moves with it rather than pinning 0.2.
-    const advertised = 100;
-    const atFloor = Math.round(advertised * MIN_PLAYABLE_FRACTION);
+    const sampled = 100;
+    const atFloor = Math.round(sampled * MIN_PLAYABLE_FRACTION);
     mockGetAll.mockResolvedValueOnce([row(10), row(11)]);
-    itemCounts({ 10: advertised, 11: advertised }, { 10: atFloor, 11: atFloor - 1 });
+    playableSample({
+      10: { sampled, playable: atFloor },
+      11: { sampled, playable: atFloor - 1 },
+    });
     const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
     await handler(req as never, res as never);
     const body = res._json() as any;
     expect(body.items.map((i: any) => i.id)).toEqual([10]);
   });
 
-  it('mode=public: a collection advertising ZERO items is NOT dropped (no 0/0 NaN drop)', async () => {
-    // Neither id appears in either table → both counts are 0, and `0 / 0` is NaN,
+  it('mode=public: a collection with NOTHING SAMPLED is NOT dropped (no 0/0 NaN drop)', async () => {
+    // The id is absent from the sample map → `sampled` is 0, and `0 / 0` is NaN,
     // which fails every comparison. Without the explicit zero branch this row is
     // silently dropped by a filter that has nothing to say about it.
     mockGetAll.mockResolvedValueOnce([row(10)]);
-    itemCounts({}, {});
+    playableSample({});
+    itemCounts({});
     const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
     await handler(req as never, res as never);
     const body = res._json() as any;
@@ -620,9 +673,8 @@ describe('GET /api/v1/blocks/collections', () => {
     // and terminate the feed while qualifying collections remained further down.
     const rows = [row(10), row(9), row(8), row(7), row(6)];
     mockGetAll.mockResolvedValueOnce(rows);
-    itemCounts(
-      { 10: 100, 9: 100, 8: 100, 7: 100, 6: 100 },
-      { 10: 1, 9: 1, 8: 1, 7: 1, 6: 1 } // 1% — every one below the floor
+    playableSample(
+      Object.fromEntries(rows.map((r) => [r.id, { sampled: 100, playable: 1 }])) // 1%
     );
     const { req, res } = createMocks({ query: { mode: 'public', limit: '1' } });
     await handler(req as never, res as never);
@@ -634,30 +686,29 @@ describe('GET /api/v1/blocks/collections', () => {
     expect(body.nextCursor).toBe(6);
   });
 
-  it('mode=public: counts are resolved over the CEILING-PASSING candidates, before the page is chosen', async () => {
-    // The floor decides which rows the page consumes, so both counts must cover
+  it('mode=public: the SAMPLE covers the CEILING-PASSING candidates, resolved before the page is chosen', async () => {
+    // The floor decides which rows the page consumes, so the sample must cover
     // every row that could still appear — not just the ones that survived. Id 9 is
-    // dropped by the floor yet must have been COUNTED, or the floor could not have
-    // dropped it; id 8 is over the ceiling (8 & 3 === 0) and must NOT be counted,
+    // dropped by the floor yet must have been SAMPLED, or the floor could not have
+    // dropped it; id 8 is over the ceiling (8 & 3 === 0) and must NOT be sampled,
     // since it can never appear.
     mockGetAll.mockResolvedValueOnce([row(10), row(9), row(8, 8)]);
-    itemCounts({ 10: 100, 9: 100 }, { 10: 90, 9: 1 });
+    playableSample({ 10: { sampled: 100, playable: 90 }, 9: { sampled: 100, playable: 1 } });
+    itemCounts({ 10: 100, 9: 100 });
     const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
     await handler(req as never, res as never);
     const body = res._json() as any;
     expect(body.items.map((i: any) => i.id)).toEqual([10]);
 
-    const calls = mockItemCount.mock.calls.map((c: any[]) => c[0]);
-    // Exactly two count queries: one advertised, one clamped to the token ceiling.
-    expect(calls).toHaveLength(2);
-    const advertisedCall = calls.find((a: any) => a.browsingLevel === undefined);
-    const playableCall = calls.find((a: any) => a.browsingLevel !== undefined);
-    expect(advertisedCall).toBeTruthy();
-    expect(playableCall.browsingLevel).toBe(3);
-    for (const call of calls) {
-      expect(call.collectionIds).toEqual([10, 9]);
-      expect(call.status).toBe('ACCEPTED');
-    }
+    // Exactly ONE sample query, over the ceiling-passing ids, at the token ceiling.
+    expect(mockPlayableSample).toHaveBeenCalledTimes(1);
+    const [sampledIds, sampledLevel, ...extra] = mockPlayableSample.mock.calls[0] as any[];
+    expect(sampledIds).toEqual([10, 9]);
+    expect(sampledLevel).toBe(3);
+    // 🔴 No third argument: the endpoint must NOT carry its own copy of the cap.
+    // The measured value lives on PLAYABLE_SAMPLE_SIZE, and a second one here
+    // would drift away from it silently.
+    expect(extra).toEqual([]);
   });
 
   it('🔴 mode=mine: a collection FAR below the floor is STILL RETURNED (the floor is discovery-only)', async () => {
@@ -672,6 +723,8 @@ describe('GET /api/v1/blocks/collections', () => {
       { id: 21, name: 'Mine, mostly safe', description: null, read: 'Public', userId: 42, image: null },
     ]);
     itemCounts({ 20: 2080, 21: 100 }, { 20: 19, 21: 90 }); // 0.9% and 90%
+    // Even if the sample said "drop it", this branch must not consult it.
+    playableSample({ 20: { sampled: 200, playable: 1 }, 21: { sampled: 200, playable: 180 } });
     mockFollowed.mockResolvedValueOnce(new Set<number>());
     const { req, res } = createMocks({ query: { mode: 'mine', limit: '24' } });
     await handler(req as never, res as never);
@@ -679,9 +732,11 @@ describe('GET /api/v1/blocks/collections', () => {
     const body = res._json() as any;
     // BOTH, id DESC — the 0.9% one is not dropped.
     expect(body.items.map((i: any) => i.id)).toEqual([21, 20]);
+    // …and the branch does not pay for a sample it does not use.
+    expect(mockPlayableSample).not.toHaveBeenCalled();
   });
 
-  it('mode=mine: itemCount is CLAMPED (the count is wanted in both modes, only the DROP is not)', async () => {
+  it('🔴 mode=mine: itemCount is the EXACT CLAMPED count (the population here is bounded, so it is affordable)', async () => {
     mockUserCollections.mockResolvedValueOnce([
       { id: 21, name: 'Mine', description: null, read: 'Public', userId: 42, image: null },
     ]);
@@ -691,6 +746,9 @@ describe('GET /api/v1/blocks/collections', () => {
     await handler(req as never, res as never);
     const body = res._json() as any;
     // 19, the number the player will serve — NOT the 2080 the card used to promise.
+    // This branch counts only the subject's own, already-sliced collections: no
+    // over-fetch window and no popularity-ranked giants, so the clamp's cost is
+    // nothing like it is on public discovery.
     expect(body.items[0].itemCount).toBe(19);
     // One count query on this branch, and it carries the ceiling.
     const calls = mockItemCount.mock.calls.map((c: any[]) => c[0]);
@@ -713,12 +771,12 @@ describe('GET /api/v1/blocks/collections', () => {
 });
 
 describe('meetsPlayableFloor', () => {
-  it('an empty collection is KEPT — the fraction is not computable, not "zero"', () => {
+  it('nothing sampled is KEPT — the fraction is not computable, not "zero"', () => {
     // `0 / 0` is NaN and every NaN comparison is false, so the absence of this
     // branch is a silent drop rather than a visible error.
     expect(meetsPlayableFloor(0, 0)).toBe(true);
-    // Defensive: a negative advertised count can only come from a corrupt read,
-    // and must not be treated as a mismatch either.
+    // Defensive: a negative sampled count can only come from a corrupt read, and
+    // must not be treated as a mismatch either.
     expect(meetsPlayableFloor(-1, 0)).toBe(true);
   });
 
@@ -728,17 +786,18 @@ describe('meetsPlayableFloor', () => {
   });
 
   it('is a FRACTION, not an absolute count', () => {
-    // The live shape the floor is aimed at: a huge collection with a large absolute
-    // playable count is still mostly unplayable. Any threshold on `playable` alone
-    // would keep this (216 items is plenty) and would be the wrong rule.
-    expect(meetsPlayableFloor(2078, 216)).toBe(false);
+    // The live shape the floor is aimed at, scaled into a 200-item sample: a large
+    // absolute playable count is still mostly unplayable. Any threshold on
+    // `playable` alone would keep this (21 of a sample is plenty of items in a
+    // 2,078-item collection) and would be the wrong rule.
+    expect(meetsPlayableFloor(200, 21)).toBe(false);
     // …while a tiny collection that is entirely playable passes on 5 items.
     expect(meetsPlayableFloor(5, 5)).toBe(true);
   });
 
-  it('a fully playable collection always passes, at any size', () => {
+  it('a fully playable collection always passes, at any sample size', () => {
     expect(meetsPlayableFloor(1, 1)).toBe(true);
-    expect(meetsPlayableFloor(34577, 34577)).toBe(true);
+    expect(meetsPlayableFloor(200, 200)).toBe(true);
   });
 
   it('MIN_PLAYABLE_FRACTION is a fraction in (0, 1]', () => {


### PR DESCRIPTION
> **Revised.** The first revision of this PR computed an **exact clamped item count** over the discovery over-fetch window. That was measured against a production-scale replica and is a **~31× regression on the discovery front door**, so it is gone. The correctness work survives; the expensive half is replaced by a bounded, order-pinned sample. The measurements and what they force are in [Cost](#cost--why-the-exact-count-is-gone).

## The problem

On a SFW domain, App Blocks collection discovery is dominated by collections that are overwhelmingly mature, and every card advertises an item count the player will never serve.

Measured on the live first page (24 rows):

| | advertised | playable at a SFW ceiling | |
|---|---|---|---|
| rank 2 — a mature video collection | 2,078 | 216 | 10% |
| rank 13 — a mature image collection | 2,080 | 19 | 1% |
| a large contest collection | 34,577 | ~97% | fine |

**A collection's own `nsfwLevel` cannot separate these.** It is a bitmask OR-ed over the collection's items, so the 97%-safe contest collection and the 1%-safe mature one carry the **identical** value (29 = PG|R|X|XXX), and both *intersect* a SFW ceiling.

**Gating harder on it is not an option either.** Strict containment (`nsfwLevel & ~browsingLevel === 0`) was measured against the live population and **rejected**: it drops **21 of the 24 rows on page 1 (87.5%)**, including every contest collection, and takes the whole population from 29,095 to 12,389 (−57.4%). This PR deliberately does not implement it.

The separating signal is **how much of the collection survives the ceiling**.

## Cost — why the exact count is gone

Measured on a production-scale replica, over the real page-1 over-fetch window under this endpoint's default sort (`Most Followers`): **97 collections, 298,469 accepted items, largest 34,577, mean 3,077.** Steady-state, cold run discarded, the id-selection subquery removed so only the count is timed.

| query | run 1 | run 2 |
|---|---|---|
| **before** — 1 unclamped count, 24 ids (what `main` runs) | **85 ms** | **82 ms** |
| unclamped, 97 ids | 84 ms | 78 ms |
| **exact CLAMPED, 97 ids (revision 1 of this PR)** | **2829 ms** | **2563 ms** |
| exact clamped, 24 ids | 2076 ms | 2079 ms |
| **THIS QUERY, as shipped (`ORDER BY id DESC`)** | **399 ms** | **412 ms** |
| ...the same with a bare `LIMIT`, no `ORDER BY` | 102 ms | 107 ms |
| unordered sample, cap 500/collection | 354 ms | — |

**Mechanism.** The unclamped count is an `Index Only Scan` on `CollectionItem_collectionId_status_covered` — no heap access at all. `LEFT JOIN "Image"` forfeits that covering index and becomes a `Nested Loop Left Join` over ~300k rows, `Buffers: shared hit=1713835`.

**Narrowing `OVERFETCH` is not the fix**, and revision 1's PR body was wrong to name it as the first knob: clamping 24 ids instead of 97 costs 2076 ms against 2829 ms — **~27%, not the order of magnitude needed.** The cost is dominated by a handful of very large collections that are on page 1 *because* the sort ranks them there.

🔴 **The last three rows are a CORRECTION.** An earlier revision of this PR quoted **257 ms** for the sample and said it was measured with this ordering. It was not — 257 ms was an **unordered** `LIMIT 200`, and the order pin (the thing that makes the 1-in-84 verdict deterministic rather than a coin toss) was added afterwards. Re-measured on the shipped shape it is **~400 ms**: still ~7× cheaper than the exact clamp it replaces, so the decision is unchanged, but ~4.7× the unclamped baseline rather than the ~3× the old number implied. **The figure was never asserted on by any test**, which is exactly how it travelled from a probe into a comment, a commit message and this body unchallenged.

**Where the pin's cost comes from**, since ~4× is more than it looks: no index gives `(collectionId, status)` rows in `id` order, so the LATERAL reads the **whole collection** through the covering index — mean 3,077 rows, 34,577 at the tail — and quicksorts it before taking 200. The cap bounds what the JOIN and the count touch, **not what the scan reads**. An index on `(collectionId, status, id DESC)` would remove the sort; that is a migration, applied by hand per environment here, so it is left as a follow-up rather than smuggled into this PR.

**Accuracy of the sample**, over the same 97 collections: a 200-item sample and the exact count agree on the 20% floor for **97 of 97** (63 keeps either way, **0 disagreements**). 500 buys nothing measurable and widens the worst case, so the cap is **200**.

### 🔴 It is order-sensitive, and that shapes the design

Comparing an **oldest-200** sample against a **newest-200** sample over the **84** collections holding more than 200 items:

- **1 order disagreement** — one collection's floor verdict flips depending on which end you read.
- **max fraction gap 0.800** — one collection differs by 80 percentage points between its two ends. Its character changed over time.
- mean gap 0.038.

So the sample **pins its order explicitly** — `ORDER BY ci."id" DESC` inside the LATERAL — and never a bare `LIMIT`, which takes *physical* row order: neither stable nor reviewable, and it would make that 1-in-84 verdict a coin flip. **Newest-first is the defensible end:** it is what a viewer opening the collection sees first, and a collection that has recently gone mature should be judged on what it is *now*, not what it was.

Both numbers are recorded in the code next to `PLAYABLE_SAMPLE_SIZE`, so nobody has to re-measure to find them.

## What this does

1. **`getCollectionPlayableSample` (new, in `block-collections.service.ts`).** One bounded `CROSS JOIN LATERAL` per candidate collection: the newest `PLAYABLE_SAMPLE_SIZE` (**200**, exported) accepted items, and how many of them the ceiling permits. Returns `{sampled, playable}` per id.
2. **Public discovery drops collections below `MIN_PLAYABLE_FRACTION` (0.2)**, computed from that sample.
3. **`mode=public` `itemCount` is the ADVERTISED (unclamped) count** — the same query, over the same `limit`-sized id list, that this endpoint has always run. It is not a lie: it is the collection's real size, and the floor now guarantees most of it is playable. A **sample-extrapolated estimate is deliberately not substituted** — a field that reads as exact must not carry one.
4. **`mode=mine` keeps the exact clamped count.** That branch counts only the subject's own, already-sliced collections: a bounded population with no over-fetch window and no popularity-ranked giants, so it does not have this cost profile. The reasoning is stated at the call site.
5. **`getCollectionItemCount` keeps its optional `browsingLevel`** — the LEFT JOIN, the `imageId IS NULL` escape, the fail-closed orphan handling and its whole PGlite suite are unchanged. **It has one production caller: `mode=mine`.** It is not dead code, but it is no longer on the hot discovery path.

### 🔴 The floor is a ranking heuristic, not a safety gate

Stated where it is defined, in both the constant's doc and the sample function's. It decides whether a card is worth *showing*, on the theory that a card promising 2,080 items and opening onto 19 is a bad card. **It protects nobody from mature media.** Per-item maturity is enforced on the **detail endpoint**, where the media is actually read, and on the cover via `getFallbackCoverImages`. A collection this floor keeps can still be 79% mature; a collection it drops was never unsafe. And it is now an **approximation** of that heuristic — the fraction is over the collection's recent items, not the whole collection.

### The sample is not image-only

`nsfwLevel` lives on `Image`, so an inner `JOIN "Image"` would score every model / post / article item as unplayable — and those collections would not merely rank lower, they would report `sampled: 0` and fall out. Hence `LEFT JOIN` plus an explicit `s."imageId" IS NULL` escape. An item whose `Image` row is gone is **sampled but not playable** (fail-closed, matching `getFallbackCoverImages`).

Covered by executing the real SQL on an in-process Postgres (PGlite), not by string-matching it — `JOIN` and `LEFT JOIN`, and `LIMIT` with and without `ORDER BY`, contain the same fragments in the same order, so no text assertion can tell them apart.

### The floor is discovery-only

`mode=mine` never drops. The subject created or bookmarked every collection in that list; hiding one for being mostly mature makes it look deleted — the defect class the detail surface already settled the other way (an empty own-collection is shown *disabled with a reason*, never hidden). That branch does not even issue the sample query.

### A collection with nothing sampled is kept

`0 / 0` is `NaN` and every `NaN` comparison is false, so without an explicit branch it would be silently dropped by a filter that has nothing to say about it. The floor detects a *maturity mismatch*; a collection with no items has none.

## Pagination

The public branch already over-fetches `limit * 4 + 1` and walks rows until the page fills, so **the floor is applied inside that walk, not after the page is chosen.** A dropped row is walked past exactly like a maturity-clamped one, so the page still fills toward `limit` and the keyset cursor still advances.

**The cost, stated plainly:** the floor drops more rows than the ceiling alone did, so the "consumed the entire over-fetch without filling `limit`" branch is no longer rare — **a page can come back short**, occasionally empty. What it never does is come back *unwalkable*: that branch sets the cursor to the last fetched row, advancing by `OVERFETCH - 1` rows per request. Filtering after the slice was rejected precisely because a page that filtered to empty would emit no cursor and **terminate the feed** while qualifying collections remained. A test drives exactly that page and asserts the cursor advances.

**Per-request query cost after this change:** one `getAllCollections` (unchanged) + **one bounded sample over the ceiling-passing candidates** (~400 ms measured, as shipped) + the unclamped count over the final page (~85 ms, unchanged from `main`) + followed/fallback-cover lookups (unchanged). Revision 1's two grouped counts, one of them clamped over the whole over-fetch window, are gone.

## Call-site ledger

`collection-item-count-clamp-wiring.test.ts` enumerates every `getCollectionItemCount` call site in `src/` from the **tree** via the TypeScript AST and pins, per `file::enclosingFunction`, **in source order**, whether each one clamps.

It now guards the **cost** as much as the correctness, because the optional parameter is silent in both directions:

- Adding it to the public branch restores the ~31× regression. Nothing about the response changes shape — it just gets slow.
- Dropping it from `mode=mine` sends a viewer's own card back to advertising items their ceiling hides.

Both are mutants below, and each is killed.

## Verification

- **Typecheck** (`node scripts/typecheck.mjs`, run from the worktree): **0 errors**.
- **Unit** (`node scripts/test-unit-run.mjs`): the four affected files are **65/65 green**. **Full unit suite: 38,256 passed / 26 failed / 33 skipped over 1,649 files.** The 26 failures are in three files this PR does not touch (`recent-source-images.store`, `sticker-reveal.store`, `AppBlocks/hiddenBlocks`); a **pristine `origin/main` worktree reproduces exactly the same 26**, so they are pre-existing and unrelated.
- **Red at base**: the new/changed tests were run against two bases with only the three production files reverted.
  - **at `origin/main` = `1de892bab9`** (feature absent): **30 failed / 35 passed** of 65 — the whole new sample suite (14/14), the ledger's pin, 11 endpoint tests, and the clamped half of the `getCollectionItemCount` PGlite suite (4 of 11; the unclamped half correctly still passes, which is the "existing callers are unaffected" claim). `main` has since advanced to `72022e4be2` (#4651, unrelated to collections and touching none of these files).
  - **at `e1a58307d6`** (revision 1 — the exact clamped count): **20 failed / 45 passed**. The interesting ones: the ledger fails on the old three-call clamped shape, and *"the count query is NOT clamped"* fails — i.e. the new suite catches the design this revision replaces, not just its absence.
- **Mutation**: **15 targeted mutants, every one `cmp`-verified to have landed before running** (a no-op edit reads exactly like a survivor). **All 15 killed, zero survivors**, each by an assertion that names the thing broken:

  | mutant | killed by |
  |---|---|
  | drop `ORDER BY` from the LATERAL | "samples the NEWEST items" + "reading the wrong end FLIPS THE FLOOR VERDICT" |
  | `ORDER BY id DESC` → `ASC` | same two |
  | `LEFT JOIN "Image"` → `JOIN` | "keeps NON-IMAGE items unconditionally" (+6) |
  | `PLAYABLE_SAMPLE_SIZE` 200 → 201 | "PLAYABLE_SAMPLE_SIZE is 200 — pinned absolutely" (only that one; every other fixture derives from the constant, which is why the absolute pin exists) |
  | drop the `LIMIT` | "the cap is PER COLLECTION" + "the DEFAULT sample size is PLAYABLE_SAMPLE_SIZE" |
  | `LIMIT n` → `LIMIT n + 1` | "the DEFAULT sample size is PLAYABLE_SAMPLE_SIZE" |
  | drop the `imageId IS NULL` escape | "keeps NON-IMAGE items unconditionally" (+5) |
  | drop the `nsfwLevel = 0` (unrated) clause | "a MIXED collection keeps permitted images…" (+3) |
  | swap `meetsPlayableFloor` args | the 5 public-floor endpoint tests |
  | public `itemCount` ← sampled playable | "the count query is NOT clamped" + "DROPS a collection below the floor" |
  | public count gains `browsingLevel` | the **ledger** + "the count query is NOT clamped" |
  | drop the `sampled <= 0` branch | "nothing sampled is KEPT" (+10) |
  | `>=` → `>` at the floor | "inclusive at the floor and exclusive below it" |
  | endpoint passes its own cap literal | "the SAMPLE covers the CEILING-PASSING candidates" (no third argument) |
  | `mine` count loses `browsingLevel` | the **ledger** + "`mode=mine` itemCount is the EXACT CLAMPED count" |

- **Merged-tree check with the one overlapping open PR, #4597** (`feat/allow-creators-to-archive-collections`; overlap is `collection.service.ts`). Re-run for this revision, on `main@72022e4be2` + #4597 + this branch: **merges with no conflict**, and both PRs' suites are **72/72 green together**. Typecheck on that tree reports 2 errors, both inside #4597's own files (`archivedAt` missing from the generated Prisma client) — and the **control** (`main` + #4597 **without** this PR) reports **the identical 2**, so this PR contributes none. **Not based on #4597.**
- **Formatting**: `src/pages/api/v1/blocks/collections/index.ts` and `src/tests/api/v1/blocks/collections-endpoint.test.ts` do not satisfy `prettier --check` — **they already did not on `origin/main`**, so this PR neither introduces nor fixes it, and reformatting them would bury the diff.

## Tests kept, rewritten, deleted

- **Kept unchanged:** `collection-item-count-clamp.behavior.test.ts` (the whole PGlite suite for `getCollectionItemCount` — the function is unchanged), and every pre-existing endpoint test (authz, sort aliases, cover fallback/clamp, pagination, `mode=mine` read-split, 400 shape).
- **Rewritten:** the five floor tests in `collections-endpoint.test.ts`, from "two count queries" onto the sample; the `meetsPlayableFloor` unit block, for the `sampled` rename; the ledger's expectation row (three calls → two) and its rationale.
- **Added:** `collection-playable-sample.behavior.test.ts` (14 PGlite tests), a test pinning that the public count is **not** clamped and covers only the final page, and a test pinning that the endpoint passes **no** cap of its own.
- **Deleted:** nothing.

## Notes

- No Prisma migration — nothing schema-level changed.
- Two endpoint tests pass at base *and* at HEAD by construction (`mode=mine` never drops; a collection with nothing sampled is never dropped), because with no floor at all there is nothing to drop. They are **invariant guards** with respect to `main`, not regression coverage; their evidence is the mutation run.
- **The measurements in this body are not reproducible from CI.** They were taken by hand against a production-scale replica. The accuracy and order-sensitivity figures (97/97, 1-in-84, 0.800) come from the same session and are recorded in the code so they survive this PR.


