### PR TITLE
feat(blocks): publish coverNsfwLevel on the collections list response

### DIFF
--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -18,7 +18,7 @@ import {
   getFallbackCoverImages,
   getFollowedCollectionIds,
   hydrateBlockSubject,
-  toCoverImageUrl,
+  toCoverFields,
 } from '~/server/services/blocks/block-collections.service';
 import { resolveCatalogBrowsingLevel } from '~/server/utils/block-catalog-maturity';
 import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
@@ -57,8 +57,23 @@ import {
  * domain. The separating signal is HOW MUCH OF THE COLLECTION SURVIVES THE
  * CEILING, sampled — see `MIN_PLAYABLE_FRACTION` and `PLAYABLE_SAMPLE_SIZE`.
  *
- * Response: `{ items: [{ id, name, description, coverImageUrl, itemCount,
- *   curator:{ userId, username }, isPublic, followed }], nextCursor }`.
+ * Response: `{ items: [{ id, name, description, coverImageUrl, coverNsfwLevel?,
+ *   itemCount, curator:{ userId, username }, isPublic, followed }], nextCursor }`.
+ *
+ * 🔴 `coverNsfwLevel` IS THE LEVEL OF THE COVER BEING SERVED — NOT THE
+ * COLLECTION'S `nsfwLevel`, AND THE NAME IS DELIBERATE. The collection-level value
+ * is the OR-ed bitmask described above, which cannot separate a 97%-safe contest
+ * collection from a 1%-safe mature one; a field named `nsfwLevel` on this response
+ * would invite exactly that confusion. This one describes a SINGLE IMAGE: whichever
+ * image `coverImageUrl` resolves to — the primary `Collection.image` when it is
+ * usable, otherwise the maturity-clamped fallback, which is the collection's
+ * NEWEST permitted accepted item (not a "highest-rated representative"; nothing
+ * here ranks items). Both fields are produced together by `toCoverFields` from the
+ * one chosen image, so they can never describe different images.
+ *
+ * 🔴 IT IS OMITTED WHEN THERE IS NO COVER, AND `0` IS A REAL LEVEL. A consumer
+ * reads `undefined` as "no claim — use your own domain ceiling" and any supplied
+ * value as authoritative, so `0` (unrated) must never stand in for "absent".
  *
  * 🔴 `itemCount` DIFFERS BY MODE, DELIBERATELY. In `mode=mine` it is CLAMPED to
  * the token's ceiling — that branch counts only the subject's own collections, a
@@ -314,7 +329,10 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
           id: c.id,
           name: c.name,
           description: c.description ?? null,
-          coverImageUrl: toCoverImageUrl(primaryCoverUsable(c) ? c.image : fallbackCovers.get(c.id)),
+          // ONE image in, BOTH cover fields out — the url and the level of that
+          // same image. Splitting these back into two expressions is how a
+          // fallback cover ends up advertising the primary's level.
+          ...toCoverFields(primaryCoverUsable(c) ? c.image : fallbackCovers.get(c.id)),
           itemCount: countMap.get(c.id) ?? 0,
           curator: { userId: c.userId, username: c.user?.username ?? null },
           isPublic: c.read === CollectionReadConfiguration.Public,
@@ -394,7 +412,8 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
         id: c.id,
         name: c.name,
         description: c.description ?? null,
-        coverImageUrl: toCoverImageUrl(primaryCoverUsable(c) ? c.image : fallbackCovers.get(c.id)),
+        // Same single-image projection as public discovery — see the note there.
+        ...toCoverFields(primaryCoverUsable(c) ? c.image : fallbackCovers.get(c.id)),
         itemCount: countMap.get(c.id) ?? 0,
         curator: { userId: c.userId, username: subjectUser.username ?? null },
         isPublic: c.read === CollectionReadConfiguration.Public,

--- a/src/server/services/blocks/block-collections.service.ts
+++ b/src/server/services/blocks/block-collections.service.ts
@@ -94,9 +94,66 @@ export function toCoverImageUrl(
 }
 
 /**
+ * The cover fields a block collection card carries on the wire, produced TOGETHER
+ * from ONE image so they can never describe different images.
+ *
+ * 🔴 `coverNsfwLevel` IS NOT THE COLLECTION'S `nsfwLevel`, AND THE NAME IS THE
+ * GUARD. A Collection's own `nsfwLevel` is a bitmask OR-ed over its items, so a
+ * 97%-safe contest collection and a 1%-safe mature one both carry 29 — it cannot
+ * separate them, and a consumer that blurred on it would blur nearly everything or
+ * nothing. This field is a much narrower claim: the maturity level of THE SINGLE
+ * IMAGE being served as `coverImageUrl`, so a consumer can gate the thumbnail it
+ * is actually about to paint. Never rename it to `nsfwLevel`.
+ *
+ * 🔴 ABSENT MEANS "NO COVER", AND `0` IS A REAL LEVEL (unrated). Consumers branch
+ * on `undefined` (→ fall back to their own domain ceiling) versus a supplied
+ * value (→ authoritative, gate on it), so emitting `0` for "there is no cover"
+ * would silently move them onto the wrong path. When `coverImageUrl` is null the
+ * field is OMITTED; when a cover exists and is unrated, `0` is published as a real
+ * value.
+ */
+export type BlockCollectionCoverFields = {
+  coverImageUrl: string | null;
+  coverNsfwLevel?: number;
+};
+
+/**
+ * Project ONE image into the pair of cover fields — the url and the maturity level
+ * OF THAT SAME IMAGE.
+ *
+ * 🔴 WHY THIS IS ONE FUNCTION AND NOT TWO. The discovery cover is the primary
+ * `Collection.image` OR a maturity-clamped fallback item, chosen per collection.
+ * Publishing the primary's level beside a fallback url is WORSE than publishing
+ * nothing: a consumer treats a supplied level as authoritative and an absent one as
+ * "fall back to the ceiling", so a mismatched level is a lie it will gate on.
+ * Taking a single image and emitting both fields from it makes the mismatch
+ * unrepresentable rather than merely tested for — the caller picks the image once.
+ *
+ * SEMANTIC OF THE LEVEL: it is the level of THE IMAGE BEING SERVED as the cover,
+ * whichever image that is. For a fallback cover that image is the collection's
+ * NEWEST clamped accepted item (`getFallbackCoverImages` orders by
+ * `ci."createdAt" DESC`) — it is deliberately not a "best" or "highest-rated"
+ * representative, and nothing here ranks items.
+ *
+ * The `coverImageUrl === null` test — not a separate "is there an image" check —
+ * is what ties the presence of the level to the presence of the url: the two are
+ * decided by the same expression, so they cannot drift apart.
+ */
+export function toCoverFields(
+  image: { url?: string | null; type?: string | null; nsfwLevel?: number | null } | null | undefined
+): BlockCollectionCoverFields {
+  const coverImageUrl = toCoverImageUrl(image);
+  // No cover → the field is ABSENT (not 0); see the type's doc comment.
+  if (coverImageUrl === null) return { coverImageUrl: null };
+  // A cover with a null/absent level is UNRATED, which is the real level 0 — the
+  // same `?? 0` normalisation every other maturity read on this surface uses.
+  return { coverImageUrl, coverNsfwLevel: image?.nsfwLevel ?? 0 };
+}
+
+/**
  * Fallback cover source for collections whose own cover is null OR is itself over
- * the ceiling: the media (url,type) of each collection's most-recent ACCEPTED
- * item WHOSE OWN `Image.nsfwLevel` is PERMITTED by the token's clamped
+ * the ceiling: the media (url,type,nsfwLevel) of each collection's most-recent
+ * ACCEPTED item WHOSE OWN `Image.nsfwLevel` is PERMITTED by the token's clamped
  * `browsingLevel`. This is the maturity clamp the discovery cover MUST apply — a
  * MIXED-bucket collection (nsfwLevel 29) intersects a SFW ceiling and passes the
  * collection-level discovery gate, but its newest item can be R/X; surfacing that
@@ -108,19 +165,27 @@ export function toCoverImageUrl(
  * collection (filtering after `distinct` would drop the cover entirely). Returns
  * a Map keyed by collectionId; a collection with no permitted item is absent
  * (→ placeholder tile).
+ *
+ * 🔴 `nsfwLevel` IS SELECTED, NOT JUST FILTERED ON. The endpoint publishes the
+ * level of the cover it actually serves (`toCoverFields`), and for a fallback
+ * cover THIS row is that cover — so its own level has to travel with it. Reading
+ * the primary `Collection.image`'s level instead would describe a different image
+ * (that is precisely the image this map exists to REPLACE), which is the one
+ * failure mode a maturity field must not have.
  */
 export async function getFallbackCoverImages(
   collectionIds: number[],
   browsingLevel: number
-): Promise<Map<number, { url: string | null; type: string | null }>> {
+): Promise<Map<number, { url: string | null; type: string | null; nsfwLevel: number }>> {
   if (collectionIds.length === 0) return new Map();
   const rows = await dbRead.$queryRaw<
-    { collectionId: number; url: string | null; type: string | null }[]
+    { collectionId: number; url: string | null; type: string | null; nsfwLevel: number | null }[]
   >`
     SELECT DISTINCT ON (ci."collectionId")
       ci."collectionId" as "collectionId",
       i."url" as "url",
-      i."type"::text as "type"
+      i."type"::text as "type",
+      i."nsfwLevel" as "nsfwLevel"
     FROM "CollectionItem" ci
     JOIN "Image" i ON i."id" = ci."imageId"
     WHERE ci."collectionId" IN (${Prisma.join(collectionIds)})
@@ -128,10 +193,11 @@ export async function getFallbackCoverImages(
       AND ((i."nsfwLevel" & ${browsingLevel}) != 0 OR i."nsfwLevel" = 0)
     ORDER BY ci."collectionId", ci."createdAt" DESC
   `;
-  const map = new Map<number, { url: string | null; type: string | null }>();
+  const map = new Map<number, { url: string | null; type: string | null; nsfwLevel: number }>();
   for (const r of rows) {
     if (r.collectionId != null && r.url) {
-      map.set(r.collectionId, { url: r.url, type: r.type ?? null });
+      // An unrated image stores 0; a null column read is the same "unrated" claim.
+      map.set(r.collectionId, { url: r.url, type: r.type ?? null, nsfwLevel: r.nsfwLevel ?? 0 });
     }
   }
   return map;

--- a/src/tests/api/v1/blocks/block-collections-cover.test.ts
+++ b/src/tests/api/v1/blocks/block-collections-cover.test.ts
@@ -19,6 +19,7 @@ vi.mock('~/server/auth/session-client', () => ({ sessionClient: {} }));
 
 import {
   getFallbackCoverImages,
+  toCoverFields,
   toCoverImageUrl,
 } from '~/server/services/blocks/block-collections.service';
 import { dbMock } from '~/__tests__/mocks/db.mock';
@@ -49,6 +50,69 @@ describe('toCoverImageUrl', () => {
   });
 });
 
