### PR TITLE
fix(search): re-index collections when a model or image is removed

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260906190000_collection_imageid_idx/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260906190000_collection_imageid_idx/migration.sql
@@ -2,17 +2,28 @@
 --
 -- The collections search index denormalizes a cover image onto every collection document, and
 -- CollectionCard renders `if (data.image) return [data.image]` — the cover wins over item images.
--- `Collection.imageId -> Image` is `onDelete: SetNull`, so deleting a cover image leaves the
--- document holding a dead thumbnail with no CollectionItem row pointing at it. The reindex enqueue
--- therefore has to look the collection up BY that column.
+-- Deleting a cover image otherwise leaves the document holding a dead thumbnail with no
+-- CollectionItem row pointing at it, so the reindex enqueue has to look the collection up BY that
+-- column. (`Collection.imageId` is not a foreign key in the deployed database, so nothing clears
+-- it on delete either.)
 --
--- Without this index that lookup is a parallel sequential scan of a ~17.3M-row / 4.9 GB table
--- (measured cost 451,531, against ~10,000 for every other leg of the same query combined), on a
--- user-facing image-delete path. With it the leg is an index probe.
+-- Without this index that lookup is a parallel sequential scan of the ~17.3M-row / 2,817 MB heap:
+-- measured, the seven-leg resolve costs 461,408 with the leg enabled and unindexed, against 9,876
+-- with it disabled. That is on a user-facing image-delete path which `deleteImages` runs at up to
+-- five concurrent batches.
 --
--- 🔴 APPLY THIS BEFORE DEPLOYING the collections-reindex change that reads it. Migrations here are
--- applied by hand, so the ordering is a human step, not something the deploy enforces.
+-- 🔴 NO `IF NOT EXISTS`, DELIBERATELY. `CREATE INDEX CONCURRENTLY` leaves an INVALID index behind
+-- when it fails, and that index still occupies the name — so `IF NOT EXISTS` would turn the retry
+-- into a silent no-op that prints `CREATE INDEX` and repairs nothing. Without it the retry errors
+-- loudly and you take the recovery below. The application gate reads `indisvalid AND indisready`
+-- rather than mere existence, so a half-built or failed index does NOT switch the cover leg on.
 --
--- CONCURRENTLY cannot run inside a transaction block; run this statement on its own.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "Collection_imageId_idx" ON "Collection" ("imageId")
+-- Recovery if this fails partway (check: `SELECT indisvalid, indisready FROM pg_index
+-- WHERE indexrelid = '"Collection_imageId_idx"'::regclass;` — anything but `t | t` is unusable):
+--
+--   DROP INDEX CONCURRENTLY "Collection_imageId_idx";
+--   -- then re-run the CREATE below
+--
+-- CONCURRENTLY cannot run inside a transaction block; run each statement on its own.
+CREATE INDEX CONCURRENTLY "Collection_imageId_idx" ON "Collection" ("imageId")
   WHERE "imageId" IS NOT NULL;

--- a/packages/civitai-db-schema/prisma/migrations/20260906190000_collection_imageid_idx/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260906190000_collection_imageid_idx/migration.sql
@@ -1,0 +1,18 @@
+-- Index `Collection."imageId"` so a deleted image can find the collections whose COVER it is.
+--
+-- The collections search index denormalizes a cover image onto every collection document, and
+-- CollectionCard renders `if (data.image) return [data.image]` — the cover wins over item images.
+-- `Collection.imageId -> Image` is `onDelete: SetNull`, so deleting a cover image leaves the
+-- document holding a dead thumbnail with no CollectionItem row pointing at it. The reindex enqueue
+-- therefore has to look the collection up BY that column.
+--
+-- Without this index that lookup is a parallel sequential scan of a ~17.3M-row / 4.9 GB table
+-- (measured cost 451,531, against ~10,000 for every other leg of the same query combined), on a
+-- user-facing image-delete path. With it the leg is an index probe.
+--
+-- 🔴 APPLY THIS BEFORE DEPLOYING the collections-reindex change that reads it. Migrations here are
+-- applied by hand, so the ordering is a human step, not something the deploy enforces.
+--
+-- CONCURRENTLY cannot run inside a transaction block; run this statement on its own.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Collection_imageId_idx" ON "Collection" ("imageId")
+  WHERE "imageId" IS NOT NULL;

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:3242':
+  'server/services/image.service.ts:3267':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:3286':
+  'server/services/image.service.ts:3311':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4055':
+  'server/services/image.service.ts:4080':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4865':
+  'server/services/image.service.ts:4890':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -219,7 +219,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:3286')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:3311')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/services/__tests__/collection-media-index.test.ts
+++ b/src/server/services/__tests__/collection-media-index.test.ts
@@ -139,6 +139,30 @@ describe('getCollectionIdsForModelCascade', () => {
       dropped: 0,
     });
   });
+
+  // `CollectionItem` is a ~208M-row table. Bridging the two columns with a single
+  // `OR` makes the predicate non-sargable: Postgres can use NEITHER the modelId nor
+  // the imageId index, and falls back to scanning an unrelated index end to end with
+  // the whole condition as a post-scan Filter (measured: 43.3M estimated rows, total
+  // cost 3,336,745). Split into two UNIONed legs, each probes its own index
+  // (measured: cost 73.76, both legs index-only scans; 74.52 for the parameterised
+  // generic plan, which is the shape Prisma sends).
+  //
+  // The guard is "no OR anywhere in this statement" rather than a spelling check on
+  // the good form: this query has no other legitimate use for one, so any OR that
+  // appears here is the non-sargable shape coming back.
+  it('splits the two columns into UNIONed legs so each can use its own index', async () => {
+    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_A));
+
+    await getCollectionIdsForModelCascade({ modelId: MODEL_ID });
+
+    const sql = sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/\bUNION\b/);
+    // Two independent scans of the table, one per column.
+    expect(sql.match(/FROM "CollectionItem"/g)).toHaveLength(2);
+    // The non-sargable bridge must not come back.
+    expect(sql).not.toMatch(/\bOR\b/);
+  });
 });
 
 describe('enqueueCollectionRebuild', () => {
@@ -203,6 +227,25 @@ describe('enqueueCollectionRebuild', () => {
         cap: 3,
       })
     );
+  });
+
+  // Every lookup here stops at `LIMIT cap + 1`, so the count that comes back is only
+  // ever "at least one more than the cap" — the true overflow is never observed and
+  // cannot be. A message asserting an exact figure would be a claim the query was
+  // never in a position to make, so the wording is pinned as a lower bound.
+  it('words the truncation warning as a lower bound, not an exact count', async () => {
+    await enqueueCollectionRebuild({
+      collectionIds: [COLLECTION_B],
+      dropped: 4,
+      source: 'model-perma-delete',
+      cap: 2,
+    });
+
+    const warning = loggingMock.logToAxiom.mock.calls
+      .map((c) => c[0] as { name?: string; message?: string })
+      .find((a) => a?.name === 'collection-media-index-enqueue-truncated');
+
+    expect(warning?.message).toContain('at least');
   });
 
   it('never throws when the queue write fails, so post-delete cleanup still runs', async () => {

--- a/src/server/services/__tests__/collection-media-index.test.ts
+++ b/src/server/services/__tests__/collection-media-index.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
- * Unit coverage for the collections-reindex enqueue used by every model/image
- * removal path.
+ * Unit coverage for the collections-reindex enqueue used by every model/image removal
+ * path.
  *
  * The defect it exists for: `prepareBatches` in collections.search-index.ts filters on
  * `c."createdAt" >= lastUpdatedAt`, so the incremental sweep only revisits NEWLY
@@ -20,6 +20,7 @@ const { mockCollectionsQueueUpdate } = vi.hoisted(() => ({
 }));
 
 vi.mock('~/server/search-index', () => ({
+  articlesSearchIndex: { queueUpdate: vi.fn() },
   collectionsSearchIndex: { queueUpdate: mockCollectionsQueueUpdate },
   imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
   imagesSearchIndex: { queueUpdate: vi.fn() },
@@ -27,6 +28,7 @@ vi.mock('~/server/search-index', () => ({
 }));
 
 import {
+  COVER_INDEX_NAME,
   enqueueCollectionRebuild,
   getCollectionIdsForMedia,
   getCollectionIdsForModelCascade,
@@ -44,57 +46,71 @@ const COLLECTION_C = 7743;
 
 const rows = (...ids: number[]) => ids.map((collectionId) => ({ collectionId }));
 
-// The template-tag call arrives as [strings, ...values]; join to recover the SQL text.
-const sqlOf = (call: unknown[]) => (call[0] as string[]).join('?');
+// The template-tag call arrives as [strings, ...values]. Joining `strings` alone is
+// NOT enough here: the cover leg is interpolated as a nested `Prisma.sql` fragment, so
+// its text lives in the VALUES and a naive join renders it as `?` — an assertion on
+// the leg would then fail whether or not the leg is present. Splice nested fragments
+// back in so these assertions read the statement as it will actually be sent.
+const sqlOf = (call: unknown[]) => {
+  const [strings, ...values] = call as [string[], ...unknown[]];
+  return strings
+    .map((chunk, i) => {
+      if (i === 0) return chunk;
+      const value = values[i - 1] as { sql?: string } | undefined;
+      return (typeof value?.sql === 'string' ? value.sql : '?') + chunk;
+    })
+    .join('');
+};
+
+const isGate = (sql: string) => sql.includes('pg_class');
+
+/** The image path asks the catalog whether the cover index exists before building its
+ *  query, so every image fixture has to answer that question first. */
+function primeImageLookup({ coverIndex, found }: { coverIndex: boolean; found: number[] }) {
+  dbMock.dbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) => {
+    const sql = Array.from(strings).join('?');
+    if (isGate(sql)) return [{ present: coverIndex }];
+    return rows(...found);
+  });
+}
+
+/** The SQL the image path actually built, i.e. not the catalog gate. */
+const imageQuerySql = () =>
+  sqlOf(
+    dbMock.dbWrite.$queryRaw.mock.calls.find(
+      ([strings]: [string[]]) => !isGate(Array.from(strings).join('?'))
+    ) as unknown[]
+  );
+
+const warningNamed = (name: string) =>
+  loggingMock.logToAxiom.mock.calls
+    .map((c) => c[0] as { name?: string; message?: string })
+    .find((a) => a?.name === name);
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('getCollectionIdsForMedia', () => {
+describe('getCollectionIdsForMedia — models', () => {
   it('resolves collections by modelId and enqueues nothing on its own', async () => {
     dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_A, COLLECTION_B));
 
     const result = await getCollectionIdsForMedia({ modelIds: [MODEL_ID] });
 
-    expect(result).toEqual({ collectionIds: [COLLECTION_A, COLLECTION_B], dropped: 0 });
+    expect(result).toEqual({ collectionIds: [COLLECTION_A, COLLECTION_B], truncated: false });
     expect(sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0])).toContain('"CollectionItem"');
     expect(sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0])).toContain('"modelId"');
     expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
   });
 
-  it('resolves collections by imageId', async () => {
-    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_C));
-
-    const result = await getCollectionIdsForMedia({ imageIds: [IMAGE_ID] });
-
-    expect(result.collectionIds).toEqual([COLLECTION_C]);
-    expect(sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0])).toContain('"imageId"');
-  });
-
-  it('dedupes a collection that holds both a removed model and a removed image', async () => {
-    dbMock.dbWrite.$queryRaw
-      .mockResolvedValueOnce(rows(COLLECTION_A, COLLECTION_B))
-      .mockResolvedValueOnce(rows(COLLECTION_B, COLLECTION_C));
-
-    const result = await getCollectionIdsForMedia({
-      modelIds: [MODEL_ID],
-      imageIds: [IMAGE_ID],
-    });
-
-    expect(result.collectionIds).toEqual([COLLECTION_A, COLLECTION_B, COLLECTION_C]);
-  });
-
   it('does not query at all when given no ids', async () => {
     const result = await getCollectionIdsForMedia({ modelIds: [], imageIds: [] });
 
-    expect(result).toEqual({ collectionIds: [], dropped: 0 });
+    expect(result).toEqual({ collectionIds: [], truncated: false });
     expect(dbMock.dbWrite.$queryRaw).not.toHaveBeenCalled();
   });
 
-  it('reports how many collections it dropped when the cap is exceeded', async () => {
-    // Cap of 3 against 5 distinct collections: two are dropped. The ids are chosen so
-    // no assertion below can be satisfied by a coincidence of ordering.
+  it('flags truncation when the cap is exceeded', async () => {
     dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(
       rows(COLLECTION_A, COLLECTION_B, COLLECTION_C, 5519, 6284)
     );
@@ -102,33 +118,156 @@ describe('getCollectionIdsForMedia', () => {
     const result = await getCollectionIdsForMedia({ modelIds: [MODEL_ID], cap: 3 });
 
     expect(result.collectionIds).toEqual([COLLECTION_A, COLLECTION_B, COLLECTION_C]);
-    expect(result.dropped).toBe(2);
+    expect(result.truncated).toBe(true);
   });
 
   it('never throws when the lookup fails, so a caller can resolve before its delete', async () => {
     dbMock.dbWrite.$queryRaw.mockRejectedValueOnce(new Error('connection reset'));
 
-    const result = await getCollectionIdsForMedia({ modelIds: [MODEL_ID], source: 'image-delete' });
+    const result = await getCollectionIdsForMedia({ modelIds: [MODEL_ID], source: 'model-delete' });
 
-    expect(result).toEqual({ collectionIds: [], dropped: 0 });
-    expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'collection-media-index-resolve-failed', type: 'error' })
-    );
+    expect(result).toEqual({ collectionIds: [], truncated: false });
+    expect(warningNamed('collection-media-index-resolve-failed')).toBeDefined();
+  });
+
+  // `logToAxiom` JSON.stringifies its payload, and an Error has no enumerable own
+  // properties — so a raw one serialises to `{}` and the cause is lost.
+  //
+  // 🔴 The assertion has to be made AFTER that round-trip. Asserting
+  // `objectContaining({ message })` on the payload directly passes for a raw Error too
+  // (a live Error really does have `.message`), so it cannot tell the two apart — it
+  // was written that way first and a mutant swapping `safeError(error)` for `error`
+  // survived it. Serialising here is what makes the guard able to fail.
+  it('logs the cause through safeError, which survives JSON serialisation', async () => {
+    dbMock.dbWrite.$queryRaw.mockRejectedValueOnce(new Error('connection reset'));
+
+    await getCollectionIdsForMedia({ modelIds: [MODEL_ID], source: 'model-delete' });
+
+    const payload = warningNamed('collection-media-index-resolve-failed') as
+      | { error?: unknown }
+      | undefined;
+    const serialised = JSON.parse(JSON.stringify({ error: payload?.error })) as {
+      error?: Record<string, unknown>;
+    };
+
+    expect(serialised.error).toMatchObject({ name: 'Error', message: 'connection reset' });
+  });
+});
+
+describe('getCollectionIdsForMedia — images', () => {
+  // An image reaches a collection document by six routes and only ONE of them is a
+  // CollectionItem.imageId row. Resolving by that column alone — the obvious reading —
+  // misses the two commonest (a Model item's gallery image, a Post item's first
+  // image), which is how the collection that prompted this work stayed stale: both its
+  // items are model-type with imageId NULL.
+  it('resolves every route by which an image reaches a collection document', async () => {
+    primeImageLookup({ coverIndex: true, found: [COLLECTION_A] });
+
+    await getCollectionIdsForMedia({ imageIds: [IMAGE_ID], source: 'image-delete' });
+
+    const sql = imageQuerySql();
+    expect(sql).toContain('ci."imageId"'); // 1. the image as an item
+    expect(sql).toContain('c."imageId"'); // 2. the collection's cover
+    expect(sql).toContain('ci."postId"'); // 3. a post item's first image
+    expect(sql).toContain('ci."modelId"'); // 4. a model item's gallery image
+    expect(sql).toContain('ci."articleId"'); // 5. an article item's cover
+    expect(sql).toContain('ci."model3dId"'); // 6. a model3d item's thumbnail
+  });
+
+  // Mirrors modelItemImage's own join in collections.search-index.ts. Without the
+  // userId equality the two disagree about which image a collection would show.
+  it('mirrors the index CTE join, including the post/model owner equality', async () => {
+    primeImageLookup({ coverIndex: true, found: [COLLECTION_A] });
+
+    await getCollectionIdsForMedia({ imageIds: [IMAGE_ID], source: 'image-delete' });
+
+    const sql = imageQuerySql();
+    expect(sql).toContain('"ModelVersion"');
+    expect(sql).toMatch(/m\."userId"\s*=\s*p\."userId"/);
+  });
+
+  // Every leg has to stay independently indexable; an OR across two columns is
+  // non-sargable against a ~208M-row table. Case-insensitive so a lowercase `or`
+  // cannot walk the guard.
+  it('keeps the routes in UNIONed legs rather than one OR-ed predicate', async () => {
+    primeImageLookup({ coverIndex: true, found: [COLLECTION_A] });
+
+    await getCollectionIdsForMedia({ imageIds: [IMAGE_ID], source: 'image-delete' });
+
+    const sql = imageQuerySql();
+    expect(sql).toMatch(/\bUNION\b/);
+    expect(sql).not.toMatch(/\bOR\b/i);
+  });
+
+  // Without "Collection_imageId_idx" the cover leg is a parallel sequential scan of a
+  // ~4.9 GB table (measured cost 451,531 against 9,974 for the whole rest of the
+  // query). Migrations here are applied by hand, so the code cannot assume the index
+  // exists just because the migration shipped alongside it.
+  it('omits the cover leg and warns when its index is missing', async () => {
+    primeImageLookup({ coverIndex: false, found: [COLLECTION_B] });
+
+    const result = await getCollectionIdsForMedia({ imageIds: [IMAGE_ID], source: 'image-delete' });
+
+    const sql = imageQuerySql();
+    expect(sql).not.toContain('c."imageId"');
+    expect(sql).toContain('ci."imageId"'); // the other legs still run
+    expect(result.collectionIds).toEqual([COLLECTION_B]);
+
+    const warning = warningNamed('collection-media-index-cover-leg-skipped');
+    expect(warning?.message).toContain(COVER_INDEX_NAME);
+  });
+
+  it('does not warn about the cover leg when the index is present', async () => {
+    primeImageLookup({ coverIndex: true, found: [COLLECTION_B] });
+
+    await getCollectionIdsForMedia({ imageIds: [IMAGE_ID], source: 'image-delete' });
+
+    expect(warningNamed('collection-media-index-cover-leg-skipped')).toBeUndefined();
+  });
+
+  // A failure resolving images must not throw away collections already resolved for
+  // models: half a correct answer beats none.
+  it('keeps the model-leg results when the image leg fails', async () => {
+    dbMock.dbWrite.$queryRaw
+      .mockResolvedValueOnce(rows(COLLECTION_C)) // model leg
+      .mockResolvedValueOnce([{ present: true }]) // cover-index gate
+      .mockRejectedValueOnce(new Error('statement timeout')); // image legs
+
+    const result = await getCollectionIdsForMedia({
+      modelIds: [MODEL_ID],
+      imageIds: [IMAGE_ID],
+      source: 'model-perma-delete',
+    });
+
+    expect(result.collectionIds).toEqual([COLLECTION_C]);
+    expect(warningNamed('collection-media-index-resolve-failed')).toBeDefined();
   });
 });
 
 describe('getCollectionIdsForModelCascade', () => {
-  it('resolves the model and its cascading gallery images in one statement', async () => {
+  it('resolves the model, its posts and its gallery images', async () => {
     dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_B, COLLECTION_A));
 
     const result = await getCollectionIdsForModelCascade({ modelId: MODEL_ID });
 
     expect(result.collectionIds).toEqual([COLLECTION_B, COLLECTION_A]);
     const sql = sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0]);
-    // Both arms matter: the model's own membership AND the images the cascade reaps.
     expect(sql).toContain('ci."modelId"');
     expect(sql).toContain('ci."imageId"');
     expect(sql).toContain('"ModelVersion"');
+  });
+
+  // model.service hard-deletes Posts inside the same transaction and
+  // CollectionItem.postId is onDelete: Cascade, while the index denormalizes a post
+  // item's first image — so a Post-type membership row goes stale exactly like a
+  // model-type one and has to be resolved before the cascade removes it.
+  it('resolves the posts the cascade will delete, not just models and images', async () => {
+    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_A));
+
+    await getCollectionIdsForModelCascade({ modelId: MODEL_ID });
+
+    const sql = sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0]);
+    expect(sql).toContain('ci."postId"');
   });
 
   it('never throws, so a failed lookup cannot cancel the delete that follows', async () => {
@@ -136,32 +275,27 @@ describe('getCollectionIdsForModelCascade', () => {
 
     await expect(getCollectionIdsForModelCascade({ modelId: MODEL_ID })).resolves.toEqual({
       collectionIds: [],
-      dropped: 0,
+      truncated: false,
     });
   });
 
-  // `CollectionItem` is a ~208M-row table. Bridging the two columns with a single
-  // `OR` makes the predicate non-sargable: Postgres can use NEITHER the modelId nor
-  // the imageId index, and falls back to scanning an unrelated index end to end with
-  // the whole condition as a post-scan Filter (measured: 43.3M estimated rows, total
-  // cost 3,336,745). Split into two UNIONed legs, each probes its own index
-  // (measured: cost 73.76, both legs index-only scans; 74.52 for the parameterised
-  // generic plan, which is the shape Prisma sends).
+  // `CollectionItem` is a ~208M-row table. Bridging the columns with a single `OR`
+  // makes the predicate non-sargable: Postgres uses none of the three indexes and
+  // scans an unrelated one end to end with the whole condition as a post-scan Filter
+  // (measured: 43.3M estimated rows, total cost 3,336,745). As separate UNIONed legs
+  // every branch is an index scan (measured: cost 89.68 for the three-leg form).
   //
   // The guard is "no OR anywhere in this statement" rather than a spelling check on
-  // the good form: this query has no other legitimate use for one, so any OR that
-  // appears here is the non-sargable shape coming back.
-  it('splits the two columns into UNIONed legs so each can use its own index', async () => {
+  // the good form: this query has no other legitimate use for one.
+  it('splits the columns into UNIONed legs so each can use its own index', async () => {
     dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_A));
 
     await getCollectionIdsForModelCascade({ modelId: MODEL_ID });
 
     const sql = sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0]);
     expect(sql).toMatch(/\bUNION\b/);
-    // Two independent scans of the table, one per column.
-    expect(sql.match(/FROM "CollectionItem"/g)).toHaveLength(2);
-    // The non-sargable bridge must not come back.
-    expect(sql).not.toMatch(/\bOR\b/);
+    expect(sql.match(/FROM "CollectionItem"/g)).toHaveLength(3);
+    expect(sql).not.toMatch(/\bOR\b/i);
   });
 });
 