+describe('toCoverFields', () => {
+  it('🔴 NO COVER → the level field is ABSENT, not 0', () => {
+    // `0` is a REAL level (unrated). A consumer branches on `undefined` (no claim →
+    // use its own domain ceiling) versus any supplied value (authoritative), so
+    // emitting 0 for "there is no cover" silently moves it onto the other path.
+    for (const noImage of [null, undefined, { url: null, type: 'image' }, { url: '', type: 'image' }]) {
+      const fields = toCoverFields(noImage);
+      expect(fields.coverImageUrl).toBeNull();
+      // The KEY must be missing — `{ coverNsfwLevel: undefined }` would serialise
+      // away too, but asserting on the key is what pins the omission itself.
+      expect('coverNsfwLevel' in fields).toBe(false);
+      expect(Object.keys(fields)).toEqual(['coverImageUrl']);
+    }
+  });
+
+  it('🔴 an UNRATED (0) cover publishes a real 0 — the field is present', () => {
+    // The mirror of the case above, and the reason the absence test is not enough
+    // on its own: 0 must survive as a value rather than collapsing into "absent".
+    const fields = toCoverFields({ url: 'k', type: 'image', nsfwLevel: 0 });
+    expect(fields.coverNsfwLevel).toBe(0);
+    expect('coverNsfwLevel' in fields).toBe(true);
+  });
+
+  it('publishes the level verbatim for a rated cover', () => {
+    expect(toCoverFields({ url: 'k', type: 'image', nsfwLevel: 1 }).coverNsfwLevel).toBe(1);
+    expect(toCoverFields({ url: 'k', type: 'image', nsfwLevel: 4 }).coverNsfwLevel).toBe(4);
+    expect(toCoverFields({ url: 'k', type: 'image', nsfwLevel: 28 }).coverNsfwLevel).toBe(28);
+  });
+
+  it('a cover with a null/absent level is UNRATED (0), because it HAS a cover', () => {
+    expect(toCoverFields({ url: 'k', type: 'image', nsfwLevel: null }).coverNsfwLevel).toBe(0);
+    expect(toCoverFields({ url: 'k', type: 'image' }).coverNsfwLevel).toBe(0);
+  });
+
+  it('🔴 the url and the level come from THE SAME image — both halves move together', () => {
+    // The pairing is the whole point: a level describing an image other than the
+    // one in `coverImageUrl` is worse than no level at all, because the consumer
+    // treats a supplied level as authoritative.
+    const a = toCoverFields({ url: 'image-a', type: 'image', nsfwLevel: 1 });
+    const b = toCoverFields({ url: 'image-b', type: 'image', nsfwLevel: 16 });
+    expect(JSON.parse(a.coverImageUrl!).src).toBe('image-a');
+    expect(a.coverNsfwLevel).toBe(1);
+    expect(JSON.parse(b.coverImageUrl!).src).toBe('image-b');
+    expect(b.coverNsfwLevel).toBe(16);
+  });
+
+  it('a VIDEO cover keeps the poster shaping AND carries that video item\'s level', () => {
+    const fields = toCoverFields({ url: 'clip', type: 'video', nsfwLevel: 2 });
+    const out = JSON.parse(fields.coverImageUrl!);
+    expect(out.type).toBe('image');
+    expect(out.transcode).toBe(true);
+    expect(fields.coverNsfwLevel).toBe(2);
+  });
+
+  it('does NOT emit a bare `nsfwLevel` key (that name means the COLLECTION bitmask)', () => {
+    // Invariant guard, not regression coverage: a Collection's own `nsfwLevel` is
+    // OR-ed over its items and cannot separate a 97%-safe collection from a
+    // 1%-safe one, so the two names must never be confusable on this response.
+    const fields = toCoverFields({ url: 'k', type: 'image', nsfwLevel: 4 }) as Record<string, unknown>;
+    expect('nsfwLevel' in fields).toBe(false);
+  });
+});
+
 describe('getFallbackCoverImages (maturity clamp)', () => {
   beforeEach(() => mockQueryRaw.mockReset());
 
@@ -60,13 +124,13 @@ describe('getFallbackCoverImages (maturity clamp)', () => {
 
   it('threads browsingLevel into a BITWISE-clamped query and maps only url-bearing rows', async () => {
     mockQueryRaw.mockResolvedValueOnce([
-      { collectionId: 10, url: 'sfw-10', type: 'image' },
-      { collectionId: 11, url: 'clip-11', type: 'video' },
-      { collectionId: 12, url: null, type: 'image' }, // no url → dropped (placeholder)
+      { collectionId: 10, url: 'sfw-10', type: 'image', nsfwLevel: 1 },
+      { collectionId: 11, url: 'clip-11', type: 'video', nsfwLevel: 2 },
+      { collectionId: 12, url: null, type: 'image', nsfwLevel: 1 }, // no url → dropped
     ]);
     const map = await getFallbackCoverImages([10, 11, 12], 3);
-    expect(map.get(10)).toEqual({ url: 'sfw-10', type: 'image' });
-    expect(map.get(11)).toEqual({ url: 'clip-11', type: 'video' });
+    expect(map.get(10)).toEqual({ url: 'sfw-10', type: 'image', nsfwLevel: 1 });
+    expect(map.get(11)).toEqual({ url: 'clip-11', type: 'video', nsfwLevel: 2 });
     expect(map.has(12)).toBe(false);
 
     // The raw tagged-template call must carry the browsingLevel (3) as a bound
@@ -79,6 +143,42 @@ describe('getFallbackCoverImages (maturity clamp)', () => {
     expect(sql).toContain('DISTINCT ON (ci."collectionId")');
     expect(sql).toContain('ORDER BY ci."collectionId", ci."createdAt" DESC');
     expect(values).toContain(3);
+  });
+
+  it('🔴 SELECTS the item nsfwLevel, so a fallback cover can publish ITS OWN level', async () => {
+    // The level is not merely a filter predicate here: the endpoint publishes the
+    // level of the cover it serves, and for a fallback cover THIS row is that
+    // cover. Selecting only (url,type) is what forces the endpoint to describe the
+    // primary image it just rejected.
+    mockQueryRaw.mockResolvedValueOnce([{ collectionId: 10, url: 'k', type: 'image', nsfwLevel: 4 }]);
+    const map = await getFallbackCoverImages([10], 7);
+    expect(map.get(10)?.nsfwLevel).toBe(4);
+
+    const [strings] = mockQueryRaw.mock.calls[0] as unknown as [TemplateStringsArray, ...unknown[]];
+    // The projection, not the WHERE clause: an aliased select of the column.
+    expect(strings.join(' ? ')).toContain('i."nsfwLevel" as "nsfwLevel"');
+  });
+
+  it('a NULL nsfwLevel column reads as the real level 0 (unrated), never dropped', async () => {
+    // Unrated is a value, not an absence — a row with a null level still yields a
+    // usable cover, and `0` is what the wire must carry for it.
+    mockQueryRaw.mockResolvedValueOnce([{ collectionId: 10, url: 'k', type: 'image', nsfwLevel: null }]);
+    const map = await getFallbackCoverImages([10], 3);
+    expect(map.get(10)).toEqual({ url: 'k', type: 'image', nsfwLevel: 0 });
+  });
+
+  it('🔴 SEAM: a fallback map value feeds toCoverFields and its level survives verbatim', async () => {
+    // The two halves of this change meet here — `getFallbackCoverImages` carries a
+    // level and `toCoverFields` publishes it. Each is green on its own even if the
+    // map value and the projection's input shape disagree; this is the only
+    // assertion that loads BOTH surfaces.
+    mockQueryRaw.mockResolvedValueOnce([
+      { collectionId: 10, url: 'fallback-key', type: 'image', nsfwLevel: 2 },
+    ]);
+    const map = await getFallbackCoverImages([10], 3);
+    const fields = toCoverFields(map.get(10));
+    expect(fields.coverNsfwLevel).toBe(2);
+    expect(JSON.parse(fields.coverImageUrl!).src).toBe('fallback-key');
   });
 
   it('a stricter ceiling is threaded through verbatim', async () => {

--- a/src/tests/api/v1/blocks/collections-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/collections-endpoint.test.ts
@@ -97,6 +97,17 @@ vi.mock('~/server/services/blocks/block-collections.service', () => ({
   // image yields `edge:`; null when there is no url — mirrors toCoverImageUrl.
   toCoverImageUrl: (img: any) =>
     img?.url ? `${img.type === 'video' ? 'poster' : 'edge'}:${img.url}` : null,
+  // FAITHFUL PORT of toCoverFields: both fields derived from THE ONE image passed
+  // in, level omitted entirely when there is no url. Written this way on purpose —
+  // it means these tests can only observe WHICH IMAGE the endpoint chose, which is
+  // the endpoint's half of the contract. The projection's own semantics (0 vs
+  // absent, null → 0, the url/level pairing) are exercised against the REAL
+  // function in block-collections-cover.test.ts.
+  toCoverFields: (img: any) => {
+    const coverImageUrl = img?.url ? `${img.type === 'video' ? 'poster' : 'edge'}:${img.url}` : null;
+    if (coverImageUrl === null) return { coverImageUrl: null };
+    return { coverImageUrl, coverNsfwLevel: img?.nsfwLevel ?? 0 };
+  },
   // REAL bitwise semantics (Flags.intersects OR unrated 0) — NOT a `<=` — so the
   // maturity clamp on covers is exercised faithfully: a MIXED bucket (29) still
   // intersects a SFW ceiling (3), and a mature bucket (28) does NOT (28 & 3 = 0).
@@ -286,6 +297,8 @@ describe('GET /api/v1/blocks/collections', () => {
       name: 'A',
       description: 'desc A',
       coverImageUrl: 'edge:img10',
+      // The primary cover carries no explicit level → unrated, published as a real 0.
+      coverNsfwLevel: 0,
       itemCount: 5,
       curator: { userId: 100, username: 'alice' },
       isPublic: true,
@@ -754,6 +767,236 @@ describe('GET /api/v1/blocks/collections', () => {
     const calls = mockItemCount.mock.calls.map((c: any[]) => c[0]);
     expect(calls).toHaveLength(1);
     expect(calls[0].browsingLevel).toBe(3);
+  });
+
+  // ---- coverNsfwLevel: the maturity of the cover ACTUALLY SERVED ----
+  //
+  // The consumer (the playable-collections block) gates its card blur on
+  // `coverNsfwLevel` when present and falls back to its own domain ceiling when it
+  // is absent. That makes a SUPPLIED level authoritative, so the only thing worse
+  // than not publishing it is publishing one that describes a different image than
+  // the one in `coverImageUrl` — which is exactly what happens when the cover is a
+  // maturity-clamped FALLBACK and the level comes from the primary that was just
+  // rejected. These pin the pairing at the endpoint, i.e. which image it hands to
+  // the projection; the projection's own rules are pinned against the real
+  // function in block-collections-cover.test.ts.
+
+  it('🔴 mode=public: a MATURE primary is clamped out → the level is the FALLBACK\'s, not the rejected primary\'s', async () => {
+    // The headline case. Collection passes discovery (1 & 3), its own cover is
+    // mature (28 & 3 === 0) so the served cover is the clamped fallback. Publishing
+    // 28 beside the SFW fallback url would tell the consumer to blur an image that
+    // is safe — and, run the other way, would hand it a safe-looking level for a
+    // mature thumbnail.
+    mockGetAll.mockResolvedValueOnce([
+      {
+        id: 10,
+        name: 'A',
+        description: null,
+        read: 'Public',
+        nsfwLevel: 1,
+        userId: 1,
+        user: { id: 1, username: 'a' },
+        image: { url: 'mature-cover', type: 'image', nsfwLevel: 28 },
+      },
+    ]);
+    mockFallbackCovers.mockResolvedValueOnce(
+      new Map([[10, { url: 'sfw-item', type: 'image', nsfwLevel: 1 }]])
+    );
+    mockItemCount.mockResolvedValueOnce([{ id: 10, count: 3 }]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items[0].coverImageUrl).toBe('edge:sfw-item');
+    expect(body.items[0].coverNsfwLevel).toBe(1);
+    // …and emphatically NOT the level of the image that was rejected.
+    expect(body.items[0].coverNsfwLevel).not.toBe(28);
+  });
+
+  it('🔴 mode=public: a USABLE primary → the level is the PRIMARY\'s, even when a fallback row exists', async () => {
+    // The other direction of the same pairing. The fallback map is deliberately
+    // populated for this id with a DIFFERENT level; the endpoint serves the primary
+    // url, so it must publish the primary's level. Reading the level off the map
+    // unconditionally passes the mature case above and fails here.
+    mockGetAll.mockResolvedValueOnce([
+      {
+        id: 10,
+        name: 'A',
+        description: null,
+        read: 'Public',
+        nsfwLevel: 1,
+        userId: 1,
+        user: { id: 1, username: 'a' },
+        image: { url: 'primary-cover', type: 'image', nsfwLevel: 2 },
+      },
+    ]);
+    mockFallbackCovers.mockResolvedValueOnce(
+      new Map([[10, { url: 'other-item', type: 'image', nsfwLevel: 16 }]])
+    );
+    mockItemCount.mockResolvedValueOnce([{ id: 10, count: 3 }]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items[0].coverImageUrl).toBe('edge:primary-cover');
+    expect(body.items[0].coverNsfwLevel).toBe(2);
+    expect(body.items[0].coverNsfwLevel).not.toBe(16);
+  });
+
+  it('🔴 mode=public: NO cover at all → coverNsfwLevel is ABSENT from the item, never 0', async () => {
+    // No primary, no fallback → `coverImageUrl` is null and there is nothing to
+    // make a claim about. `0` means UNRATED, a real level, and the consumer's guard
+    // branches on `undefined` vs a value — so a 0 here silently changes its path.
+    //
+    // 🔴 THE SECOND COLLECTION IS WHAT MAKES THIS A TEST. An "is the key absent?"
+    // assertion is satisfied for free by a response that never carries the field at
+    // all — it passed on pre-change code, which publishes no level anywhere. The
+    // cover-bearing sibling in the SAME page proves this response DOES publish
+    // levels, so the absence on id 10 is a decision rather than a vacuum.
+    mockGetAll.mockResolvedValueOnce([
+      { id: 10, name: 'Bare', description: null, read: 'Public', nsfwLevel: 1, userId: 1, user: { id: 1, username: 'a' }, image: null },
+      // Level 2 INTERSECTS the ceiling 3, so this primary is served — a level that
+      // did not (4 & 3 === 0) would be clamped out onto an empty fallback and leave
+      // this collection cover-less too, quietly restoring the vacuum.
+      { id: 9, name: 'Covered', description: null, read: 'Public', nsfwLevel: 1, userId: 1, user: { id: 1, username: 'a' }, image: { url: 'k9', type: 'image', nsfwLevel: 2 } },
+    ]);
+    mockFallbackCovers.mockResolvedValueOnce(new Map());
+    mockItemCount.mockResolvedValueOnce([{ id: 10, count: 0 }, { id: 9, count: 1 }]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    const [bare, covered] = body.items;
+    expect(covered.coverImageUrl).toBe('edge:k9');
+    expect(covered.coverNsfwLevel).toBe(2); // the field IS being published here…
+    expect(bare.coverImageUrl).toBeNull(); // …and withheld here, on purpose.
+    expect('coverNsfwLevel' in bare).toBe(false);
+    expect(bare.coverNsfwLevel).toBeUndefined();
+    // And it survives the wire: JSON drops an absent key rather than nulling it.
+    expect(JSON.parse(JSON.stringify(bare))).not.toHaveProperty('coverNsfwLevel');
+  });
+
+  it('🔴 mode=public: an UNRATED (0) cover publishes a real 0 — presence is not "truthy"', async () => {
+    // The mirror of the absence case, and the mutation that a `if (level)` guard
+    // would pass: unrated is a level, and the card must be told so rather than
+    // being pushed onto the no-claim path.
+    mockGetAll.mockResolvedValueOnce([
+      {
+        id: 10,
+        name: 'A',
+        description: null,
+        read: 'Public',
+        nsfwLevel: 1,
+        userId: 1,
+        user: { id: 1, username: 'a' },
+        image: { url: 'unrated-cover', type: 'image', nsfwLevel: 0 },
+      },
+    ]);
+    mockItemCount.mockResolvedValueOnce([{ id: 10, count: 3 }]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items[0].coverImageUrl).toBe('edge:unrated-cover');
+    expect(body.items[0].coverNsfwLevel).toBe(0);
+    expect('coverNsfwLevel' in body.items[0]).toBe(true);
+  });
+
+  it('🔴 mode=public: EVERY item\'s level matches the image its url came from (mixed page)', async () => {
+    // A relationship assertion over a page holding all three shapes at once —
+    // primary-served, fallback-served, no-cover. A per-shape test can be satisfied
+    // by three separate right answers; this fails if the endpoint ever pairs one
+    // item's url with another item's (or another image's) level.
+    mockGetAll.mockResolvedValueOnce([
+      // 10: usable primary (2 & 3 !== 0) → primary url + primary level.
+      { id: 10, name: 'P', description: null, read: 'Public', nsfwLevel: 1, userId: 1, user: { id: 1, username: 'a' }, image: { url: 'p10', type: 'image', nsfwLevel: 2 } },
+      // 11: mature primary (8 & 3 === 0) → clamped out, fallback url + fallback level.
+      { id: 11, name: 'F', description: null, read: 'Public', nsfwLevel: 1, userId: 1, user: { id: 1, username: 'a' }, image: { url: 'p11', type: 'image', nsfwLevel: 8 } },
+      // 12: no primary and no fallback row → no cover at all.
+      { id: 12, name: 'N', description: null, read: 'Public', nsfwLevel: 1, userId: 1, user: { id: 1, username: 'a' }, image: null },
+    ]);
+    // The levels here are pairwise distinct AND distinct from every primary level
+    // above, so no mutant can produce the expected value by coincidence.
+    mockFallbackCovers.mockResolvedValueOnce(
+      new Map([[11, { url: 'f11', type: 'image', nsfwLevel: 1 }]])
+    );
+    mockItemCount.mockResolvedValueOnce([{ id: 10, count: 1 }, { id: 11, count: 1 }, { id: 12, count: 1 }]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+
+    // The level each url is KNOWN to carry, keyed by the url the endpoint served.
+    const levelOfServedImage: Record<string, number> = { 'edge:p10': 2, 'edge:f11': 1 };
+    expect(body.items).toHaveLength(3);
+    for (const item of body.items) {
+      if (item.coverImageUrl === null) {
+        expect('coverNsfwLevel' in item).toBe(false);
+      } else {
+        expect(levelOfServedImage).toHaveProperty(item.coverImageUrl);
+        expect(item.coverNsfwLevel).toBe(levelOfServedImage[item.coverImageUrl]);
+      }
+    }
+    // Pin the shapes too, so a page that silently collapsed to one shape cannot
+    // satisfy the loop above vacuously.
+    expect(body.items.map((i: any) => i.coverImageUrl)).toEqual(['edge:p10', 'edge:f11', null]);
+  });
+
+  it('🔴 mode=mine: the served cover\'s level is published on the subject\'s OWN collections too', async () => {
+    // The `mine` branch is a second, independent mapping site — the pairing has to
+    // hold there as well, and it has its own primary/fallback/none mix.
+    claimsBox.claims = fakeClaims({
+      scopes: ['collections:read:self', 'collections:read:private'],
+    });
+    mockUserCollections.mockResolvedValueOnce([
+      // 22: usable primary.
+      { id: 22, name: 'Own primary', description: null, read: 'Public', userId: 42, image: { url: 'own22', type: 'image', nsfwLevel: 2 } },
+      // 21: mature primary (8 & 3 === 0) → clamped out onto the fallback.
+      { id: 21, name: 'Own mature cover', description: null, read: 'Private', userId: 42, image: { url: 'own21', type: 'image', nsfwLevel: 8 } },
+      // 20: no cover anywhere.
+      { id: 20, name: 'Own bare', description: null, read: 'Public', userId: 42, image: null },
+    ]);
+    mockFallbackCovers.mockResolvedValueOnce(
+      new Map([[21, { url: 'own21-fallback', type: 'image', nsfwLevel: 1 }]])
+    );
+    mockItemCount.mockResolvedValueOnce([{ id: 22, count: 1 }]);
+    mockFollowed.mockResolvedValueOnce(new Set<number>());
+    const { req, res } = createMocks({ query: { mode: 'mine', limit: '24' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    const body = res._json() as any;
+    const byId = Object.fromEntries(body.items.map((i: any) => [i.id, i]));
+    expect(byId[22].coverImageUrl).toBe('edge:own22');
+    expect(byId[22].coverNsfwLevel).toBe(2);
+    expect(byId[21].coverImageUrl).toBe('edge:own21-fallback');
+    expect(byId[21].coverNsfwLevel).toBe(1);
+    expect(byId[21].coverNsfwLevel).not.toBe(8);
+    expect(byId[20].coverImageUrl).toBeNull();
+    expect('coverNsfwLevel' in byId[20]).toBe(false);
+    // The clamped-out own cover is the one sent to the fallback lookup, at the
+    // token ceiling — same authority as public discovery.
+    expect(mockFallbackCovers).toHaveBeenCalledWith([21, 20], 3);
+  });
+
+  it('the item never carries a bare `nsfwLevel` key (that name means the COLLECTION bitmask)', async () => {
+    // Invariant guard, not regression coverage — it also held before this change.
+    // The collection-level `nsfwLevel` is OR-ed over items and cannot separate a
+    // 97%-safe collection from a 1%-safe one, so leaking it under that name onto a
+    // per-card response would invite a consumer to gate on the wrong quantity.
+    mockGetAll.mockResolvedValueOnce([
+      { id: 10, name: 'A', description: null, read: 'Public', nsfwLevel: 29, userId: 1, user: { id: 1, username: 'a' }, image: { url: 'k', type: 'image', nsfwLevel: 1 } },
+    ]);
+    mockItemCount.mockResolvedValueOnce([{ id: 10, count: 1 }]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect('nsfwLevel' in body.items[0]).toBe(false);
+    expect(Object.keys(body.items[0]).sort()).toEqual([
+      'coverImageUrl',
+      'coverNsfwLevel',
+      'curator',
+      'description',
+      'followed',
+      'id',
+      'isPublic',
+      'itemCount',
+      'name',
+    ]);
   });
 
   it('400 returns a STRING error message + flattened details (not a raw ZodError)', async () => {


### PR DESCRIPTION
## What

`GET /api/v1/blocks/collections` returns a `coverImageUrl` per collection but no maturity level for that cover. This adds an optional `coverNsfwLevel` alongside it, on both `mode=public` and `mode=mine`.

Verified against the live endpoint before starting: the first item's keys were exactly `[coverImageUrl, curator, description, followed, id, isPublic, itemCount, name]`.

Additive and non-breaking — no existing field changed or removed, and no schema change (`Image.nsfwLevel` already exists).

## Why now

The consumer already exists and is already written against this field. A first-party collections block declares `coverNsfwLevel?: number` in its types and reads it at three call sites behind `nsfwLevel !== undefined ? shouldBlur(nsfwLevel) : !isSfw`. Today it is always `undefined`, so every card falls back to a domain-wide ceiling instead of gating on the cover it is actually painting.

## The three things that make this subtle

**1. The level must describe the cover ACTUALLY RETURNED.** The cover is `primaryCoverUsable(c) ? c.image : fallbackCovers.get(c.id)` — the primary `Collection.image` when its own level clears the token's clamped ceiling, otherwise the maturity-clamped fallback item. Publishing the primary's level beside a fallback url is *worse than publishing nothing*: the consumer treats a supplied level as authoritative and an absent one as "fall back to the ceiling", so a mismatched level is a lie it will gate on — and the mismatch case is exactly the one where the primary was rejected for being mature.

Rather than test for that, `toCoverFields()` makes it unrepresentable: it takes **one** image and returns **both** fields from it, so the caller picks the image once and the two cannot drift.

**2. `getFallbackCoverImages` did not return the level.** It selected `url` and `type` only — `nsfwLevel` appeared solely in the `WHERE`. For a fallback cover *that row is the served image*, so its own level now travels with it. Its only two call sites are the two mapping sites in this endpoint; both are updated in this PR.

**3. No cover ⇒ the field is ABSENT, never `0`.** `0` is a real level meaning *unrated*, and the consumer's guard branches on `undefined` vs a real value, so emitting `0` for "there is no cover" would silently move it onto a different code path. The presence of the level is decided by the same expression as the presence of the url (`coverImageUrl === null`), so they cannot disagree.

## Naming, deliberately

It is `coverNsfwLevel`, **not** `nsfwLevel`. A Collection has its own `nsfwLevel` — a bitmask OR-ed over its items — and this endpoint's existing doc comment already records at length that it cannot separate a 97%-safe contest collection from a 1%-safe mature one (both carry `29`). A field named `nsfwLevel` on this response would invite exactly that confusion. Both doc comments say so explicitly, and a test asserts the item's key set contains no bare `nsfwLevel`.

## Semantic, and a consumer-side mismatch to fix separately

The fallback cover is selected `ORDER BY ci."createdAt" DESC` — the **newest** clamped accepted item. It is deliberately not a "best" or "highest-rated representative"; nothing on this path ranks items. The server-side doc comment now states the semantic as *the level of the image being served as the cover*.

⚠️ The consumer's own type comment currently describes the cover as "its highest-rated representative item", which does not match what the server selects. That is a comment fix in the consuming repo, not here — flagging it so it can be corrected there.

## Verification

Runner: `node scripts/test-unit-run.mjs` (→ `vitest run --project 'unit*'`); typecheck `node scripts/typecheck.mjs`.

- **Full unit suite:** `1649 passed | 3 skipped (1652)` files, `38311 passed | 33 skipped (38344)` tests.
- **Typecheck:** `0 type errors`.
- **Adjacent suites** (`src/server/services/blocks/__tests__`, `collection-item-count-clamp*`, `src/tests/api/v1`): `210 passed` files / `4628 passed` tests.
- **ESLint** on the four changed files: 0 errors (51 pre-existing-style `no-explicit-any` warnings in the test file).

**Red at base.** Both test files were run against `origin/main`'s sources with the new tests in place: **19 failed / 40 passed**. Every new or changed assertion is red at base; the 40 are the pre-existing tests, unchanged.

One new test initially passed at base and was strengthened rather than counted: an "is the key absent?" assertion is satisfied for free by a response that publishes no level anywhere. It now includes a cover-bearing sibling in the same page, which proves the response *does* publish levels, and it is red at base.

Two assertions are **invariant guards, not regression coverage**, and are labelled as such in-file: "no bare `nsfwLevel` key" held before this change too.

**Mutation-checked — 13 mutants, all killed**, each by the intended test with that test's own assertion, on inputs no earlier check rejects. Every mutant edit was `cmp`-verified to have actually changed the file before the run.

| # | Mutation | Killed by |
|---|---|---|
| M1 | no-cover emits `0` instead of omitting | `NO COVER → the level field is ABSENT, not 0` |
| M2 | truthiness guard drops a real `0` | `an UNRATED (0) cover publishes a real 0` |
| M3 | absent level normalises to 1, not 0 | `a cover with a null/absent level is UNRATED (0)` |
| M4 | fallback map drops the level | 4 tests incl. the seam test |
| M5 | null column level becomes 1 | `a NULL nsfwLevel column reads as the real level 0` |
| M6 | SQL stops selecting `nsfwLevel` | `SELECTS the item nsfwLevel` |
| M7 | public branch levels the PRIMARY unconditionally | mature-clamped / no-cover / mixed-page |
| M8 | public branch levels the FALLBACK unconditionally | usable-primary / no-cover / mixed-page |
| M9 | mine branch levels the PRIMARY unconditionally | `mode=mine: the served cover's level…` |
| M10 | field renamed to `nsfwLevel` | 7 tests |
| M11 | mine branch levels the FALLBACK unconditionally | `mode=mine: the served cover's level…` |
| M12 | mine branch coerces no-cover to `0` | `mode=mine: the served cover's level…` |

M9's first anchor was a **substring of the public branch's more-indented line**, so it silently mutated the public branch and reported the public tests as killers. Caught by the anchor-occurrence count in the harness, re-anchored on the preceding comment line, and re-run — the corrected M9/M11/M12 are each killed by the `mode=mine` test alone, which is what proves that branch is independently covered.

Coverage includes: primary-cover, fallback-cover, no-cover, unrated (`0`) published as a real `0`, both modes, and a mixed page asserting item-by-item that each published level belongs to the image its url came from.

## Not verified

Only the SQL text is asserted for the `nsfwLevel` projection — `dbRead.$queryRaw` is mocked, as it already was for this function, so the column is not exercised against a live Postgres. The `?? 0` normalisation of a null column read is covered at the mapping layer, not against a real null row.

## Overlap with open PRs

Based directly on `main`, not stacked. Checked both adjacent open PRs for file overlap: **none**.

- **#4661** (`zach/collections-index-stale-images`) — touches `collection-media-index.ts`, `image.service.ts`, `model.service.ts`, a migration. No shared file.
- **#4597** (`feat/allow-creators-to-archive-collections`) — touches `collection.service.ts`, controllers/routers/schema/selectors, a migration. No shared file; this PR does not modify `collection.service.ts`.