@@ -169,7 +303,7 @@ describe('enqueueCollectionRebuild', () => {
   it('queues an Update — never a Delete — for each collection', async () => {
     await enqueueCollectionRebuild({
       collectionIds: [COLLECTION_A, COLLECTION_C],
-      dropped: 0,
+      truncated: false,
       source: 'model-delete',
     });
 
@@ -183,7 +317,7 @@ describe('enqueueCollectionRebuild', () => {
   it('does not touch the index when there is nothing to rebuild', async () => {
     const result = await enqueueCollectionRebuild({
       collectionIds: [],
-      dropped: 0,
+      truncated: false,
       source: 'model-delete',
     });
 
@@ -196,12 +330,15 @@ describe('enqueueCollectionRebuild', () => {
     // above every named constant so a batch boundary cannot coincide with an id.
     const ids = Array.from({ length: 1200 }, (_, i) => 20_000 + i);
 
-    await enqueueCollectionRebuild({ collectionIds: ids, dropped: 0, source: 'model-delete' });
+    await enqueueCollectionRebuild({
+      collectionIds: ids,
+      truncated: false,
+      source: 'model-delete',
+    });
 
     expect(mockCollectionsQueueUpdate).toHaveBeenCalledTimes(3);
     const sizes = mockCollectionsQueueUpdate.mock.calls.map((c) => (c[0] as unknown[]).length);
     expect(sizes).toEqual([500, 500, 200]);
-    // Every id is queued exactly once, and every one as an Update.
     const queued = mockCollectionsQueueUpdate.mock.calls.flatMap(
       (c) => c[0] as { id: number; action: string }[]
     );
@@ -210,10 +347,10 @@ describe('enqueueCollectionRebuild', () => {
     expect(queued.every((q) => q.action === SearchIndexUpdateQueueAction.Update)).toBe(true);
   });
 
-  it('logs what it dropped rather than truncating silently', async () => {
+  it('warns rather than truncating silently', async () => {
     await enqueueCollectionRebuild({
       collectionIds: [COLLECTION_A],
-      dropped: 17,
+      truncated: true,
       source: 'model-perma-delete',
       cap: 3,
     });
@@ -223,29 +360,26 @@ describe('enqueueCollectionRebuild', () => {
         name: 'collection-media-index-enqueue-truncated',
         type: 'warning',
         source: 'model-perma-delete',
-        dropped: 17,
         cap: 3,
       })
     );
   });
 
-  // Every lookup here stops at `LIMIT cap + 1`, so the count that comes back is only
-  // ever "at least one more than the cap" — the true overflow is never observed and
-  // cannot be. A message asserting an exact figure would be a claim the query was
-  // never in a position to make, so the wording is pinned as a lower bound.
-  it('words the truncation warning as a lower bound, not an exact count', async () => {
+  // Every lookup stops at `LIMIT cap + 1`, so any figure the warning could quote is 1
+  // however large the real overflow — and real models sit far past the cap (one
+  // measured in 86,153 distinct collections). Quoting "1 more is stale" there would
+  // understate by five orders of magnitude, so no number is quoted at all.
+  it('does not quote a number it cannot know for the overflow', async () => {
     await enqueueCollectionRebuild({
       collectionIds: [COLLECTION_B],
-      dropped: 4,
+      truncated: true,
       source: 'model-perma-delete',
       cap: 2,
     });
 
-    const warning = loggingMock.logToAxiom.mock.calls
-      .map((c) => c[0] as { name?: string; message?: string })
-      .find((a) => a?.name === 'collection-media-index-enqueue-truncated');
-
-    expect(warning?.message).toContain('at least');
+    const warning = warningNamed('collection-media-index-enqueue-truncated');
+    expect(warning?.message).toContain('unknown number');
+    expect(warning?.message).not.toMatch(/\b1 more\b/);
   });
 
   it('never throws when the queue write fails, so post-delete cleanup still runs', async () => {
@@ -253,13 +387,16 @@ describe('enqueueCollectionRebuild', () => {
 
     const result = await enqueueCollectionRebuild({
       collectionIds: [COLLECTION_B],
-      dropped: 0,
+      truncated: false,
       source: 'image-delete',
     });
 
     expect(result.queued).toBe(0);
     expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'collection-media-index-enqueue-failed', type: 'error' })
+      expect.objectContaining({
+        name: 'collection-media-index-enqueue-failed',
+        error: expect.objectContaining({ message: 'redis unavailable' }),
+      })
     );
   });
 });

--- a/src/server/services/__tests__/collection-media-index.test.ts
+++ b/src/server/services/__tests__/collection-media-index.test.ts
@@ -193,6 +193,11 @@ describe('getCollectionIdsForImages — routes', () => {
   });
 });
 
+// ⚠️ These gate assertions are SPELLED, not structural: they check the statement text
+// mentions `pg_index` / `indisvalid` / `relnamespace`, so a predicate written
+// `AND x.indisvalid = false` would satisfy them. With `$queryRaw` behind a mock there
+// is no way to evaluate the predicate without a real database, so this is the limit of
+// what a unit test can pin here — recorded rather than papered over.
 describe('getCollectionIdsForImages — the cover-index gate', () => {
   // 🔴 A `CREATE INDEX CONCURRENTLY` row appears in pg_class from the START of the
   // build and stays there permanently if the build FAILS. A name-only check therefore

--- a/src/server/services/__tests__/collection-media-index.test.ts
+++ b/src/server/services/__tests__/collection-media-index.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
- * Unit coverage for the collections-reindex enqueue used by every model/image removal
- * path.
+ * Unit coverage for the collections-reindex enqueue used by the image and
+ * permanent-model-delete removal paths.
  *
  * The defect it exists for: `prepareBatches` in collections.search-index.ts filters on
  * `c."createdAt" >= lastUpdatedAt`, so the incremental sweep only revisits NEWLY
@@ -30,9 +30,8 @@ vi.mock('~/server/search-index', () => ({
 import {
   COVER_INDEX_NAME,
   enqueueCollectionRebuild,
-  getCollectionIdsForMedia,
+  getCollectionIdsForImages,
   getCollectionIdsForModelCascade,
-  queueCollectionsForMedia,
 } from '~/server/services/collection-media-index';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbMock } from '~/__tests__/mocks/db.mock';
@@ -64,8 +63,8 @@ const sqlOf = (call: unknown[]) => {
 
 const isGate = (sql: string) => sql.includes('pg_class');
 
-/** The image path asks the catalog whether the cover index exists before building its
- *  query, so every image fixture has to answer that question first. */
+/** The image path asks the catalog whether the cover index is usable before it builds
+ *  its query, so every image fixture has to answer that question first. */
 function primeImageLookup({ coverIndex, found }: { coverIndex: boolean; found: number[] }) {
   dbMock.dbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) => {
     const sql = Array.from(strings).join('?');
@@ -74,88 +73,31 @@ function primeImageLookup({ coverIndex, found }: { coverIndex: boolean; found: n
   });
 }
 
-/** The SQL the image path actually built, i.e. not the catalog gate. */
-const imageQuerySql = () =>
-  sqlOf(
-    dbMock.dbWrite.$queryRaw.mock.calls.find(
-      ([strings]: [string[]]) => !isGate(Array.from(strings).join('?'))
-    ) as unknown[]
-  );
+const callMatching = (want: boolean) =>
+  dbMock.dbWrite.$queryRaw.mock.calls.find(
+    ([strings]: [string[]]) => isGate(Array.from(strings).join('?')) === want
+  ) as unknown[] | undefined;
 
-const warningNamed = (name: string) =>
+/** The SQL the image path actually built, i.e. not the catalog gate. */
+const imageQuerySql = () => sqlOf(callMatching(false)!);
+const gateSql = () => sqlOf(callMatching(true)!);
+
+const logNamed = (name: string) =>
   loggingMock.logToAxiom.mock.calls
-    .map((c) => c[0] as { name?: string; message?: string })
+    .map((c) => c[0] as { name?: string; message?: string; error?: unknown })
     .find((a) => a?.name === name);
+
+/** Axiom JSON.stringifies its payload; asserting after that round-trip is the only way
+ *  to tell `safeError(e)` from a raw `Error`, which satisfies `objectContaining` too. */
+const serialisedError = (name: string) =>
+  JSON.parse(JSON.stringify({ e: logNamed(name)?.error })).e as Record<string, unknown> | undefined;
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('getCollectionIdsForMedia — models', () => {
-  it('resolves collections by modelId and enqueues nothing on its own', async () => {
-    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_A, COLLECTION_B));
-
-    const result = await getCollectionIdsForMedia({ modelIds: [MODEL_ID] });
-
-    expect(result).toEqual({ collectionIds: [COLLECTION_A, COLLECTION_B], truncated: false });
-    expect(sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0])).toContain('"CollectionItem"');
-    expect(sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0])).toContain('"modelId"');
-    expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
-  });
-
-  it('does not query at all when given no ids', async () => {
-    const result = await getCollectionIdsForMedia({ modelIds: [], imageIds: [] });
-
-    expect(result).toEqual({ collectionIds: [], truncated: false });
-    expect(dbMock.dbWrite.$queryRaw).not.toHaveBeenCalled();
-  });
-
-  it('flags truncation when the cap is exceeded', async () => {
-    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(
-      rows(COLLECTION_A, COLLECTION_B, COLLECTION_C, 5519, 6284)
-    );
-
-    const result = await getCollectionIdsForMedia({ modelIds: [MODEL_ID], cap: 3 });
-
-    expect(result.collectionIds).toEqual([COLLECTION_A, COLLECTION_B, COLLECTION_C]);
-    expect(result.truncated).toBe(true);
-  });
-
-  it('never throws when the lookup fails, so a caller can resolve before its delete', async () => {
-    dbMock.dbWrite.$queryRaw.mockRejectedValueOnce(new Error('connection reset'));
-
-    const result = await getCollectionIdsForMedia({ modelIds: [MODEL_ID], source: 'model-delete' });
-
-    expect(result).toEqual({ collectionIds: [], truncated: false });
-    expect(warningNamed('collection-media-index-resolve-failed')).toBeDefined();
-  });
-
-  // `logToAxiom` JSON.stringifies its payload, and an Error has no enumerable own
-  // properties — so a raw one serialises to `{}` and the cause is lost.
-  //
-  // 🔴 The assertion has to be made AFTER that round-trip. Asserting
-  // `objectContaining({ message })` on the payload directly passes for a raw Error too
-  // (a live Error really does have `.message`), so it cannot tell the two apart — it
-  // was written that way first and a mutant swapping `safeError(error)` for `error`
-  // survived it. Serialising here is what makes the guard able to fail.
-  it('logs the cause through safeError, which survives JSON serialisation', async () => {
-    dbMock.dbWrite.$queryRaw.mockRejectedValueOnce(new Error('connection reset'));
-
-    await getCollectionIdsForMedia({ modelIds: [MODEL_ID], source: 'model-delete' });
-
-    const payload = warningNamed('collection-media-index-resolve-failed') as
-      | { error?: unknown }
-      | undefined;
-    const serialised = JSON.parse(JSON.stringify({ error: payload?.error })) as {
-      error?: Record<string, unknown>;
-    };
-
-    expect(serialised.error).toMatchObject({ name: 'Error', message: 'connection reset' });
-  });
-});
-
-describe('getCollectionIdsForMedia — images', () => {
-  // An image reaches a collection document by six routes and only ONE of them is a
+describe('getCollectionIdsForImages — routes', () => {
+  // An image reaches a collection document by seven routes and only ONE of them is a
   // CollectionItem.imageId row. Resolving by that column alone — the obvious reading —
   // misses the two commonest (a Model item's gallery image, a Post item's first
   // image), which is how the collection that prompted this work stayed stale: both its
@@ -163,7 +105,7 @@ describe('getCollectionIdsForMedia — images', () => {
   it('resolves every route by which an image reaches a collection document', async () => {
     primeImageLookup({ coverIndex: true, found: [COLLECTION_A] });
 
-    await getCollectionIdsForMedia({ imageIds: [IMAGE_ID], source: 'image-delete' });
+    await getCollectionIdsForImages({ imageIds: [IMAGE_ID], source: 'image-delete' });
 
     const sql = imageQuerySql();
     expect(sql).toContain('ci."imageId"'); // 1. the image as an item
@@ -172,6 +114,20 @@ describe('getCollectionIdsForMedia — images', () => {
     expect(sql).toContain('ci."modelId"'); // 4. a model item's gallery image
     expect(sql).toContain('ci."articleId"'); // 5. an article item's cover
     expect(sql).toContain('ci."model3dId"'); // 6. a model3d item's thumbnail
+    expect(sql).toContain('u."profilePictureId"'); // 7. the owner's avatar
+  });
+
+  // Route 7 is invisible to the CTE list: pullData fetches profile pictures with a
+  // separate `db.image.findMany` and transformData ships it as `user.profilePicture`
+  // on EVERY collection document. Enumerating from the CTEs alone misses it.
+  it('resolves the owner-avatar route, which is not one of the index CTEs', async () => {
+    primeImageLookup({ coverIndex: true, found: [COLLECTION_A] });
+
+    await getCollectionIdsForImages({ imageIds: [IMAGE_ID], source: 'image-delete' });
+
+    const sql = imageQuerySql();
+    expect(sql).toMatch(/JOIN "User" u ON u\.id = c\."userId"/);
+    expect(sql).toContain('u."profilePictureId"');
   });
 
   // Mirrors modelItemImage's own join in collections.search-index.ts. Without the
@@ -179,7 +135,7 @@ describe('getCollectionIdsForMedia — images', () => {
   it('mirrors the index CTE join, including the post/model owner equality', async () => {
     primeImageLookup({ coverIndex: true, found: [COLLECTION_A] });
 
-    await getCollectionIdsForMedia({ imageIds: [IMAGE_ID], source: 'image-delete' });
+    await getCollectionIdsForImages({ imageIds: [IMAGE_ID], source: 'image-delete' });
 
     const sql = imageQuerySql();
     expect(sql).toContain('"ModelVersion"');
@@ -192,55 +148,124 @@ describe('getCollectionIdsForMedia — images', () => {
   it('keeps the routes in UNIONed legs rather than one OR-ed predicate', async () => {
     primeImageLookup({ coverIndex: true, found: [COLLECTION_A] });
 
-    await getCollectionIdsForMedia({ imageIds: [IMAGE_ID], source: 'image-delete' });
+    await getCollectionIdsForImages({ imageIds: [IMAGE_ID], source: 'image-delete' });
 
     const sql = imageQuerySql();
     expect(sql).toMatch(/\bUNION\b/);
     expect(sql).not.toMatch(/\bOR\b/i);
   });
 
-  // Without "Collection_imageId_idx" the cover leg is a parallel sequential scan of a
-  // ~4.9 GB table (measured cost 451,531 against 9,974 for the whole rest of the
-  // query). Migrations here are applied by hand, so the code cannot assume the index
-  // exists just because the migration shipped alongside it.
-  it('omits the cover leg and warns when its index is missing', async () => {
+  it('does not query at all when given no ids', async () => {
+    const result = await getCollectionIdsForImages({ imageIds: [] });
+
+    expect(result).toEqual({ collectionIds: [], truncated: false });
+    expect(dbMock.dbWrite.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('flags truncation when the cap is exceeded', async () => {
+    primeImageLookup({
+      coverIndex: true,
+      found: [COLLECTION_A, COLLECTION_B, COLLECTION_C, 5519, 6284],
+    });
+
+    const result = await getCollectionIdsForImages({ imageIds: [IMAGE_ID], cap: 3 });
+
+    expect(result.collectionIds).toEqual([COLLECTION_A, COLLECTION_B, COLLECTION_C]);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('never throws when the lookup fails, so a caller can resolve before its delete', async () => {
+    dbMock.dbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) => {
+      if (isGate(Array.from(strings).join('?'))) return [{ present: true }];
+      throw new Error('connection reset');
+    });
+
+    const result = await getCollectionIdsForImages({
+      imageIds: [IMAGE_ID],
+      source: 'image-delete',
+    });
+
+    expect(result).toEqual({ collectionIds: [], truncated: false });
+    expect(serialisedError('collection-media-index-resolve-failed')).toMatchObject({
+      name: 'Error',
+      message: 'connection reset',
+    });
+  });
+});
+
+describe('getCollectionIdsForImages — the cover-index gate', () => {
+  // 🔴 A `CREATE INDEX CONCURRENTLY` row appears in pg_class from the START of the
+  // build and stays there permanently if the build FAILS. A name-only check therefore
+  // returns true throughout a multi-minute build of a 2.8 GB heap, and forever after a
+  // failure — switching the cover leg on in exactly the window the gate exists to
+  // cover, so every image delete pays a parallel sequential scan concurrently with the
+  // build. `indisvalid AND indisready` is what makes the gate mean "usable".
+  it('asks whether the index is VALID and READY, not merely named', async () => {
+    primeImageLookup({ coverIndex: true, found: [COLLECTION_A] });
+
+    await getCollectionIdsForImages({ imageIds: [IMAGE_ID], source: 'image-delete' });
+
+    const sql = gateSql();
+    expect(sql).toContain('pg_index');
+    expect(sql).toContain('indisvalid');
+    expect(sql).toContain('indisready');
+  });
+
+  // `relname` is not unique across schemas and this database has a second one, so an
+  // unqualified match could be satisfied by an index of the same name elsewhere.
+  it('qualifies the catalog lookup to the public schema', async () => {
+    primeImageLookup({ coverIndex: true, found: [COLLECTION_A] });
+
+    await getCollectionIdsForImages({ imageIds: [IMAGE_ID], source: 'image-delete' });
+
+    expect(gateSql()).toContain('relnamespace');
+  });
+
+  it('omits the cover leg and warns when the index is not usable', async () => {
     primeImageLookup({ coverIndex: false, found: [COLLECTION_B] });
 
-    const result = await getCollectionIdsForMedia({ imageIds: [IMAGE_ID], source: 'image-delete' });
+    const result = await getCollectionIdsForImages({
+      imageIds: [IMAGE_ID],
+      source: 'image-delete',
+    });
 
     const sql = imageQuerySql();
     expect(sql).not.toContain('c."imageId"');
     expect(sql).toContain('ci."imageId"'); // the other legs still run
     expect(result.collectionIds).toEqual([COLLECTION_B]);
-
-    const warning = warningNamed('collection-media-index-cover-leg-skipped');
-    expect(warning?.message).toContain(COVER_INDEX_NAME);
+    expect(logNamed('collection-media-index-cover-leg-skipped')?.message).toContain(
+      COVER_INDEX_NAME
+    );
   });
 
-  it('does not warn about the cover leg when the index is present', async () => {
+  it('does not warn about the cover leg when the index is usable', async () => {
     primeImageLookup({ coverIndex: true, found: [COLLECTION_B] });
 
-    await getCollectionIdsForMedia({ imageIds: [IMAGE_ID], source: 'image-delete' });
+    await getCollectionIdsForImages({ imageIds: [IMAGE_ID], source: 'image-delete' });
 
-    expect(warningNamed('collection-media-index-cover-leg-skipped')).toBeUndefined();
+    expect(logNamed('collection-media-index-cover-leg-skipped')).toBeUndefined();
   });
 
-  // A failure resolving images must not throw away collections already resolved for
-  // models: half a correct answer beats none.
-  it('keeps the model-leg results when the image leg fails', async () => {
-    dbMock.dbWrite.$queryRaw
-      .mockResolvedValueOnce(rows(COLLECTION_C)) // model leg
-      .mockResolvedValueOnce([{ present: true }]) // cover-index gate
-      .mockRejectedValueOnce(new Error('statement timeout')); // image legs
+  // Six of the seven legs do not depend on the cover index, so a blip on that one
+  // extra catalog round-trip must not decide whether they run. Inside the main try it
+  // would send the whole resolve to the catch and return nothing — a regression the
+  // gate itself introduced, since before the gate there was no probe to fail.
+  it('still resolves the other six legs when the catalog probe fails', async () => {
+    dbMock.dbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) => {
+      if (isGate(Array.from(strings).join('?'))) throw new Error('statement timeout');
+      return rows(COLLECTION_C);
+    });
 
-    const result = await getCollectionIdsForMedia({
-      modelIds: [MODEL_ID],
+    const result = await getCollectionIdsForImages({
       imageIds: [IMAGE_ID],
-      source: 'model-perma-delete',
+      source: 'image-delete',
     });
 
     expect(result.collectionIds).toEqual([COLLECTION_C]);
-    expect(warningNamed('collection-media-index-resolve-failed')).toBeDefined();
+    expect(imageQuerySql()).toContain('ci."postId"');
+    expect(serialisedError('collection-media-index-cover-probe-failed')).toMatchObject({
+      message: 'statement timeout',
+    });
   });
 });
 
@@ -266,8 +291,7 @@ describe('getCollectionIdsForModelCascade', () => {
 
     await getCollectionIdsForModelCascade({ modelId: MODEL_ID });
 
-    const sql = sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0]);
-    expect(sql).toContain('ci."postId"');
+    expect(sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0])).toContain('ci."postId"');
   });
 
   it('never throws, so a failed lookup cannot cancel the delete that follows', async () => {
@@ -284,9 +308,6 @@ describe('getCollectionIdsForModelCascade', () => {
   // scans an unrelated one end to end with the whole condition as a post-scan Filter
   // (measured: 43.3M estimated rows, total cost 3,336,745). As separate UNIONed legs
   // every branch is an index scan (measured: cost 89.68 for the three-leg form).
-  //
-  // The guard is "no OR anywhere in this statement" rather than a spelling check on
-  // the good form: this query has no other legitimate use for one.
   it('splits the columns into UNIONed legs so each can use its own index', async () => {
     dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_A));
 
@@ -304,7 +325,7 @@ describe('enqueueCollectionRebuild', () => {
     await enqueueCollectionRebuild({
       collectionIds: [COLLECTION_A, COLLECTION_C],
       truncated: false,
-      source: 'model-delete',
+      source: 'image-delete',
     });
 
     expect(mockCollectionsQueueUpdate).toHaveBeenCalledTimes(1);
@@ -318,7 +339,7 @@ describe('enqueueCollectionRebuild', () => {
     const result = await enqueueCollectionRebuild({
       collectionIds: [],
       truncated: false,
-      source: 'model-delete',
+      source: 'image-delete',
     });
 
     expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
@@ -333,7 +354,7 @@ describe('enqueueCollectionRebuild', () => {
     await enqueueCollectionRebuild({
       collectionIds: ids,
       truncated: false,
-      source: 'model-delete',
+      source: 'image-delete',
     });
 
     expect(mockCollectionsQueueUpdate).toHaveBeenCalledTimes(3);
@@ -377,7 +398,7 @@ describe('enqueueCollectionRebuild', () => {
       cap: 2,
     });
 
-    const warning = warningNamed('collection-media-index-enqueue-truncated');
+    const warning = logNamed('collection-media-index-enqueue-truncated');
     expect(warning?.message).toContain('unknown number');
     expect(warning?.message).not.toMatch(/\b1 more\b/);
   });
@@ -392,32 +413,11 @@ describe('enqueueCollectionRebuild', () => {
     });
 
     expect(result.queued).toBe(0);
-    expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'collection-media-index-enqueue-failed',
-        error: expect.objectContaining({ message: 'redis unavailable' }),
-      })
-    );
-  });
-});
-
-describe('queueCollectionsForMedia', () => {
-  it('resolves then enqueues an Update for each resolved collection', async () => {
-    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_C, COLLECTION_A));
-
-    await queueCollectionsForMedia({ modelIds: [MODEL_ID], source: 'model-delete' });
-
-    expect(mockCollectionsQueueUpdate).toHaveBeenCalledWith([
-      { id: COLLECTION_C, action: SearchIndexUpdateQueueAction.Update },
-      { id: COLLECTION_A, action: SearchIndexUpdateQueueAction.Update },
-    ]);
-  });
-
-  it('enqueues nothing when the model was in no collection', async () => {
-    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce([]);
-
-    await queueCollectionsForMedia({ modelIds: [MODEL_ID], source: 'model-delete' });
-
-    expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
+    // Asserted after the JSON round-trip for the same reason as the resolve failure:
+    // `objectContaining({ message })` is satisfied by a raw Error too.
+    expect(serialisedError('collection-media-index-enqueue-failed')).toMatchObject({
+      name: 'Error',
+      message: 'redis unavailable',
+    });
   });
 });

--- a/src/server/services/__tests__/collection-media-index.test.ts
+++ b/src/server/services/__tests__/collection-media-index.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit coverage for the collections-reindex enqueue used by every model/image
+ * removal path.
+ *
+ * The defect it exists for: `prepareBatches` in collections.search-index.ts filters on
+ * `c."createdAt" >= lastUpdatedAt`, so the incremental sweep only revisits NEWLY
+ * CREATED collections. An existing collection is rebuilt only via an explicit enqueue,
+ * and no removal path issued one — so a collection kept serving the thumbnail of a
+ * model or image that had been deleted.
+ *
+ * Fixture discipline: every collection id here is distinct from every other, from the
+ * model/image ids that resolve it, and from the cap and batch-size constants the
+ * assertions name. A mutant that hardcodes any literal in the module cannot survive.
+ */
+
+const { mockCollectionsQueueUpdate } = vi.hoisted(() => ({
+  mockCollectionsQueueUpdate: vi.fn(),
+}));
+
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: mockCollectionsQueueUpdate },
+  imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+  modelsSearchIndex: { queueUpdate: vi.fn() },
+}));
+
+import {
+  enqueueCollectionRebuild,
+  getCollectionIdsForMedia,
+  getCollectionIdsForModelCascade,
+  queueCollectionsForMedia,
+} from '~/server/services/collection-media-index';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
+
+const MODEL_ID = 4212;
+const IMAGE_ID = 6631;
+const COLLECTION_A = 8801;
+const COLLECTION_B = 9107;
+const COLLECTION_C = 7743;
+
+const rows = (...ids: number[]) => ids.map((collectionId) => ({ collectionId }));
+
+// The template-tag call arrives as [strings, ...values]; join to recover the SQL text.
+const sqlOf = (call: unknown[]) => (call[0] as string[]).join('?');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getCollectionIdsForMedia', () => {
+  it('resolves collections by modelId and enqueues nothing on its own', async () => {
+    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_A, COLLECTION_B));
+
+    const result = await getCollectionIdsForMedia({ modelIds: [MODEL_ID] });
+
+    expect(result).toEqual({ collectionIds: [COLLECTION_A, COLLECTION_B], dropped: 0 });
+    expect(sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0])).toContain('"CollectionItem"');
+    expect(sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0])).toContain('"modelId"');
+    expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
+  });
+
+  it('resolves collections by imageId', async () => {
+    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_C));
+
+    const result = await getCollectionIdsForMedia({ imageIds: [IMAGE_ID] });
+
+    expect(result.collectionIds).toEqual([COLLECTION_C]);
+    expect(sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0])).toContain('"imageId"');
+  });
+
+  it('dedupes a collection that holds both a removed model and a removed image', async () => {
+    dbMock.dbWrite.$queryRaw
+      .mockResolvedValueOnce(rows(COLLECTION_A, COLLECTION_B))
+      .mockResolvedValueOnce(rows(COLLECTION_B, COLLECTION_C));
+
+    const result = await getCollectionIdsForMedia({
+      modelIds: [MODEL_ID],
+      imageIds: [IMAGE_ID],
+    });
+
+    expect(result.collectionIds).toEqual([COLLECTION_A, COLLECTION_B, COLLECTION_C]);
+  });
+
+  it('does not query at all when given no ids', async () => {
+    const result = await getCollectionIdsForMedia({ modelIds: [], imageIds: [] });
+
+    expect(result).toEqual({ collectionIds: [], dropped: 0 });
+    expect(dbMock.dbWrite.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('reports how many collections it dropped when the cap is exceeded', async () => {
+    // Cap of 3 against 5 distinct collections: two are dropped. The ids are chosen so
+    // no assertion below can be satisfied by a coincidence of ordering.
+    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(
+      rows(COLLECTION_A, COLLECTION_B, COLLECTION_C, 5519, 6284)
+    );
+
+    const result = await getCollectionIdsForMedia({ modelIds: [MODEL_ID], cap: 3 });
+
+    expect(result.collectionIds).toEqual([COLLECTION_A, COLLECTION_B, COLLECTION_C]);
+    expect(result.dropped).toBe(2);
+  });
+
+  it('never throws when the lookup fails, so a caller can resolve before its delete', async () => {
+    dbMock.dbWrite.$queryRaw.mockRejectedValueOnce(new Error('connection reset'));
+
+    const result = await getCollectionIdsForMedia({ modelIds: [MODEL_ID], source: 'image-delete' });
+
+    expect(result).toEqual({ collectionIds: [], dropped: 0 });
+    expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'collection-media-index-resolve-failed', type: 'error' })
+    );
+  });
+});
+
+describe('getCollectionIdsForModelCascade', () => {
+  it('resolves the model and its cascading gallery images in one statement', async () => {
+    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_B, COLLECTION_A));
+
+    const result = await getCollectionIdsForModelCascade({ modelId: MODEL_ID });
+
+    expect(result.collectionIds).toEqual([COLLECTION_B, COLLECTION_A]);
+    const sql = sqlOf(dbMock.dbWrite.$queryRaw.mock.calls[0]);
+    // Both arms matter: the model's own membership AND the images the cascade reaps.
+    expect(sql).toContain('ci."modelId"');
+    expect(sql).toContain('ci."imageId"');
+    expect(sql).toContain('"ModelVersion"');
+  });
+
+  it('never throws, so a failed lookup cannot cancel the delete that follows', async () => {
+    dbMock.dbWrite.$queryRaw.mockRejectedValueOnce(new Error('deadlock detected'));
+
+    await expect(getCollectionIdsForModelCascade({ modelId: MODEL_ID })).resolves.toEqual({
+      collectionIds: [],
+      dropped: 0,
+    });
+  });
+});
+
+describe('enqueueCollectionRebuild', () => {
+  it('queues an Update — never a Delete — for each collection', async () => {
+    await enqueueCollectionRebuild({
+      collectionIds: [COLLECTION_A, COLLECTION_C],
+      dropped: 0,
+      source: 'model-delete',
+    });
+
+    expect(mockCollectionsQueueUpdate).toHaveBeenCalledTimes(1);
+    expect(mockCollectionsQueueUpdate).toHaveBeenCalledWith([
+      { id: COLLECTION_A, action: SearchIndexUpdateQueueAction.Update },
+      { id: COLLECTION_C, action: SearchIndexUpdateQueueAction.Update },
+    ]);
+  });
+
+  it('does not touch the index when there is nothing to rebuild', async () => {
+    const result = await enqueueCollectionRebuild({
+      collectionIds: [],
+      dropped: 0,
+      source: 'model-delete',
+    });
+
+    expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
+    expect(result.queued).toBe(0);
+  });
+
+  it('batches so one enormous id list never becomes one enormous queue write', async () => {
+    // 1200 distinct ids against a 500 batch size => 500 / 500 / 200. Ids start well
+    // above every named constant so a batch boundary cannot coincide with an id.
+    const ids = Array.from({ length: 1200 }, (_, i) => 20_000 + i);
+
+    await enqueueCollectionRebuild({ collectionIds: ids, dropped: 0, source: 'model-delete' });
+
+    expect(mockCollectionsQueueUpdate).toHaveBeenCalledTimes(3);
+    const sizes = mockCollectionsQueueUpdate.mock.calls.map((c) => (c[0] as unknown[]).length);
+    expect(sizes).toEqual([500, 500, 200]);
+    // Every id is queued exactly once, and every one as an Update.
+    const queued = mockCollectionsQueueUpdate.mock.calls.flatMap(
+      (c) => c[0] as { id: number; action: string }[]
+    );
+    expect(queued).toHaveLength(1200);
+    expect(new Set(queued.map((q) => q.id)).size).toBe(1200);
+    expect(queued.every((q) => q.action === SearchIndexUpdateQueueAction.Update)).toBe(true);
+  });
+
+  it('logs what it dropped rather than truncating silently', async () => {
+    await enqueueCollectionRebuild({
+      collectionIds: [COLLECTION_A],
+      dropped: 17,
+      source: 'model-perma-delete',
+      cap: 3,
+    });
+
+    expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'collection-media-index-enqueue-truncated',
+        type: 'warning',
+        source: 'model-perma-delete',
+        dropped: 17,
+        cap: 3,
+      })
+    );
+  });
+
+  it('never throws when the queue write fails, so post-delete cleanup still runs', async () => {
+    mockCollectionsQueueUpdate.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    const result = await enqueueCollectionRebuild({
+      collectionIds: [COLLECTION_B],
+      dropped: 0,
+      source: 'image-delete',
+    });
+
+    expect(result.queued).toBe(0);
+    expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'collection-media-index-enqueue-failed', type: 'error' })
+    );
+  });
+});
+
+describe('queueCollectionsForMedia', () => {
+  it('resolves then enqueues an Update for each resolved collection', async () => {
+    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows(COLLECTION_C, COLLECTION_A));
+
+    await queueCollectionsForMedia({ modelIds: [MODEL_ID], source: 'model-delete' });
+
+    expect(mockCollectionsQueueUpdate).toHaveBeenCalledWith([
+      { id: COLLECTION_C, action: SearchIndexUpdateQueueAction.Update },
+      { id: COLLECTION_A, action: SearchIndexUpdateQueueAction.Update },
+    ]);
+  });
+
+  it('enqueues nothing when the model was in no collection', async () => {
+    dbMock.dbWrite.$queryRaw.mockResolvedValueOnce([]);
+
+    await queueCollectionsForMedia({ modelIds: [MODEL_ID], source: 'model-delete' });
+
+    expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/image-removal-collection-reindex.test.ts
+++ b/src/server/services/__tests__/image-removal-collection-reindex.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as PromClient from '~/server/prom/client';
+
+/**
+ * Regression coverage: deleting an image must rebuild every collection that contained
+ * it.
+ *
+ * `collections_v3` denormalizes an image per collection item, and the collections
+ * index's incremental sweep only revisits NEWLY CREATED collections
+ * (`c."createdAt" >= lastUpdatedAt` in prepareBatches). image.service had no
+ * collections enqueue at all, so a collection whose cover item was a deleted image
+ * kept serving a thumbnail that no longer resolves.
+ *
+ * `CollectionItem.imageId` is `onDelete: Cascade`, so the membership rows vanish with
+ * the image — the resolve has to happen BEFORE the delete or there is nothing left to
+ * read. That ordering is asserted below, not assumed.
+ *
+ * Fixture discipline: image ids, collection ids and post ids are pairwise distinct and
+ * of different magnitudes, so a value read from the wrong variable cannot pass.
+ */
+
+const { mockCollectionsQueueUpdate, mockQueueImageSearchIndexUpdate, mockDeleteImageFromS3 } =
+  vi.hoisted(() => ({
+    mockCollectionsQueueUpdate: vi.fn(),
+    mockQueueImageSearchIndexUpdate: vi.fn(),
+    mockDeleteImageFromS3: vi.fn(),
+  }));
+
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof PromClient>();
+  return { ...actual, registerCounter: () => ({ inc: vi.fn() }) };
+});
+
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: mockCollectionsQueueUpdate },
+  imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+  modelsSearchIndex: { queueUpdate: vi.fn() },
+}));
+
+import * as imageService from '~/server/services/image.service';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const { deleteImageById, deleteImages } = imageService;
+
+const IMAGE_ID = 6631;
+const OTHER_IMAGE_ID = 6684;
+const POST_ID = 7012;
+const OWNER_ID = 3307;
+const COLLECTION_A = 8801;
+const COLLECTION_B = 9107;
+
+const mockDbWrite = dbMock.dbWrite;
+
+const expectedUpdatePayload = (ids: number[]) =>
+  ids.map((id) => ({ id, action: SearchIndexUpdateQueueAction.Update }));
+
+const isCollectionLookup = (strings: ArrayLike<string>) =>
+  Array.from(strings).join('?').includes('"CollectionItem"');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(imageService, 'queueImageSearchIndexUpdate').mockImplementation(
+    mockQueueImageSearchIndexUpdate as never
+  );
+  vi.spyOn(imageService, 'deleteImageFromS3').mockImplementation(mockDeleteImageFromS3 as never);
+});
+
+describe('deleteImageById', () => {
+  beforeEach(() => {
+    mockDbWrite.image.delete.mockResolvedValue({
+      url: 'some-url',
+      postId: POST_ID,
+      nsfwLevel: 1,
+      userId: OWNER_ID,
+    });
+    mockDbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) =>
+      isCollectionLookup(strings)
+        ? [{ collectionId: COLLECTION_A }, { collectionId: COLLECTION_B }]
+        : []
+    );
+  });
+
+  it('queues an Update for every collection that contained the deleted image', async () => {
+    await deleteImageById({ id: IMAGE_ID, updatePost: false });
+
+    expect(mockCollectionsQueueUpdate).toHaveBeenCalledWith(
+      expectedUpdatePayload([COLLECTION_A, COLLECTION_B])
+    );
+  });
+
+  it('resolves the collections BEFORE the delete, since CollectionItem cascades away', async () => {
+    const order: string[] = [];
+    mockDbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) => {
+      if (!isCollectionLookup(strings)) return [];
+      order.push('resolve');
+      return [{ collectionId: COLLECTION_A }];
+    });
+    mockDbWrite.image.delete.mockImplementation(async () => {
+      order.push('delete');
+      return { url: 'some-url', postId: POST_ID, nsfwLevel: 1, userId: OWNER_ID };
+    });
+
+    await deleteImageById({ id: IMAGE_ID, updatePost: false });
+
+    expect(order).toEqual(['resolve', 'delete']);
+  });
+
+  it('resolves by the deleted image id', async () => {
+    await deleteImageById({ id: IMAGE_ID, updatePost: false });
+
+    const call = mockDbWrite.$queryRaw.mock.calls.find(([strings]: [string[]]) =>
+      isCollectionLookup(strings)
+    );
+    expect(call).toBeDefined();
+    expect((call as unknown[])[0].join('?')).toContain('"imageId"');
+    const boundValues = (call as unknown[])
+      .slice(1)
+      .flatMap((v) => (v && typeof v === 'object' && 'values' in v ? (v as any).values : [v]));
+    expect(boundValues).toContain(IMAGE_ID);
+  });
+
+  it('still deletes the image when the collections lookup fails', async () => {
+    mockDbWrite.$queryRaw.mockRejectedValue(new Error('connection reset'));
+
+    await deleteImageById({ id: IMAGE_ID, updatePost: false });
+
+    expect(mockDbWrite.image.delete).toHaveBeenCalled();
+    expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteImages — bulk', () => {
+  beforeEach(() => {
+    mockDbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) =>
+      isCollectionLookup(strings)
+        ? [{ collectionId: COLLECTION_B }, { collectionId: COLLECTION_A }]
+        : [
+            { id: IMAGE_ID, url: 'a', postId: POST_ID, nsfwLevel: 1, userId: OWNER_ID },
+            { id: OTHER_IMAGE_ID, url: 'b', postId: POST_ID, nsfwLevel: 1, userId: OWNER_ID },
+          ]
+    );
+  });
+
+  it('queues an Update for every collection holding any of the deleted images', async () => {
+    await deleteImages([IMAGE_ID, OTHER_IMAGE_ID], false);
+
+    expect(mockCollectionsQueueUpdate).toHaveBeenCalledWith(
+      expectedUpdatePayload([COLLECTION_B, COLLECTION_A])
+    );
+  });
+
+  it('resolves the collections before issuing the bulk DELETE', async () => {
+    const order: string[] = [];
+    mockDbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) => {
+      const sql = Array.from(strings).join('?');
+      if (isCollectionLookup(strings)) {
+        order.push('resolve');
+        return [{ collectionId: COLLECTION_A }];
+      }
+      // Only the image DELETE is timed; the path issues other raw statements
+      // afterwards that say nothing about this ordering.
+      if (sql.includes('DELETE FROM "Image"')) {
+        order.push('delete');
+        return [{ id: IMAGE_ID, url: 'a', postId: POST_ID, nsfwLevel: 1, userId: OWNER_ID }];
+      }
+      return [];
+    });
+
+    await deleteImages([IMAGE_ID], false);
+
+    expect(order).toEqual(['resolve', 'delete']);
+  });
+});

--- a/src/server/services/__tests__/image-removal-collection-reindex.test.ts
+++ b/src/server/services/__tests__/image-removal-collection-reindex.test.ts
@@ -57,7 +57,11 @@ vi.mock('~/env/server', () => ({
 
 vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
 
+// `articlesSearchIndex` is load-bearing here, not decoration: image.service imports it,
+// so a factory that omits it leaves the module with a missing binding — the stale
+// wholesale-mock shape that has broken suites elsewhere in this repo.
 vi.mock('~/server/search-index', () => ({
+  articlesSearchIndex: { queueUpdate: vi.fn() },
   collectionsSearchIndex: { queueUpdate: mockCollectionsQueueUpdate },
   imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
   imagesSearchIndex: { queueUpdate: vi.fn() },
@@ -85,6 +89,12 @@ const expectedUpdatePayload = (ids: number[]) =>
 const isCollectionLookup = (strings: ArrayLike<string>) =>
   Array.from(strings).join('?').includes('"CollectionItem"');
 
+// The image resolve asks the catalog whether the cover-leg index exists before it
+// builds its query. These suites answer "yes" so they exercise the shape that runs
+// once the migration is applied.
+const isCoverIndexGate = (strings: ArrayLike<string>) =>
+  Array.from(strings).join('?').includes('pg_class');
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.spyOn(imageService, 'queueImageSearchIndexUpdate').mockImplementation(
@@ -101,11 +111,12 @@ describe('deleteImageById', () => {
       nsfwLevel: 1,
       userId: OWNER_ID,
     });
-    mockDbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) =>
-      isCollectionLookup(strings)
+    mockDbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) => {
+      if (isCoverIndexGate(strings)) return [{ present: true }];
+      return isCollectionLookup(strings)
         ? [{ collectionId: COLLECTION_A }, { collectionId: COLLECTION_B }]
-        : []
-    );
+        : [];
+    });
   });
 
   it('queues an Update for every collection that contained the deleted image', async () => {
@@ -160,7 +171,9 @@ describe('deleteImageById', () => {
 describe('deleteImages — bulk', () => {
   beforeEach(() => {
     mockDbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) =>
-      isCollectionLookup(strings)
+      isCoverIndexGate(strings)
+        ? [{ present: true }]
+        : isCollectionLookup(strings)
         ? [{ collectionId: COLLECTION_B }, { collectionId: COLLECTION_A }]
         : [
             { id: IMAGE_ID, url: 'a', postId: POST_ID, nsfwLevel: 1, userId: OWNER_ID },
@@ -197,5 +210,32 @@ describe('deleteImages — bulk', () => {
     await deleteImages([IMAGE_ID], false);
 
     expect(order).toEqual(['resolve', 'delete']);
+  });
+
+  // `deleteImages` has no try/catch of its own and the resolve is its FIRST statement,
+  // so the whole bulk delete — the DELETE itself, the index de-queue and the S3
+  // cleanup that follows — rests on the resolve never throwing. Nothing else in this
+  // suite would notice if that contract broke.
+  it('still issues the bulk DELETE when the collections lookup fails', async () => {
+    const seen: string[] = [];
+    mockDbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) => {
+      const sql = Array.from(strings).join('?');
+      if (isCoverIndexGate(strings)) throw new Error('connection reset');
+      if (sql.includes('DELETE FROM "Image"')) {
+        seen.push('delete');
+        return [{ id: IMAGE_ID, url: 'a', postId: POST_ID, nsfwLevel: 1, userId: OWNER_ID }];
+      }
+      return [];
+    });
+
+    // Asserted on the statements the path issues rather than on the intra-module
+    // helpers: `vi.spyOn(imageService, …)` cannot intercept a call image.service makes
+    // to its own binding, so a "was deleteImageFromS3 called" assertion would be
+    // unobservable here and would pass or fail for reasons unrelated to this contract.
+    const result = await deleteImages([IMAGE_ID], false);
+
+    expect(seen).toEqual(['delete']);
+    expect(result).toBeDefined();
+    expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/model-removal-collection-reindex.test.ts
+++ b/src/server/services/__tests__/model-removal-collection-reindex.test.ts
@@ -111,11 +111,7 @@ vi.mock('~/server/utils/cache-helpers', () => ({
 vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
 vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));
 
-import {
-  deleteModelById,
-  permaDeleteModelById,
-  unpublishModelById,
-} from '~/server/services/model.service';
+import { deleteModelById, permaDeleteModelById } from '~/server/services/model.service';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 const mockDbRead = dbMock.dbRead;
@@ -162,28 +158,22 @@ describe('deleteModelById — soft delete', () => {
     });
   });
 
-  it('queues an Update for every collection that contained the model', async () => {
+  // 🔴 DELIBERATELY NO ENQUEUE. An earlier revision queued a collections rebuild here.
+  // It was provably a no-op: the index's image CTEs filter only on
+  // `i."ingestion" = 'Scanned' AND i."needsReview" IS NULL` — no `Model.status`, no
+  // `Model.deletedAt` — and a soft delete leaves the Model, Post and Image rows intact,
+  // so the rebuild re-emits the same image. The cost was up to 10,000 Meilisearch
+  // enqueues per soft delete for no change in output. When the image is genuinely
+  // removed, deleteImageById/deleteImages enqueue it themselves.
+  //
+  // If the product answer is "hide a soft-deleted model's images from collection
+  // cards", the CTE predicate and this enqueue are needed TOGETHER — neither alone
+  // does anything. Re-adding the enqueue by itself will not fix that, which is what
+  // this guard is here to say.
+  it('does not queue a collections rebuild, which would be a no-op', async () => {
     await deleteModelById({ id: MODEL_ID, userId: OWNER_ID } as any);
 
-    expect(mockCollectionsQueueUpdate).toHaveBeenCalledWith(
-      expectedUpdatePayload([COLLECTION_A, COLLECTION_B])
-    );
-  });
-
-  it('resolves those collections by the deleted model id', async () => {
-    await deleteModelById({ id: MODEL_ID, userId: OWNER_ID } as any);
-
-    const call = mockDbWrite.$queryRaw.mock.calls.find(([strings]: [string[]]) =>
-      strings.join('?').includes('"CollectionItem"')
-    );
-    expect(call).toBeDefined();
-    expect((call as unknown[])[0].join('?')).toContain('"modelId"');
-    // The id list is bound through `Prisma.join`, which arrives as a Prisma.Sql
-    // fragment carrying its own values — flatten one level to reach the id itself.
-    const boundValues = (call as unknown[])
-      .slice(1)
-      .flatMap((v) => (v && typeof v === 'object' && 'values' in v ? (v as any).values : [v]));
-    expect(boundValues).toContain(MODEL_ID);
+    expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
   });
 
   it('still runs the trailing bid cleanup when the collections enqueue fails', async () => {
@@ -256,40 +246,5 @@ describe('permaDeleteModelById — permanent delete', () => {
 
     expect(mockDbWrite.model.delete).toHaveBeenCalled();
     expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
-  });
-});
-
-describe('unpublishModelById', () => {
-  beforeEach(() => {
-    mockDbWrite.model.findUniqueOrThrow.mockResolvedValue({
-      id: MODEL_ID,
-      userId: OWNER_ID,
-      status: 'Published',
-      meta: {},
-      nsfwLevel: 1,
-      modelVersions: [{ id: VERSION_ID }],
-    });
-    mockDbWrite.model.update.mockResolvedValue({
-      id: MODEL_ID,
-      userId: OWNER_ID,
-      status: 'Unpublished',
-      meta: {},
-      nsfwLevel: 1,
-      modelVersions: [{ id: VERSION_ID }],
-    });
-    mockDbWrite.post.findMany.mockResolvedValue([{ id: 7012 }]);
-    mockDbWrite.image.findMany.mockResolvedValue([{ id: 6631 }]);
-  });
-
-  it('queues an Update for every collection that contained the unpublished model', async () => {
-    await unpublishModelById({
-      id: MODEL_ID,
-      userId: OWNER_ID,
-      isModerator: true,
-    } as any);
-
-    expect(mockCollectionsQueueUpdate).toHaveBeenCalledWith(
-      expectedUpdatePayload([COLLECTION_A, COLLECTION_B])
-    );
   });
 });

--- a/src/server/services/__tests__/model-removal-collection-reindex.test.ts
+++ b/src/server/services/__tests__/model-removal-collection-reindex.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Regression coverage: removing a model must rebuild every collection that contained
+ * it.
+ *
+ * `collections_v3` denormalizes an image for each of a collection's first items, and
+ * `prepareBatches` in collections.search-index.ts filters on
+ * `c."createdAt" >= lastUpdatedAt` — so the incremental sweep only ever revisits NEWLY
+ * CREATED collections. An existing collection is rebuilt only when something enqueues
+ * it explicitly, and none of the three model removal paths did: soft delete, permanent
+ * delete and unpublish each queued the MODEL index (and the image index) while leaving
+ * the collections holding that model pointing at a thumbnail that no longer resolves.
+ *
+ * These assert the real resolve→enqueue chain, not a spy on a wrapper: the collections
+ * index client is the only thing mocked, so a payload assertion here pins the ids and
+ * the action that actually reach it.
+ *
+ * Fixture discipline: the model id, the collection ids and the version/post/image ids
+ * are pairwise distinct and distinct from one another's magnitudes, so an id read from
+ * the wrong variable cannot satisfy an assertion by coincidence.
+ */
+
+const {
+  mockCollectionsQueueUpdate,
+  mockModelsQueueUpdate,
+  mockQueueImageSearchIndexUpdate,
+  mockDeleteBidsForModel,
+} = vi.hoisted(() => ({
+  mockCollectionsQueueUpdate: vi.fn(),
+  mockModelsQueueUpdate: vi.fn(),
+  mockQueueImageSearchIndexUpdate: vi.fn(),
+  mockDeleteBidsForModel: vi.fn(),
+}));
+
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  preventReplicationLag: vi.fn(),
+  getDbWithoutLag: vi.fn(async () => mockDbRead),
+  preventModelVersionLagBatch: vi.fn(),
+}));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {}, pgDbReadLong: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null, Tracker: class {} }));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(() => false), FLIPT_FEATURE_FLAGS: {} }));
+vi.mock('~/server/metrics', () => ({ modelMetrics: {} }));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: {},
+  modelTagCache: { refresh: vi.fn() },
+  modelVotableTagsCache: { bust: vi.fn() },
+  userBasicCache: {},
+  userModelCountCache: { refresh: vi.fn() },
+}));
+
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: mockCollectionsQueueUpdate },
+  imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+  modelsSearchIndex: { queueUpdate: mockModelsQueueUpdate },
+}));
+vi.mock('~/server/services/auction.service', () => ({
+  deleteBidsForModel: mockDeleteBidsForModel,
+  getLastAuctionReset: vi.fn(),
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getMultiAccountTransactionsByPrefix: vi.fn(),
+  getUserBuzzAccountByAccountTypes: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+}));
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTagsForModels: vi.fn(),
+}));
+vi.mock('~/server/services/blocklist.service', () => ({
+  throwOnBlockedLinkDomain: vi.fn(),
+  throwOnBlockedUserContent: vi.fn(),
+}));
+vi.mock('~/server/services/collection.service', () => ({
+  getAvailableCollectionItemsFilterForUser: vi.fn(),
+  getUserCollectionPermissionsById: vi.fn(),
+  saveItemInCollections: vi.fn(),
+}));
+vi.mock('~/server/services/cosmetic.service', () => ({ getCosmeticsForEntity: vi.fn() }));
+vi.mock('~/server/services/creator-program.service', () => ({
+  getValidCreatorMembershipMap: vi.fn(),
+}));
+vi.mock('~/server/services/generation/generation.service', () => ({
+  getUnavailableResources: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(),
+  getImagesForModelVersionCache: {},
+  queueImageSearchIndexUpdate: mockQueueImageSearchIndexUpdate,
+}));
+vi.mock('~/server/services/model-file.service', () => ({ getFilesForModelVersionCache: {} }));
+vi.mock('~/server/services/model-version.service', () => ({
+  bustMvCache: vi.fn(),
+  bustPublicModelResponseCache: vi.fn(),
+  createModelVersionPostFromTraining: vi.fn(),
+  publishModelVersionsWithEarlyAccess: vi.fn(),
+}));
+vi.mock('~/server/services/subscriptions.service', () => ({ getHighestTierSubscription: vi.fn() }));
+vi.mock('~/server/services/system-cache', () => ({ getCategoryTags: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({
+  deleteBasicDataForUser: vi.fn(),
+  getCosmeticsForUsers: vi.fn(),
+  getProfilePicturesForUsers: vi.fn(),
+}));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  bustFetchThroughCache: vi.fn(),
+  fetchThroughCache: vi.fn(),
+}));
+vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
+vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));
+
+import {
+  deleteModelById,
+  permaDeleteModelById,
+  unpublishModelById,
+} from '~/server/services/model.service';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+const mockDbRead = dbMock.dbRead;
+const mockDbWrite = dbMock.dbWrite;
+
+const MODEL_ID = 4212;
+const OWNER_ID = 3307;
+const VERSION_ID = 5150;
+const COLLECTION_A = 8801;
+const COLLECTION_B = 9107;
+
+/**
+ * The only `$queryRaw` these paths issue against `CollectionItem` is the collections
+ * resolver's. Branching on the SQL rather than on call order means the assertion does
+ * not silently start reading someone else's query if one is added later.
+ */
+function primeCollectionLookup(collectionIds: number[]) {
+  mockDbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) => {
+    const sql = Array.from(strings).join('?');
+    if (sql.includes('"CollectionItem"'))
+      return collectionIds.map((collectionId) => ({ collectionId }));
+    return [];
+  });
+}
+
+const expectedUpdatePayload = (ids: number[]) =>
+  ids.map((id) => ({ id, action: SearchIndexUpdateQueueAction.Update }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDbWrite.$transaction.mockImplementation(async (arg: any) =>
+    typeof arg === 'function' ? arg(mockDbWrite) : Promise.all(arg)
+  );
+  primeCollectionLookup([COLLECTION_A, COLLECTION_B]);
+});
+
+describe('deleteModelById — soft delete', () => {
+  beforeEach(() => {
+    mockDbWrite.model.update.mockResolvedValue({
+      id: MODEL_ID,
+      userId: OWNER_ID,
+      nsfwLevel: 1,
+      modelVersions: [{ id: VERSION_ID }],
+    });
+  });
+
+  it('queues an Update for every collection that contained the model', async () => {
+    await deleteModelById({ id: MODEL_ID, userId: OWNER_ID } as any);
+
+    expect(mockCollectionsQueueUpdate).toHaveBeenCalledWith(
+      expectedUpdatePayload([COLLECTION_A, COLLECTION_B])
+    );
+  });
+
+  it('resolves those collections by the deleted model id', async () => {
+    await deleteModelById({ id: MODEL_ID, userId: OWNER_ID } as any);
+
+    const call = mockDbWrite.$queryRaw.mock.calls.find(([strings]: [string[]]) =>
+      strings.join('?').includes('"CollectionItem"')
+    );
+    expect(call).toBeDefined();
+    expect((call as unknown[])[0].join('?')).toContain('"modelId"');
+    // The id list is bound through `Prisma.join`, which arrives as a Prisma.Sql
+    // fragment carrying its own values — flatten one level to reach the id itself.
+    const boundValues = (call as unknown[])
+      .slice(1)
+      .flatMap((v) => (v && typeof v === 'object' && 'values' in v ? (v as any).values : [v]));
+    expect(boundValues).toContain(MODEL_ID);
+  });
+
+  it('still runs the trailing bid cleanup when the collections enqueue fails', async () => {
+    mockCollectionsQueueUpdate.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    await expect(deleteModelById({ id: MODEL_ID, userId: OWNER_ID } as any)).resolves.toBeTruthy();
+    expect(mockDeleteBidsForModel).toHaveBeenCalledWith({ modelId: MODEL_ID });
+  });
+});
+
+describe('permaDeleteModelById — permanent delete', () => {
+  beforeEach(() => {
+    mockDbWrite.modelFile.findMany.mockResolvedValue([]);
+    mockDbWrite.model.findUnique.mockResolvedValue({
+      id: MODEL_ID,
+      userId: OWNER_ID,
+      nsfwLevel: 1,
+      modelVersions: [{ id: VERSION_ID }],
+    });
+    mockDbWrite.post.findMany.mockResolvedValue([{ id: 7012 }]);
+    mockDbWrite.image.findMany.mockResolvedValue([{ id: 6631 }]);
+    mockDbWrite.model.delete.mockResolvedValue({ id: MODEL_ID, userId: OWNER_ID });
+  });
+
+  it('queues an Update for every collection that contained the model or its images', async () => {
+    await permaDeleteModelById({ id: MODEL_ID, userId: OWNER_ID } as any);
+
+    expect(mockCollectionsQueueUpdate).toHaveBeenCalledWith(
+      expectedUpdatePayload([COLLECTION_A, COLLECTION_B])
+    );
+  });
+
+  it('resolves the collections BEFORE the delete, since CollectionItem cascades away', async () => {
+    const order: string[] = [];
+    mockDbWrite.$queryRaw.mockImplementation(async (strings: TemplateStringsArray) => {
+      const sql = Array.from(strings).join('?');
+      if (sql.includes('"CollectionItem"')) {
+        order.push('resolve');
+        return [{ collectionId: COLLECTION_A }];
+      }
+      return [];
+    });
+    mockDbWrite.model.delete.mockImplementation(async () => {
+      order.push('delete');
+      return { id: MODEL_ID, userId: OWNER_ID };
+    });
+
+    await permaDeleteModelById({ id: MODEL_ID, userId: OWNER_ID } as any);
+
+    expect(order).toEqual(['resolve', 'delete']);
+  });
+
+  it('still deletes the model when the collections lookup fails', async () => {
+    mockDbWrite.$queryRaw.mockRejectedValue(new Error('connection reset'));
+
+    await permaDeleteModelById({ id: MODEL_ID, userId: OWNER_ID } as any);
+
+    expect(mockDbWrite.model.delete).toHaveBeenCalled();
+    expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('unpublishModelById', () => {
+  beforeEach(() => {
+    mockDbWrite.model.findUniqueOrThrow.mockResolvedValue({
+      id: MODEL_ID,
+      userId: OWNER_ID,
+      status: 'Published',
+      meta: {},
+      nsfwLevel: 1,
+      modelVersions: [{ id: VERSION_ID }],
+    });
+    mockDbWrite.model.update.mockResolvedValue({
+      id: MODEL_ID,
+      userId: OWNER_ID,
+      status: 'Unpublished',
+      meta: {},
+      nsfwLevel: 1,
+      modelVersions: [{ id: VERSION_ID }],
+    });
+    mockDbWrite.post.findMany.mockResolvedValue([{ id: 7012 }]);
+    mockDbWrite.image.findMany.mockResolvedValue([{ id: 6631 }]);
+  });
+
+  it('queues an Update for every collection that contained the unpublished model', async () => {
+    await unpublishModelById({
+      id: MODEL_ID,
+      userId: OWNER_ID,
+      isModerator: true,
+    } as any);
+
+    expect(mockCollectionsQueueUpdate).toHaveBeenCalledWith(
+      expectedUpdatePayload([COLLECTION_A, COLLECTION_B])
+    );
+  });
+});

--- a/src/server/services/__tests__/model-removal-collection-reindex.test.ts
+++ b/src/server/services/__tests__/model-removal-collection-reindex.test.ts
@@ -1,20 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
- * Regression coverage: removing a model must rebuild every collection that contained
- * it.
+ * Coverage for the two model removal paths, which want OPPOSITE things.
  *
  * `collections_v3` denormalizes an image for each of a collection's first items, and
  * `prepareBatches` in collections.search-index.ts filters on
  * `c."createdAt" >= lastUpdatedAt` — so the incremental sweep only ever revisits NEWLY
  * CREATED collections. An existing collection is rebuilt only when something enqueues
- * it explicitly, and none of the three model removal paths did: soft delete, permanent
- * delete and unpublish each queued the MODEL index (and the image index) while leaving
- * the collections holding that model pointing at a thumbnail that no longer resolves.
+ * it explicitly.
  *
- * These assert the real resolve→enqueue chain, not a spy on a wrapper: the collections
- * index client is the only thing mocked, so a payload assertion here pins the ids and
- * the action that actually reach it.
+ *   permaDeleteModelById  MUST enqueue. The rows genuinely go away, so the document
+ *                         would otherwise keep a thumbnail that no longer resolves.
+ *                         These tests assert the real resolve→enqueue chain: the
+ *                         collections index client is the only thing mocked, so the
+ *                         payload assertions pin the ids and the action that actually
+ *                         reach it, and the ordering assertions pin that the resolve
+ *                         happens before the cascade removes what it reads.
+ *
+ *   deleteModelById       MUST NOT enqueue. A soft delete leaves every row intact and
+ *                         the index CTEs filter only on ingestion/needsReview, so a
+ *                         rebuild re-emits the same image — the enqueue was a provable
+ *                         no-op costing up to 10,000 queue writes per delete. The test
+ *                         below pins its absence; see the comment there for what would
+ *                         have to change for it to be worth re-adding.
+ *
+ * `unpublishModelById` was in an earlier revision of this file for the same reason as
+ * the soft delete, and is not exercised here at all now that it has no enqueue.
  *
  * Fixture discipline: the model id, the collection ids and the version/post/image ids
  * are pairwise distinct and distinct from one another's magnitudes, so an id read from
@@ -174,13 +185,6 @@ describe('deleteModelById — soft delete', () => {
     await deleteModelById({ id: MODEL_ID, userId: OWNER_ID } as any);
 
     expect(mockCollectionsQueueUpdate).not.toHaveBeenCalled();
-  });
-
-  it('still runs the trailing bid cleanup when the collections enqueue fails', async () => {
-    mockCollectionsQueueUpdate.mockRejectedValueOnce(new Error('redis unavailable'));
-
-    await expect(deleteModelById({ id: MODEL_ID, userId: OWNER_ID } as any)).resolves.toBeTruthy();
-    expect(mockDeleteBidsForModel).toHaveBeenCalledWith({ modelId: MODEL_ID });
   });
 });
 

--- a/src/server/services/__tests__/model-removal-collection-reindex.test.ts
+++ b/src/server/services/__tests__/model-removal-collection-reindex.test.ts
@@ -51,6 +51,7 @@ vi.mock('~/server/redis/caches', () => ({
 }));
 
 vi.mock('~/server/search-index', () => ({
+  articlesSearchIndex: { queueUpdate: vi.fn() },
   collectionsSearchIndex: { queueUpdate: mockCollectionsQueueUpdate },
   imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
   imagesSearchIndex: { queueUpdate: vi.fn() },
@@ -233,6 +234,19 @@ describe('permaDeleteModelById — permanent delete', () => {
     await permaDeleteModelById({ id: MODEL_ID, userId: OWNER_ID } as any);
 
     expect(order).toEqual(['resolve', 'delete']);
+  });
+
+  // model.service hard-deletes the model's Posts in the same transaction, and
+  // CollectionItem.postId is onDelete: Cascade while the index denormalizes a post
+  // item's first image — so Post-type membership rows go stale too and must be
+  // resolved before the cascade removes them.
+  it('resolves the posts the cascade deletes, not only the model and its images', async () => {
+    await permaDeleteModelById({ id: MODEL_ID, userId: OWNER_ID } as any);
+
+    const call = mockDbWrite.$queryRaw.mock.calls.find(([strings]: [string[]]) =>
+      strings.join('?').includes('"CollectionItem"')
+    );
+    expect((call as unknown[])[0].join('?')).toContain('ci."postId"');
   });
 
   it('still deletes the model when the collections lookup fails', async () => {

--- a/src/server/services/collection-media-index.ts
+++ b/src/server/services/collection-media-index.ts
@@ -16,24 +16,33 @@ import { collectionsSearchIndex } from '~/server/search-index';
 // `Update`, never `Delete`: the collection still exists, only its document needs
 // rebuilding. A `Delete` would evict a collection that is still perfectly real.
 //
-// 🔴 AN IMAGE REACHES A COLLECTION DOCUMENT BY SIX ROUTES, ONLY ONE OF WHICH IS A
+// 🔴 AN IMAGE REACHES A COLLECTION DOCUMENT BY SEVEN ROUTES, ONLY ONE OF WHICH IS A
 // `CollectionItem.imageId` ROW. Resolving by that column alone — the obvious reading —
-// misses five of them, including the two most common. Enumerated from the index's own
-// CTEs (collections.search-index.ts) plus the document's cover field:
+// misses six of them, including the two most common.
 //
-//   1. imageItemImage    CollectionItem.imageId  -> the image directly
-//   2. postItemImage     CollectionItem.postId   -> that post's FIRST image
-//   3. modelItemImage    CollectionItem.modelId  -> image -> Post -> ModelVersion -> Model
-//   4. articleItemImage  CollectionItem.articleId-> Article.coverId
-//   5. model3dItemImage  CollectionItem.model3dId-> Model3D.thumbnailImageId
-//   6. the collection's own cover, Collection.imageId (SetNull, not a CollectionItem)
+// 🔴 ENUMERATE FROM `pullData` AND `transformData`, NOT FROM THE CTEs. An earlier
+// version of this comment said SIX and derived them from the item-image CTE list; that
+// method structurally cannot see route 7, which is a separate `findMany`. If you add a
+// route, the question to ask is "what image ids does the document contain", not "what
+// does the big CTE join".
+//
+//   1. imageItemImage    CollectionItem.imageId   -> the image directly
+//   2. postItemImage     CollectionItem.postId    -> that post's FIRST image
+//   3. modelItemImage    CollectionItem.modelId   -> image -> Post -> ModelVersion -> Model
+//   4. articleItemImage  CollectionItem.articleId -> Article.coverId
+//   5. model3dItemImage  CollectionItem.model3dId -> Model3D.thumbnailImageId
+//   6. the collection's own cover, Collection.imageId
+//   7. the owner's avatar, User.profilePictureId -> Collection.userId
+//      (fetched by a separate `db.image.findMany` in pullData and shipped as
+//       `user.profilePicture` on EVERY collection document — not a CTE at all)
 //
 // Route 6 is the one that matters most on screen: CollectionCard renders
 // `if (data.image) return [data.image]`, so a cover WINS over every item image, and
 // most public collections with a cover use one that is not among their own items.
 //
-// The joins below mirror the CTEs' own conditions — including `m."userId" =
-// p."userId"` — so this and the index agree on which image a collection would show.
+// The joins for routes 2-5 mirror the CTEs' own conditions — including
+// `m."userId" = p."userId"` — so this and the index agree on which image a collection
+// would show.
 //
 // This is a LEAF module on purpose. It is imported by both model.service and
 // image.service, and its sibling collection-index-sync.ts already imports
@@ -49,13 +58,18 @@ import { collectionsSearchIndex } from '~/server/search-index';
 
 // `CollectionItem.modelId` / `.postId` / `.imageId` are all `onDelete: Cascade`, so on
 // a HARD delete the membership rows disappear with the row that owned them. Callers on
-// a hard-delete path must therefore resolve ids BEFORE the delete; a soft delete or an
-// unpublish leaves the rows in place and can resolve after.
+// a hard-delete path must therefore resolve ids BEFORE the delete.
+//
+// ⚠️ `Collection.imageId` and `User.profilePictureId` are NOT cascade-cleared, and in
+// the deployed database they are not even foreign keys — `Collection` carries exactly
+// one FK (`Collection_userId_fkey`), so a cover can and does point at an `Image` row
+// that no longer exists. Nothing here depends on that: routes 6 and 7 are resolved
+// before the delete like the rest. It is recorded because the Prisma schema's
+// `onDelete: SetNull` reads like a guarantee the database does not actually make.
 //
 // 🔴 EVERY LEG MUST BE INDEPENDENTLY INDEXABLE. Bridging two columns with an `OR`
 // makes the predicate non-sargable and costs a full scan of a ~208M-row table, so the
-// legs stay in separate UNION branches and each was checked to produce its own index
-// scan. Do not merge them back into one `WHERE ... OR ...`.
+// legs stay in separate UNION branches. Do not merge them into one `WHERE ... OR ...`.
 const DEFAULT_COLLECTION_CAP = 10_000;
 
 // One enqueue writes its ids into a Redis queue as a single command. Chunking keeps
@@ -83,9 +97,9 @@ function applyCap(rows: { collectionId: number }[], cap: number): CollectionsToR
 }
 
 function logFailure(name: string, source: string, message: string, error: unknown) {
-  // `safeError`, never the raw Error: `logToAxiom` JSON.stringifies its payload and a
-  // bare Error serialises to `{}`, which would record that something failed while
-  // discarding the only part worth logging.
+  // `safeError`, never the raw Error: `logToAxiom` JSON.stringifies its payload and an
+  // Error has no enumerable own properties, so a bare one serialises to `{}` — which
+  // records that something failed while discarding the only part worth logging.
   logToAxiom({
     type: 'error',
     name,
@@ -95,51 +109,57 @@ function logFailure(name: string, source: string, message: string, error: unknow
   }).catch(() => undefined);
 }
 
-/** Collections holding these models as items. Membership rows only — a model item's
- * gallery image is resolved from the model, so no image walk is needed here. */
-function modelLegSql(modelIds: number[], cap: number) {
-  return dbWrite.$queryRaw<{ collectionId: number }[]>`
-    SELECT DISTINCT "collectionId" FROM "CollectionItem"
-    WHERE "modelId" IN (${Prisma.join(modelIds)})
-    LIMIT ${cap + 1}
-  `;
-}
-
 export const COVER_INDEX_NAME = 'Collection_imageId_idx';
 
 /**
- * Is the cover leg's index present?
+ * Is the cover leg's index present AND USABLE?
  *
- * 🔴 The cover leg is GATED on this, because without the index it is a parallel
- * sequential scan of a ~17.3M-row / 4.9 GB table — measured cost 451,531, against
- * ~10,000 for every other leg of the same query combined — on a user-facing delete
- * path, and `deleteImages` would pay it once per 100-image batch. Migrations here are
- * applied by hand, so "the migration ships in the same PR" does not mean the index
- * exists when this code first runs; the gate is what makes that ordering safe rather
- * than merely documented.
+ * 🔴 `pg_class` alone is NOT sufficient, and getting this wrong fails OPEN. A
+ * `CREATE INDEX CONCURRENTLY` row appears in `pg_class` from the START of the build
+ * and stays there permanently if the build fails — so a name-only check returns true
+ * throughout a multi-minute build of a 2.8 GB heap, and forever after a failure. That
+ * is precisely the window this gate exists to cover: the deploy-then-migrate ordering
+ * would switch the cover leg on while the index is still being built, and every image
+ * delete would pay the sequential scan concurrently with the build, on the primary,
+ * up to five at a time (`deleteImages` runs `Limiter({ batchSize: 100 })`, whose
+ * default concurrency is 5). `indisvalid AND indisready` is what makes the gate mean
+ * "usable by the planner" rather than "someone started building this once".
  *
- * A catalog lookup, not a cached flag: it is an index probe on pg_class costing far
- * less than the six-leg query it guards, and re-reading it means the leg starts
- * working the moment the migration is applied, with no deploy or restart.
+ * Schema-qualified because `relname` is not unique across schemas and this database
+ * has a second one (`fk_remediation_backup`).
  *
- * Once the index exists in every environment, this gate and its branch can be deleted.
+ * A catalog lookup, not a cached flag: two index scans, cost 5.01 — far less than the
+ * seven-leg query it guards — and re-reading it means the leg starts working the
+ * moment the index becomes valid, with no deploy or restart.
+ *
+ * Once the index is valid in every environment, this gate and its branch can go.
  */
 async function coverIndexExists() {
   const rows = await dbWrite.$queryRaw<{ present: boolean }[]>`
     SELECT EXISTS (
-      SELECT 1 FROM pg_class WHERE relname = ${COVER_INDEX_NAME} AND relkind = 'i'
+      SELECT 1 FROM pg_class c
+      JOIN pg_index x ON x.indexrelid = c.oid
+      WHERE c.relname = ${COVER_INDEX_NAME}
+        AND c.relkind = 'i'
+        AND c.relnamespace = 'public'::regnamespace
+        AND x.indisvalid
+        AND x.indisready
     ) AS "present"
   `;
   return rows[0]?.present === true;
 }
 
 /**
- * Collections whose document shows any of these images, by all six routes.
+ * Collections whose document shows any of these images, by all seven routes.
  *
- * Plans verified with EXPLAIN on a read replica: five legs are index probes
+ * Plans verified with EXPLAIN on a read replica. Five legs are single-index probes
  * (CollectionItem_imageId_lookup, CollectionItem_postId_lookup, CollectionItem_modelId,
- * CollectionItem_article_idx, CollectionItem_model3dId_idx). The sixth — the cover —
- * is included only when its index exists; see `coverIndexExists`.
+ * CollectionItem_model3dId_idx, and User_profilePictureId_key + Collection_userId_idx
+ * for the avatar). The article leg is NOT a probe — `CollectionItem_article_idx` is
+ * `("collectionId","articleId")` and nothing leads on `articleId`, so it scans that
+ * partial index (measured ~2,799 rows per outer row, against 2.00 for postId). It is
+ * bounded — the index is 7.7 MB — so it is kept rather than given an index of its own.
+ * The cover leg is included only when its index is valid; see `coverIndexExists`.
  */
 function imageLegsSql(imageIds: number[], cap: number, includeCover: boolean) {
   const ids = Prisma.join(imageIds);
@@ -171,79 +191,70 @@ function imageLegsSql(imageIds: number[], cap: number, includeCover: boolean) {
       SELECT ci."collectionId" FROM "CollectionItem" ci
         WHERE ci."model3dId" IN (
           SELECT m3.id FROM "Model3D" m3 WHERE m3."thumbnailImageId" IN (${ids}))
+      UNION
+      SELECT c.id AS "collectionId" FROM "Collection" c
+        JOIN "User" u ON u.id = c."userId"
+        WHERE u."profilePictureId" IN (${ids})
     ) x
     LIMIT ${cap + 1}
   `;
 }
 
 /**
- * Resolve the collections whose documents show the given models/images.
+ * Resolve the collections whose documents show any of the given images.
  *
  * Reads through `dbWrite` so a just-committed transaction is visible — the replica may
  * still be behind, and a missed row here is a permanently stale document, not a late
- * one. Never throws: a caller on a hard-delete path runs this immediately before its
- * delete, so an exception would cancel the deletion the user actually asked for.
+ * one. Never throws: callers run this immediately before their delete, so an exception
+ * would cancel the deletion the user actually asked for.
  */
-export async function getCollectionIdsForMedia({
-  modelIds = [],
-  imageIds = [],
+export async function getCollectionIdsForImages({
+  imageIds,
   source = 'unknown',
   cap = DEFAULT_COLLECTION_CAP,
 }: {
-  modelIds?: number[];
-  imageIds?: number[];
+  imageIds: number[];
   source?: string;
   cap?: number;
 }): Promise<CollectionsToRebuild> {
-  const uniqueModelIds = [...new Set(modelIds)];
   const uniqueImageIds = [...new Set(imageIds)];
-  if (!uniqueModelIds.length && !uniqueImageIds.length) return EMPTY;
+  if (!uniqueImageIds.length) return EMPTY;
 
-  // Each media kind is resolved by its own statement and caught separately: a failure
-  // resolving images must not discard collections already found for models. Losing
-  // half the answer is worse than reporting the half we have, because the half we have
-  // is still correct.
-  const rows: { collectionId: number }[] = [];
-
-  if (uniqueModelIds.length) {
-    try {
-      rows.push(...(await modelLegSql(uniqueModelIds, cap)));
-    } catch (error) {
-      logFailure(
-        'collection-media-index-resolve-failed',
-        source,
-        'failed to resolve collections for removed models',
-        error
-      );
-    }
+  // 🔴 The catalog probe gets its OWN catch. Six of the seven legs do not depend on the
+  // cover index, so a timeout or connection blip on this one extra round-trip must not
+  // decide whether they run at all — inside the outer try it would send the whole
+  // resolve to the catch and return nothing.
+  let withCover = false;
+  try {
+    withCover = await coverIndexExists();
+  } catch (error) {
+    logFailure(
+      'collection-media-index-cover-probe-failed',
+      source,
+      `could not determine whether "${COVER_INDEX_NAME}" is usable; continuing without the cover leg`,
+      error
+    );
   }
 
-  if (uniqueImageIds.length) {
-    try {
-      const withCover = await coverIndexExists();
-      if (!withCover)
-        logToAxiom({
-          type: 'warning',
-          name: 'collection-media-index-cover-leg-skipped',
-          message: `${source}: "${COVER_INDEX_NAME}" is missing, so collections whose COVER is a removed image are not being re-indexed. Apply the migration that creates it.`,
-          source,
-        }).catch(() => undefined);
-      rows.push(...(await imageLegsSql(uniqueImageIds, cap, withCover)));
-    } catch (error) {
-      logFailure(
-        'collection-media-index-resolve-failed',
-        source,
-        'failed to resolve collections for removed images',
-        error
-      );
-    }
-  }
+  if (!withCover)
+    logToAxiom({
+      type: 'warning',
+      name: 'collection-media-index-cover-leg-skipped',
+      message: `${source}: "${COVER_INDEX_NAME}" is not present and valid, so collections whose COVER is a removed image are not being re-indexed. Apply the migration that creates it.`,
+      source,
+    }).catch(() => undefined);
 
-  // Checking the union is enough to catch a truncating leg, even though each statement
-  // is capped independently: a leg that truncated returns exactly `cap + 1` distinct
-  // ids, so the union is always at least `cap + 1` and `applyCap` sees it. What is NOT
-  // recoverable is the magnitude — hence `truncated`, not a count.
-  return applyCap(rows, cap);
+  try {
+    return applyCap(await imageLegsSql(uniqueImageIds, cap, withCover), cap);
+  } catch (error) {
+    logFailure(
+      'collection-media-index-resolve-failed',
+      source,
+      'failed to resolve collections for removed images',
+      error
+    );
+    return EMPTY;
+  }
 }
 
 /**
@@ -322,7 +333,7 @@ export async function enqueueCollectionRebuild({
   source,
   cap = DEFAULT_COLLECTION_CAP,
 }: CollectionsToRebuild & {
-  /** Names the removal path in logs, e.g. 'model-delete'. */
+  /** Names the removal path in logs, e.g. 'image-delete'. */
   source: string;
   cap?: number;
 }) {
@@ -358,23 +369,4 @@ export async function enqueueCollectionRebuild({
     }).catch(() => undefined);
 
   return { queued: collectionIds.length, truncated };
-}
-
-/**
- * Resolve + enqueue in one step, for the paths whose membership rows survive the
- * removal (a soft delete, an unpublish).
- */
-export async function queueCollectionsForMedia({
-  modelIds = [],
-  imageIds = [],
-  source,
-  cap = DEFAULT_COLLECTION_CAP,
-}: {
-  modelIds?: number[];
-  imageIds?: number[];
-  source: string;
-  cap?: number;
-}) {
-  const resolved = await getCollectionIdsForMedia({ modelIds, imageIds, source, cap });
-  return enqueueCollectionRebuild({ ...resolved, source, cap });
 }

--- a/src/server/services/collection-media-index.ts
+++ b/src/server/services/collection-media-index.ts
@@ -36,6 +36,23 @@ import { collectionsSearchIndex } from '~/server/search-index';
 //      (fetched by a separate `db.image.findMany` in pullData and shipped as
 //       `user.profilePicture` on EVERY collection document — not a CTE at all)
 //
+// ⚠️ ROUTE 7 IS NARROWER THAN THE OTHER SIX, AND ONLY COVERS DELETING A *LIVE* AVATAR.
+// It matches `u."profilePictureId" IN (ids)`, i.e. images that are SOMEONE'S AVATAR
+// RIGHT NOW. The usual way an avatar image dies is the deferred reaper, and that path
+// cannot match: `remove-replaced-images` calls `getStillReferencedImageIds`, which
+// filters out every id that is still a `profilePictureId`, before it calls
+// `deleteImages`. So for a REPLACED avatar this leg resolves zero collections, by
+// construction, every time. `deleteUser` is the same shape — it deletes the user's
+// collections before their images.
+//
+// The gap that leaves is real and is NOT closed here: a user changes their avatar, the
+// old Image row and its object are destroyed 30 days later, and every collection they
+// own still ships `user.profilePicture` pointing at a dead url. Closing it needs an
+// enqueue at REPLACEMENT time, which is a different trigger from removal and outside
+// what this module is wired to. Tracked separately. The leg is kept because it is
+// correct for the case it does match (a moderator or ingestion delete of a live
+// avatar) and costs ~28, bounded because `profilePictureId` is `@unique`.
+//
 // Route 6 is the one that matters most on screen: CollectionCard renders
 // `if (data.image) return [data.image]`, so a cover WINS over every item image, and
 // most public collections with a cover use one that is not among their own items.
@@ -157,8 +174,8 @@ async function coverIndexExists() {
  * CollectionItem_model3dId_idx, and User_profilePictureId_key + Collection_userId_idx
  * for the avatar). The article leg is NOT a probe — `CollectionItem_article_idx` is
  * `("collectionId","articleId")` and nothing leads on `articleId`, so it scans that
- * partial index (measured ~2,799 rows per outer row, against 2.00 for postId). It is
- * bounded — the index is 7.7 MB — so it is kept rather than given an index of its own.
+ * partial index: row estimate 271 per outer row, against 6 for the postId leg. It is
+ * bounded — the index is 7,712 kB — so it is kept rather than given one of its own.
  * The cover leg is included only when its index is valid; see `coverIndexExists`.
  */
 function imageLegsSql(imageIds: number[], cap: number, includeCover: boolean) {

--- a/src/server/services/collection-media-index.ts
+++ b/src/server/services/collection-media-index.ts
@@ -34,8 +34,15 @@ import { collectionsSearchIndex } from '~/server/search-index';
 // `CollectionItem.modelId` / `.imageId` are both `onDelete: Cascade`, so on a HARD
 // delete the membership rows disappear with the row that owned them. Callers on a
 // hard-delete path must therefore resolve ids BEFORE the delete; a soft delete or an
-// unpublish leaves the rows in place and can resolve after. Both columns carry a hash
-// index, so the lookup is a straight index probe.
+// unpublish leaves the rows in place and can resolve after.
+//
+// Each column is separately indexed in the live database — "CollectionItem_modelId"
+// and "CollectionItem_imageId_lookup", both BTREE. (The Prisma schema annotates these
+// `type: Hash`; the deployed indexes are btree, and it is the deployed ones the
+// planner uses.) An index is only reached when a statement constrains ONE of the two
+// columns, which is why every query below keeps them in separate statements or
+// separate UNION legs rather than joining them with `OR` — see the note on
+// `getCollectionIdsForModelCascade`.
 const DEFAULT_COLLECTION_CAP = 10_000;
 
 // One enqueue writes its ids into a Redis queue as a single command. Chunking keeps
@@ -43,6 +50,19 @@ const DEFAULT_COLLECTION_CAP = 10_000;
 // case rather than sending one enormous payload.
 const ENQUEUE_BATCH_SIZE = 500;
 
+/**
+ * `dropped` is a LOWER BOUND on the collections left un-queued, never an exact count.
+ *
+ * Every lookup stops at `LIMIT cap + 1`, so the largest overflow any of them can
+ * observe is one — the query is deliberately not in a position to learn the true
+ * total, and paying for it would mean removing the cap that makes these safe. The
+ * multi-column case compounds it: `getCollectionIdsForMedia` runs one statement per
+ * column, each independently capped, so both can truncate before the union is formed.
+ *
+ * `dropped > 0` is still an exact signal that something was dropped: a truncating leg
+ * returns `cap + 1` distinct ids, so the union is always at least `cap + 1`. Only the
+ * magnitude is unknown, which is why the warning is worded "at least N".
+ */
 export type CollectionsToRebuild = { collectionIds: number[]; dropped: number };
 
 const EMPTY: CollectionsToRebuild = { collectionIds: [], dropped: 0 };
@@ -90,7 +110,10 @@ export async function getCollectionIdsForMedia({
     // DISTINCT COLLECTIONS. Prisma's `distinct` has historically been applied after
     // the rows come back, which would make `take` a cap on membership ROWS instead —
     // a handful of huge collections could then exhaust it while naming few documents.
-    // One statement per column so each uses its own hash index.
+    // One statement per column, never one statement with an `OR` across both: a
+    // two-column `OR` is non-sargable and costs a full index scan of a ~208M-row
+    // table (the note on `getCollectionIdsForModelCascade` has the measurements).
+    // Each statement here is independently capped, so `dropped` is a lower bound.
     if (uniqueModelIds.length)
       rows.push(
         ...(await dbWrite.$queryRaw<{ collectionId: number }[]>`
@@ -143,11 +166,30 @@ export async function getCollectionIdsForModelCascade({
   cap?: number;
 }): Promise<CollectionsToRebuild> {
   try {
+    // 🔴 The two columns MUST stay in separate UNIONed legs. Bridging them with a
+    // single `OR` makes the predicate non-sargable on a ~208M-row table: Postgres can
+    // then use NEITHER "CollectionItem_modelId" NOR "CollectionItem_imageId_lookup",
+    // and falls back to scanning an unrelated index
+    // ("CollectionItem_unique_entity_with_model3d_key") end to end with the whole
+    // condition as a post-scan Filter — an estimated 43.3M rows, total cost 3,336,745.
+    // The `LIMIT` does not rescue it: its own node estimates 309,852 on the assumption
+    // that the cap fills early, but for the ordinary case of a model in a handful of
+    // collections the de-duplication cannot conclude until the scan is essentially
+    // exhausted, so the realistic figure is the full one.
+    //
+    // Split into legs, each probes its own index: total cost 73.76, both legs
+    // index-only scans. Verified to survive parameterisation, which is what Prisma
+    // actually sends — the generic plan keeps both index conditions
+    // ("modelId" = $1, "imageId" = i.id) at cost 74.52.
+    //
+    // Plans read with EXPLAIN (no ANALYZE) against a read replica. This query runs on
+    // the permanent-delete path.
     const rows = await dbWrite.$queryRaw<{ collectionId: number }[]>`
-      SELECT DISTINCT ci."collectionId"
-      FROM "CollectionItem" ci
-      WHERE ci."modelId" = ${modelId}
-         OR ci."imageId" IN (
+      SELECT DISTINCT x."collectionId" FROM (
+        SELECT ci."collectionId" FROM "CollectionItem" ci WHERE ci."modelId" = ${modelId}
+        UNION
+        SELECT ci."collectionId" FROM "CollectionItem" ci
+        WHERE ci."imageId" IN (
               SELECT i.id
               FROM "Image" i
               JOIN "Post" p ON p.id = i."postId"
@@ -155,6 +197,7 @@ export async function getCollectionIdsForModelCascade({
               JOIN "Model" m ON m.id = mv."modelId" AND m."userId" = p."userId"
               WHERE mv."modelId" = ${modelId}
             )
+      ) x
       LIMIT ${cap + 1}
     `;
     return applyCap(rows, cap);
@@ -206,11 +249,13 @@ export async function enqueueCollectionRebuild({
 
   if (dropped > 0)
     // Named, not silent: past the cap those documents stay stale until a full
-    // reindex, and nobody can notice that from an absent log line.
+    // reindex, and nobody can notice that from an absent log line. "at least" is
+    // load-bearing — see the note on CollectionsToRebuild; the true overflow is
+    // capped out of view, so an exact figure here would be a fabricated one.
     logToAxiom({
       type: 'warning',
       name: 'collection-media-index-enqueue-truncated',
-      message: `${source}: capped at ${cap} collections; ${dropped} more remain stale until a full reindex.`,
+      message: `${source}: capped at ${cap} collections; at least ${dropped} more remain stale until a full reindex.`,
       source,
       cap,
       dropped,

--- a/src/server/services/collection-media-index.ts
+++ b/src/server/services/collection-media-index.ts
@@ -204,7 +204,6 @@ export async function getCollectionIdsForMedia({
   // half the answer is worse than reporting the half we have, because the half we have
   // is still correct.
   const rows: { collectionId: number }[] = [];
-  let truncated = false;
 
   if (uniqueModelIds.length) {
     try {
@@ -240,10 +239,11 @@ export async function getCollectionIdsForMedia({
     }
   }
 
-  const capped = applyCap(rows, cap);
-  // Either statement can independently hit its own `LIMIT cap + 1`, so the union may
-  // already be short before `applyCap` ever sees it.
-  return { ...capped, truncated: capped.truncated || truncated };
+  // Checking the union is enough to catch a truncating leg, even though each statement
+  // is capped independently: a leg that truncated returns exactly `cap + 1` distinct
+  // ids, so the union is always at least `cap + 1` and `applyCap` sees it. What is NOT
+  // recoverable is the magnitude — hence `truncated`, not a count.
+  return applyCap(rows, cap);
 }
 
 /**

--- a/src/server/services/collection-media-index.ts
+++ b/src/server/services/collection-media-index.ts
@@ -1,0 +1,239 @@
+import { Prisma } from '@prisma/client';
+import { chunk } from 'lodash-es';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { dbWrite } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
+import { collectionsSearchIndex } from '~/server/search-index';
+
+// Removing a model or an image leaves every collection that contained it holding a
+// stale denormalized snapshot, and nothing about the removal reaches the collections
+// index on its own: `prepareBatches` in collections.search-index.ts filters on
+// `c."createdAt" >= lastUpdatedAt`, so the incremental sweep only ever sees NEWLY
+// CREATED collections. That `createdAt` filter is deliberate (it stops an old edit
+// triggering a full reindex) and is not the thing to change — an existing collection
+// is only revisited via an explicit enqueue, so the enqueue is what was missing.
+//
+// `Update`, never `Delete`: the collection still exists, only its document needs
+// rebuilding. The index resolves item images by joining live `Image`/`Post`/
+// `ModelVersion`/`Model`, so re-running it over the collection drops the vanished
+// image on its own — the document self-heals. A `Delete` would evict a collection
+// that is still perfectly real.
+//
+// This is a LEAF module on purpose. It is imported by both model.service and
+// image.service, and its sibling collection-index-sync.ts already imports
+// image.service (for `queueImageSearchIndexUpdate`) — putting these functions there
+// would make image.service import a module that imports image.service back. Nothing
+// here imports another service, so no cycle is possible from either caller.
+//
+// EVERY exported function here is non-throwing by contract. They are bookkeeping for
+// a search index, called around deletes that have either already committed or are
+// about to; a failure must cost a stale document, never the user's delete. Failures
+// are logged rather than swallowed, because silence is indistinguishable from "this
+// model was in no collections".
+
+// `CollectionItem.modelId` / `.imageId` are both `onDelete: Cascade`, so on a HARD
+// delete the membership rows disappear with the row that owned them. Callers on a
+// hard-delete path must therefore resolve ids BEFORE the delete; a soft delete or an
+// unpublish leaves the rows in place and can resolve after. Both columns carry a hash
+// index, so the lookup is a straight index probe.
+const DEFAULT_COLLECTION_CAP = 10_000;
+
+// One enqueue writes its ids into a Redis queue as a single command. Chunking keeps
+// that command bounded for the pathological "model is in thousands of collections"
+// case rather than sending one enormous payload.
+const ENQUEUE_BATCH_SIZE = 500;
+
+export type CollectionsToRebuild = { collectionIds: number[]; dropped: number };
+
+const EMPTY: CollectionsToRebuild = { collectionIds: [], dropped: 0 };
+
+function applyCap(rows: { collectionId: number }[], cap: number): CollectionsToRebuild {
+  const collectionIds = [...new Set(rows.map((r) => r.collectionId))];
+  return {
+    collectionIds: collectionIds.slice(0, cap),
+    dropped: Math.max(0, collectionIds.length - cap),
+  };
+}
+
+function logFailure(name: string, source: string, message: string, error: unknown) {
+  logToAxiom({ type: 'error', name, message: `${source}: ${message}`, source, error }).catch(
+    () => undefined
+  );
+}
+
+/**
+ * Resolve the collections that contain the given models/images.
+ *
+ * Reads through `dbWrite` so a just-committed transaction is visible — the replica may
+ * still be behind, and a missed row here is a permanently stale document, not a late
+ * one. Never throws: a caller on a hard-delete path runs this immediately before its
+ * delete, so an exception would cancel the deletion the user actually asked for.
+ */
+export async function getCollectionIdsForMedia({
+  modelIds = [],
+  imageIds = [],
+  source = 'unknown',
+  cap = DEFAULT_COLLECTION_CAP,
+}: {
+  modelIds?: number[];
+  imageIds?: number[];
+  source?: string;
+  cap?: number;
+}): Promise<CollectionsToRebuild> {
+  const uniqueModelIds = [...new Set(modelIds)];
+  const uniqueImageIds = [...new Set(imageIds)];
+  if (!uniqueModelIds.length && !uniqueImageIds.length) return EMPTY;
+
+  try {
+    const rows: { collectionId: number }[] = [];
+    // Raw DISTINCT rather than Prisma's `distinct`, because the cap has to apply to
+    // DISTINCT COLLECTIONS. Prisma's `distinct` has historically been applied after
+    // the rows come back, which would make `take` a cap on membership ROWS instead —
+    // a handful of huge collections could then exhaust it while naming few documents.
+    // One statement per column so each uses its own hash index.
+    if (uniqueModelIds.length)
+      rows.push(
+        ...(await dbWrite.$queryRaw<{ collectionId: number }[]>`
+          SELECT DISTINCT "collectionId" FROM "CollectionItem"
+          WHERE "modelId" IN (${Prisma.join(uniqueModelIds)})
+          LIMIT ${cap + 1}
+        `)
+      );
+    if (uniqueImageIds.length)
+      rows.push(
+        ...(await dbWrite.$queryRaw<{ collectionId: number }[]>`
+          SELECT DISTINCT "collectionId" FROM "CollectionItem"
+          WHERE "imageId" IN (${Prisma.join(uniqueImageIds)})
+          LIMIT ${cap + 1}
+        `)
+      );
+
+    return applyCap(rows, cap);
+  } catch (error) {
+    logFailure(
+      'collection-media-index-resolve-failed',
+      source,
+      'failed to resolve collections for removed media',
+      error
+    );
+    return EMPTY;
+  }
+}
+
+/**
+ * Resolve the collections a PERMANENT model delete will orphan — both the model's own
+ * membership and that of every gallery image the cascade takes with it.
+ *
+ * Must be called BEFORE the deleting transaction. `CollectionItem` cascades from both
+ * `Model` and `Image`, so after the commit there is nothing left to resolve; and it
+ * cannot be moved inside the transaction either, because a failed statement aborts a
+ * Postgres transaction outright — a hiccup in this bookkeeping read would take the
+ * whole delete down with it. Run outside and non-throwing, it can only cost a reindex.
+ *
+ * The image sub-select mirrors the transaction's own post lookup (versions of this
+ * model, posts owned by the model's owner) so the two see the same image set.
+ */
+export async function getCollectionIdsForModelCascade({
+  modelId,
+  source = 'model-perma-delete',
+  cap = DEFAULT_COLLECTION_CAP,
+}: {
+  modelId: number;
+  source?: string;
+  cap?: number;
+}): Promise<CollectionsToRebuild> {
+  try {
+    const rows = await dbWrite.$queryRaw<{ collectionId: number }[]>`
+      SELECT DISTINCT ci."collectionId"
+      FROM "CollectionItem" ci
+      WHERE ci."modelId" = ${modelId}
+         OR ci."imageId" IN (
+              SELECT i.id
+              FROM "Image" i
+              JOIN "Post" p ON p.id = i."postId"
+              JOIN "ModelVersion" mv ON mv.id = p."modelVersionId"
+              JOIN "Model" m ON m.id = mv."modelId" AND m."userId" = p."userId"
+              WHERE mv."modelId" = ${modelId}
+            )
+      LIMIT ${cap + 1}
+    `;
+    return applyCap(rows, cap);
+  } catch (error) {
+    logFailure(
+      'collection-media-index-resolve-failed',
+      source,
+      `failed to resolve collections for model ${modelId}`,
+      error
+    );
+    return EMPTY;
+  }
+}
+
+/**
+ * Queue a rebuild of the given collections.
+ *
+ * Never throws: every caller runs this AFTER its delete has committed, so an exception
+ * would shortcut the cleanup steps that follow (S3 objects, bid cleanup, cache busts)
+ * and leak far more than a stale thumbnail.
+ */
+export async function enqueueCollectionRebuild({
+  collectionIds,
+  dropped = 0,
+  source,
+  cap = DEFAULT_COLLECTION_CAP,
+}: CollectionsToRebuild & {
+  /** Names the removal path in logs, e.g. 'model-delete'. */
+  source: string;
+  cap?: number;
+}) {
+  if (!collectionIds.length) return { queued: 0, dropped };
+
+  try {
+    for (const batch of chunk(collectionIds, ENQUEUE_BATCH_SIZE)) {
+      await collectionsSearchIndex.queueUpdate(
+        batch.map((id) => ({ id, action: SearchIndexUpdateQueueAction.Update }))
+      );
+    }
+  } catch (error) {
+    logFailure(
+      'collection-media-index-enqueue-failed',
+      source,
+      'failed to queue collection search index update',
+      error
+    );
+    return { queued: 0, dropped };
+  }
+
+  if (dropped > 0)
+    // Named, not silent: past the cap those documents stay stale until a full
+    // reindex, and nobody can notice that from an absent log line.
+    logToAxiom({
+      type: 'warning',
+      name: 'collection-media-index-enqueue-truncated',
+      message: `${source}: capped at ${cap} collections; ${dropped} more remain stale until a full reindex.`,
+      source,
+      cap,
+      dropped,
+    }).catch(() => undefined);
+
+  return { queued: collectionIds.length, dropped };
+}
+
+/**
+ * Resolve + enqueue in one step, for the paths whose membership rows survive the
+ * removal (a soft delete, an unpublish).
+ */
+export async function queueCollectionsForMedia({
+  modelIds = [],
+  imageIds = [],
+  source,
+  cap = DEFAULT_COLLECTION_CAP,
+}: {
+  modelIds?: number[];
+  imageIds?: number[];
+  source: string;
+  cap?: number;
+}) {
+  const resolved = await getCollectionIdsForMedia({ modelIds, imageIds, source, cap });
+  return enqueueCollectionRebuild({ ...resolved, source, cap });
+}

--- a/src/server/services/collection-media-index.ts
+++ b/src/server/services/collection-media-index.ts
@@ -2,87 +2,182 @@ import { Prisma } from '@prisma/client';
 import { chunk } from 'lodash-es';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbWrite } from '~/server/db/client';
-import { logToAxiom } from '~/server/logging/client';
+import { logToAxiom, safeError } from '~/server/logging/client';
 import { collectionsSearchIndex } from '~/server/search-index';
 
-// Removing a model or an image leaves every collection that contained it holding a
-// stale denormalized snapshot, and nothing about the removal reaches the collections
-// index on its own: `prepareBatches` in collections.search-index.ts filters on
+// Removing a model or an image leaves every collection that showed it holding a stale
+// denormalized snapshot, and nothing about the removal reaches the collections index
+// on its own: `prepareBatches` in collections.search-index.ts filters on
 // `c."createdAt" >= lastUpdatedAt`, so the incremental sweep only ever sees NEWLY
 // CREATED collections. That `createdAt` filter is deliberate (it stops an old edit
 // triggering a full reindex) and is not the thing to change — an existing collection
 // is only revisited via an explicit enqueue, so the enqueue is what was missing.
 //
 // `Update`, never `Delete`: the collection still exists, only its document needs
-// rebuilding. The index resolves item images by joining live `Image`/`Post`/
-// `ModelVersion`/`Model`, so re-running it over the collection drops the vanished
-// image on its own — the document self-heals. A `Delete` would evict a collection
-// that is still perfectly real.
+// rebuilding. A `Delete` would evict a collection that is still perfectly real.
+//
+// 🔴 AN IMAGE REACHES A COLLECTION DOCUMENT BY SIX ROUTES, ONLY ONE OF WHICH IS A
+// `CollectionItem.imageId` ROW. Resolving by that column alone — the obvious reading —
+// misses five of them, including the two most common. Enumerated from the index's own
+// CTEs (collections.search-index.ts) plus the document's cover field:
+//
+//   1. imageItemImage    CollectionItem.imageId  -> the image directly
+//   2. postItemImage     CollectionItem.postId   -> that post's FIRST image
+//   3. modelItemImage    CollectionItem.modelId  -> image -> Post -> ModelVersion -> Model
+//   4. articleItemImage  CollectionItem.articleId-> Article.coverId
+//   5. model3dItemImage  CollectionItem.model3dId-> Model3D.thumbnailImageId
+//   6. the collection's own cover, Collection.imageId (SetNull, not a CollectionItem)
+//
+// Route 6 is the one that matters most on screen: CollectionCard renders
+// `if (data.image) return [data.image]`, so a cover WINS over every item image, and
+// most public collections with a cover use one that is not among their own items.
+//
+// The joins below mirror the CTEs' own conditions — including `m."userId" =
+// p."userId"` — so this and the index agree on which image a collection would show.
 //
 // This is a LEAF module on purpose. It is imported by both model.service and
 // image.service, and its sibling collection-index-sync.ts already imports
-// image.service (for `queueImageSearchIndexUpdate`) — putting these functions there
+// image.service (for `queueImageSearchIndexUpdate`), so putting these functions there
 // would make image.service import a module that imports image.service back. Nothing
 // here imports another service, so no cycle is possible from either caller.
 //
-// EVERY exported function here is non-throwing by contract. They are bookkeeping for
-// a search index, called around deletes that have either already committed or are
-// about to; a failure must cost a stale document, never the user's delete. Failures
-// are logged rather than swallowed, because silence is indistinguishable from "this
-// model was in no collections".
+// EVERY exported function is non-throwing by contract. They are bookkeeping for a
+// search index, called around deletes that have either already committed or are about
+// to; a failure must cost a stale document, never the user's delete. Failures are
+// logged rather than swallowed, because silence is indistinguishable from "this model
+// was in no collections".
 
-// `CollectionItem.modelId` / `.imageId` are both `onDelete: Cascade`, so on a HARD
-// delete the membership rows disappear with the row that owned them. Callers on a
-// hard-delete path must therefore resolve ids BEFORE the delete; a soft delete or an
+// `CollectionItem.modelId` / `.postId` / `.imageId` are all `onDelete: Cascade`, so on
+// a HARD delete the membership rows disappear with the row that owned them. Callers on
+// a hard-delete path must therefore resolve ids BEFORE the delete; a soft delete or an
 // unpublish leaves the rows in place and can resolve after.
 //
-// Each column is separately indexed in the live database — "CollectionItem_modelId"
-// and "CollectionItem_imageId_lookup", both BTREE. (The Prisma schema annotates these
-// `type: Hash`; the deployed indexes are btree, and it is the deployed ones the
-// planner uses.) An index is only reached when a statement constrains ONE of the two
-// columns, which is why every query below keeps them in separate statements or
-// separate UNION legs rather than joining them with `OR` — see the note on
-// `getCollectionIdsForModelCascade`.
+// 🔴 EVERY LEG MUST BE INDEPENDENTLY INDEXABLE. Bridging two columns with an `OR`
+// makes the predicate non-sargable and costs a full scan of a ~208M-row table, so the
+// legs stay in separate UNION branches and each was checked to produce its own index
+// scan. Do not merge them back into one `WHERE ... OR ...`.
 const DEFAULT_COLLECTION_CAP = 10_000;
 
 // One enqueue writes its ids into a Redis queue as a single command. Chunking keeps
-// that command bounded for the pathological "model is in thousands of collections"
-// case rather than sending one enormous payload.
+// that command bounded for the pathological "model is in tens of thousands of
+// collections" case rather than sending one enormous payload.
 const ENQUEUE_BATCH_SIZE = 500;
 
 /**
- * `dropped` is a LOWER BOUND on the collections left un-queued, never an exact count.
+ * `truncated` says only THAT the cap was reached, never by how much.
  *
  * Every lookup stops at `LIMIT cap + 1`, so the largest overflow any of them can
  * observe is one — the query is deliberately not in a position to learn the true
- * total, and paying for it would mean removing the cap that makes these safe. The
- * multi-column case compounds it: `getCollectionIdsForMedia` runs one statement per
- * column, each independently capped, so both can truncate before the union is formed.
- *
- * `dropped > 0` is still an exact signal that something was dropped: a truncating leg
- * returns `cap + 1` distinct ids, so the union is always at least `cap + 1`. Only the
- * magnitude is unknown, which is why the warning is worded "at least N".
+ * total. Reporting a number here would mean reporting `1` in exactly the case the
+ * warning exists for: real models sit far past the cap (measured: one in 86,153
+ * distinct collections), so "1 more is stale" would understate by five orders of
+ * magnitude. The overflow is unknown, and the warning says so.
  */
-export type CollectionsToRebuild = { collectionIds: number[]; dropped: number };
+export type CollectionsToRebuild = { collectionIds: number[]; truncated: boolean };
 
-const EMPTY: CollectionsToRebuild = { collectionIds: [], dropped: 0 };
+const EMPTY: CollectionsToRebuild = { collectionIds: [], truncated: false };
 
 function applyCap(rows: { collectionId: number }[], cap: number): CollectionsToRebuild {
   const collectionIds = [...new Set(rows.map((r) => r.collectionId))];
-  return {
-    collectionIds: collectionIds.slice(0, cap),
-    dropped: Math.max(0, collectionIds.length - cap),
-  };
+  return { collectionIds: collectionIds.slice(0, cap), truncated: collectionIds.length > cap };
 }
 
 function logFailure(name: string, source: string, message: string, error: unknown) {
-  logToAxiom({ type: 'error', name, message: `${source}: ${message}`, source, error }).catch(
-    () => undefined
-  );
+  // `safeError`, never the raw Error: `logToAxiom` JSON.stringifies its payload and a
+  // bare Error serialises to `{}`, which would record that something failed while
+  // discarding the only part worth logging.
+  logToAxiom({
+    type: 'error',
+    name,
+    message: `${source}: ${message}`,
+    source,
+    error: safeError(error),
+  }).catch(() => undefined);
+}
+
+/** Collections holding these models as items. Membership rows only — a model item's
+ * gallery image is resolved from the model, so no image walk is needed here. */
+function modelLegSql(modelIds: number[], cap: number) {
+  return dbWrite.$queryRaw<{ collectionId: number }[]>`
+    SELECT DISTINCT "collectionId" FROM "CollectionItem"
+    WHERE "modelId" IN (${Prisma.join(modelIds)})
+    LIMIT ${cap + 1}
+  `;
+}
+
+export const COVER_INDEX_NAME = 'Collection_imageId_idx';
+
+/**
+ * Is the cover leg's index present?
+ *
+ * 🔴 The cover leg is GATED on this, because without the index it is a parallel
+ * sequential scan of a ~17.3M-row / 4.9 GB table — measured cost 451,531, against
+ * ~10,000 for every other leg of the same query combined — on a user-facing delete
+ * path, and `deleteImages` would pay it once per 100-image batch. Migrations here are
+ * applied by hand, so "the migration ships in the same PR" does not mean the index
+ * exists when this code first runs; the gate is what makes that ordering safe rather
+ * than merely documented.
+ *
+ * A catalog lookup, not a cached flag: it is an index probe on pg_class costing far
+ * less than the six-leg query it guards, and re-reading it means the leg starts
+ * working the moment the migration is applied, with no deploy or restart.
+ *
+ * Once the index exists in every environment, this gate and its branch can be deleted.
+ */
+async function coverIndexExists() {
+  const rows = await dbWrite.$queryRaw<{ present: boolean }[]>`
+    SELECT EXISTS (
+      SELECT 1 FROM pg_class WHERE relname = ${COVER_INDEX_NAME} AND relkind = 'i'
+    ) AS "present"
+  `;
+  return rows[0]?.present === true;
 }
 
 /**
- * Resolve the collections that contain the given models/images.
+ * Collections whose document shows any of these images, by all six routes.
+ *
+ * Plans verified with EXPLAIN on a read replica: five legs are index probes
+ * (CollectionItem_imageId_lookup, CollectionItem_postId_lookup, CollectionItem_modelId,
+ * CollectionItem_article_idx, CollectionItem_model3dId_idx). The sixth — the cover —
+ * is included only when its index exists; see `coverIndexExists`.
+ */
+function imageLegsSql(imageIds: number[], cap: number, includeCover: boolean) {
+  const ids = Prisma.join(imageIds);
+  const coverLeg = includeCover
+    ? Prisma.sql`
+      UNION
+      SELECT c.id AS "collectionId" FROM "Collection" c WHERE c."imageId" IN (${ids})`
+    : Prisma.empty;
+  return dbWrite.$queryRaw<{ collectionId: number }[]>`
+    SELECT DISTINCT x."collectionId" FROM (
+      SELECT ci."collectionId" FROM "CollectionItem" ci WHERE ci."imageId" IN (${ids})
+      ${coverLeg}
+      UNION
+      SELECT ci."collectionId" FROM "CollectionItem" ci
+        WHERE ci."postId" IN (
+          SELECT i."postId" FROM "Image" i WHERE i.id IN (${ids}) AND i."postId" IS NOT NULL)
+      UNION
+      SELECT ci."collectionId" FROM "CollectionItem" ci
+        WHERE ci."modelId" IN (
+          SELECT m.id FROM "Image" i
+          JOIN "Post" p ON p.id = i."postId"
+          JOIN "ModelVersion" mv ON mv.id = p."modelVersionId"
+          JOIN "Model" m ON m.id = mv."modelId" AND m."userId" = p."userId"
+          WHERE i.id IN (${ids}))
+      UNION
+      SELECT ci."collectionId" FROM "CollectionItem" ci
+        WHERE ci."articleId" IN (SELECT a.id FROM "Article" a WHERE a."coverId" IN (${ids}))
+      UNION
+      SELECT ci."collectionId" FROM "CollectionItem" ci
+        WHERE ci."model3dId" IN (
+          SELECT m3.id FROM "Model3D" m3 WHERE m3."thumbnailImageId" IN (${ids}))
+    ) x
+    LIMIT ${cap + 1}
+  `;
+}
+
+/**
+ * Resolve the collections whose documents show the given models/images.
  *
  * Reads through `dbWrite` so a just-committed transaction is visible — the replica may
  * still be behind, and a missed row here is a permanently stale document, not a late
@@ -104,57 +199,67 @@ export async function getCollectionIdsForMedia({
   const uniqueImageIds = [...new Set(imageIds)];
   if (!uniqueModelIds.length && !uniqueImageIds.length) return EMPTY;
 
-  try {
-    const rows: { collectionId: number }[] = [];
-    // Raw DISTINCT rather than Prisma's `distinct`, because the cap has to apply to
-    // DISTINCT COLLECTIONS. Prisma's `distinct` has historically been applied after
-    // the rows come back, which would make `take` a cap on membership ROWS instead —
-    // a handful of huge collections could then exhaust it while naming few documents.
-    // One statement per column, never one statement with an `OR` across both: a
-    // two-column `OR` is non-sargable and costs a full index scan of a ~208M-row
-    // table (the note on `getCollectionIdsForModelCascade` has the measurements).
-    // Each statement here is independently capped, so `dropped` is a lower bound.
-    if (uniqueModelIds.length)
-      rows.push(
-        ...(await dbWrite.$queryRaw<{ collectionId: number }[]>`
-          SELECT DISTINCT "collectionId" FROM "CollectionItem"
-          WHERE "modelId" IN (${Prisma.join(uniqueModelIds)})
-          LIMIT ${cap + 1}
-        `)
-      );
-    if (uniqueImageIds.length)
-      rows.push(
-        ...(await dbWrite.$queryRaw<{ collectionId: number }[]>`
-          SELECT DISTINCT "collectionId" FROM "CollectionItem"
-          WHERE "imageId" IN (${Prisma.join(uniqueImageIds)})
-          LIMIT ${cap + 1}
-        `)
-      );
+  // Each media kind is resolved by its own statement and caught separately: a failure
+  // resolving images must not discard collections already found for models. Losing
+  // half the answer is worse than reporting the half we have, because the half we have
+  // is still correct.
+  const rows: { collectionId: number }[] = [];
+  let truncated = false;
 
-    return applyCap(rows, cap);
-  } catch (error) {
-    logFailure(
-      'collection-media-index-resolve-failed',
-      source,
-      'failed to resolve collections for removed media',
-      error
-    );
-    return EMPTY;
+  if (uniqueModelIds.length) {
+    try {
+      rows.push(...(await modelLegSql(uniqueModelIds, cap)));
+    } catch (error) {
+      logFailure(
+        'collection-media-index-resolve-failed',
+        source,
+        'failed to resolve collections for removed models',
+        error
+      );
+    }
   }
+
+  if (uniqueImageIds.length) {
+    try {
+      const withCover = await coverIndexExists();
+      if (!withCover)
+        logToAxiom({
+          type: 'warning',
+          name: 'collection-media-index-cover-leg-skipped',
+          message: `${source}: "${COVER_INDEX_NAME}" is missing, so collections whose COVER is a removed image are not being re-indexed. Apply the migration that creates it.`,
+          source,
+        }).catch(() => undefined);
+      rows.push(...(await imageLegsSql(uniqueImageIds, cap, withCover)));
+    } catch (error) {
+      logFailure(
+        'collection-media-index-resolve-failed',
+        source,
+        'failed to resolve collections for removed images',
+        error
+      );
+    }
+  }
+
+  const capped = applyCap(rows, cap);
+  // Either statement can independently hit its own `LIMIT cap + 1`, so the union may
+  // already be short before `applyCap` ever sees it.
+  return { ...capped, truncated: capped.truncated || truncated };
 }
 
 /**
- * Resolve the collections a PERMANENT model delete will orphan — both the model's own
- * membership and that of every gallery image the cascade takes with it.
+ * Resolve the collections a PERMANENT model delete will orphan — the model's own
+ * membership, plus the posts and gallery images the cascade takes with it.
  *
- * Must be called BEFORE the deleting transaction. `CollectionItem` cascades from both
- * `Model` and `Image`, so after the commit there is nothing left to resolve; and it
- * cannot be moved inside the transaction either, because a failed statement aborts a
- * Postgres transaction outright — a hiccup in this bookkeeping read would take the
- * whole delete down with it. Run outside and non-throwing, it can only cost a reindex.
+ * Must be called BEFORE the deleting transaction. `CollectionItem` cascades from
+ * `Model`, `Post` AND `Image`, so after the commit there is nothing left to resolve;
+ * and it cannot be moved inside the transaction either, because a failed statement
+ * aborts a Postgres transaction outright — a hiccup in this bookkeeping read would
+ * take the whole delete down with it. Run outside and non-throwing, it can only cost
+ * a reindex.
  *
- * The image sub-select mirrors the transaction's own post lookup (versions of this
- * model, posts owned by the model's owner) so the two see the same image set.
+ * The post and image sub-selects mirror the deleting transaction's own lookups
+ * (versions of this model, posts owned by the model's owner) so the two agree on
+ * which rows are going away.
  */
 export async function getCollectionIdsForModelCascade({
   modelId,
@@ -166,37 +271,29 @@ export async function getCollectionIdsForModelCascade({
   cap?: number;
 }): Promise<CollectionsToRebuild> {
   try {
-    // 🔴 The two columns MUST stay in separate UNIONed legs. Bridging them with a
-    // single `OR` makes the predicate non-sargable on a ~208M-row table: Postgres can
-    // then use NEITHER "CollectionItem_modelId" NOR "CollectionItem_imageId_lookup",
-    // and falls back to scanning an unrelated index
-    // ("CollectionItem_unique_entity_with_model3d_key") end to end with the whole
-    // condition as a post-scan Filter — an estimated 43.3M rows, total cost 3,336,745.
-    // The `LIMIT` does not rescue it: its own node estimates 309,852 on the assumption
-    // that the cap fills early, but for the ordinary case of a model in a handful of
-    // collections the de-duplication cannot conclude until the scan is essentially
-    // exhausted, so the realistic figure is the full one.
-    //
-    // Split into legs, each probes its own index: total cost 73.76, both legs
-    // index-only scans. Verified to survive parameterisation, which is what Prisma
-    // actually sends — the generic plan keeps both index conditions
-    // ("modelId" = $1, "imageId" = i.id) at cost 74.52.
-    //
-    // Plans read with EXPLAIN (no ANALYZE) against a read replica. This query runs on
-    // the permanent-delete path.
+    // 🔴 Three UNIONed legs, never one `WHERE ... OR ... OR ...`. Measured on a read
+    // replica: the OR form cannot use any of the three indexes and degrades to a
+    // 43.3M-row scan of an unrelated index with the whole condition as a post-scan
+    // Filter (cost 3,336,745); as separate legs every branch is an index scan
+    // (cost 89.68). This runs on the permanent-delete path.
     const rows = await dbWrite.$queryRaw<{ collectionId: number }[]>`
       SELECT DISTINCT x."collectionId" FROM (
         SELECT ci."collectionId" FROM "CollectionItem" ci WHERE ci."modelId" = ${modelId}
         UNION
         SELECT ci."collectionId" FROM "CollectionItem" ci
-        WHERE ci."imageId" IN (
-              SELECT i.id
-              FROM "Image" i
-              JOIN "Post" p ON p.id = i."postId"
-              JOIN "ModelVersion" mv ON mv.id = p."modelVersionId"
-              JOIN "Model" m ON m.id = mv."modelId" AND m."userId" = p."userId"
-              WHERE mv."modelId" = ${modelId}
-            )
+          WHERE ci."postId" IN (
+            SELECT p.id FROM "Post" p
+            JOIN "ModelVersion" mv ON mv.id = p."modelVersionId"
+            JOIN "Model" m ON m.id = mv."modelId" AND m."userId" = p."userId"
+            WHERE mv."modelId" = ${modelId})
+        UNION
+        SELECT ci."collectionId" FROM "CollectionItem" ci
+          WHERE ci."imageId" IN (
+            SELECT i.id FROM "Image" i
+            JOIN "Post" p ON p.id = i."postId"
+            JOIN "ModelVersion" mv ON mv.id = p."modelVersionId"
+            JOIN "Model" m ON m.id = mv."modelId" AND m."userId" = p."userId"
+            WHERE mv."modelId" = ${modelId})
       ) x
       LIMIT ${cap + 1}
     `;
@@ -221,7 +318,7 @@ export async function getCollectionIdsForModelCascade({
  */
 export async function enqueueCollectionRebuild({
   collectionIds,
-  dropped = 0,
+  truncated = false,
   source,
   cap = DEFAULT_COLLECTION_CAP,
 }: CollectionsToRebuild & {
@@ -229,7 +326,7 @@ export async function enqueueCollectionRebuild({
   source: string;
   cap?: number;
 }) {
-  if (!collectionIds.length) return { queued: 0, dropped };
+  if (!collectionIds.length) return { queued: 0, truncated };
 
   try {
     for (const batch of chunk(collectionIds, ENQUEUE_BATCH_SIZE)) {
@@ -244,24 +341,23 @@ export async function enqueueCollectionRebuild({
       'failed to queue collection search index update',
       error
     );
-    return { queued: 0, dropped };
+    return { queued: 0, truncated };
   }
 
-  if (dropped > 0)
-    // Named, not silent: past the cap those documents stay stale until a full
-    // reindex, and nobody can notice that from an absent log line. "at least" is
-    // load-bearing — see the note on CollectionsToRebuild; the true overflow is
-    // capped out of view, so an exact figure here would be a fabricated one.
+  if (truncated)
+    // Named, not silent: past the cap those documents stay stale until a full reindex,
+    // and nobody can notice that from an absent log line. No figure is quoted — see
+    // the note on CollectionsToRebuild; the lookup stops one past the cap, so any
+    // number here would be `1` however large the real overflow is.
     logToAxiom({
       type: 'warning',
       name: 'collection-media-index-enqueue-truncated',
-      message: `${source}: capped at ${cap} collections; at least ${dropped} more remain stale until a full reindex.`,
+      message: `${source}: capped at ${cap} collections; an unknown number beyond the cap remain stale until a full reindex.`,
       source,
       cap,
-      dropped,
     }).catch(() => undefined);
 
-  return { queued: collectionIds.length, dropped };
+  return { queued: collectionIds.length, truncated };
 }
 
 /**

--- a/src/server/services/collection-media-index.ts
+++ b/src/server/services/collection-media-index.ts
@@ -56,7 +56,9 @@ import { collectionsSearchIndex } from '~/server/search-index';
 // enqueue at REPLACEMENT time, which is a different trigger from removal and outside
 // what this module is wired to. Tracked separately. The leg is kept because it is
 // correct for the case it does match (a moderator or ingestion delete of a live
-// avatar) and costs 9.47, bounded because `profilePictureId` is `@unique`.
+// avatar). Its cost scales with the number of bound ids — measured 9.47 at one,
+// 18.94 at two, 28.41 at three — so at the 100-id batch `deleteImages` uses it is
+// ~950, not 9.47. Bounded per id because `profilePictureId` is `@unique`.
 //
 // Route 6 is the one that matters most on screen: CollectionCard renders
 // `if (data.image) return [data.image]`, so a cover WINS over every item image, and
@@ -177,8 +179,9 @@ async function coverIndexExists() {
  * Plans verified with EXPLAIN on a read replica. Five legs are index probes:
  * CollectionItem_imageId_lookup, CollectionItem_postId_lookup, CollectionItem_modelId
  * and CollectionItem_model3dId_idx, plus the avatar leg, which is two probes joined
- * (User_profilePictureId_key then Collection_userId_idx, cost 9.47). The article leg is NOT a probe — `CollectionItem_article_idx` is
- * `("collectionId","articleId")` and nothing leads on `articleId`, so it scans that
+ * (User_profilePictureId_key then Collection_userId_idx; see the route-7 note above
+ * for its per-id cost). The article leg is NOT a probe — `CollectionItem_article_idx`
+ * is `("collectionId","articleId")` and nothing leads on `articleId`, so it scans that
  * partial index: row estimate 271 per outer row, against 6 for the postId leg. It is
  * bounded — the index is 7,712 kB — so it is kept rather than given one of its own.
  * The cover leg is included only when its index is valid; see `coverIndexExists`.

--- a/src/server/services/collection-media-index.ts
+++ b/src/server/services/collection-media-index.ts
@@ -42,8 +42,13 @@ import { collectionsSearchIndex } from '~/server/search-index';
 // cannot match: `remove-replaced-images` calls `getStillReferencedImageIds`, which
 // filters out every id that is still a `profilePictureId`, before it calls
 // `deleteImages`. So for a REPLACED avatar this leg resolves zero collections, by
-// construction, every time. `deleteUser` is the same shape — it deletes the user's
-// collections before their images.
+// construction, every time.
+//
+// `deleteUser` reaches the same outcome by a DIFFERENT mechanism: it nulls
+// `profilePictureId` inside its own transaction, so by the time that user's images are
+// destroyed (later, by `remove-deleted-user-images`) nothing matches this leg either.
+// It does NOT delete the user's collections — `removeAllContent` is the function that
+// does that, and it is a separate moderator endpoint.
 //
 // The gap that leaves is real and is NOT closed here: a user changes their avatar, the
 // old Image row and its object are destroyed 30 days later, and every collection they
@@ -51,7 +56,7 @@ import { collectionsSearchIndex } from '~/server/search-index';
 // enqueue at REPLACEMENT time, which is a different trigger from removal and outside
 // what this module is wired to. Tracked separately. The leg is kept because it is
 // correct for the case it does match (a moderator or ingestion delete of a live
-// avatar) and costs ~28, bounded because `profilePictureId` is `@unique`.
+// avatar) and costs 9.47, bounded because `profilePictureId` is `@unique`.
 //
 // Route 6 is the one that matters most on screen: CollectionCard renders
 // `if (data.image) return [data.image]`, so a cover WINS over every item image, and
@@ -100,7 +105,7 @@ const ENQUEUE_BATCH_SIZE = 500;
  * Every lookup stops at `LIMIT cap + 1`, so the largest overflow any of them can
  * observe is one — the query is deliberately not in a position to learn the true
  * total. Reporting a number here would mean reporting `1` in exactly the case the
- * warning exists for: real models sit far past the cap (measured: one in 86,153
+ * warning exists for: real models sit far past the cap (measured: one in 86,156
  * distinct collections), so "1 more is stale" would understate by five orders of
  * magnitude. The overflow is unknown, and the warning says so.
  */
@@ -169,10 +174,10 @@ async function coverIndexExists() {
 /**
  * Collections whose document shows any of these images, by all seven routes.
  *
- * Plans verified with EXPLAIN on a read replica. Five legs are single-index probes
- * (CollectionItem_imageId_lookup, CollectionItem_postId_lookup, CollectionItem_modelId,
- * CollectionItem_model3dId_idx, and User_profilePictureId_key + Collection_userId_idx
- * for the avatar). The article leg is NOT a probe — `CollectionItem_article_idx` is
+ * Plans verified with EXPLAIN on a read replica. Five legs are index probes:
+ * CollectionItem_imageId_lookup, CollectionItem_postId_lookup, CollectionItem_modelId
+ * and CollectionItem_model3dId_idx, plus the avatar leg, which is two probes joined
+ * (User_profilePictureId_key then Collection_userId_idx, cost 9.47). The article leg is NOT a probe — `CollectionItem_article_idx` is
  * `("collectionId","articleId")` and nothing leads on `articleId`, so it scans that
  * partial index: row estimate 271 per outer row, against 6 for the postId leg. It is
  * bounded — the index is 7,712 kB — so it is kept rather than given one of its own.

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -146,6 +146,10 @@ import {
   getUserCollectionPermissionsById,
   getUserCollectionPermissionsByIds,
 } from '~/server/services/collection.service';
+import {
+  enqueueCollectionRebuild,
+  getCollectionIdsForMedia,
+} from '~/server/services/collection-media-index';
 import { enforceBlockedBrowsingTags } from '~/server/services/blocked-browsing-tags.service';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
 import {
@@ -611,6 +615,17 @@ export const deleteImageById = async ({
 }: GetByIdInput & { updatePost?: boolean }) => {
   updatePost ??= true;
   try {
+    // Resolved BEFORE the delete: `CollectionItem.imageId` is `onDelete: Cascade`, so
+    // once the row is gone there is no way left to learn which collections were
+    // showing this image. Their documents denormalize it and the collections index
+    // only sweeps newly created collections, so without this they keep rendering a
+    // thumbnail for an image that no longer exists. The resolver is non-throwing, so
+    // a failure here costs the reindex rather than cancelling the delete.
+    const collectionsToRebuild = await getCollectionIdsForMedia({
+      imageIds: [id],
+      source: 'image-delete',
+    });
+
     const image = await dbWrite.image.delete({
       where: { id },
       select: { url: true, postId: true, nsfwLevel: true, userId: true },
@@ -635,6 +650,7 @@ export const deleteImageById = async ({
       invalidateExistence,
       imageMetaCache.refresh(id),
       imageMetadataCache.refresh(id),
+      enqueueCollectionRebuild({ ...collectionsToRebuild, source: 'image-delete' }),
     ]);
 
     return image;
@@ -722,6 +738,14 @@ export async function deleteImages(
   { retractPublicBlobs = false }: PurgeResizeCacheRetraction = {}
 ) {
   const images = await Limiter({ batchSize: 100 }).process(ids, async (ids, batchIndex) => {
+    // Resolved before the DELETE for the same reason as deleteImageById: the
+    // membership rows cascade away with the images, taking with them the only record
+    // of which collection documents now hold a dead thumbnail.
+    const collectionsToRebuild = await getCollectionIdsForMedia({
+      imageIds: ids,
+      source: 'image-delete-bulk',
+    });
+
     const results = await dbWrite.$queryRaw<
       { id: number; url: string; postId: number | null; nsfwLevel: number; userId: number }[]
     >`
@@ -745,6 +769,7 @@ export async function deleteImages(
       invalidateExistence,
       imageMetaCache.refresh(imageIds),
       imageMetadataCache.refresh(imageIds),
+      enqueueCollectionRebuild({ ...collectionsToRebuild, source: 'image-delete-bulk' }),
     ]);
 
     await Limiter({ batchSize: 5 }).process(

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -148,7 +148,7 @@ import {
 } from '~/server/services/collection.service';
 import {
   enqueueCollectionRebuild,
-  getCollectionIdsForMedia,
+  getCollectionIdsForImages,
 } from '~/server/services/collection-media-index';
 import { enforceBlockedBrowsingTags } from '~/server/services/blocked-browsing-tags.service';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
@@ -621,7 +621,7 @@ export const deleteImageById = async ({
     // only sweeps newly created collections, so without this they keep rendering a
     // thumbnail for an image that no longer exists. The resolver is non-throwing, so
     // a failure here costs the reindex rather than cancelling the delete.
-    const collectionsToRebuild = await getCollectionIdsForMedia({
+    const collectionsToRebuild = await getCollectionIdsForImages({
       imageIds: [id],
       source: 'image-delete',
     });
@@ -741,7 +741,7 @@ export async function deleteImages(
     // Resolved before the DELETE for the same reason as deleteImageById: the
     // membership rows cascade away with the images, taking with them the only record
     // of which collection documents now hold a dead thumbnail.
-    const collectionsToRebuild = await getCollectionIdsForMedia({
+    const collectionsToRebuild = await getCollectionIdsForImages({
       imageIds: ids,
       source: 'image-delete-bulk',
     });

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2135,6 +2135,12 @@ export const permaDeleteModelById = async ({
     // `enqueueCollectionRebuild` is non-throwing by contract, but wrapped anyway so
     // this step matches its siblings above rather than resting the S3 and
     // storage-resolver cleanup below on another module keeping that promise.
+    //
+    // ⚠️ This catch is therefore UNREACHABLE through the real callee, and no test
+    // pins it: removing the try/catch entirely leaves the suite green, measured. It is
+    // defence-in-depth against the contract being broken later, not covered behaviour.
+    // Exercising it would mean mocking collection-media-index in a suite that
+    // deliberately runs the real one so its payload assertions mean something.
     try {
       await enqueueCollectionRebuild({
         ...collectionsToRebuild,

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2020,7 +2020,8 @@ export const permaDeleteModelById = async ({
   let versionIds: number[] = [];
 
   // Resolved BEFORE the tx, not inside it and not after: `CollectionItem` cascades
-  // from both `Model` and `Image`, so post-commit there is nothing left to read, and a
+  // from `Model`, `Post` AND `Image` — all three of which this transaction destroys —
+  // so post-commit there is nothing left to read, and a
   // failed statement inside a Postgres tx aborts the whole tx — this bookkeeping read
   // must never be able to take the delete down with it. The resolver is non-throwing,
   // so a failure costs the reindex, not the deletion.

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -30,7 +30,7 @@ import {
 } from '~/server/db/db-lag-helpers';
 import { createProfanityFilter } from '~/libs/profanity-simple';
 import { isFlipt } from '~/server/flipt/client';
-import { logToAxiom } from '~/server/logging/client';
+import { logToAxiom, safeError } from '~/server/logging/client';
 import {
   isTransientMeiliError,
   MeiliCallTimeoutError,
@@ -102,7 +102,6 @@ import {
 import {
   enqueueCollectionRebuild,
   getCollectionIdsForModelCascade,
-  queueCollectionsForMedia,
 } from '~/server/services/collection-media-index';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
 import type { ImagesForModelVersions } from '~/server/services/image.service';
@@ -1895,24 +1894,6 @@ export const deleteModelById = async ({
       });
     }
   }
-  // Queue a rebuild of every collection holding this model, so the document is
-  // refreshed from current data. Safe to resolve here: a soft delete leaves the
-  // CollectionItem rows in place. Non-throwing, so the trailing cache bust and bid
-  // cleanup still run.
-  //
-  // ⚠️ This does NOT by itself stop the collection rendering the model's thumbnail.
-  // The index's image CTEs filter on `i."ingestion" = 'Scanned' AND i."needsReview"
-  // IS NULL` and nothing else — no `Model.status`, no `Model.deletedAt`. A soft delete
-  // leaves the Model, Post and Image rows intact, so a rebuild re-emits the same
-  // image. (Verified against production: a model with `status=Deleted` and `deletedAt`
-  // set is an ACCEPTED item in 41 collections and its `modelItemImage` join still
-  // returns live images.) The enqueue is kept because it is correct and does the right
-  // thing once the image is genuinely gone — a later hard delete, or the image being
-  // removed — and because a rebuild from current data is never wrong. Whether a
-  // soft-deleted model should keep supplying collection art is a product question
-  // about collection-card semantics, not something to settle by adding a status
-  // predicate to a shared index CTE.
-  await queueCollectionsForMedia({ modelIds: [id], source: 'model-delete' });
   // Drop the origin-side public GET /api/v1/models/[id] response cache so a
   // deleted model stops serving a stale 200 (it would 404 on rebuild).
   await bustPublicModelResponseCache(id);
@@ -2164,7 +2145,9 @@ export const permaDeleteModelById = async ({
         type: 'error',
         name: 'model-perma-delete-collection-search-index',
         message: `Failed to queue collection search index update for model ${id}`,
-        error,
+        // `logToAxiom` JSON.stringifies its payload and a bare Error serialises to
+        // `{}`. The siblings above predate that finding; this one does not.
+        error: safeError(error),
       });
     }
     // Clean up S3 objects for all deleted ModelFiles (admin-triggered, latency-tolerant → await).
@@ -3604,20 +3587,6 @@ export const unpublishModelById = async ({
       error,
     });
   }
-
-  // An unpublished model is dropped from the model index and its images from the
-  // image index, but the collections holding it keep a denormalized snapshot that no
-  // sweep revisits. Queue a rebuild so the document is refreshed from current data.
-  // The model row survives an unpublish, so the CollectionItem rows are resolvable
-  // here.
-  //
-  // ⚠️ Same caveat as the soft-delete path: this does NOT stop the collection
-  // rendering the model's art. The index's image CTEs filter only on
-  // `i."ingestion" = 'Scanned' AND i."needsReview" IS NULL` — no `Post.publishedAt` —
-  // and an unpublish nulls `publishedAt` while leaving Post and Image rows intact, so
-  // the rebuild re-emits the same image. Kept for the same reason: it is correct, and
-  // it is what makes the document right once the underlying image actually goes.
-  await queueCollectionsForMedia({ modelIds: [id], source: 'model-unpublish' });
 
   await deleteBidsForModel({ modelId: id });
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1895,11 +1895,23 @@ export const deleteModelById = async ({
       });
     }
   }
-  // Rebuild every collection that contained this model. The collections index
-  // denormalizes item images, and its incremental sweep only revisits newly created
-  // collections — so without this the collection keeps showing the deleted model's
-  // thumbnail forever. Safe to resolve here: a soft delete leaves the CollectionItem
-  // rows in place. Non-throwing, so the trailing cache bust and bid cleanup still run.
+  // Queue a rebuild of every collection holding this model, so the document is
+  // refreshed from current data. Safe to resolve here: a soft delete leaves the
+  // CollectionItem rows in place. Non-throwing, so the trailing cache bust and bid
+  // cleanup still run.
+  //
+  // ⚠️ This does NOT by itself stop the collection rendering the model's thumbnail.
+  // The index's image CTEs filter on `i."ingestion" = 'Scanned' AND i."needsReview"
+  // IS NULL` and nothing else — no `Model.status`, no `Model.deletedAt`. A soft delete
+  // leaves the Model, Post and Image rows intact, so a rebuild re-emits the same
+  // image. (Verified against production: a model with `status=Deleted` and `deletedAt`
+  // set is an ACCEPTED item in 41 collections and its `modelItemImage` join still
+  // returns live images.) The enqueue is kept because it is correct and does the right
+  // thing once the image is genuinely gone — a later hard delete, or the image being
+  // removed — and because a rebuild from current data is never wrong. Whether a
+  // soft-deleted model should keep supplying collection art is a product question
+  // about collection-card semantics, not something to settle by adding a status
+  // predicate to a shared index CTE.
   await queueCollectionsForMedia({ modelIds: [id], source: 'model-delete' });
   // Drop the origin-side public GET /api/v1/models/[id] response cache so a
   // deleted model stops serving a stale 200 (it would 404 on rebuild).
@@ -2136,14 +2148,25 @@ export const permaDeleteModelById = async ({
         });
       }
     }
-    // Rebuild the collections that held this model or its gallery images, using the
-    // pre-tx snapshot — the membership rows cascaded away with the delete, so this is
-    // the only remaining record of which documents went stale. Non-throwing, so the
-    // S3 and storage-resolver cleanup below still runs.
-    await enqueueCollectionRebuild({
-      ...collectionsToRebuild,
-      source: 'model-perma-delete',
-    });
+    // Rebuild the collections that held this model, its posts or its gallery images,
+    // using the pre-tx snapshot — the membership rows cascaded away with the delete,
+    // so this is the only remaining record of which documents went stale.
+    // `enqueueCollectionRebuild` is non-throwing by contract, but wrapped anyway so
+    // this step matches its siblings above rather than resting the S3 and
+    // storage-resolver cleanup below on another module keeping that promise.
+    try {
+      await enqueueCollectionRebuild({
+        ...collectionsToRebuild,
+        source: 'model-perma-delete',
+      });
+    } catch (error) {
+      logToAxiom({
+        type: 'error',
+        name: 'model-perma-delete-collection-search-index',
+        message: `Failed to queue collection search index update for model ${id}`,
+        error,
+      });
+    }
     // Clean up S3 objects for all deleted ModelFiles (admin-triggered, latency-tolerant → await).
     if (modelFileUrls.length > 0) {
       try {
@@ -3584,9 +3607,16 @@ export const unpublishModelById = async ({
 
   // An unpublished model is dropped from the model index and its images from the
   // image index, but the collections holding it keep a denormalized snapshot that no
-  // sweep revisits. Rebuild them so the collection stops rendering a thumbnail whose
-  // post is no longer published. The model row survives an unpublish, so the
-  // CollectionItem rows are still resolvable here.
+  // sweep revisits. Queue a rebuild so the document is refreshed from current data.
+  // The model row survives an unpublish, so the CollectionItem rows are resolvable
+  // here.
+  //
+  // ⚠️ Same caveat as the soft-delete path: this does NOT stop the collection
+  // rendering the model's art. The index's image CTEs filter only on
+  // `i."ingestion" = 'Scanned' AND i."needsReview" IS NULL` — no `Post.publishedAt` —
+  // and an unpublish nulls `publishedAt` while leaving Post and Image rows intact, so
+  // the rebuild re-emits the same image. Kept for the same reason: it is correct, and
+  // it is what makes the document right once the underlying image actually goes.
   await queueCollectionsForMedia({ modelIds: [id], source: 'model-unpublish' });
 
   await deleteBidsForModel({ modelId: id });

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -99,6 +99,11 @@ import {
   getUserCollectionPermissionsById,
   saveItemInCollections,
 } from '~/server/services/collection.service';
+import {
+  enqueueCollectionRebuild,
+  getCollectionIdsForModelCascade,
+  queueCollectionsForMedia,
+} from '~/server/services/collection-media-index';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
 import type { ImagesForModelVersions } from '~/server/services/image.service';
 import {
@@ -1890,6 +1895,12 @@ export const deleteModelById = async ({
       });
     }
   }
+  // Rebuild every collection that contained this model. The collections index
+  // denormalizes item images, and its incremental sweep only revisits newly created
+  // collections — so without this the collection keeps showing the deleted model's
+  // thumbnail forever. Safe to resolve here: a soft delete leaves the CollectionItem
+  // rows in place. Non-throwing, so the trailing cache bust and bid cleanup still run.
+  await queueCollectionsForMedia({ modelIds: [id], source: 'model-delete' });
   // Drop the origin-side public GET /api/v1/models/[id] response cache so a
   // deleted model stops serving a stale 200 (it would 404 on rebuild).
   await bustPublicModelResponseCache(id);
@@ -2015,6 +2026,13 @@ export const permaDeleteModelById = async ({
   // post-commit storage-resolver deregister can reach every reaped version.
   let versionIds: number[] = [];
 
+  // Resolved BEFORE the tx, not inside it and not after: `CollectionItem` cascades
+  // from both `Model` and `Image`, so post-commit there is nothing left to read, and a
+  // failed statement inside a Postgres tx aborts the whole tx — this bookkeeping read
+  // must never be able to take the delete down with it. The resolver is non-throwing,
+  // so a failure costs the reindex, not the deletion.
+  const collectionsToRebuild = await getCollectionIdsForModelCascade({ modelId: id });
+
   const deletionResult = await dbWrite.$transaction(
     async (tx) => {
       // Snapshot ModelFile URLs inside the tx — read before the cascade nukes the rows.
@@ -2118,6 +2136,14 @@ export const permaDeleteModelById = async ({
         });
       }
     }
+    // Rebuild the collections that held this model or its gallery images, using the
+    // pre-tx snapshot — the membership rows cascaded away with the delete, so this is
+    // the only remaining record of which documents went stale. Non-throwing, so the
+    // S3 and storage-resolver cleanup below still runs.
+    await enqueueCollectionRebuild({
+      ...collectionsToRebuild,
+      source: 'model-perma-delete',
+    });
     // Clean up S3 objects for all deleted ModelFiles (admin-triggered, latency-tolerant → await).
     if (modelFileUrls.length > 0) {
       try {
@@ -3555,6 +3581,13 @@ export const unpublishModelById = async ({
       error,
     });
   }
+
+  // An unpublished model is dropped from the model index and its images from the
+  // image index, but the collections holding it keep a denormalized snapshot that no
+  // sweep revisits. Rebuild them so the collection stops rendering a thumbnail whose
+  // post is no longer published. The model row survives an unpublish, so the
+  // CollectionItem rows are still resolvable here.
+  await queueCollectionsForMedia({ modelIds: [id], source: 'model-unpublish' });
 
   await deleteBidsForModel({ modelId: id });
 


### PR DESCRIPTION
## The defect

Collection search results render broken thumbnails for models and images that have been deleted.

`collections_v3` denormalizes images onto every collection document. Nothing about removing that media ever reached the index, so the document kept a snapshot of things that no longer exist.

**Why nothing reached it.** `prepareBatches` in `src/server/search-index/collections.search-index.ts` filters candidate collections on `c."createdAt" >= lastUpdatedAt`, so the incremental sweep only ever revisits **newly created** collections. An existing collection is rebuilt only when something enqueues it explicitly — and no removal path did. `model.service.ts` had exactly one `collectionsSearchIndex.queueUpdate` call before this PR (the featured-models path); `image.service.ts` had none.

`collection-index-sync.ts` does not cover this: it runs the opposite direction (collection membership → `images_v6.collectionIds`).

## An image reaches a collection document by seven routes

Only one of them is a `CollectionItem.imageId` row. Resolving by that column alone — the obvious reading, and what the first version of this PR did — misses six, including the two commonest. The collection that prompted this work has two items, both model-type with `imageId` NULL; its thumbnail arrives via `modelItemImage`, so the original fix resolved **zero** collections for it.

| # | Source | Route |
|---|---|---|
| 1 | `imageItemImage` CTE | `CollectionItem.imageId` → the image directly |
| 2 | `postItemImage` CTE | `CollectionItem.postId` → that post's **first** image |
| 3 | `modelItemImage` CTE | `CollectionItem.modelId` → image → Post → ModelVersion → Model |
| 4 | `articleItemImage` CTE | `CollectionItem.articleId` → `Article.coverId` |
| 5 | `model3dItemImage` CTE | `CollectionItem.model3dId` → `Model3D.thumbnailImageId` |
| 6 | the document's cover field | `Collection.imageId` |
| 7 | a separate `findMany` in `pullData` | `User.profilePictureId` → `Collection.userId` — **partial, see below** |

Route 6 matters most on screen — `CollectionCard` renders `if (data.image) return [data.image]`, so a cover wins over every item image. Route 7 is invisible to anyone enumerating from the CTE list, which is how it was missed twice: profile pictures are fetched by their own `db.image.findMany` and shipped as `user.profilePicture` on **every** collection document. The code comment now says to enumerate from `pullData` and `transformData`, not from the CTEs.

⚠️ **Route 7 is only partly covered, deliberately.** The leg matches `u."profilePictureId" IN (ids)` — images that are someone's avatar *right now*. The usual way an avatar image dies is the deferred reaper, and that path **cannot** match: `remove-replaced-images` calls `getStillReferencedImageIds`, which filters out every id that is still a `profilePictureId`, before calling `deleteImages`. So for a *replaced* avatar this leg resolves zero collections, by construction, every time. `deleteUser` reaches the same outcome by a different mechanism — it nulls `profilePictureId` inside its own transaction, so by the time that user's images are destroyed (later, by `remove-deleted-user-images`) nothing matches this leg either. It does **not** delete the user's collections; `removeAllContent` is the function that does that.

The leg is kept because it is correct for what it does match — a moderator or ingestion delete of a live avatar — and its cost scales with the number of bound ids — measured 9.47 at one, 18.94 at two, 28.41 at three — so at the 100-id batch `deleteImages` uses it is ~950, not 9.47. Bounded per id because `profilePictureId` is `@unique`. **The remaining gap is real and is not closed here:** a user changes their avatar, the old `Image` row and its object are destroyed 30 days later, and every collection they own still ships `user.profilePicture` pointing at a dead url. Closing it needs an enqueue at *replacement* time, which is a different trigger from removal. Tracked separately.

The joins for routes 2–5 mirror the CTEs' own conditions, including `m."userId" = p."userId"`, so this and the index agree on which image a collection would show.

## What this changes

A leaf module, `src/server/services/collection-media-index.ts`, resolving the affected collections and queueing them for rebuild, wired into the image-delete paths and the permanent model delete.

**`Update`, not `Delete`.** The collection still exists; only its document needs rebuilding. A `Delete` would evict a real collection.

**Resolve before the delete.** `CollectionItem.modelId`/`.postId`/`.imageId` are all `onDelete: Cascade`, so once the row is gone there is nothing left to read. For `permaDeleteModelById` the resolve is deliberately **outside** the transaction: a failed statement aborts a Postgres transaction outright, so a bookkeeping read placed inside could take the whole delete down with it. It gains a `postId` leg because that path hard-deletes Posts in the same transaction.

**Non-throwing by contract.** Every exported function logs and returns rather than throwing — these run around deletes that have already committed or are about to, so a failure must cost a stale document, never the user's delete.

**Volume.** Ids are deduped, the enqueue is chunked at 500 per queue write, and the resolve caps at 10,000 distinct collections. The cap applies to distinct *collections*, not membership rows — hence raw `SELECT DISTINCT … LIMIT` rather than Prisma's `distinct`, which has historically been applied after rows come back. Truncation is logged (`collection-media-index-enqueue-truncated`) **without a figure**: every lookup stops at `LIMIT cap + 1`, so any number quoted would be `1` however large the real overflow, and real models sit far past the cap (one measured in **86,156** distinct collections).

## Plans

`EXPLAIN` (no `ANALYZE`), read replica, `pg_is_in_recovery()` confirmed.

🔴 **The image-resolve cost scales with the number of bound ids, so each row below says how many it was measured at.** `deleteImages` batches **100** ids (`Limiter({ batchSize: 100 })`, concurrency 5), so the 100-id row is the one that describes the bulk path; the 1-id row describes a single-image delete.

| Query | bound ids | Cost | Notes |
|---|---|---|---|
| **image resolve as it ships today** (gate false, six legs) | 1 | **9,924** | every leg an index scan |
| **image resolve as it ships today** (gate false, six legs) | **100** | **2,017,779** | the bulk path — 203× the 1-id figure |
| image resolve with the cover leg on, index absent | 1 | 461,456 | 46.5× the 1-id six-leg figure |
| image resolve with the cover leg on, index absent | **100** | **2,487,317** | **+23%** over six legs, not 46.5× |
| model cascade, three legs | n/a (one model) | 89.68 | vs **3,336,745** for the `OR` form it replaced |
| cover-index gate | n/a (catalog) | 5.01 | two index scans on the catalogs |

**What the gate is and is not worth.** At one bound id the cover leg dominates (46.5×), which is where the "47×" figure in earlier revisions of this PR came from. At the batch size the code actually uses, the marginal cost of the cover leg is **+23%** — the other six legs have grown to dominate it. The gate is still right, but for a reason the ratio does not carry: what it prevents is a **parallel sequential scan of the 2,817 MB `Collection` heap**, up to five concurrently, on the primary, potentially while a `CREATE INDEX CONCURRENTLY` is building on that same table. Weigh it on that, not on a multiplier.

The cascade query originally bridged its columns with a single `OR`, which is not sargable against a ~208M-row table: Postgres used none of the indexes and scanned an unrelated one end to end (43.3M estimated rows) with the whole condition as a post-scan `Filter`. Split into `UNION`ed legs, every branch is an index scan. Verified to survive parameterisation — the shape Prisma sends — at cost 74.52 for the two-leg form.

Five legs are index probes — four single (`CollectionItem_imageId_lookup`, `_postId_lookup`, `_modelId`, `_model3dId_idx`) plus the avatar leg, which is two probes joined (`User_profilePictureId_key` then `Collection_userId_idx`; per-id cost above). The **article leg is not**: `CollectionItem_article_idx` is `("collectionId","articleId")` and nothing leads on `articleId`, so it scans that partial index: row estimate **271** per outer row, against **6** for the `postId` leg. (An earlier revision of this line said "2,799 rows" — that was the leg's *cost* span, not a row count.) It is bounded — the index is 7,712 kB — so it stays rather than getting one of its own.

## The cover leg is gated, and ships with a migration

`Collection.imageId` has **no index**. Without one the leg is a parallel sequential scan of the ~17.3M-row / **2,817 MB** heap. So it is gated on the index being present *and usable*, and ships with `20260906190000_collection_imageid_idx`.

The gate checks `indisvalid AND indisready`, joined through `pg_index` and schema-qualified — not merely that the name exists in `pg_class`:

> A `CREATE INDEX CONCURRENTLY` row appears in `pg_class` from the **start** of the build and stays there permanently if the build **fails**. A name-only check therefore returns true throughout a multi-minute build, and forever after a failure — switching the leg on in exactly the window the gate exists to cover, so every image delete would pay the seq scan concurrently with the build, on the primary, up to five at a time (`deleteImages` uses `Limiter({ batchSize: 100 })`, default concurrency 5).

The migration deliberately has **no `IF NOT EXISTS`**: a failed `CONCURRENTLY` build leaves an INVALID index occupying the name, and `IF NOT EXISTS` would turn the retry into a silent no-op that prints `CREATE INDEX` and repairs nothing. A `DROP INDEX CONCURRENTLY` recovery step is documented in the migration.

**Not verified:** the post-index plan for the cover leg. `hypopg` is available but not installed, and `CREATE EXTENSION`/`CREATE INDEX` are writes — impossible on a replica and not something to do to a primary for a test. The seq-scan plan is measured; the indexed plan is predicted.

## Soft delete and unpublish: deliberately no enqueue

Earlier revisions queued a rebuild on `deleteModelById` and `unpublishModelById`. Both were **provably no-ops**: the index's image CTEs filter only on `i."ingestion" = 'Scanned' AND i."needsReview" IS NULL` — no `Model.status`, no `Model.deletedAt`, no `Post.publishedAt` — so a soft delete or unpublish leaves the Model, Post and Image rows intact and the rebuild re-emits the same image. Verified in production: a model with `status=Deleted` and `deletedAt` set is an ACCEPTED item in 41 collections and its `modelItemImage` join still returns live images.

They have been **removed**. The cost was up to 10,000 Meilisearch enqueues per soft delete for no change in output, and the justification that kept them ("correct once the image is genuinely gone") is served elsewhere — when the image is genuinely removed, the image-delete paths fire their own enqueue.

**Open question for a reviewer:** if the product answer is *"hide a soft-deleted model's images from collection cards"*, the CTE predicate and this enqueue are needed **together** — neither alone does anything. Adding a status predicate to a shared index CTE changes collection-card semantics for every soft-deleted model on the site, which is a product decision, not one to make inside this PR. A test pins the absence and records this.

## Corrections to claims this code was making

- **The indexes are btree, not hash.** Every index on `CollectionItem.modelId`/`.imageId` is `USING btree`; the Prisma schema annotates them `type: Hash`. The deployed ones are what the planner uses.
- **`Collection.imageId` has no foreign key.** `Collection` carries exactly one (`Collection_userId_fkey`), so the schema's `onDelete: SetNull` is not a guarantee the database makes — a cover can and does point at a deleted `Image`. No behavioural consequence here (the resolve runs before the delete either way), but the premise was wrong.
- **`truncated`, not a count** — see Volume above.

## Test matrix

34 tests. Every guard was watched failing on the behaviour it pins, and eleven mutants across three rounds were each killed by their designated guard:

| Mutation | Killed by |
|---|---|
| cascade `OR` form restored | `splits the columns into UNIONed legs…` |
| cascade without the `postId` leg | `resolves the posts the cascade will delete…` |
| image resolve reduced to the `imageId` leg | `resolves every route by which an image reaches…` |
| the avatar leg dropped | `resolves the owner-avatar route, which is not one of the index CTEs` |
| gate reverted to a name-only `pg_class` check | `asks whether the index is VALID and READY, not merely named` |
| cover probe moved back inside the main try | `still resolves the other six legs when the catalog probe fails` |
| cover leg run ungated | `omits the cover leg and warns when the index is not usable` |
| soft-delete enqueue re-added | `does not queue a collections rebuild, which would be a no-op` |
| raw `Error` instead of `safeError` | `never throws when the queue write fails…` |
| a number quoted for the overflow | `does not quote a number it cannot know for the overflow` |
| image-leg failure discarding results | `still resolves the other six legs…` |

🔴 **One mutant survived on first run** and is worth recording: the `safeError` guard asserted `objectContaining({ message })`, which a live `Error` also satisfies, so it could never fail. It now asserts after a JSON round-trip — the transformation that actually decides whether the cause survives. Two other bugs were in the test harness rather than the code: `sqlOf` joined only the template strings, rendering an interpolated `Prisma.sql` fragment as `?`; and an assertion used `vi.spyOn` on an intra-module call, which cannot be intercepted.

Gates: `pnpm typecheck` 0 errors; `pnpm test:lint-rules` 476 passed; `src/server/services/__tests__/` + the Flipt ledger 394 files / 5598 passed.

## Known and tracked, not fixed here

A collection whose **last** item is hard-deleted stops matching the index's `EXISTS` clause, so `pullData` returns nothing and `pushData` is upsert-only — the stale document survives permanently. Real and not rare — roughly one collection in five holds exactly one item (two `TABLESAMPLE` runs put it at 19.2% and 22.0%; the exact share does not matter here) — but it needs a `deleteDocs` path and is a defect in the index sync's push semantics rather than in these enqueues. Tracked separately.

Backfilling already-stale documents is also out of scope; this stops new ones being created.



