### PR TITLE
feat(blocks): collection follow/unfollow over the host bridge, behind a host-chrome consent confirm

### DIFF
--- a/src/components/AppBlocks/BlockHostTokenRetry.browser.test.tsx
+++ b/src/components/AppBlocks/BlockHostTokenRetry.browser.test.tsx
@@ -77,6 +77,13 @@ vi.mock('~/utils/trpc', () => ({
   // wholesale module mock MUST re-declare it or the ESM link fails.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     blocks: {
       getEffectiveCheckpoint: {
         useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),

--- a/src/components/AppBlocks/IframeHost.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHost.browser.test.tsx
@@ -55,6 +55,13 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
 
 vi.mock('~/utils/trpc', () => ({
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     blocks: {
       getEffectiveCheckpoint: {
         useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -54,6 +54,11 @@ import { useBlockIframeSrc } from './useBlockIframeSrc';
 import { usePostMessage } from './usePostMessage';
 import type { BlockInitPayload, BlockInstall, ModelSlotContext, SlotContext } from './types';
 import { dialogStore } from '~/components/Dialog/dialogStore';
+import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
+import {
+  buildCollectionFollowConsentCopy,
+  resolveCollectionFollowRequest,
+} from './collectionFollowGate';
 import type { BuyBuzzModalProps } from '~/components/Modals/BuyBuzzModal';
 import { openResourceSelectModal } from '~/components/Dialog/triggers/resource-select';
 import { getBaseModelGroup, getBaseModelsByGroup } from '~/shared/constants/basemodel.constants';
@@ -1095,6 +1100,13 @@ export function IframeHost({
   // link was clicked from. So the predicate mirrors the route's own
   // `getServerSideProps` conjunction, not just the pages flag.
   const features = useFeatureFlags();
+  // The AUTHORITATIVE signed-in signal for this host. Deliberately not
+  // `context.viewerUserId`: that is a slot-context field the producing page fills
+  // in, so it describes the render context rather than the live session, and the
+  // SET_COLLECTION_FOLLOW handler below refuses an anonymous viewer on it (the
+  // property the HTTP endpoint enforced with a 403 on an anonymous block token).
+  // `AppBlockChrome` already calls this hook, so it costs nothing new here.
+  const currentUser = useCurrentUser();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   // The host trust frame (`framed()` below) — the box the VIEWER sees, which is
   // the chrome bar plus the iframe. Needed so layer 4 of the height clamp can
@@ -2485,6 +2497,14 @@ export function IframeHost({
   const sharedUnvoteMutation = trpc.apps.shared.unvote.useMutation();
   const sharedWithdrawMutation = trpc.apps.shared.withdraw.useMutation();
   const sharedReportMutation = trpc.apps.shared.report.useMutation();
+  // Collection follow/unfollow bridge (SET_COLLECTION_FOLLOW). SESSION-authed
+  // (protectedProcedure) — these are the SAME procedures the site's own follow
+  // button calls, so the handler self-binds to `ctx.user.id` server-side and
+  // reuses `addContributorToCollection` / `removeContributorFromCollection`
+  // verbatim. The block token is deliberately NOT involved: the point of this
+  // bridge is that a block needs no `collections:write:self` scope.
+  const followCollectionMutation = trpc.collection.follow.useMutation();
+  const unfollowCollectionMutation = trpc.collection.unfollow.useMutation();
 
   useEffect(() => {
     const off = onMessage<
@@ -2785,6 +2805,85 @@ export function IframeHost({
     );
     return off;
   }, [onMessage, send, token, trpcUtils, sharedReportMutation]);
+
+  // ── SET_COLLECTION_FOLLOW → COLLECTION_FOLLOW_RESULT ────────────────────────
+  //
+  // A block asks the host to follow / unfollow a collection for the viewer. The
+  // decision layer is SHARED with PageBlockHost (`collectionFollowGate.ts`) and
+  // carries the full rationale; the only thing this host contributes is its own
+  // signed-in signal (`currentUser`). There is no mod-review sandbox on the model
+  // slot, so `reviewNack` is constant false here.
+  //
+  // 🔴 THE CONSENT BOUNDARY IS THE CONFIRM CLICK. This bridge exists so a block
+  // no longer needs the `collections:write:self` scope, which was the viewer's
+  // consent step on the HTTP path. The replacement is host chrome the sandboxed
+  // iframe cannot fake or restyle: NOTHING is written until the viewer clicks
+  // through `ConfirmDialog`. Do not "simplify" this by calling the mutation
+  // directly — that silently converts a consented action into an unconsented one.
+  //
+  // REQUEST-style ⇒ every terminal path (refusal / cancel / success / error)
+  // MUST reply exactly once or the block hangs to its SDK timeout; the `settled`
+  // latch guards a double-reply. Only a payload with no usable requestId is
+  // dropped — there is nothing to reply to.
+  useEffect(() => {
+    const off = onMessage<unknown>('SET_COLLECTION_FOLLOW', (raw) => {
+      const gate = resolveCollectionFollowRequest({
+        raw,
+        signedIn: currentUser?.id != null,
+        // The model slot has no review sandbox (pending apps are reviewed on the
+        // page host), so there is nothing to NACK for here.
+        reviewNack: false,
+      });
+      if (gate.kind === 'drop') return;
+      if (gate.kind === 'refuse') {
+        send('COLLECTION_FOLLOW_RESULT', { requestId: gate.requestId, error: gate.error });
+        return;
+      }
+      const { requestId, collectionId, follow } = gate.request;
+      let settled = false;
+      const reply = (payload: Record<string, unknown>) => {
+        if (settled) return;
+        settled = true;
+        send('COLLECTION_FOLLOW_RESULT', { requestId, ...payload });
+      };
+      const copy = buildCollectionFollowConsentCopy({ follow, appName: install.manifest.name });
+      dialogStore.trigger({
+        component: ConfirmDialog,
+        props: {
+          title: copy.title,
+          message: copy.message,
+          labels: { confirm: copy.confirmLabel, cancel: 'Cancel' },
+          confirmProps: { color: 'blue' },
+          onConfirm: async () => {
+            try {
+              // Self-bound server-side: the handlers pass `ctx.user.id` as BOTH
+              // actor and target, so `collectionId` is the ONLY thing the block
+              // influences.
+              if (follow) await followCollectionMutation.mutateAsync({ collectionId });
+              else await unfollowCollectionMutation.mutateAsync({ collectionId });
+              reply({ result: { collectionId, followed: follow } });
+            } catch (err) {
+              // FORBIDDEN from the collection services (e.g. a private
+              // collection this viewer may not follow) lands here as a message,
+              // never as a hang.
+              reply({ error: err instanceof Error ? err.message : 'unknown' });
+            }
+          },
+          // Dismiss (Cancel / X / escape) = consent DECLINED. Settle the block's
+          // promise explicitly rather than leaving it to time out.
+          onCancel: () => reply({ error: 'declined' }),
+        },
+      });
+    });
+    return off;
+  }, [
+    onMessage,
+    send,
+    currentUser,
+    install.manifest.name,
+    followCollectionMutation,
+    unfollowCollectionMutation,
+  ]);
 
   useEffect(() => {
     if (status !== 'ready') return;

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -58,8 +58,10 @@ import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import {
   buildCollectionFollowConsentCopy,
   createCollectionFollowSettlement,
+  createCollectionLookupBudget,
   resolveCollectionFollowRequest,
   resolveCollectionIdentity,
+  type CollectionLookupBudget,
 } from './collectionFollowGate';
 import type { BuyBuzzModalProps } from '~/components/Modals/BuyBuzzModal';
 import { openResourceSelectModal } from '~/components/Dialog/triggers/resource-select';
@@ -2507,6 +2509,13 @@ export function IframeHost({
   // bridge is that a block needs no `collections:write:self` scope.
   const followCollectionMutation = trpc.collection.follow.useMutation();
   const unfollowCollectionMutation = trpc.collection.unfollow.useMutation();
+  // 🔴 This block instance's DISTINCT-collection-id lookup budget. A ref, not
+  // module scope and not state: per-instance (two blocks on a page cannot drain
+  // each other), reset on remount, and read synchronously inside the message
+  // handler. Lazily constructed so a render never allocates a Set it throws away.
+  // The reasoning — and the authenticated visibility oracle it closes — lives on
+  // `createCollectionLookupBudget`.
+  const collectionLookupBudgetRef = useRef<CollectionLookupBudget | null>(null);
 
   useEffect(() => {
     const off = onMessage<
@@ -2855,6 +2864,20 @@ export function IframeHost({
         requestId,
         emit: (payload) => send('COLLECTION_FOLLOW_RESULT', payload),
       });
+      // 🔴 BOUND THE PROBE, BEFORE SPENDING AN AUTHENTICATED READ. The identity
+      // lookup below runs in the VIEWER'S session and completes before any
+      // dialog, so without a bound it is a per-id "can this viewer see it?"
+      // oracle the block can drive at the transport's 30 msg/s. DISTINCT ids,
+      // not calls — a repeat is free forever, so re-following a collection the
+      // viewer has already been asked about keeps working past the cap. The
+      // refusal deliberately reuses `collection-unavailable`; a distinct code
+      // would hand back the bit the cap withholds. Full reasoning (incl. why a
+      // distinct-id cap rather than a time window) on the factory.
+      const lookupBudget = (collectionLookupBudgetRef.current ??= createCollectionLookupBudget());
+      if (!lookupBudget.admit(collectionId)) {
+        settlement.reply({ error: 'collection-unavailable' });
+        return;
+      }
       void (async () => {
         // Resolve WHO/WHAT the viewer is being asked about, server-side, from the
         // same id we are about to act on. A failed lookup refuses WITH a reply —

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -57,7 +57,9 @@ import { dialogStore } from '~/components/Dialog/dialogStore';
 import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import {
   buildCollectionFollowConsentCopy,
+  createCollectionFollowSettlement,
   resolveCollectionFollowRequest,
+  resolveCollectionIdentity,
 } from './collectionFollowGate';
 import type { BuyBuzzModalProps } from '~/components/Modals/BuyBuzzModal';
 import { openResourceSelectModal } from '~/components/Dialog/triggers/resource-select';
@@ -2814,21 +2816,30 @@ export function IframeHost({
   // signed-in signal (`currentUser`). There is no mod-review sandbox on the model
   // slot, so `reviewNack` is constant false here.
   //
-  // 🔴 THE CONSENT BOUNDARY IS THE CONFIRM CLICK. This bridge exists so a block
-  // no longer needs the `collections:write:self` scope, which was the viewer's
-  // consent step on the HTTP path. The replacement is host chrome the sandboxed
-  // iframe cannot fake or restyle: NOTHING is written until the viewer clicks
-  // through `ConfirmDialog`. Do not "simplify" this by calling the mutation
-  // directly — that silently converts a consented action into an unconsented one.
+  // 🔴 THE CONSENT BOUNDARY IS THE CONFIRM CLICK, AND IT IS THE ONLY CONSENT THIS
+  // PATH HAS EVER HAD. The HTTP endpoint's `collections:write:self` scope is
+  // CONSENT-EXEMPT server-side, so it never prompted anyone — see the retracted
+  // claim recorded in `collectionFollowGate.ts`. This bridge therefore TIGHTENS a
+  // zero-prompt path into one prompt per action. Do not "simplify" it by calling
+  // the mutation directly, and do not delete the confirm as redundant with a
+  // scope grant that does not exist.
   //
-  // REQUEST-style ⇒ every terminal path (refusal / cancel / success / error)
-  // MUST reply exactly once or the block hangs to its SDK timeout; the `settled`
-  // latch guards a double-reply. Only a payload with no usable requestId is
-  // dropped — there is nothing to reply to.
+  // 🔴 THE DIALOG MUST NAME THE COLLECTION, and the name must be the one the HOST
+  // resolved from `collectionId` — never one the block supplied. A block can
+  // render its own "Follow ⭐ Cute Cats" card and post a different id; host chrome
+  // that asserts nothing about the object cannot contradict it.
+  //
+  // REQUEST-style ⇒ every terminal path (refusal / lookup failure / cancel /
+  // success / error) MUST reply exactly once or the block hangs to its SDK
+  // timeout; `createCollectionFollowSettlement` owns that latch AND the consent
+  // latch that keeps `declined` meaning "no write occurred". Only a payload with
+  // no usable requestId is dropped — there is nothing to reply to.
   useEffect(() => {
     const off = onMessage<unknown>('SET_COLLECTION_FOLLOW', (raw) => {
       const gate = resolveCollectionFollowRequest({
         raw,
+        // `readGateStatus()` (not a closed-over `status`) — see its definition.
+        ready: readGateStatus() === 'ready',
         signedIn: currentUser?.id != null,
         // The model slot has no review sandbox (pending apps are reviewed on the
         // page host), so there is nothing to NACK for here.
@@ -2840,47 +2851,81 @@ export function IframeHost({
         return;
       }
       const { requestId, collectionId, follow } = gate.request;
-      let settled = false;
-      const reply = (payload: Record<string, unknown>) => {
-        if (settled) return;
-        settled = true;
-        send('COLLECTION_FOLLOW_RESULT', { requestId, ...payload });
-      };
-      const copy = buildCollectionFollowConsentCopy({ follow, appName: install.manifest.name });
-      dialogStore.trigger({
-        component: ConfirmDialog,
-        props: {
-          title: copy.title,
-          message: copy.message,
-          labels: { confirm: copy.confirmLabel, cancel: 'Cancel' },
-          confirmProps: { color: 'blue' },
-          onConfirm: async () => {
-            try {
-              // Self-bound server-side: the handlers pass `ctx.user.id` as BOTH
-              // actor and target, so `collectionId` is the ONLY thing the block
-              // influences.
-              if (follow) await followCollectionMutation.mutateAsync({ collectionId });
-              else await unfollowCollectionMutation.mutateAsync({ collectionId });
-              reply({ result: { collectionId, followed: follow } });
-            } catch (err) {
-              // FORBIDDEN from the collection services (e.g. a private
-              // collection this viewer may not follow) lands here as a message,
-              // never as a hang.
-              reply({ error: err instanceof Error ? err.message : 'unknown' });
-            }
-          },
-          // Dismiss (Cancel / X / escape) = consent DECLINED. Settle the block's
-          // promise explicitly rather than leaving it to time out.
-          onCancel: () => reply({ error: 'declined' }),
-        },
+      const settlement = createCollectionFollowSettlement({
+        requestId,
+        emit: (payload) => send('COLLECTION_FOLLOW_RESULT', payload),
       });
+      void (async () => {
+        // Resolve WHO/WHAT the viewer is being asked about, server-side, from the
+        // same id we are about to act on. A failed lookup refuses WITH a reply —
+        // never a hang, and never a dialog missing the name it promised.
+        let identity;
+        try {
+          identity = resolveCollectionIdentity(
+            await trpcUtils.collection.getById.fetch({ id: collectionId }, { staleTime: 0 })
+          );
+        } catch {
+          // Not found / not visible / feature-flagged / network — all one
+          // outcome, so the reply cannot be used to probe for existence.
+          identity = { kind: 'unavailable' } as const;
+        }
+        if (identity.kind !== 'ok') {
+          settlement.reply({ error: 'collection-unavailable' });
+          return;
+        }
+        const copy = buildCollectionFollowConsentCopy({
+          follow,
+          appName: install.manifest.name,
+          collectionId,
+          collection: identity.identity,
+        });
+        dialogStore.trigger({
+          // Per-request id so two SET_COLLECTION_FOLLOW calls can't dedup against
+          // each other in the dialog store's silent `if (!exists)` drop — a
+          // dropped dialog would be a request that never replies, i.e. a hang.
+          // (Insurance, matching the OPEN_IMAGE_UPLOAD handler; the collision was
+          // not reproducible, since rendering a Mantine modal costs >1 ms.)
+          id: `block-collection-follow-${requestId}`,
+          component: ConfirmDialog,
+          props: {
+            title: copy.title,
+            message: copy.message,
+            labels: { confirm: copy.confirmLabel, cancel: 'Cancel' },
+            confirmProps: { color: 'blue' },
+            onConfirm: async () => {
+              // SYNCHRONOUS, before any await: from here on a dismissal must not
+              // be able to claim `declined` for a write that is under way.
+              settlement.markConsented();
+              try {
+                // Self-bound server-side: the handlers pass `ctx.user.id` as BOTH
+                // actor and target, so `collectionId` is the ONLY thing the block
+                // influences.
+                if (follow) await followCollectionMutation.mutateAsync({ collectionId });
+                else await unfollowCollectionMutation.mutateAsync({ collectionId });
+                settlement.reply({ result: { collectionId, followed: follow } });
+              } catch (err) {
+                // FORBIDDEN from the collection services (e.g. a private
+                // collection this viewer may not follow) lands here as a message,
+                // never as a hang.
+                settlement.reply({ error: err instanceof Error ? err.message : 'unknown' });
+              }
+            },
+            // Dismiss (Cancel / X / escape / overlay) = consent DECLINED. Settle
+            // the block's promise explicitly rather than leaving it to time out —
+            // unless consent was already given, in which case this is a no-op.
+            onCancel: settlement.decline,
+          },
+        });
+      })();
     });
     return off;
   }, [
     onMessage,
     send,
+    readGateStatus,
     currentUser,
     install.manifest.name,
+    trpcUtils,
     followCollectionMutation,
     unfollowCollectionMutation,
   ]);

--- a/src/components/AppBlocks/IframeHostCollectionFollow.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostCollectionFollow.browser.test.tsx
@@ -1,0 +1,367 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { useDialogStore } from '~/components/Dialog/dialogStore';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace import for the `importOriginal` spread below (the repo's
+// local-rules/no-wholesale-module-mock cure).
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * SET_COLLECTION_FOLLOW → COLLECTION_FOLLOW_RESULT on the MODEL-SLOT host.
+ *
+ * 🔴 THIS SUITE IS HALF THE COVERAGE. `PageBlockHost` is a SEPARATE surface with
+ * its own postMessage bridge; the two hosts share only the pure decision module
+ * (`collectionFollowGate.ts`), so wiring one and not the other is invisible to
+ * either suite alone. The structural half of that is
+ * `hostHandlerParity.test.ts`, which requires BOTH hosts to register a handler;
+ * this file is the behavioural half for the model slot, mirrored by
+ * `PageBlockHostCollectionFollow.browser.test.tsx`.
+ *
+ * The property under test is the CONSENT boundary: this bridge exists so a block
+ * no longer needs the `collections:write:self` scope (whose grant used to BE the
+ * viewer's consent), so nothing may be written until the viewer clicks through
+ * host chrome the sandboxed iframe cannot fake.
+ */
+
+const { followMutate, unfollowMutate, currentUser } = vi.hoisted(() => ({
+  followMutate: vi.fn(),
+  unfollowMutate: vi.fn(),
+  // Mutable so one file can cover BOTH the signed-in and the anonymous viewer —
+  // the anonymous refusal is a security property, not an edge case, so it must
+  // be exercised against the real host rather than only in the gate's unit test.
+  currentUser: { value: null as { id: number } | null },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => currentUser.value }));
+
+// This factory REPLACES the module, so it must name every export this file's
+// module graph imports — including `useOptionalFeatureFlags`, which the app-block
+// chrome reads. Omitting one makes the FILE fail to import, which reports as
+// `Tests no tests` rather than as a failure.
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: false, appBlocksPages: false }),
+  useOptionalFeatureFlags: () => ({ appBlocks: false, appBlocksPages: false }),
+}));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: followMutate }) },
+      unfollow: { useMutation: () => ({ mutateAsync: unfollowMutate }) },
+    },
+    blocks: {
+      getEffectiveCheckpoint: {
+        useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),
+      },
+      getShowcaseImages: { useQuery: () => ({ data: [], isLoading: false }) },
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      updateUserSettings: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', () => ({
+  useBrowsingLevelDebounced: () => 1,
+}));
+
+// eslint-disable-next-line import/first
+import { IframeHost } from '~/components/AppBlocks/IframeHost';
+// eslint-disable-next-line import/first
+import type { BlockInstall, ModelSlotContext } from '~/components/AppBlocks/types';
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+function iframeEl() {
+  return page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+}
+
+function postFromBlock(type: string, payload?: unknown) {
+  const cw = iframeEl().contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+function listenForReply() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const cw = iframeEl().contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    of: (type: string) => received.filter((m) => m.type === type),
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+function lastDialog() {
+  const dialogs = useDialogStore.getState().dialogs;
+  if (dialogs.length === 0) throw new Error('no modal opened');
+  return dialogs[dialogs.length - 1];
+}
+
+const install: BlockInstall = {
+  blockInstanceId: 'inst_test',
+  blockId: 'my-model-app',
+  appId: 'app_test',
+  appBlockId: 'apb_test',
+  manifest: {
+    name: 'Playable Collections',
+    scopes: [],
+    iframe: {
+      src: SAME_ORIGIN_SRC,
+      minHeight: 200,
+      maxHeight: 800,
+      resizable: true,
+      sandbox: 'allow-scripts',
+    },
+  },
+  publisherSettings: {},
+  enabled: true,
+  renderMode: 'iframe',
+  trustTier: 'internal',
+};
+
+const context: ModelSlotContext = {
+  slotId: 'model.sidebar_top',
+  entityType: 'model',
+  modelId: 123,
+  modelVersionId: 456,
+  modelName: 'Some Model',
+  modelType: 'Checkpoint',
+  modelNsfwLevel: 1,
+  creatorUserId: 7,
+  viewerUserId: 42,
+  viewerNsfwEnabled: false,
+  viewerUsername: 'tester',
+  theme: 'light',
+};
+
+const baseProps = {
+  install,
+  context,
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+};
+
+async function mountAndReady() {
+  renderWithProviders(<IframeHost {...baseProps} />);
+  await vi.waitFor(() => {
+    if (!iframeEl().contentWindow) throw new Error('not mounted yet');
+  });
+  const replies = listenForReply();
+  // POSITIVE CONTROL: the listener is proven to observe real host pushes before
+  // any assertion rests on it — a `toBeUndefined()` on a channel wired to
+  // nothing is indistinguishable from a genuine absence.
+  await vi.waitFor(() => {
+    if (replies.of('BLOCK_INIT').length === 0) throw new Error('listener saw no BLOCK_INIT');
+  });
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    if (iframeEl().getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+  return replies;
+}
+
+type ConfirmProps = {
+  title: string;
+  message: string;
+  labels: { confirm: string; cancel: string };
+  onConfirm: () => Promise<void> | void;
+  onCancel: () => void;
+};
+
+describe('IframeHost SET_COLLECTION_FOLLOW (consent-gated follow, model slot)', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+    followMutate.mockReset();
+    unfollowMutate.mockReset();
+    currentUser.value = { id: 42 };
+  });
+
+  test('opens a host-chrome consent confirm BEFORE any write; on CONFIRM calls collection.follow', async () => {
+    followMutate.mockResolvedValue(undefined);
+    const replies = await mountAndReady();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_follow',
+      collectionId: 77,
+      follow: true,
+    });
+
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    expect(followMutate).not.toHaveBeenCalled();
+    const props = lastDialog().props as ConfirmProps;
+    expect(props.title).toBe('Follow this collection?');
+    // The model host names the app from its INSTALL manifest (the page host uses
+    // its `appName` prop) — assert it actually reaches the dialog.
+    expect(props.message).toContain('Playable Collections');
+    expect(props.labels.confirm).toBe('Follow');
+
+    await props.onConfirm();
+
+    expect(followMutate).toHaveBeenCalledWith({ collectionId: 77 });
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_follow',
+        result: { collectionId: 77, followed: true },
+      });
+    });
+    replies.stop();
+  });
+
+  test('follow:false routes to collection.unfollow and replies followed:false', async () => {
+    unfollowMutate.mockResolvedValue(undefined);
+    const replies = await mountAndReady();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_unfollow',
+      collectionId: 78,
+      follow: false,
+    });
+
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    const props = lastDialog().props as ConfirmProps;
+    expect(props.title).toBe('Unfollow this collection?');
+    expect(props.labels.confirm).toBe('Unfollow');
+    await props.onConfirm();
+
+    expect(unfollowMutate).toHaveBeenCalledWith({ collectionId: 78 });
+    expect(followMutate).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_unfollow',
+        result: { collectionId: 78, followed: false },
+      });
+    });
+    replies.stop();
+  });
+
+  test('🔴 on DISMISS (consent declined) replies `declined` and NEVER writes', async () => {
+    const replies = await mountAndReady();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', { requestId: 'rq_no', collectionId: 5, follow: true });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+
+    (lastDialog().props as ConfirmProps).onCancel();
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_no', error: 'declined' });
+    });
+    expect(followMutate).not.toHaveBeenCalled();
+    expect(unfollowMutate).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('🔴 an ANONYMOUS viewer is refused with sign-in-required — no dialog, no write', async () => {
+    currentUser.value = null;
+    const replies = await mountAndReady();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', { requestId: 'rq_anon', collectionId: 5, follow: true });
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_anon', error: 'sign-in-required' });
+    });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(followMutate).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('a malformed collectionId is REFUSED with a reply (never a silent hang)', async () => {
+    const replies = await mountAndReady();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', { requestId: 'rq_bad', collectionId: 0, follow: true });
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_bad', error: 'invalid-request' });
+    });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    replies.stop();
+  });
+
+  test('a payload with no requestId is dropped (no dialog, no reply)', async () => {
+    const replies = await mountAndReady();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', { collectionId: 5, follow: true });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(replies.last('COLLECTION_FOLLOW_RESULT')).toBeUndefined();
+    expect(followMutate).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('a server FORBIDDEN comes back as an error reply, exactly once', async () => {
+    followMutate.mockRejectedValue(new Error('You do not have permission to follow'));
+    const replies = await mountAndReady();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', { requestId: 'rq_403', collectionId: 9, follow: true });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    await (lastDialog().props as ConfirmProps).onConfirm();
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_403',
+        error: 'You do not have permission to follow',
+      });
+    });
+    expect(replies.of('COLLECTION_FOLLOW_RESULT')).toHaveLength(1);
+    replies.stop();
+  });
+});

--- a/src/components/AppBlocks/IframeHostCollectionFollow.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostCollectionFollow.browser.test.tsx
@@ -18,15 +18,25 @@ import type * as TrpcMod from '~/utils/trpc';
  * this file is the behavioural half for the model slot, mirrored by
  * `PageBlockHostCollectionFollow.browser.test.tsx`.
  *
- * The property under test is the CONSENT boundary: this bridge exists so a block
- * no longer needs the `collections:write:self` scope (whose grant used to BE the
- * viewer's consent), so nothing may be written until the viewer clicks through
- * host chrome the sandboxed iframe cannot fake.
+ * The property under test is the CONSENT boundary. ⚠️ An earlier version of this
+ * header said the dropped `collections:write:self` scope's grant "used to BE the
+ * viewer's consent" — RETRACTED, and false: that scope is in
+ * `CONSENT_EXEMPT_SCOPES` (`src/server/services/blocks/scope-grant.service.ts`),
+ * so it always minted WITHOUT a prompt and no grant row exists. The HTTP path had
+ * zero prompts; this confirm is the only consent this operation has ever had, so
+ * these tests are pinning a TIGHTENING, not policing a loosening. Nothing may be
+ * written until the viewer clicks through host chrome the sandboxed iframe cannot
+ * fake — and that chrome must NAME the collection the host itself resolved, or it
+ * asserts nothing the block's own UI could contradict.
  */
 
-const { followMutate, unfollowMutate, currentUser } = vi.hoisted(() => ({
+const { followMutate, unfollowMutate, getByIdFetch, currentUser } = vi.hoisted(() => ({
   followMutate: vi.fn(),
   unfollowMutate: vi.fn(),
+  // The HOST-SIDE collection lookup that makes the consent dialog name its
+  // object. Mocked per-test so a suite can exercise the found / not-visible /
+  // lookup-failed arms independently of any block-supplied string.
+  getByIdFetch: vi.fn(),
   // Mutable so one file can cover BOTH the signed-in and the anonymous viewer —
   // the anonymous refusal is a security property, not an edge case, so it must
   // be exercised against the real host rather than only in the gate's unit test.
@@ -78,6 +88,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
       },
     },
     useUtils: () => ({
+      collection: { getById: { fetch: getByIdFetch } },
       apps: {
         shared: {
           list: { fetch: vi.fn() },
@@ -137,6 +148,30 @@ function listenForReply() {
     stop: () => cw.removeEventListener('message', handler),
   };
 }
+
+/**
+ * What `collection.getById` returns for a collection this viewer CAN see. The
+ * host resolves the consent dialog's subject from this — never from anything the
+ * block sent.
+ */
+const VISIBLE_COLLECTION = {
+  collection: { id: 77, name: 'Cute Cats', user: { id: 3, username: 'alice' } },
+  permissions: { read: true, write: false, manage: false },
+  collaborators: [],
+  pendingReviewCount: 0,
+};
+
+/**
+ * What it returns for a collection that does NOT exist, and — identically — for
+ * one this viewer may not see. `getCollectionByIdHandler` produces this same
+ * shape for both, which is the existence-leak guarantee the host inherits.
+ */
+const UNAVAILABLE_COLLECTION = {
+  collection: null,
+  permissions: { read: false, write: false, manage: false },
+  collaborators: [],
+  pendingReviewCount: 0,
+};
 
 function lastDialog() {
   const dialogs = useDialogStore.getState().dialogs;
@@ -215,11 +250,33 @@ type ConfirmProps = {
   onCancel: () => void;
 };
 
+/**
+ * Mount and take a listener, but DELIBERATELY never send `BLOCK_READY` — the
+ * pre-handshake state a block reaches on load, before the viewer has interacted
+ * with it at all.
+ */
+async function mountWithoutHandshake() {
+  renderWithProviders(<IframeHost {...baseProps} />);
+  await vi.waitFor(() => {
+    if (!iframeEl().contentWindow) throw new Error('not mounted yet');
+  });
+  const replies = listenForReply();
+  // Same positive control as `mountAndReady`: prove the channel is live before
+  // any assertion rests on what it does or does not carry.
+  await vi.waitFor(() => {
+    if (replies.of('BLOCK_INIT').length === 0) throw new Error('listener saw no BLOCK_INIT');
+  });
+  expect(iframeEl().getAttribute('data-block-ready')).not.toBe('true');
+  return replies;
+}
+
 describe('IframeHost SET_COLLECTION_FOLLOW (consent-gated follow, model slot)', () => {
   beforeEach(() => {
     useDialogStore.getState().closeAll();
     followMutate.mockReset();
     unfollowMutate.mockReset();
+    getByIdFetch.mockReset();
+    getByIdFetch.mockResolvedValue(VISIBLE_COLLECTION);
     currentUser.value = { id: 42 };
   });
 
@@ -362,6 +419,109 @@ describe('IframeHost SET_COLLECTION_FOLLOW (consent-gated follow, model slot)', 
       });
     });
     expect(replies.of('COLLECTION_FOLLOW_RESULT')).toHaveLength(1);
+    replies.stop();
+  });
+});
+
+/**
+ * 🔴 F1 REGRESSION (model slot). The dialog previously named NO collection: a
+ * block could render "Follow ⭐ Cute Cats", post a different id, and host chrome
+ * would assert nothing that could contradict it.
+ */
+describe('IframeHost SET_COLLECTION_FOLLOW — the confirm names the HOST-RESOLVED collection', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+    followMutate.mockReset();
+    unfollowMutate.mockReset();
+    getByIdFetch.mockReset();
+    getByIdFetch.mockResolvedValue(VISIBLE_COLLECTION);
+    currentUser.value = { id: 42 };
+  });
+
+  test('🔴 fetches the collection by the SAME id it will act on and names it in the dialog', async () => {
+    const replies = await mountAndReady();
+    postFromBlock('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_named',
+      collectionId: 900123,
+      follow: true,
+      // A block-supplied name must NOT reach the dialog — the host has no field
+      // for it and must never grow one.
+      collectionName: 'Totally Safe Kittens',
+    });
+
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    expect(getByIdFetch).toHaveBeenCalledWith({ id: 900123 }, { staleTime: 0 });
+    const msg = (lastDialog().props as ConfirmProps).message;
+    expect(msg).toContain('“Cute Cats” by alice');
+    expect(msg).not.toContain('Totally Safe Kittens');
+    replies.stop();
+  });
+
+  test('🔴 a collection the viewer cannot see is REFUSED with a reply and NO dialog', async () => {
+    getByIdFetch.mockResolvedValue(UNAVAILABLE_COLLECTION);
+    const replies = await mountAndReady();
+    postFromBlock('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_priv',
+      collectionId: 4242,
+      follow: true,
+    });
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_priv', error: 'collection-unavailable' });
+    });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(followMutate).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('a FAILED lookup refuses with the same code — never a hang, never a nameless dialog', async () => {
+    getByIdFetch.mockRejectedValue(new Error('NOT_FOUND'));
+    const replies = await mountAndReady();
+    postFromBlock('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_boom',
+      collectionId: 4243,
+      follow: true,
+    });
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_boom', error: 'collection-unavailable' });
+    });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    replies.stop();
+  });
+});
+
+/**
+ * 🔴 F2 REGRESSION (model slot). A pre-handshake block could pop a permission
+ * modal with zero user interaction. This is the only ungated REQUEST-style
+ * handler that performs an account WRITE.
+ */
+describe('IframeHost SET_COLLECTION_FOLLOW — pre-handshake gate', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+    followMutate.mockReset();
+    unfollowMutate.mockReset();
+    getByIdFetch.mockReset();
+    getByIdFetch.mockResolvedValue(VISIBLE_COLLECTION);
+    currentUser.value = { id: 42 };
+  });
+
+  test('🔴 a block that never sent BLOCK_READY gets `not-ready` and NO dialog', async () => {
+    const replies = await mountWithoutHandshake();
+    postFromBlock('SET_COLLECTION_FOLLOW', { requestId: 'rq_pre', collectionId: 77, follow: true });
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_pre', error: 'not-ready' });
+    });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(getByIdFetch).not.toHaveBeenCalled();
+    expect(followMutate).not.toHaveBeenCalled();
     replies.stop();
   });
 });

--- a/src/components/AppBlocks/IframeHostCollectionFollow.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostCollectionFollow.browser.test.tsx
@@ -1,5 +1,8 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { page } from 'vitest/browser';
+// Explicit mid-test unmount, for the "the budget is per block INSTANCE" pin. The
+// harness's own `afterEach` uses the same helper.
+import { cleanup } from 'vitest-browser-react';
 import { useDialogStore } from '~/components/Dialog/dialogStore';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
@@ -524,4 +527,235 @@ describe('IframeHost SET_COLLECTION_FOLLOW — pre-handshake gate', () => {
     expect(followMutate).not.toHaveBeenCalled();
     replies.stop();
   });
+});
+
+/**
+ * 🔴 F4 REGRESSION (model slot) — THE BOUND ON THE VISIBILITY ORACLE.
+ *
+ * F1 moved the `collection.getById` lookup BEFORE the dialog so the confirm can
+ * name its object. That is right, and it handed the block a capability: it now
+ * learns `collection-unavailable` vs. dialog-shown with no click at all, i.e. per
+ * id, "can this viewer see it?" — an AUTHENTICATED read a sandboxed cross-origin
+ * block cannot perform itself, driven at the transport's 30 messages/second.
+ *
+ * The bound is a per-block-instance cap on DISTINCT collection ids, held in a ref
+ * by EACH host separately. The page host's copy is invisible to this suite and
+ * vice versa, so both are pinned.
+ */
+
+const OVER_BUDGET_FIRST_ID = 500_001;
+
+function replyFor(replies: ReturnType<typeof listenForReply>, requestId: string) {
+  return replies
+    .of('COLLECTION_FOLLOW_RESULT')
+    .map((m) => m.payload as Record<string, unknown>)
+    .find((p) => p?.requestId === requestId);
+}
+
+async function awaitReply(replies: ReturnType<typeof listenForReply>, requestId: string) {
+  let found: Record<string, unknown> | undefined;
+  await vi.waitFor(() => {
+    found = replyFor(replies, requestId);
+    if (!found) throw new Error(`no reply for ${requestId} yet`);
+  });
+  return found as Record<string, unknown>;
+}
+
+/**
+ * The transport drops inbound messages past 30 per rolling second
+ * (`RATE_LIMIT_MAX_MESSAGES`, usePostMessage.ts) and a dropped message never
+ * replies — which would look exactly like the budget refusing. These suites post
+ * 20+ messages, so they pace themselves well under that ceiling. Without this the
+ * tests below would be measuring the transport, not the budget.
+ */
+let paceMarks: number[] = [];
+async function pacedPost(type: string, payload: unknown) {
+  const now = Date.now();
+  paceMarks = paceMarks.filter((t) => now - t < 1200);
+  if (paceMarks.length >= 18) {
+    await new Promise((r) => setTimeout(r, Math.max(0, 1200 - (now - paceMarks[0]))));
+    paceMarks = [];
+  }
+  postFromBlock(type, payload);
+  paceMarks.push(Date.now());
+}
+
+async function mountReadyAndSettled() {
+  const replies = await mountAndReady();
+  // The handshake's own posts count against the same 30/s inbound budget. Drain
+  // the window before the burst.
+  await new Promise((r) => setTimeout(r, 1200));
+  paceMarks = [];
+  return replies;
+}
+
+/** Spend the whole budget on 20 DISTINCT ids the viewer cannot see. */
+async function spendBudgetOnUnseeableIds(replies: ReturnType<typeof listenForReply>) {
+  for (let i = 1; i <= 20; i++) {
+    const requestId = `rq_budget_${i}`;
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId,
+      collectionId: OVER_BUDGET_FIRST_ID + i - 1,
+      follow: true,
+    });
+    await awaitReply(replies, requestId);
+  }
+}
+
+describe('IframeHost SET_COLLECTION_FOLLOW — per-instance distinct-id lookup budget', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+    followMutate.mockReset();
+    unfollowMutate.mockReset();
+    getByIdFetch.mockReset();
+    getByIdFetch.mockResolvedValue(UNAVAILABLE_COLLECTION);
+    currentUser.value = { id: 42 };
+    paceMarks = [];
+  });
+
+  test('🔴 past the cap the host STOPS LOOKING UP — the 21st distinct id costs no authed read', async () => {
+    const replies = await mountReadyAndSettled();
+
+    await spendBudgetOnUnseeableIds(replies);
+    // Positive control: those 20 were genuinely resolved, so the unchanged count
+    // below is a measurement and not a handler that was never wired.
+    expect(getByIdFetch).toHaveBeenCalledTimes(20);
+
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_budget_21',
+      collectionId: OVER_BUDGET_FIRST_ID + 20,
+      follow: true,
+    });
+    const over = await awaitReply(replies, 'rq_budget_21');
+
+    // 🔴 THE BOUND: the reply came back, and NO lookup was spent producing it.
+    expect(getByIdFetch).toHaveBeenCalledTimes(20);
+    expect(over).toEqual({ requestId: 'rq_budget_21', error: 'collection-unavailable' });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(followMutate).not.toHaveBeenCalled();
+    replies.stop();
+  }, 30_000);
+
+  // ⚠️ SHAPE GUARD, NOT A REGRESSION TEST — labelled rather than counted. It is
+  // GREEN at `25efb688b2` (measured), and necessarily so: with no budget there is
+  // no second refusal path to be distinguishable from. What it guards is the
+  // FUTURE — a maintainer adding a `lookup-budget-exhausted` code, a `retryAfter`,
+  // or any other field that would tell "I am capped" from "you cannot see it".
+  // Mutation-checked in that direction rather than against the base.
+  test('🔴 the over-budget refusal is INDISTINGUISHABLE from "you cannot see it"', async () => {
+    const replies = await mountReadyAndSettled();
+
+    await spendBudgetOnUnseeableIds(replies);
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_budget_21',
+      collectionId: OVER_BUDGET_FIRST_ID + 20,
+      follow: true,
+    });
+
+    // `rq_budget_1` was a REAL lookup that came back not-visible; `rq_budget_21`
+    // was refused unlooked. A block must not be able to tell them apart, or the
+    // cap hands back the very bit it exists to withhold.
+    const notVisible = await awaitReply(replies, 'rq_budget_1');
+    const overBudget = await awaitReply(replies, 'rq_budget_21');
+    const withoutId = (p: Record<string, unknown>) => {
+      const { requestId: _drop, ...rest } = p;
+      return rest;
+    };
+    expect(withoutId(overBudget)).toEqual(withoutId(notVisible));
+    expect(overBudget).toEqual({ requestId: 'rq_budget_21', error: 'collection-unavailable' });
+    replies.stop();
+  }, 30_000);
+
+  test('🔴 an ALREADY-RESOLVED id still works past the cap — re-following never breaks', async () => {
+    getByIdFetch.mockImplementation((input: { id: number }) =>
+      Promise.resolve(input.id === 77 ? VISIBLE_COLLECTION : UNAVAILABLE_COLLECTION)
+    );
+    followMutate.mockResolvedValue(undefined);
+    const replies = await mountReadyAndSettled();
+
+    // 1 of 20: a collection the viewer really can see, followed for real.
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_keep_1',
+      collectionId: 77,
+      follow: true,
+    });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    await (lastDialog().props as ConfirmProps).onConfirm();
+    await awaitReply(replies, 'rq_keep_1');
+    useDialogStore.getState().closeAll();
+
+    // 19 more distinct ids exhaust the rest of the budget.
+    for (let i = 1; i <= 19; i++) {
+      const requestId = `rq_fill_${i}`;
+      await pacedPost('SET_COLLECTION_FOLLOW', {
+        requestId,
+        collectionId: OVER_BUDGET_FIRST_ID + i,
+        follow: true,
+      });
+      await awaitReply(replies, requestId);
+    }
+    const spent = getByIdFetch.mock.calls.length;
+    expect(spent).toBe(20);
+
+    // A NEW id is now refused unlooked…
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_new_after_cap',
+      collectionId: 999_777,
+      follow: true,
+    });
+    expect(await awaitReply(replies, 'rq_new_after_cap')).toEqual({
+      requestId: 'rq_new_after_cap',
+      error: 'collection-unavailable',
+    });
+    expect(getByIdFetch).toHaveBeenCalledTimes(spent);
+
+    // …while the collection the viewer already consented about resolves, opens a
+    // named dialog and writes, exactly as before. This is the half a naive
+    // per-call rate limit would have broken.
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_keep_2',
+      collectionId: 77,
+      follow: false,
+    });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    expect(getByIdFetch).toHaveBeenCalledTimes(spent + 1);
+    const props = lastDialog().props as ConfirmProps;
+    // 🔴 F1 is NOT regressed by the budget: the dialog still names the object.
+    expect(props.message).toContain('“Cute Cats” by alice');
+    unfollowMutate.mockResolvedValue(undefined);
+    await props.onConfirm();
+    expect(unfollowMutate).toHaveBeenCalledWith({ collectionId: 77 });
+    expect(await awaitReply(replies, 'rq_keep_2')).toEqual({
+      requestId: 'rq_keep_2',
+      result: { collectionId: 77, followed: false },
+    });
+    replies.stop();
+  }, 30_000);
+
+  test('🔴 the budget is PER BLOCK INSTANCE — a remount starts fresh', async () => {
+    const first = await mountReadyAndSettled();
+    await spendBudgetOnUnseeableIds(first);
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_budget_21',
+      collectionId: OVER_BUDGET_FIRST_ID + 20,
+      follow: true,
+    });
+    await awaitReply(first, 'rq_budget_21');
+    expect(getByIdFetch).toHaveBeenCalledTimes(20);
+    first.stop();
+
+    // A module-scope ledger would survive this; a ref does not.
+    await cleanup();
+    const second = await mountReadyAndSettled();
+
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_remount',
+      collectionId: OVER_BUDGET_FIRST_ID + 20,
+      follow: true,
+    });
+    await awaitReply(second, 'rq_remount');
+    // The fresh instance looked it up — 21 total across the two mounts.
+    expect(getByIdFetch).toHaveBeenCalledTimes(21);
+    second.stop();
+  }, 30_000);
 });

--- a/src/components/AppBlocks/IframeHostInitContractV2.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostInitContractV2.browser.test.tsx
@@ -58,6 +58,13 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
 vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof TrpcMod>()),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     blocks: {
       getEffectiveCheckpoint: {
         useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),

--- a/src/components/AppBlocks/IframeHostReadyTransition.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostReadyTransition.browser.test.tsx
@@ -115,6 +115,13 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
 // `shouldStartInit` fires and the controller arms its readiness timeout).
 vi.mock('~/utils/trpc', () => ({
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     blocks: {
       getEffectiveCheckpoint: {
         useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),

--- a/src/components/AppBlocks/IframeHostStatusGates.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostStatusGates.browser.test.tsx
@@ -86,6 +86,13 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
 vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof Trpc>()),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     blocks: {
       getEffectiveCheckpoint: {
         useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),

--- a/src/components/AppBlocks/IframeHostThemeChange.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostThemeChange.browser.test.tsx
@@ -53,6 +53,13 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
 vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof TrpcMod>()),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     blocks: {
       getEffectiveCheckpoint: {
         useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),

--- a/src/components/AppBlocks/IframeHostViewportHeightClamp.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostViewportHeightClamp.browser.test.tsx
@@ -113,6 +113,13 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
 vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof TrpcMod>()),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     blocks: {
       getEffectiveCheckpoint: {
         useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -38,6 +38,13 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import — silently, since this suite is report-only.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -32,6 +32,10 @@ import {
   toHostGateStatus,
 } from './pageBlockHostLogic';
 import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
+import {
+  buildCollectionFollowConsentCopy,
+  resolveCollectionFollowRequest,
+} from './collectionFollowGate';
 import { projectSafeGenerationResource } from '~/server/schema/blocks/generation-resource-projection';
 import type { BlockUploadedImageInfo } from './BlockImageUploadModal';
 import type { BlockSourceImageInfo } from './BlockGenerationSourceUploadModal';
@@ -1864,6 +1868,15 @@ export function PageBlockHost({
   // the whole point (the real download gates apply). A MUTATION deliberately: the
   // response carries a short-lived signed URL (see the router comment).
   const resolveWildcardPackMutation = trpc.generation.resolveWildcardPack.useMutation();
+  // Collection follow/unfollow bridge (SET_COLLECTION_FOLLOW). SESSION-authed
+  // (protectedProcedure), like resolveWildcardPack above and for the same reason:
+  // these are the SAME procedures the site's own follow button calls, so the
+  // handler self-binds to `ctx.user.id` server-side and reuses
+  // `addContributorToCollection` / `removeContributorFromCollection` verbatim.
+  // The block token is deliberately NOT involved — the point of this bridge is
+  // that a block needs no `collections:write:self` scope.
+  const followCollectionMutation = trpc.collection.follow.useMutation();
+  const unfollowCollectionMutation = trpc.collection.unfollow.useMutation();
   // In-flight fetch+parse count for the concurrency cap below. A ref (not state)
   // so incrementing/decrementing never re-renders and the count is read
   // synchronously in the message handler (JS is single-threaded, so the
@@ -3755,6 +3768,86 @@ export function PageBlockHost({
     });
     return off;
   }, [onMessage, send, resolveWildcardPackMutation, reviewMode]);
+
+  // ── SET_COLLECTION_FOLLOW → COLLECTION_FOLLOW_RESULT ────────────────────────
+  //
+  // A block asks the host to follow / unfollow a collection for the viewer. The
+  // decision layer is SHARED with IframeHost (`collectionFollowGate.ts`) and
+  // carries the full rationale; the two things this host contributes are its own
+  // `viewer` prop (the signed-in signal) and `reviewNack`.
+  //
+  // 🔴 THE CONSENT BOUNDARY IS THE CONFIRM CLICK. This bridge exists so a block
+  // no longer needs the `collections:write:self` scope, which was the viewer's
+  // consent step on the HTTP path. The replacement is host chrome the sandboxed
+  // iframe cannot fake or restyle: NOTHING is written until the viewer clicks
+  // through `ConfirmDialog`, exactly as PUBLISH_GENERATION_OUTPUTS does. Do not
+  // "simplify" this by calling the mutation directly — that silently converts a
+  // consented action into an unconsented one.
+  //
+  // REQUEST-style ⇒ every terminal path (refusal / cancel / success / error)
+  // MUST reply exactly once or the block hangs to its SDK timeout; the `settled`
+  // latch guards a double-reply the way the publish handler's does. Only a
+  // payload with no usable requestId is dropped — there is nothing to reply to.
+  useEffect(() => {
+    const off = onMessage<unknown>('SET_COLLECTION_FOLLOW', (raw) => {
+      const gate = resolveCollectionFollowRequest({
+        raw,
+        // `viewer` is non-null ONLY for a signed-in viewer (the page route
+        // renders for logged-out viewers too, with viewer: null).
+        signedIn: viewer != null,
+        reviewNack,
+      });
+      if (gate.kind === 'drop') return;
+      if (gate.kind === 'refuse') {
+        send('COLLECTION_FOLLOW_RESULT', { requestId: gate.requestId, error: gate.error });
+        return;
+      }
+      const { requestId, collectionId, follow } = gate.request;
+      let settled = false;
+      const reply = (payload: Record<string, unknown>) => {
+        if (settled) return;
+        settled = true;
+        send('COLLECTION_FOLLOW_RESULT', { requestId, ...payload });
+      };
+      const copy = buildCollectionFollowConsentCopy({ follow, appName });
+      dialogStore.trigger({
+        component: ConfirmDialog,
+        props: {
+          title: copy.title,
+          message: copy.message,
+          labels: { confirm: copy.confirmLabel, cancel: 'Cancel' },
+          confirmProps: { color: 'blue' },
+          onConfirm: async () => {
+            try {
+              // Self-bound server-side: the handlers pass `ctx.user.id` as BOTH
+              // actor and target, so `collectionId` is the ONLY thing the block
+              // influences.
+              if (follow) await followCollectionMutation.mutateAsync({ collectionId });
+              else await unfollowCollectionMutation.mutateAsync({ collectionId });
+              reply({ result: { collectionId, followed: follow } });
+            } catch (err) {
+              // FORBIDDEN from the collection services (e.g. a private
+              // collection this viewer may not follow) lands here as a message,
+              // never as a hang.
+              reply({ error: err instanceof Error ? err.message : 'unknown' });
+            }
+          },
+          // Dismiss (Cancel / X / escape) = consent DECLINED. Settle the block's
+          // promise explicitly rather than leaving it to time out.
+          onCancel: () => reply({ error: 'declined' }),
+        },
+      });
+    });
+    return off;
+  }, [
+    onMessage,
+    send,
+    viewer,
+    reviewNack,
+    appName,
+    followCollectionMutation,
+    unfollowCollectionMutation,
+  ]);
 
   // ONE sanitized label for the whole launch surface — the avatar initial, the
   // loading skeleton's accessible name and the visible "Starting …" copy all derive from

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -34,7 +34,9 @@ import {
 import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import {
   buildCollectionFollowConsentCopy,
+  createCollectionFollowSettlement,
   resolveCollectionFollowRequest,
+  resolveCollectionIdentity,
 } from './collectionFollowGate';
 import { projectSafeGenerationResource } from '~/server/schema/blocks/generation-resource-projection';
 import type { BlockUploadedImageInfo } from './BlockImageUploadModal';
@@ -3776,22 +3778,30 @@ export function PageBlockHost({
   // carries the full rationale; the two things this host contributes are its own
   // `viewer` prop (the signed-in signal) and `reviewNack`.
   //
-  // 🔴 THE CONSENT BOUNDARY IS THE CONFIRM CLICK. This bridge exists so a block
-  // no longer needs the `collections:write:self` scope, which was the viewer's
-  // consent step on the HTTP path. The replacement is host chrome the sandboxed
-  // iframe cannot fake or restyle: NOTHING is written until the viewer clicks
-  // through `ConfirmDialog`, exactly as PUBLISH_GENERATION_OUTPUTS does. Do not
-  // "simplify" this by calling the mutation directly — that silently converts a
-  // consented action into an unconsented one.
+  // 🔴 THE CONSENT BOUNDARY IS THE CONFIRM CLICK, AND IT IS THE ONLY CONSENT THIS
+  // PATH HAS EVER HAD. The HTTP endpoint's `collections:write:self` scope is
+  // CONSENT-EXEMPT server-side, so it never prompted anyone — see the retracted
+  // claim recorded in `collectionFollowGate.ts`. This bridge therefore TIGHTENS a
+  // zero-prompt path into one prompt per action. Do not "simplify" it by calling
+  // the mutation directly, and do not delete the confirm as redundant with a
+  // scope grant that does not exist.
   //
-  // REQUEST-style ⇒ every terminal path (refusal / cancel / success / error)
-  // MUST reply exactly once or the block hangs to its SDK timeout; the `settled`
-  // latch guards a double-reply the way the publish handler's does. Only a
-  // payload with no usable requestId is dropped — there is nothing to reply to.
+  // 🔴 THE DIALOG MUST NAME THE COLLECTION, and the name must be the one the HOST
+  // resolved from `collectionId` — never one the block supplied. A block can
+  // render its own "Follow ⭐ Cute Cats" card and post a different id; host chrome
+  // that asserts nothing about the object cannot contradict it.
+  //
+  // REQUEST-style ⇒ every terminal path (refusal / lookup failure / cancel /
+  // success / error) MUST reply exactly once or the block hangs to its SDK
+  // timeout; `createCollectionFollowSettlement` owns that latch AND the consent
+  // latch that keeps `declined` meaning "no write occurred". Only a payload with
+  // no usable requestId is dropped — there is nothing to reply to.
   useEffect(() => {
     const off = onMessage<unknown>('SET_COLLECTION_FOLLOW', (raw) => {
       const gate = resolveCollectionFollowRequest({
         raw,
+        // `readGateStatus()` (not a closed-over `status`) — see its definition.
+        ready: readGateStatus() === 'ready',
         // `viewer` is non-null ONLY for a signed-in viewer (the page route
         // renders for logged-out viewers too, with viewer: null).
         signedIn: viewer != null,
@@ -3803,48 +3813,82 @@ export function PageBlockHost({
         return;
       }
       const { requestId, collectionId, follow } = gate.request;
-      let settled = false;
-      const reply = (payload: Record<string, unknown>) => {
-        if (settled) return;
-        settled = true;
-        send('COLLECTION_FOLLOW_RESULT', { requestId, ...payload });
-      };
-      const copy = buildCollectionFollowConsentCopy({ follow, appName });
-      dialogStore.trigger({
-        component: ConfirmDialog,
-        props: {
-          title: copy.title,
-          message: copy.message,
-          labels: { confirm: copy.confirmLabel, cancel: 'Cancel' },
-          confirmProps: { color: 'blue' },
-          onConfirm: async () => {
-            try {
-              // Self-bound server-side: the handlers pass `ctx.user.id` as BOTH
-              // actor and target, so `collectionId` is the ONLY thing the block
-              // influences.
-              if (follow) await followCollectionMutation.mutateAsync({ collectionId });
-              else await unfollowCollectionMutation.mutateAsync({ collectionId });
-              reply({ result: { collectionId, followed: follow } });
-            } catch (err) {
-              // FORBIDDEN from the collection services (e.g. a private
-              // collection this viewer may not follow) lands here as a message,
-              // never as a hang.
-              reply({ error: err instanceof Error ? err.message : 'unknown' });
-            }
-          },
-          // Dismiss (Cancel / X / escape) = consent DECLINED. Settle the block's
-          // promise explicitly rather than leaving it to time out.
-          onCancel: () => reply({ error: 'declined' }),
-        },
+      const settlement = createCollectionFollowSettlement({
+        requestId,
+        emit: (payload) => send('COLLECTION_FOLLOW_RESULT', payload),
       });
+      void (async () => {
+        // Resolve WHO/WHAT the viewer is being asked about, server-side, from the
+        // same id we are about to act on. A failed lookup refuses WITH a reply —
+        // never a hang, and never a dialog missing the name it promised.
+        let identity;
+        try {
+          identity = resolveCollectionIdentity(
+            await trpcUtils.collection.getById.fetch({ id: collectionId }, { staleTime: 0 })
+          );
+        } catch {
+          // Not found / not visible / feature-flagged / network — all one
+          // outcome, so the reply cannot be used to probe for existence.
+          identity = { kind: 'unavailable' } as const;
+        }
+        if (identity.kind !== 'ok') {
+          settlement.reply({ error: 'collection-unavailable' });
+          return;
+        }
+        const copy = buildCollectionFollowConsentCopy({
+          follow,
+          appName,
+          collectionId,
+          collection: identity.identity,
+        });
+        dialogStore.trigger({
+          // Per-request id so two SET_COLLECTION_FOLLOW calls can't dedup against
+          // each other in the dialog store's silent `if (!exists)` drop — a
+          // dropped dialog would be a request that never replies, i.e. a hang.
+          // (Insurance, matching the OPEN_IMAGE_UPLOAD handler; the collision was
+          // not reproducible, since rendering a Mantine modal costs >1 ms.)
+          id: `block-collection-follow-${requestId}`,
+          component: ConfirmDialog,
+          props: {
+            title: copy.title,
+            message: copy.message,
+            labels: { confirm: copy.confirmLabel, cancel: 'Cancel' },
+            confirmProps: { color: 'blue' },
+            onConfirm: async () => {
+              // SYNCHRONOUS, before any await: from here on a dismissal must not
+              // be able to claim `declined` for a write that is under way.
+              settlement.markConsented();
+              try {
+                // Self-bound server-side: the handlers pass `ctx.user.id` as BOTH
+                // actor and target, so `collectionId` is the ONLY thing the block
+                // influences.
+                if (follow) await followCollectionMutation.mutateAsync({ collectionId });
+                else await unfollowCollectionMutation.mutateAsync({ collectionId });
+                settlement.reply({ result: { collectionId, followed: follow } });
+              } catch (err) {
+                // FORBIDDEN from the collection services (e.g. a private
+                // collection this viewer may not follow) lands here as a message,
+                // never as a hang.
+                settlement.reply({ error: err instanceof Error ? err.message : 'unknown' });
+              }
+            },
+            // Dismiss (Cancel / X / escape / overlay) = consent DECLINED. Settle
+            // the block's promise explicitly rather than leaving it to time out —
+            // unless consent was already given, in which case this is a no-op.
+            onCancel: settlement.decline,
+          },
+        });
+      })();
     });
     return off;
   }, [
     onMessage,
     send,
+    readGateStatus,
     viewer,
     reviewNack,
     appName,
+    trpcUtils,
     followCollectionMutation,
     unfollowCollectionMutation,
   ]);

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -35,8 +35,10 @@ import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import {
   buildCollectionFollowConsentCopy,
   createCollectionFollowSettlement,
+  createCollectionLookupBudget,
   resolveCollectionFollowRequest,
   resolveCollectionIdentity,
+  type CollectionLookupBudget,
 } from './collectionFollowGate';
 import { projectSafeGenerationResource } from '~/server/schema/blocks/generation-resource-projection';
 import type { BlockUploadedImageInfo } from './BlockImageUploadModal';
@@ -1879,6 +1881,13 @@ export function PageBlockHost({
   // that a block needs no `collections:write:self` scope.
   const followCollectionMutation = trpc.collection.follow.useMutation();
   const unfollowCollectionMutation = trpc.collection.unfollow.useMutation();
+  // 🔴 This block instance's DISTINCT-collection-id lookup budget. A ref, not
+  // module scope and not state: per-instance (two blocks on a page cannot drain
+  // each other), reset on remount, and read synchronously inside the message
+  // handler. Lazily constructed so a render never allocates a Set it throws away.
+  // The reasoning — and the authenticated visibility oracle it closes — lives on
+  // `createCollectionLookupBudget`.
+  const collectionLookupBudgetRef = useRef<CollectionLookupBudget | null>(null);
   // In-flight fetch+parse count for the concurrency cap below. A ref (not state)
   // so incrementing/decrementing never re-renders and the count is read
   // synchronously in the message handler (JS is single-threaded, so the
@@ -3817,6 +3826,20 @@ export function PageBlockHost({
         requestId,
         emit: (payload) => send('COLLECTION_FOLLOW_RESULT', payload),
       });
+      // 🔴 BOUND THE PROBE, BEFORE SPENDING AN AUTHENTICATED READ. The identity
+      // lookup below runs in the VIEWER'S session and completes before any
+      // dialog, so without a bound it is a per-id "can this viewer see it?"
+      // oracle the block can drive at the transport's 30 msg/s. DISTINCT ids,
+      // not calls — a repeat is free forever, so re-following a collection the
+      // viewer has already been asked about keeps working past the cap. The
+      // refusal deliberately reuses `collection-unavailable`; a distinct code
+      // would hand back the bit the cap withholds. Full reasoning (incl. why a
+      // distinct-id cap rather than a time window) on the factory.
+      const lookupBudget = (collectionLookupBudgetRef.current ??= createCollectionLookupBudget());
+      if (!lookupBudget.admit(collectionId)) {
+        settlement.reply({ error: 'collection-unavailable' });
+        return;
+      }
       void (async () => {
         // Resolve WHO/WHAT the viewer is being asked about, server-side, from the
         // same id we are about to act on. A failed lookup refuses WITH a reply —

--- a/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
@@ -85,6 +85,13 @@ vi.mock('~/utils/trpc', () => ({
   // this; a wholesale module mock MUST re-declare it or the ESM link fails.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostBenchmarkGrid.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostBenchmarkGrid.browser.test.tsx
@@ -26,6 +26,13 @@ vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 vi.mock('~/utils/trpc', () => ({
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
@@ -49,6 +49,13 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {

--- a/src/components/AppBlocks/PageBlockHostCollectionFollow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCollectionFollow.browser.test.tsx
@@ -1,0 +1,360 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { useDialogStore } from '~/components/Dialog/dialogStore';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace import for the `importOriginal` spread below (the repo's
+// local-rules/no-wholesale-module-mock cure). NOT `typeof import(...)`, which
+// @typescript-eslint/consistent-type-imports rejects.
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * SET_COLLECTION_FOLLOW → COLLECTION_FOLLOW_RESULT on the PAGE host.
+ *
+ * The structural parity guard (`hostHandlerParity.test.ts`) only proves a handler
+ * is REGISTERED. These are the behavioural pins for what it does, and in
+ * particular for the property that made this bridge worth reviewing:
+ *
+ * 🔴 THE BRIDGE REMOVES A SCOPE GATE. Over HTTP a follow needed the block scope
+ * `collections:write:self`, and the viewer's grant of that scope WAS the consent.
+ * On the bridge the host acts as the signed-in session user, so the replacement
+ * consent is a HOST-CHROME CONFIRM the sandboxed iframe cannot fake. Every test
+ * below that reaches a mutation goes through that confirm first, and the two
+ * "never calls the mutation" tests are the ones that would catch it being
+ * dropped.
+ *
+ * Mirrored on the model-slot surface by `IframeHostCollectionFollow.browser.test.tsx`
+ * — the two hosts share the DECISION module but have entirely separate bridges,
+ * so neither suite can see the other's wiring.
+ */
+
+const { followMutate, unfollowMutate } = vi.hoisted(() => ({
+  followMutate: vi.fn(),
+  unfollowMutate: vi.fn(),
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: followMutate }) },
+      unfollow: { useMutation: () => ({ mutateAsync: unfollowMutate }) },
+    },
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      publishGenerationOutputs: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getImagesByIds: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+function postFromBlock(type: string, payload?: unknown) {
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+function listenForReply() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    of: (type: string) => received.filter((m) => m.type === type),
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+function lastDialog() {
+  const dialogs = useDialogStore.getState().dialogs;
+  if (dialogs.length === 0) throw new Error('no modal opened');
+  return dialogs[dialogs.length - 1];
+}
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+const baseProps = {
+  appBlockId: 'apb_test',
+  blockId: 'collections-app',
+  appId: 'app_test',
+  blockInstanceId: 'page_apb_test',
+  appName: 'Playable Collections',
+  iframeSrc: SAME_ORIGIN_SRC,
+  surface: 'page-run' as const,
+  bootSkeleton: false,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'collections-app',
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: [] as string[],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: { id: 42, username: 'tester' } as { id: number; username: string | null } | null,
+  theme: 'light' as const,
+};
+
+async function driveToReady() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+type ConfirmProps = {
+  title: string;
+  message: string;
+  labels: { confirm: string; cancel: string };
+  onConfirm: () => Promise<void> | void;
+  onCancel: () => void;
+};
+
+describe('PageBlockHost SET_COLLECTION_FOLLOW (consent-gated follow)', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+    followMutate.mockReset();
+    unfollowMutate.mockReset();
+  });
+
+  test('opens a host-chrome consent confirm BEFORE any write; on CONFIRM calls collection.follow and replies followed:true', async () => {
+    followMutate.mockResolvedValue(undefined);
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_follow',
+      collectionId: 77,
+      follow: true,
+    });
+
+    // 🔴 THE CONSENT PROPERTY: a dialog, and NO write, before the viewer clicks.
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    expect(followMutate).not.toHaveBeenCalled();
+    const props = lastDialog().props as ConfirmProps;
+    expect(props.title).toBe('Follow this collection?');
+    // The dialog names WHO is asking — a viewer cannot consent to an unnamed party.
+    expect(props.message).toContain('Playable Collections');
+    expect(props.labels.confirm).toBe('Follow');
+
+    await props.onConfirm();
+
+    // Self-bound: `collectionId` is the ONLY thing that crosses; no user id.
+    expect(followMutate).toHaveBeenCalledWith({ collectionId: 77 });
+    expect(unfollowMutate).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_follow',
+        result: { collectionId: 77, followed: true },
+      });
+    });
+    replies.stop();
+  });
+
+  test('follow:false routes to collection.unfollow and replies followed:false', async () => {
+    unfollowMutate.mockResolvedValue(undefined);
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_unfollow',
+      collectionId: 78,
+      follow: false,
+    });
+
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    const props = lastDialog().props as ConfirmProps;
+    expect(props.title).toBe('Unfollow this collection?');
+    expect(props.labels.confirm).toBe('Unfollow');
+    await props.onConfirm();
+
+    expect(unfollowMutate).toHaveBeenCalledWith({ collectionId: 78 });
+    expect(followMutate).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_unfollow',
+        result: { collectionId: 78, followed: false },
+      });
+    });
+    replies.stop();
+  });
+
+  test('🔴 on DISMISS (consent declined) replies `declined` and NEVER writes', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', { requestId: 'rq_no', collectionId: 5, follow: true });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+
+    (lastDialog().props as ConfirmProps).onCancel();
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_no', error: 'declined' });
+    });
+    expect(followMutate).not.toHaveBeenCalled();
+    expect(unfollowMutate).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('🔴 an ANONYMOUS viewer is refused with sign-in-required — no dialog, no write', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} viewer={null} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', { requestId: 'rq_anon', collectionId: 5, follow: true });
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_anon', error: 'sign-in-required' });
+    });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(followMutate).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('🔴 the mod-review sandbox NACKs before any dialog — a pending app cannot drive the reviewing mod', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_review',
+      collectionId: 5,
+      follow: true,
+    });
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_review', error: 'review-mode' });
+    });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(followMutate).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('a malformed collectionId is REFUSED with a reply (never a silent hang)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', { requestId: 'rq_bad', collectionId: -1, follow: true });
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_bad', error: 'invalid-request' });
+    });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    replies.stop();
+  });
+
+  test('a payload with no requestId is dropped (no dialog, no reply) — nothing to correlate', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', { collectionId: 5, follow: true });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(replies.last('COLLECTION_FOLLOW_RESULT')).toBeUndefined();
+    expect(followMutate).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('a server FORBIDDEN (private collection) comes back as an error reply, exactly once', async () => {
+    followMutate.mockRejectedValue(new Error('You do not have permission to follow'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', { requestId: 'rq_403', collectionId: 9, follow: true });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    await (lastDialog().props as ConfirmProps).onConfirm();
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_403',
+        error: 'You do not have permission to follow',
+      });
+    });
+    expect(replies.of('COLLECTION_FOLLOW_RESULT')).toHaveLength(1);
+    replies.stop();
+  });
+});

--- a/src/components/AppBlocks/PageBlockHostCollectionFollow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCollectionFollow.browser.test.tsx
@@ -1,5 +1,8 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
+// Explicit mid-test unmount, for the "the budget is per block INSTANCE" pin. The
+// harness's own `afterEach` uses the same helper.
+import { cleanup } from 'vitest-browser-react';
 import { DialogProvider } from '~/components/Dialog/DialogProvider';
 import { useDialogStore } from '~/components/Dialog/dialogStore';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
@@ -629,4 +632,251 @@ describe('PageBlockHost SET_COLLECTION_FOLLOW — dismissal vs. an in-flight wri
     expect(followMutate).not.toHaveBeenCalled();
     replies.stop();
   });
+});
+
+/**
+ * 🔴 F4 REGRESSION (page host) — THE BOUND ON THE VISIBILITY ORACLE.
+ *
+ * F1 moved the `collection.getById` lookup BEFORE the dialog so the confirm can
+ * name its object. That is right, and it handed the block a capability: it now
+ * learns `collection-unavailable` vs. dialog-shown with no click at all, i.e. per
+ * id, "can this viewer see it?" — an AUTHENTICATED read a sandboxed cross-origin
+ * block cannot perform itself, driven at the transport's 30 messages/second.
+ *
+ * The bound is a per-block-instance cap on DISTINCT collection ids. These pin the
+ * three properties that make it a bound rather than a speed bump: the lookup is
+ * actually SKIPPED past the cap, the refusal carries no fact about the
+ * collection, and an id the viewer has already been asked about stays free.
+ */
+
+const OVER_BUDGET_FIRST_ID = 500_001;
+
+function replyFor(replies: ReturnType<typeof listenForReply>, requestId: string) {
+  return replies
+    .of('COLLECTION_FOLLOW_RESULT')
+    .map((m) => m.payload as Record<string, unknown>)
+    .find((p) => p?.requestId === requestId);
+}
+
+async function awaitReply(replies: ReturnType<typeof listenForReply>, requestId: string) {
+  let found: Record<string, unknown> | undefined;
+  await vi.waitFor(() => {
+    found = replyFor(replies, requestId);
+    if (!found) throw new Error(`no reply for ${requestId} yet`);
+  });
+  return found as Record<string, unknown>;
+}
+
+/**
+ * The transport drops inbound messages past 30 per rolling second
+ * (`RATE_LIMIT_MAX_MESSAGES`, usePostMessage.ts) and a dropped message never
+ * replies — which would look exactly like the budget refusing. These suites post
+ * 20+ messages, so they pace themselves well under that ceiling. Without this the
+ * tests below would be measuring the transport, not the budget.
+ */
+let paceMarks: number[] = [];
+async function pacedPost(type: string, payload: unknown) {
+  const now = Date.now();
+  paceMarks = paceMarks.filter((t) => now - t < 1200);
+  if (paceMarks.length >= 18) {
+    await new Promise((r) => setTimeout(r, Math.max(0, 1200 - (now - paceMarks[0]))));
+    paceMarks = [];
+  }
+  postFromBlock(type, payload);
+  paceMarks.push(Date.now());
+}
+
+async function driveToReadySettled() {
+  await driveToReady();
+  // `driveToReady` retries BLOCK_READY, and those posts count against the same
+  // 30/s inbound budget. Drain the window before the burst.
+  await new Promise((r) => setTimeout(r, 1200));
+  paceMarks = [];
+}
+
+/**
+ * Spend the whole budget on 20 DISTINCT ids the viewer cannot see, awaiting each
+ * reply. Returns nothing: the caller reads `getByIdFetch.mock.calls.length`,
+ * which is the number that matters (20 lookups actually performed).
+ */
+async function spendBudgetOnUnseeableIds(replies: ReturnType<typeof listenForReply>) {
+  for (let i = 1; i <= 20; i++) {
+    const requestId = `rq_budget_${i}`;
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId,
+      collectionId: OVER_BUDGET_FIRST_ID + i - 1,
+      follow: true,
+    });
+    await awaitReply(replies, requestId);
+  }
+}
+
+describe('PageBlockHost SET_COLLECTION_FOLLOW — per-instance distinct-id lookup budget', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+    followMutate.mockReset();
+    unfollowMutate.mockReset();
+    getByIdFetch.mockReset();
+    getByIdFetch.mockResolvedValue(UNAVAILABLE_COLLECTION);
+    paceMarks = [];
+  });
+
+  test('🔴 past the cap the host STOPS LOOKING UP — the 21st distinct id costs no authed read', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReadySettled();
+    const replies = listenForReply();
+
+    await spendBudgetOnUnseeableIds(replies);
+    // Positive control: those 20 were genuinely resolved, so the zero below is a
+    // measurement and not a handler that was never wired.
+    expect(getByIdFetch).toHaveBeenCalledTimes(20);
+
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_budget_21',
+      collectionId: OVER_BUDGET_FIRST_ID + 20,
+      follow: true,
+    });
+    const over = await awaitReply(replies, 'rq_budget_21');
+
+    // 🔴 THE BOUND: the reply came back, and NO lookup was spent producing it.
+    expect(getByIdFetch).toHaveBeenCalledTimes(20);
+    expect(over).toEqual({ requestId: 'rq_budget_21', error: 'collection-unavailable' });
+    // Still a reply, never a hang, and never a dialog for an unnamed object.
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(followMutate).not.toHaveBeenCalled();
+    replies.stop();
+  }, 30_000);
+
+  // ⚠️ SHAPE GUARD, NOT A REGRESSION TEST — labelled rather than counted. It is
+  // GREEN at `25efb688b2` (measured), and necessarily so: with no budget there is
+  // no second refusal path to be distinguishable from. What it guards is the
+  // FUTURE — a maintainer adding a `lookup-budget-exhausted` code, a `retryAfter`,
+  // or any other field that would tell "I am capped" from "you cannot see it".
+  // Mutation-checked in that direction rather than against the base.
+  test('🔴 the over-budget refusal is INDISTINGUISHABLE from "you cannot see it"', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReadySettled();
+    const replies = listenForReply();
+
+    await spendBudgetOnUnseeableIds(replies);
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_budget_21',
+      collectionId: OVER_BUDGET_FIRST_ID + 20,
+      follow: true,
+    });
+
+    // `rq_budget_1` was a REAL lookup that came back not-visible; `rq_budget_21`
+    // was refused unlooked. A block must not be able to tell them apart, or the
+    // cap hands back the very bit it exists to withhold.
+    const notVisible = await awaitReply(replies, 'rq_budget_1');
+    const overBudget = await awaitReply(replies, 'rq_budget_21');
+    const withoutId = (p: Record<string, unknown>) => {
+      const { requestId: _drop, ...rest } = p;
+      return rest;
+    };
+    expect(withoutId(overBudget)).toEqual(withoutId(notVisible));
+    // Whole-payload, so a future field (a `retryAfter`, a distinct code, a
+    // `reason`) cannot be added without failing here.
+    expect(overBudget).toEqual({ requestId: 'rq_budget_21', error: 'collection-unavailable' });
+    replies.stop();
+  }, 30_000);
+
+  test('🔴 an ALREADY-RESOLVED id still works past the cap — re-following never breaks', async () => {
+    getByIdFetch.mockImplementation((input: { id: number }) =>
+      Promise.resolve(input.id === 77 ? VISIBLE_COLLECTION : UNAVAILABLE_COLLECTION)
+    );
+    followMutate.mockResolvedValue(undefined);
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReadySettled();
+    const replies = listenForReply();
+
+    // 1 of 20: a collection the viewer really can see, followed for real.
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_keep_1',
+      collectionId: 77,
+      follow: true,
+    });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    await (lastDialog().props as ConfirmProps).onConfirm();
+    await awaitReply(replies, 'rq_keep_1');
+    useDialogStore.getState().closeAll();
+
+    // 19 more distinct ids exhaust the rest of the budget.
+    for (let i = 1; i <= 19; i++) {
+      const requestId = `rq_fill_${i}`;
+      await pacedPost('SET_COLLECTION_FOLLOW', {
+        requestId,
+        collectionId: OVER_BUDGET_FIRST_ID + i,
+        follow: true,
+      });
+      await awaitReply(replies, requestId);
+    }
+    const spent = getByIdFetch.mock.calls.length;
+    expect(spent).toBe(20);
+
+    // A NEW id is now refused unlooked…
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_new_after_cap',
+      collectionId: 999_777,
+      follow: true,
+    });
+    expect(await awaitReply(replies, 'rq_new_after_cap')).toEqual({
+      requestId: 'rq_new_after_cap',
+      error: 'collection-unavailable',
+    });
+    expect(getByIdFetch).toHaveBeenCalledTimes(spent);
+
+    // …while the collection the viewer already consented about resolves, opens a
+    // named dialog and writes, exactly as before. This is the half a naive
+    // per-call rate limit would have broken.
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_keep_2',
+      collectionId: 77,
+      follow: false,
+    });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    expect(getByIdFetch).toHaveBeenCalledTimes(spent + 1);
+    const props = lastDialog().props as ConfirmProps;
+    // 🔴 F1 is NOT regressed by the budget: the dialog still names the object.
+    expect(props.message).toContain('“Cute Cats” by alice');
+    unfollowMutate.mockResolvedValue(undefined);
+    await props.onConfirm();
+    expect(unfollowMutate).toHaveBeenCalledWith({ collectionId: 77 });
+    expect(await awaitReply(replies, 'rq_keep_2')).toEqual({
+      requestId: 'rq_keep_2',
+      result: { collectionId: 77, followed: false },
+    });
+    replies.stop();
+  }, 30_000);
+
+  test('🔴 the budget is PER BLOCK INSTANCE — a remount starts fresh', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReadySettled();
+    const first = listenForReply();
+    await spendBudgetOnUnseeableIds(first);
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_budget_21',
+      collectionId: OVER_BUDGET_FIRST_ID + 20,
+      follow: true,
+    });
+    await awaitReply(first, 'rq_budget_21');
+    expect(getByIdFetch).toHaveBeenCalledTimes(20);
+    first.stop();
+
+    // A module-scope ledger would survive this; a ref does not.
+    await cleanup();
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReadySettled();
+    const second = listenForReply();
+
+    await pacedPost('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_remount',
+      collectionId: OVER_BUDGET_FIRST_ID + 20,
+      follow: true,
+    });
+    await awaitReply(second, 'rq_remount');
+    // The fresh instance looked it up — 21 total across the two mounts.
+    expect(getByIdFetch).toHaveBeenCalledTimes(21);
+    second.stop();
+  }, 30_000);
 });

--- a/src/components/AppBlocks/PageBlockHostCollectionFollow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCollectionFollow.browser.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
-import { page } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
+import { DialogProvider } from '~/components/Dialog/DialogProvider';
 import { useDialogStore } from '~/components/Dialog/dialogStore';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
@@ -15,22 +16,34 @@ import type * as TrpcMod from '~/utils/trpc';
  * is REGISTERED. These are the behavioural pins for what it does, and in
  * particular for the property that made this bridge worth reviewing:
  *
- * 🔴 THE BRIDGE REMOVES A SCOPE GATE. Over HTTP a follow needed the block scope
- * `collections:write:self`, and the viewer's grant of that scope WAS the consent.
- * On the bridge the host acts as the signed-in session user, so the replacement
- * consent is a HOST-CHROME CONFIRM the sandboxed iframe cannot fake. Every test
- * below that reaches a mutation goes through that confirm first, and the two
- * "never calls the mutation" tests are the ones that would catch it being
- * dropped.
+ * 🔴 THE BRIDGE REMOVES A SCOPE DECLARATION, AND ADDS THE ONLY CONSENT THIS
+ * OPERATION HAS EVER HAD. ⚠️ An earlier version of this header said the viewer's
+ * grant of `collections:write:self` "WAS the consent" — RETRACTED, and false:
+ * that scope is in `CONSENT_EXEMPT_SCOPES`
+ * (`src/server/services/blocks/scope-grant.service.ts`), so it minted with no
+ * prompt and no grant row was ever recorded. What the bridge gives up is ex-ante
+ * REVIEWABILITY (the manifest `scopes` string a moderator reviews and the viewer
+ * inspects post-install); what it adds is a HOST-CHROME CONFIRM the sandboxed
+ * iframe cannot fake. Every test below that reaches a mutation goes through that
+ * confirm first, and the "never calls the mutation" tests are the ones that would
+ * catch it being dropped.
+ *
+ * 🔴 The confirm must also NAME the collection, resolved by the HOST from the id
+ * it is about to act on — a dialog that says only "a collection" asserts nothing
+ * a block's own "Follow ⭐ Cute Cats" card could contradict.
  *
  * Mirrored on the model-slot surface by `IframeHostCollectionFollow.browser.test.tsx`
  * — the two hosts share the DECISION module but have entirely separate bridges,
  * so neither suite can see the other's wiring.
  */
 
-const { followMutate, unfollowMutate } = vi.hoisted(() => ({
+const { followMutate, unfollowMutate, getByIdFetch } = vi.hoisted(() => ({
   followMutate: vi.fn(),
   unfollowMutate: vi.fn(),
+  // The HOST-SIDE collection lookup that makes the consent dialog name its
+  // object. Mocked per-test so a suite can exercise the found / not-visible /
+  // lookup-failed arms independently of any block-supplied string.
+  getByIdFetch: vi.fn(),
 }));
 
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
@@ -74,6 +87,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
       },
     },
     useUtils: () => ({
+      collection: { getById: { fetch: getByIdFetch } },
       apps: {
         shared: {
           list: { fetch: vi.fn() },
@@ -124,6 +138,30 @@ function listenForReply() {
   };
 }
 
+/**
+ * What `collection.getById` returns for a collection this viewer CAN see. The
+ * host resolves the consent dialog's subject from this — never from anything the
+ * block sent.
+ */
+const VISIBLE_COLLECTION = {
+  collection: { id: 77, name: 'Cute Cats', user: { id: 3, username: 'alice' } },
+  permissions: { read: true, write: false, manage: false },
+  collaborators: [],
+  pendingReviewCount: 0,
+};
+
+/**
+ * What it returns for a collection that does NOT exist, and — identically — for
+ * one this viewer may not see. `getCollectionByIdHandler` produces this same
+ * shape for both, which is the existence-leak guarantee the host inherits.
+ */
+const UNAVAILABLE_COLLECTION = {
+  collection: null,
+  permissions: { read: false, write: false, manage: false },
+  collaborators: [],
+  pendingReviewCount: 0,
+};
+
 function lastDialog() {
   const dialogs = useDialogStore.getState().dialogs;
   if (dialogs.length === 0) throw new Error('no modal opened');
@@ -173,11 +211,28 @@ type ConfirmProps = {
   onCancel: () => void;
 };
 
+/**
+ * Mount and wait for the iframe, but DELIBERATELY never send `BLOCK_READY` — the
+ * pre-handshake state a block reaches on load, before the viewer has interacted
+ * with it at all.
+ */
+async function mountWithoutHandshake() {
+  renderWithProviders(<PageBlockHost {...baseProps} />);
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  expect(el.getAttribute('data-block-ready')).not.toBe('true');
+}
+
 describe('PageBlockHost SET_COLLECTION_FOLLOW (consent-gated follow)', () => {
   beforeEach(() => {
     useDialogStore.getState().closeAll();
     followMutate.mockReset();
     unfollowMutate.mockReset();
+    getByIdFetch.mockReset();
+    getByIdFetch.mockResolvedValue(VISIBLE_COLLECTION);
   });
 
   test('opens a host-chrome consent confirm BEFORE any write; on CONFIRM calls collection.follow and replies followed:true', async () => {
@@ -355,6 +410,223 @@ describe('PageBlockHost SET_COLLECTION_FOLLOW (consent-gated follow)', () => {
       });
     });
     expect(replies.of('COLLECTION_FOLLOW_RESULT')).toHaveLength(1);
+    replies.stop();
+  });
+});
+
+/**
+ * 🔴 F1 REGRESSION (page host). The dialog previously named NO collection: a
+ * block could render "Follow ⭐ Cute Cats", post a different id, and host chrome
+ * would assert nothing that could contradict it.
+ */
+describe('PageBlockHost SET_COLLECTION_FOLLOW — the confirm names the HOST-RESOLVED collection', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+    followMutate.mockReset();
+    unfollowMutate.mockReset();
+    getByIdFetch.mockReset();
+    getByIdFetch.mockResolvedValue(VISIBLE_COLLECTION);
+  });
+
+  test('🔴 fetches the collection by the SAME id it will act on and names it in the dialog', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_named',
+      collectionId: 900123,
+      follow: true,
+      // A block-supplied name must NOT reach the dialog — the host has no field
+      // for it and must never grow one.
+      collectionName: 'Totally Safe Kittens',
+    });
+
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    expect(getByIdFetch).toHaveBeenCalledWith({ id: 900123 }, { staleTime: 0 });
+    const msg = (lastDialog().props as ConfirmProps).message;
+    // The WHOLE sentence, so a cosmetic reword that drops the object fails here.
+    expect(msg).toBe(
+      'Playable Collections wants to follow “Cute Cats” by alice with your Civitai account. It will appear in your collections until you unfollow it.'
+    );
+    expect(msg).not.toContain('Totally Safe Kittens');
+    replies.stop();
+  });
+
+  test('🔴 a collection the viewer cannot see is REFUSED with a reply and NO dialog', async () => {
+    getByIdFetch.mockResolvedValue(UNAVAILABLE_COLLECTION);
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_priv',
+      collectionId: 4242,
+      follow: true,
+    });
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_priv', error: 'collection-unavailable' });
+    });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(followMutate).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('a FAILED lookup refuses with the same code — never a hang, never a nameless dialog', async () => {
+    getByIdFetch.mockRejectedValue(new Error('NOT_FOUND'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_boom',
+      collectionId: 4243,
+      follow: true,
+    });
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_boom', error: 'collection-unavailable' });
+    });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    replies.stop();
+  });
+});
+
+/**
+ * 🔴 F2 REGRESSION (page host). A pre-handshake block could pop a permission
+ * modal with zero user interaction. This is the only ungated REQUEST-style
+ * handler that performs an account WRITE.
+ */
+describe('PageBlockHost SET_COLLECTION_FOLLOW — pre-handshake gate', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+    followMutate.mockReset();
+    unfollowMutate.mockReset();
+    getByIdFetch.mockReset();
+    getByIdFetch.mockResolvedValue(VISIBLE_COLLECTION);
+  });
+
+  test('🔴 a block that never sent BLOCK_READY gets `not-ready` and NO dialog', async () => {
+    await mountWithoutHandshake();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', { requestId: 'rq_pre', collectionId: 77, follow: true });
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_pre', error: 'not-ready' });
+    });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(getByIdFetch).not.toHaveBeenCalled();
+    expect(followMutate).not.toHaveBeenCalled();
+    replies.stop();
+  });
+});
+
+/**
+ * 🔴 F3 REGRESSION — driven through the REAL rendered Modal, not through
+ * `props.onCancel()`.
+ *
+ * `ConfirmDialog.handleConfirm` awaits `onConfirm()` BEFORE closing its Modal and
+ * leaves escape/overlay dismissal live during that await, so the dismissal used
+ * to win the exactly-once latch with `declined` for a follow that completed. The
+ * invariant these pin is `declined` ⇒ NO WRITE OCCURRED.
+ *
+ * `<DialogProvider />` is rendered alongside the host so the dialogStore entry
+ * becomes an actual Mantine Modal with real buttons and a real escape handler —
+ * the other suites read `props` off the store, which is exactly the "reasoned,
+ * not executed" gap this closes.
+ */
+describe('PageBlockHost SET_COLLECTION_FOLLOW — dismissal vs. an in-flight write (real Modal)', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+    followMutate.mockReset();
+    unfollowMutate.mockReset();
+    getByIdFetch.mockReset();
+    getByIdFetch.mockResolvedValue(VISIBLE_COLLECTION);
+  });
+
+  test('🔴 ESC while the mutation is in flight does NOT report `declined` for a write that happens', async () => {
+    let release: () => void = () => undefined;
+    followMutate.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          release = () => resolve();
+        })
+    );
+    renderWithProviders(
+      <>
+        <PageBlockHost {...baseProps} />
+        <DialogProvider />
+      </>
+    );
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', {
+      requestId: 'rq_race',
+      collectionId: 77,
+      follow: true,
+    });
+
+    // Real chrome: a real button in a real Modal, clicked.
+    const confirmBtn = page.getByRole('button', { name: 'Follow' });
+    await vi.waitFor(async () => {
+      await expect.element(confirmBtn).toBeInTheDocument();
+    });
+    await confirmBtn.click();
+    await vi.waitFor(() => expect(followMutate).toHaveBeenCalledTimes(1));
+
+    // Real dismissal, mid-flight, through Mantine's own escape handling.
+    await userEvent.keyboard('{Escape}');
+    release();
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_race',
+        result: { collectionId: 77, followed: true },
+      });
+    });
+    // Exactly one reply, and it is NOT `declined`.
+    expect(replies.of('COLLECTION_FOLLOW_RESULT')).toHaveLength(1);
+    replies.stop();
+  });
+
+  test('positive control: ESC BEFORE confirming still declines, through the same real Modal', async () => {
+    // Without this the test above could pass because escape never reached the
+    // Modal at all — a dismissal path wired to nothing looks identical to a
+    // dismissal correctly ignored.
+    renderWithProviders(
+      <>
+        <PageBlockHost {...baseProps} />
+        <DialogProvider />
+      </>
+    );
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_COLLECTION_FOLLOW', { requestId: 'rq_esc', collectionId: 77, follow: true });
+    const confirmBtn = page.getByRole('button', { name: 'Follow' });
+    await vi.waitFor(async () => {
+      await expect.element(confirmBtn).toBeInTheDocument();
+    });
+
+    await userEvent.keyboard('{Escape}');
+
+    await vi.waitFor(() => {
+      const r = replies.last('COLLECTION_FOLLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_esc', error: 'declined' });
+    });
+    expect(followMutate).not.toHaveBeenCalled();
     replies.stop();
   });
 });

--- a/src/components/AppBlocks/PageBlockHostFillHeight.geometry.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostFillHeight.geometry.test.tsx
@@ -103,6 +103,13 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof TrpcMod>()),
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
@@ -39,6 +39,13 @@ vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 vi.mock('~/utils/trpc', () => ({
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
@@ -32,6 +32,13 @@ vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 vi.mock('~/utils/trpc', () => ({
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blockImageUpload: {
       persist: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostInitContractV2.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostInitContractV2.browser.test.tsx
@@ -37,6 +37,13 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   // fails.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
@@ -51,6 +51,13 @@ vi.mock('~/utils/trpc', () => ({
   // this; a wholesale module mock MUST re-declare it or the ESM link fails.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
@@ -63,6 +63,13 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   // down to "0 tests collected".
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -54,6 +54,13 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {

--- a/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
@@ -63,6 +63,13 @@ vi.mock('@mantine/notifications', async (importOriginal) => {
 vi.mock('~/utils/trpc', () => ({
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: mocks.wildcard }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: mocks.submit }) },

--- a/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
@@ -62,6 +62,13 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   // down to "0 tests collected".
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
@@ -44,6 +44,13 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     // PageBlockHost wires the workflow + storage bridges at render; stub so it

--- a/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
@@ -84,6 +84,13 @@ vi.mock('~/utils/trpc', () => ({
   // wholesale, so the factory must re-declare it or the ESM link fails.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     // PageBlockHost also wires the workflow bridge at render (inert here); stub so

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -37,6 +37,13 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {

--- a/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
@@ -57,6 +57,13 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     // PageBlockHost also wires the workflow bridge at render (inert here —

--- a/src/components/AppBlocks/PageBlockHostThemeChange.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostThemeChange.browser.test.tsx
@@ -38,6 +38,13 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   // wholesale, so the factory must re-declare it or the ESM link fails.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
@@ -37,6 +37,13 @@ vi.mock('~/utils/trpc', () => ({
   // re-declare it or the ESM link fails.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
@@ -37,6 +37,13 @@ vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 vi.mock('~/utils/trpc', () => ({
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: {
       resolveWildcardPack: { useMutation: () => ({ mutateAsync: mocks.resolve }) },
     },

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -58,6 +58,13 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {

--- a/src/components/AppBlocks/collectionFollowGate.test.ts
+++ b/src/components/AppBlocks/collectionFollowGate.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCollectionFollowConsentCopy,
+  resolveCollectionFollowRequest,
+} from './collectionFollowGate';
+
+/**
+ * Unit pins for the SHARED decision layer behind the collection-follow host
+ * bridge (SET_COLLECTION_FOLLOW). Both hosts route every message through
+ * `resolveCollectionFollowRequest`, so the security properties are pinned once
+ * here and exercised end-to-end per host in
+ * `PageBlockHostCollectionFollow.browser.test.tsx` /
+ * `IframeHostCollectionFollow.browser.test.tsx`.
+ */
+
+const ok = { signedIn: true, reviewNack: false };
+
+describe('resolveCollectionFollowRequest', () => {
+  it('accepts a well-formed follow request from a signed-in viewer', () => {
+    expect(
+      resolveCollectionFollowRequest({
+        raw: { requestId: 'rq1', collectionId: 77, follow: true },
+        ...ok,
+      })
+    ).toEqual({ kind: 'confirm', request: { requestId: 'rq1', collectionId: 77, follow: true } });
+  });
+
+  it('accepts an UNfollow request (follow:false is a value, not an absence)', () => {
+    expect(
+      resolveCollectionFollowRequest({
+        raw: { requestId: 'rq2', collectionId: 5, follow: false },
+        ...ok,
+      })
+    ).toEqual({ kind: 'confirm', request: { requestId: 'rq2', collectionId: 5, follow: false } });
+  });
+
+  it('DROPS a payload with no usable requestId — there is nothing to reply to', () => {
+    for (const raw of [
+      undefined,
+      null,
+      'nope',
+      42,
+      {},
+      { collectionId: 1, follow: true },
+      { requestId: '', collectionId: 1, follow: true },
+      { requestId: 7, collectionId: 1, follow: true },
+    ]) {
+      expect(resolveCollectionFollowRequest({ raw, ...ok })).toEqual({ kind: 'drop' });
+    }
+  });
+
+  it('🔴 REFUSES an anonymous viewer — the HTTP endpoint answered 403, this replies sign-in-required', () => {
+    expect(
+      resolveCollectionFollowRequest({
+        raw: { requestId: 'rq3', collectionId: 9, follow: true },
+        signedIn: false,
+        reviewNack: false,
+      })
+    ).toEqual({ kind: 'refuse', requestId: 'rq3', error: 'sign-in-required' });
+  });
+
+  it('🔴 REFUSES under the mod-review NACK even for a perfect request from a signed-in mod', () => {
+    // This op is SESSION-authed, so it does not ride the scope-stripped review
+    // token: without this branch an untrusted pending app would drive the
+    // reviewing mod's own account.
+    expect(
+      resolveCollectionFollowRequest({
+        raw: { requestId: 'rq4', collectionId: 11, follow: true },
+        signedIn: true,
+        reviewNack: true,
+      })
+    ).toEqual({ kind: 'refuse', requestId: 'rq4', error: 'review-mode' });
+  });
+
+  it('the review NACK outranks the anonymous refusal (both refuse; review is named first)', () => {
+    expect(
+      resolveCollectionFollowRequest({
+        raw: { requestId: 'rq5', collectionId: 11, follow: true },
+        signedIn: false,
+        reviewNack: true,
+      })
+    ).toEqual({ kind: 'refuse', requestId: 'rq5', error: 'review-mode' });
+  });
+
+  it('REFUSES (never drops) a malformed collectionId — a reply, so the block cannot hang', () => {
+    for (const collectionId of [0, -1, 1.5, '12', null, undefined, NaN, Infinity]) {
+      const res = resolveCollectionFollowRequest({
+        raw: { requestId: 'rq6', collectionId, follow: true },
+        ...ok,
+      });
+      expect(res, `collectionId=${String(collectionId)}`).toEqual({
+        kind: 'refuse',
+        requestId: 'rq6',
+        error: 'invalid-request',
+      });
+    }
+    // Positive control on the same axis: `1` is the smallest accepted id, so the
+    // list above cannot be passing merely because everything is refused.
+    expect(
+      resolveCollectionFollowRequest({
+        raw: { requestId: 'rq6b', collectionId: 1, follow: true },
+        ...ok,
+      })
+    ).toEqual({ kind: 'confirm', request: { requestId: 'rq6b', collectionId: 1, follow: true } });
+  });
+
+  it('REFUSES a non-boolean `follow` (a truthy string is not a follow instruction)', () => {
+    for (const follow of ['true', 1, 0, null, undefined]) {
+      expect(
+        resolveCollectionFollowRequest({
+          raw: { requestId: 'rq7', collectionId: 3, follow },
+          ...ok,
+        })
+      ).toEqual({ kind: 'refuse', requestId: 'rq7', error: 'invalid-request' });
+    }
+  });
+
+  it('🔴 IGNORES any user id the block tries to supply — the subject is never on the wire', () => {
+    const res = resolveCollectionFollowRequest({
+      raw: {
+        requestId: 'rq8',
+        collectionId: 4,
+        follow: true,
+        userId: 999,
+        targetUserId: 999,
+        sub: 999,
+      },
+      ...ok,
+    });
+    // The resolved request carries EXACTLY three fields; nothing a block adds
+    // survives to reach a mutation call.
+    expect(res).toEqual({
+      kind: 'confirm',
+      request: { requestId: 'rq8', collectionId: 4, follow: true },
+    });
+    expect(Object.keys((res as { request: object }).request).sort()).toEqual([
+      'collectionId',
+      'follow',
+      'requestId',
+    ]);
+  });
+});
+
+describe('buildCollectionFollowConsentCopy', () => {
+  it('asks a FOLLOW question naming the app, with a Follow confirm label', () => {
+    const copy = buildCollectionFollowConsentCopy({
+      follow: true,
+      appName: 'Playable Collections',
+    });
+    expect(copy.title).toBe('Follow this collection?');
+    expect(copy.confirmLabel).toBe('Follow');
+    expect(copy.message).toContain('Playable Collections');
+    expect(copy.message).toContain('follow');
+  });
+
+  it('asks a distinct UNFOLLOW question — the two are not one string with a swapped verb', () => {
+    const copy = buildCollectionFollowConsentCopy({
+      follow: false,
+      appName: 'Playable Collections',
+    });
+    expect(copy.title).toBe('Unfollow this collection?');
+    expect(copy.confirmLabel).toBe('Unfollow');
+    expect(copy.message).toContain('unfollow');
+  });
+
+  it('falls back to "This app" when the publisher name is missing or illegible', () => {
+    for (const appName of [undefined, null, '', '   ', '​​']) {
+      expect(buildCollectionFollowConsentCopy({ follow: true, appName }).message).toContain(
+        'This app'
+      );
+    }
+  });
+
+  it('🔴 SANITIZES the publisher-controlled name — this dialog is the consent boundary', () => {
+    // A bidi override + control chars would otherwise let a publisher misrepresent
+    // WHO the viewer is granting something to, on the one screen where that matters.
+    const copy = buildCollectionFollowConsentCopy({
+      follow: true,
+      appName: 'Evil‮App\nName',
+    });
+    expect(copy.message).not.toContain('‮');
+    expect(copy.message).not.toContain('\n');
+    expect(copy.message).toContain('EvilApp Name');
+  });
+});

--- a/src/components/AppBlocks/collectionFollowGate.test.ts
+++ b/src/components/AppBlocks/collectionFollowGate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildCollectionFollowConsentCopy,
   createCollectionFollowSettlement,
+  createCollectionLookupBudget,
   resolveCollectionFollowRequest,
   resolveCollectionIdentity,
 } from './collectionFollowGate';
@@ -400,5 +401,97 @@ describe('buildCollectionFollowConsentCopy', () => {
     expect(copy.message).not.toContain('‮');
     expect(copy.message).not.toContain('\n');
     expect(copy.message).toContain('EvilApp Name');
+  });
+});
+
+/**
+ * 🔴 THE PER-INSTANCE LOOKUP BUDGET — the bound on the authenticated visibility
+ * oracle the identity lookup opened.
+ *
+ * Because the host resolves the collection BEFORE opening the dialog, a block
+ * learns "can this viewer see id N?" with no click and no viewer involvement, at
+ * the transport's 30 messages/second. A sandboxed cross-origin block cannot make
+ * that authed read itself, so the host was lending it one. These pin the bound:
+ * DISTINCT ids, repeats free forever, and a refusal that carries no fact about
+ * the collection.
+ *
+ * The behavioural cases run at `limit: 3` — deliberately NOT the production 20,
+ * so a mutant that hardcodes the constant cannot survive by matching the fixture
+ * — and the production default is pinned separately, with literal counts.
+ */
+describe('createCollectionLookupBudget', () => {
+  it('admits exactly `limit` DISTINCT ids and refuses the next new one', () => {
+    const budget = createCollectionLookupBudget(3);
+    expect(budget.admit(101)).toBe(true);
+    expect(budget.admit(202)).toBe(true);
+    expect(budget.admit(303)).toBe(true);
+    // The 4th distinct id is where enumeration would live.
+    expect(budget.admit(404)).toBe(false);
+    expect(budget.admit(505)).toBe(false);
+  });
+
+  it('🔴 a REPEAT of an admitted id is free FOREVER — re-following never stops working', () => {
+    const budget = createCollectionLookupBudget(3);
+    budget.admit(101);
+    budget.admit(202);
+    budget.admit(303);
+    expect(budget.admit(404)).toBe(false); // budget is exhausted…
+    // …and yet every id the viewer has already been asked about still resolves,
+    // any number of times. A block that legitimately follows, unfollows and
+    // re-follows one collection must not be cut off.
+    for (let i = 0; i < 50; i++) {
+      expect(budget.admit(101)).toBe(true);
+      expect(budget.admit(202)).toBe(true);
+      expect(budget.admit(303)).toBe(true);
+    }
+  });
+
+  it('counts DISTINCT ids, not calls — a repeat spends one unit, not two', () => {
+    const budget = createCollectionLookupBudget(3);
+    for (let i = 0; i < 10; i++) expect(budget.admit(101)).toBe(true);
+    // If repeats were charged, the budget would already be gone here.
+    expect(budget.admit(202)).toBe(true);
+    expect(budget.admit(303)).toBe(true);
+    expect(budget.admit(404)).toBe(false);
+  });
+
+  it('🔴 a REFUSED id is not silently admitted by asking again', () => {
+    // Otherwise the cap would be a speed bump: probe, get refused, probe again.
+    const budget = createCollectionLookupBudget(3);
+    budget.admit(101);
+    budget.admit(202);
+    budget.admit(303);
+    for (let i = 0; i < 10; i++) expect(budget.admit(404)).toBe(false);
+    // And a refusal must not have evicted anything that was already admitted.
+    expect(budget.admit(101)).toBe(true);
+  });
+
+  it('🔴 two budgets are INDEPENDENT — no module-scope ledger to share or drain', () => {
+    // The hosts hold one of these per block instance in a ref. If the ledger were
+    // module scope, two blocks on a page would drain each other and a remount
+    // would inherit an exhausted budget.
+    const a = createCollectionLookupBudget(3);
+    const b = createCollectionLookupBudget(3);
+    expect(a.admit(101)).toBe(true);
+    expect(a.admit(202)).toBe(true);
+    expect(a.admit(303)).toBe(true);
+    expect(a.admit(404)).toBe(false);
+    // b has spent nothing, including on the ids a spent.
+    expect(b.admit(404)).toBe(true);
+    expect(b.admit(505)).toBe(true);
+    expect(b.admit(606)).toBe(true);
+    expect(b.admit(707)).toBe(false);
+    // …and a is unchanged by any of it.
+    expect(a.admit(101)).toBe(true);
+    expect(a.admit(808)).toBe(false);
+  });
+
+  it('the PRODUCTION default admits 20 distinct ids and refuses the 21st', () => {
+    // Literal counts, not the exported constant: this is the pin that notices if
+    // the cap is quietly widened to a number enumeration could live inside.
+    const budget = createCollectionLookupBudget();
+    for (let i = 1; i <= 20; i++) expect(budget.admit(9000 + i)).toBe(true);
+    expect(budget.admit(9021)).toBe(false);
+    expect(budget.admit(9001)).toBe(true); // repeat, still free
   });
 });

--- a/src/components/AppBlocks/collectionFollowGate.test.ts
+++ b/src/components/AppBlocks/collectionFollowGate.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   buildCollectionFollowConsentCopy,
+  createCollectionFollowSettlement,
   resolveCollectionFollowRequest,
+  resolveCollectionIdentity,
 } from './collectionFollowGate';
 
 /**
@@ -13,7 +15,7 @@ import {
  * `IframeHostCollectionFollow.browser.test.tsx`.
  */
 
-const ok = { signedIn: true, reviewNack: false };
+const ok = { ready: true, signedIn: true, reviewNack: false };
 
 describe('resolveCollectionFollowRequest', () => {
   it('accepts a well-formed follow request from a signed-in viewer', () => {
@@ -53,6 +55,7 @@ describe('resolveCollectionFollowRequest', () => {
     expect(
       resolveCollectionFollowRequest({
         raw: { requestId: 'rq3', collectionId: 9, follow: true },
+        ready: true,
         signedIn: false,
         reviewNack: false,
       })
@@ -66,6 +69,7 @@ describe('resolveCollectionFollowRequest', () => {
     expect(
       resolveCollectionFollowRequest({
         raw: { requestId: 'rq4', collectionId: 11, follow: true },
+        ready: true,
         signedIn: true,
         reviewNack: true,
       })
@@ -76,6 +80,7 @@ describe('resolveCollectionFollowRequest', () => {
     expect(
       resolveCollectionFollowRequest({
         raw: { requestId: 'rq5', collectionId: 11, follow: true },
+        ready: true,
         signedIn: false,
         reviewNack: true,
       })
@@ -141,11 +146,178 @@ describe('resolveCollectionFollowRequest', () => {
   });
 });
 
+/**
+ * 🔴 F2 REGRESSION. Before this branch the two handlers gated on nothing but the
+ * payload and the viewer, so a block that had never sent `BLOCK_READY` — i.e. a
+ * page the viewer had not interacted with at all — could pop a permission modal
+ * on load. Three sibling handlers already document the opposite posture; this is
+ * the only ungated one that performs an ACCOUNT WRITE.
+ */
+describe('resolveCollectionFollowRequest — pre-handshake gate', () => {
+  it('🔴 REFUSES a pre-handshake request with `not-ready`, WITH a reply (never a silent drop)', () => {
+    expect(
+      resolveCollectionFollowRequest({
+        raw: { requestId: 'rq_pre', collectionId: 77, follow: true },
+        ready: false,
+        signedIn: true,
+        reviewNack: false,
+      })
+    ).toEqual({ kind: 'refuse', requestId: 'rq_pre', error: 'not-ready' });
+  });
+
+  it('the pre-handshake refusal outranks BOTH the anonymous and the malformed refusals', () => {
+    // Otherwise a pre-handshake block learns whether the viewer is signed in.
+    expect(
+      resolveCollectionFollowRequest({
+        raw: { requestId: 'rq_pre2', collectionId: -1, follow: 'nope' },
+        ready: false,
+        signedIn: false,
+        reviewNack: false,
+      })
+    ).toEqual({ kind: 'refuse', requestId: 'rq_pre2', error: 'not-ready' });
+  });
+
+  it('the review NACK still outranks the pre-handshake refusal', () => {
+    expect(
+      resolveCollectionFollowRequest({
+        raw: { requestId: 'rq_pre3', collectionId: 3, follow: true },
+        ready: false,
+        signedIn: true,
+        reviewNack: true,
+      })
+    ).toEqual({ kind: 'refuse', requestId: 'rq_pre3', error: 'review-mode' });
+  });
+
+  it('positive control: the SAME request with ready:true reaches `confirm`', () => {
+    // Without this the block above could pass merely because everything refuses.
+    expect(
+      resolveCollectionFollowRequest({
+        raw: { requestId: 'rq_pre', collectionId: 77, follow: true },
+        ready: true,
+        signedIn: true,
+        reviewNack: false,
+      })
+    ).toEqual({
+      kind: 'confirm',
+      request: { requestId: 'rq_pre', collectionId: 77, follow: true },
+    });
+  });
+});
+
+/**
+ * 🔴 F1 REGRESSION, half one. The host must learn the collection's identity from
+ * the id it is about to act on — and a collection it cannot see must be
+ * indistinguishable from one that does not exist.
+ */
+describe('resolveCollectionIdentity', () => {
+  it('reads the name and owner from a `collection.getById` result', () => {
+    expect(
+      resolveCollectionIdentity({
+        collection: { id: 77, name: 'Cute Cats', user: { id: 3, username: 'alice' } },
+        permissions: { read: true },
+      })
+    ).toEqual({ kind: 'ok', identity: { name: 'Cute Cats', ownerUsername: 'alice' } });
+  });
+
+  it('🔴 a NONEXISTENT id and a PRIVATE collection resolve IDENTICALLY (no existence leak)', () => {
+    // `getCollectionByIdHandler` returns `{ collection: null }` for BOTH: a
+    // missing row and a viewer with no read permission. Anything that told them
+    // apart would let a block enumerate private collection ids by asking the host
+    // to name them.
+    const notFound = resolveCollectionIdentity({ collection: null, permissions: {} });
+    const forbidden = resolveCollectionIdentity({
+      collection: null,
+      permissions: { read: false, write: false, manage: false },
+    });
+    expect(notFound).toEqual({ kind: 'unavailable' });
+    expect(forbidden).toEqual(notFound);
+  });
+
+  it('treats any unexpected shape as unavailable rather than rendering undefined', () => {
+    for (const raw of [undefined, null, 'nope', 42, {}, { collection: 'yes' }, { collection: 7 }]) {
+      expect(resolveCollectionIdentity(raw), JSON.stringify(raw) ?? 'undefined').toEqual({
+        kind: 'unavailable',
+      });
+    }
+  });
+
+  it('🔴 SANITIZES the fetched name and owner — other users control these strings', () => {
+    const res = resolveCollectionIdentity({
+      collection: { name: 'Cute‮Cats\nHere', user: { username: 'ali\u0000ce' } },
+    });
+    expect(res).toEqual({
+      kind: 'ok',
+      identity: { name: 'CuteCats Here', ownerUsername: 'ali ce' },
+    });
+  });
+
+  it('nulls a name/owner that sanitizes away entirely, rather than rendering ""', () => {
+    expect(
+      resolveCollectionIdentity({ collection: { name: '​​', user: { username: '   ' } } })
+    ).toEqual({ kind: 'ok', identity: { name: null, ownerUsername: null } });
+  });
+});
+
+/**
+ * 🔴 F3 REGRESSION. `ConfirmDialog.handleConfirm` awaits `onConfirm()` BEFORE
+ * closing its Modal, and does not disable escape / overlay dismissal while it
+ * waits — so a dismissal mid-flight used to win the exactly-once latch with
+ * `declined` for a write that completed. `declined` MUST mean "no write occurred".
+ */
+describe('createCollectionFollowSettlement', () => {
+  it('replies exactly once and stamps the requestId', () => {
+    const emit = vi.fn();
+    const s = createCollectionFollowSettlement({ requestId: 'rq1', emit });
+    s.reply({ result: { collectionId: 7, followed: true } });
+    s.reply({ error: 'too late' });
+    s.decline();
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith({
+      requestId: 'rq1',
+      result: { collectionId: 7, followed: true },
+    });
+  });
+
+  it('a dismissal BEFORE consent replies `declined`', () => {
+    const emit = vi.fn();
+    const s = createCollectionFollowSettlement({ requestId: 'rq2', emit });
+    s.decline();
+    expect(emit).toHaveBeenCalledWith({ requestId: 'rq2', error: 'declined' });
+  });
+
+  it('🔴 a dismissal AFTER consent is a NO-OP — the in-flight write reports itself', () => {
+    const emit = vi.fn();
+    const s = createCollectionFollowSettlement({ requestId: 'rq3', emit });
+    s.markConsented(); // synchronous, at the top of onConfirm
+    s.decline(); // ESC / overlay click while the mutation is in flight
+    expect(emit).not.toHaveBeenCalled();
+    s.reply({ result: { collectionId: 9, followed: true } }); // mutation resolves
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith({
+      requestId: 'rq3',
+      result: { collectionId: 9, followed: true },
+    });
+  });
+
+  it('a dismissal after consent does not suppress a FAILED write either', () => {
+    const emit = vi.fn();
+    const s = createCollectionFollowSettlement({ requestId: 'rq4', emit });
+    s.markConsented();
+    s.decline();
+    s.reply({ error: 'FORBIDDEN' });
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith({ requestId: 'rq4', error: 'FORBIDDEN' });
+  });
+});
+
 describe('buildCollectionFollowConsentCopy', () => {
+  const named = { collectionId: 77, collection: { name: 'Cute Cats', ownerUsername: 'alice' } };
+
   it('asks a FOLLOW question naming the app, with a Follow confirm label', () => {
     const copy = buildCollectionFollowConsentCopy({
       follow: true,
       appName: 'Playable Collections',
+      ...named,
     });
     expect(copy.title).toBe('Follow this collection?');
     expect(copy.confirmLabel).toBe('Follow');
@@ -153,10 +325,56 @@ describe('buildCollectionFollowConsentCopy', () => {
     expect(copy.message).toContain('follow');
   });
 
+  /**
+   * 🔴 F1 REGRESSION, half two. The whole sentence, pinned. A guard on WORDS is
+   * walkable by rewording, and the defect being fixed here WAS a wording: the
+   * message named no collection at all, so host chrome asserted nothing the
+   * block's own "Follow ⭐ Cute Cats" card could contradict. A cosmetic reword
+   * must fail this test.
+   */
+  it('🔴 NAMES THE COLLECTION the host resolved — id 900123 cannot hide behind "a collection"', () => {
+    expect(
+      buildCollectionFollowConsentCopy({ follow: true, appName: 'Evil App', ...named }).message
+    ).toBe(
+      'Evil App wants to follow “Cute Cats” by alice with your Civitai account. It will appear in your collections until you unfollow it.'
+    );
+    expect(
+      buildCollectionFollowConsentCopy({ follow: false, appName: 'Evil App', ...named }).message
+    ).toBe(
+      'Evil App wants to unfollow “Cute Cats” by alice with your Civitai account. It will be removed from your collections.'
+    );
+  });
+
+  it('names the collection without an owner when the owner is unknown', () => {
+    expect(
+      buildCollectionFollowConsentCopy({
+        follow: true,
+        appName: 'App',
+        collectionId: 900123,
+        collection: { name: 'Cute Cats', ownerUsername: null },
+      }).message
+    ).toBe(
+      'App wants to follow “Cute Cats” with your Civitai account. It will appear in your collections until you unfollow it.'
+    );
+  });
+
+  it('🔴 falls back to the numeric ID, never to an object-less sentence', () => {
+    const msg = buildCollectionFollowConsentCopy({
+      follow: true,
+      appName: 'App',
+      collectionId: 900123,
+      collection: { name: null, ownerUsername: null },
+    }).message;
+    expect(msg).toBe(
+      'App wants to follow collection #900123 with your Civitai account. It will appear in your collections until you unfollow it.'
+    );
+  });
+
   it('asks a distinct UNFOLLOW question — the two are not one string with a swapped verb', () => {
     const copy = buildCollectionFollowConsentCopy({
       follow: false,
       appName: 'Playable Collections',
+      ...named,
     });
     expect(copy.title).toBe('Unfollow this collection?');
     expect(copy.confirmLabel).toBe('Unfollow');
@@ -165,9 +383,9 @@ describe('buildCollectionFollowConsentCopy', () => {
 
   it('falls back to "This app" when the publisher name is missing or illegible', () => {
     for (const appName of [undefined, null, '', '   ', '​​']) {
-      expect(buildCollectionFollowConsentCopy({ follow: true, appName }).message).toContain(
-        'This app'
-      );
+      expect(
+        buildCollectionFollowConsentCopy({ follow: true, appName, ...named }).message
+      ).toContain('This app');
     }
   });
 
@@ -177,6 +395,7 @@ describe('buildCollectionFollowConsentCopy', () => {
     const copy = buildCollectionFollowConsentCopy({
       follow: true,
       appName: 'Evil‮App\nName',
+      ...named,
     });
     expect(copy.message).not.toContain('‮');
     expect(copy.message).not.toContain('\n');

--- a/src/components/AppBlocks/collectionFollowGate.ts
+++ b/src/components/AppBlocks/collectionFollowGate.ts
@@ -1,0 +1,186 @@
+import { sanitizeAppChromeName } from './appChromeName';
+
+/**
+ * SET_COLLECTION_FOLLOW — the shared, PURE decision layer for the collection
+ * follow/unfollow HOST BRIDGE. Imported by BOTH real hosts (IframeHost.tsx and
+ * PageBlockHost.tsx) so the security decision exists in ONE place rather than
+ * being open-coded twice and drifting.
+ *
+ * ── WHAT THIS BRIDGE REPLACES, AND WHAT THAT COSTS ──────────────────────────
+ *
+ * A block could already follow a collection over HTTP:
+ * `POST /api/v1/blocks/collections/[id]/follow`, gated by `withBlockScope` on the
+ * block scope `collections:write:self`. That endpoint stays live and is NOT
+ * touched by this bridge (the shipped app still calls it until it releases a
+ * version that uses the bridge).
+ *
+ * The HTTP path provided FOUR guarantees. Three of them carry across the bridge
+ * unchanged, by construction:
+ *
+ *   1. SUBJECT PINNED. HTTP pinned `userId === targetUserId === subject`, so a
+ *      block could only ever follow FOR the authenticated caller. On the bridge
+ *      the host calls the session-authed `collection.follow` / `collection.
+ *      unfollow` tRPC procedures, whose handlers (`followHandler` /
+ *      `unfollowHandler`) pass `ctx.user.id` as BOTH `userId` and `targetUserId`.
+ *      The block never supplies a user id — there is no field for one on the
+ *      wire, and the resolver below would drop it if there were.
+ *   2. ANONYMOUS REJECTED. HTTP answered an anonymous block token with 403. Here
+ *      the host refuses with `sign-in-required` BEFORE opening any UI or calling
+ *      anything (and `protectedProcedure` is the server-side backstop).
+ *   3. SAME SERVICES, VERBATIM. `followHandler`/`unfollowHandler` call the exact
+ *      `addContributorToCollection` / `removeContributorFromCollection` services
+ *      the HTTP endpoint called, which enforce their OWN permission gate (a
+ *      private collection the viewer can't follow throws FORBIDDEN). No follow
+ *      logic is re-implemented anywhere in this bridge.
+ *
+ * 🔴 THE FOURTH GUARANTEE IS THE ONE THIS MODULE EXISTS FOR: CONSENT.
+ *
+ * On HTTP the scope `collections:write:self` WAS the consent step — the viewer
+ * agreed to that capability before a token carrying it was ever minted. The
+ * bridge deliberately removes that requirement (an app using the bridge no
+ * longer declares the write scope at all), and the host acts as the signed-in
+ * session user. So without a replacement gate ANY block loaded in a host could
+ * silently make the viewer follow arbitrary collections, with no consent step
+ * the viewer ever saw. That is a real loosening, and it is not acceptable to
+ * ship it silently.
+ *
+ * The replacement is the platform's OTHER consent idiom, already used for the
+ * strictly more dangerous PUBLISH_GENERATION_OUTPUTS bridge: a HOST-CHROME
+ * confirm. The host opens its OWN dialog and performs the write only on an
+ * explicit click in host chrome — that click IS the consent boundary, and the
+ * sandboxed iframe can neither fake it nor restyle it. It is per-action and
+ * per-collection, so it is at least as strong as the install-time scope grant it
+ * replaces, and unlike that grant it cannot be spent later on a collection the
+ * viewer never saw.
+ *
+ * (The alternative reading — gate the handler on `grantedScopes` containing
+ * `collections:write:self` — was rejected deliberately: it would reinstate the
+ * exact scope the move exists to remove, leaving the bridge dead for any app
+ * that dropped it. Recorded here so a future reader does not re-derive it as an
+ * oversight.)
+ *
+ * ── WHY A SEPARATE PURE MODULE ──────────────────────────────────────────────
+ * The two hosts differ in how they learn the viewer (IframeHost: `useCurrentUser`;
+ * PageBlockHost: its `viewer` prop) and only the page host has a mod-review
+ * sandbox. Everything downstream of those two facts is identical, so it lives
+ * here, is unit-tested directly, and each host contributes only its own inputs.
+ */
+
+/** A validated, safe-to-act-on SET_COLLECTION_FOLLOW request. */
+export type CollectionFollowRequest = {
+  requestId: string;
+  collectionId: number;
+  /** true ⇒ follow, false ⇒ unfollow. */
+  follow: boolean;
+};
+
+/**
+ * The CLOSED set of host-side refusal codes carried on a
+ * `COLLECTION_FOLLOW_RESULT` `error`. Stable strings, not prose: the SDK hook
+ * branches on them (e.g. to route `sign-in-required` into a REQUEST_SIGN_IN).
+ * A SERVER failure is reported with the error's own message instead — those are
+ * open-ended by nature and the block only renders them.
+ */
+export type CollectionFollowRefusal =
+  | 'invalid-request'
+  | 'sign-in-required'
+  | 'review-mode'
+  | 'declined';
+
+export type CollectionFollowGateResult =
+  /** No usable requestId — there is nothing to reply TO, so drop it silently. */
+  | { kind: 'drop' }
+  /** Refuse WITH a reply. Never a silent drop: a REQUEST-style message that gets
+   *  no reply hangs the block to its SDK timeout (gotcha-#73). */
+  | { kind: 'refuse'; requestId: string; error: CollectionFollowRefusal }
+  /** Passed every gate — the caller must now open the host-chrome consent
+   *  confirm. `confirm`, not `proceed`: this result NEVER authorises a write on
+   *  its own, and no caller may act on it without the viewer's click. */
+  | { kind: 'confirm'; request: CollectionFollowRequest };
+
+/**
+ * Decide what a host should do with a raw SET_COLLECTION_FOLLOW payload from an
+ * untrusted iframe.
+ *
+ * Check ORDER mirrors the HTTP endpoint's, deliberately: identity first, payload
+ * second, so an anonymous caller is refused as anonymous rather than as
+ * malformed. `reviewNack` comes first because it is the one refusal that must
+ * hold even for a perfectly-formed request from a signed-in viewer.
+ *
+ * @param raw        the untrusted message payload
+ * @param signedIn   is a real session user present in the host? (IframeHost:
+ *                   `currentUser?.id != null`; PageBlockHost: `viewer != null`)
+ * @param reviewNack mod-review sandbox with "run for real" OFF. This op is
+ *                   SESSION-authed — it does NOT ride the scope-stripped review
+ *                   block token — so without this an untrusted PENDING app under
+ *                   review could drive the REVIEWING MOD's real session into
+ *                   following arbitrary collections. Same reasoning as the
+ *                   GET_WILDCARD_PACK review NACK, which is session-authed for
+ *                   the same reason.
+ */
+export function resolveCollectionFollowRequest({
+  raw,
+  signedIn,
+  reviewNack,
+}: {
+  raw: unknown;
+  signedIn: boolean;
+  reviewNack: boolean;
+}): CollectionFollowGateResult {
+  if (!raw || typeof raw !== 'object') return { kind: 'drop' };
+  const obj = raw as Record<string, unknown>;
+  // No requestId ⇒ nothing to correlate a reply to. Dropping is correct AND
+  // safe: a block that sent no requestId is not awaiting anything.
+  if (typeof obj.requestId !== 'string' || obj.requestId.length === 0) return { kind: 'drop' };
+  const requestId = obj.requestId;
+
+  if (reviewNack) return { kind: 'refuse', requestId, error: 'review-mode' };
+  if (!signedIn) return { kind: 'refuse', requestId, error: 'sign-in-required' };
+
+  // `collectionId` must be a positive integer. Numbers only — a numeric STRING
+  // is refused rather than coerced, so the wire contract stays one shape.
+  const collectionId = obj.collectionId;
+  if (
+    typeof collectionId !== 'number' ||
+    !Number.isInteger(collectionId) ||
+    collectionId <= 0 ||
+    typeof obj.follow !== 'boolean'
+  ) {
+    return { kind: 'refuse', requestId, error: 'invalid-request' };
+  }
+
+  return { kind: 'confirm', request: { requestId, collectionId, follow: obj.follow } };
+}
+
+/**
+ * The copy for the host-chrome consent confirm. Shared so both hosts ask the
+ * same question — the dialog IS the security boundary, so its wording is part of
+ * the guarantee, not decoration.
+ *
+ * The app name is PUBLISHER-controlled, so it is passed through
+ * `sanitizeAppChromeName` (the same anti-spoof used by the visible trust chrome)
+ * before being named as the party asking. Mantine renders `message` as React
+ * text, so this is not about HTML injection: it is about a bidi override or a
+ * control-char run misrepresenting WHO the viewer is granting something to, on
+ * the one screen where that matters. Falls back to the literal "This app".
+ */
+export function buildCollectionFollowConsentCopy({
+  follow,
+  appName,
+}: {
+  follow: boolean;
+  appName?: string | null;
+}): { title: string; message: string; confirmLabel: string } {
+  const who = sanitizeAppChromeName(appName) ?? 'This app';
+  return follow
+    ? {
+        title: 'Follow this collection?',
+        message: `${who} wants to follow a collection with your Civitai account. It will appear in your collections until you unfollow it.`,
+        confirmLabel: 'Follow',
+      }
+    : {
+        title: 'Unfollow this collection?',
+        message: `${who} wants to unfollow a collection with your Civitai account. It will be removed from your collections.`,
+        confirmLabel: 'Unfollow',
+      };
+}

--- a/src/components/AppBlocks/collectionFollowGate.ts
+++ b/src/components/AppBlocks/collectionFollowGate.ts
@@ -118,16 +118,11 @@ export type CollectionFollowRefusal =
    *  private collection ids by asking the host to name them. Existence-leak
    *  parity with the read path, which 404s a private collection to a non-owner.
    *
-   *  ⚠️ KNOWN, ACCEPTED SECOND-ORDER CONSEQUENCE, recorded rather than left to be
-   *  rediscovered: because the lookup now happens BEFORE the dialog, a block can
-   *  tell `collection-unavailable` from a dialog-shown outcome WITHOUT the viewer
-   *  clicking anything — i.e. it can probe, per id, "can this viewer see it?".
-   *  Previously that same bit came back only after a confirm, as a FORBIDDEN from
-   *  the mutation. The bit is coarse (visible / not), the read it rides is
-   *  `collection.getById`, and the alternative — showing a consent dialog for a
-   *  collection the host could not name — is a worse failure. If this ever needs
-   *  closing, close it with a RATE LIMIT on the host-side lookup, not by
-   *  splitting the refusal code. */
+   *  ALSO the code for a lookup the host REFUSED TO PERFORM because the block
+   *  exhausted its per-instance lookup budget (`createCollectionLookupBudget`).
+   *  🔴 THAT SHARING IS THE POINT, not an economy: a distinct "rate limited" code
+   *  would hand back exactly the bit the budget exists to withhold. See the
+   *  budget's own comment for the oracle it closes. */
   | 'collection-unavailable';
 
 export type CollectionFollowGateResult =
@@ -280,6 +275,98 @@ export function resolveCollectionIdentity(raw: unknown): CollectionIdentityResul
       ? sanitizeAppChromeName((user as { username: string }).username)
       : null;
   return { kind: 'ok', identity: { name, ownerUsername: username } };
+}
+
+/**
+ * How many DISTINCT `collectionId`s one block instance may ask the host to
+ * resolve. Small on purpose — see the reasoning on
+ * `createCollectionLookupBudget`.
+ */
+export const COLLECTION_LOOKUP_BUDGET = 20;
+
+/**
+ * Per-block-instance ledger bounding how many distinct collection ids a block
+ * may make the host look up.
+ *
+ * ── THE ORACLE THIS CLOSES ──────────────────────────────────────────────────
+ *
+ * `resolveCollectionIdentity` above is what makes the consent dialog name its
+ * object, and it costs one authenticated `collection.getById` performed BY THE
+ * HOST, IN THE VIEWER'S SESSION, BEFORE any dialog opens. So the block learns
+ * `collection-unavailable` vs. dialog-shown with no click and no viewer
+ * involvement at all — i.e. per id, "can this viewer see it?".
+ *
+ * That matters because a sandboxed cross-origin block cannot make authenticated
+ * requests to civitai.com itself. Everything it can reach on its own is the
+ * anonymous view. The host doing an authed read on its behalf therefore grants a
+ * capability the block does not otherwise have, and the transport is fast: the
+ * postMessage bridge admits 30 messages/second (`RATE_LIMIT_MAX_MESSAGES` in
+ * `usePostMessage.ts`), ~1800 probes/minute. Most collections are public, so
+ * most of those answers reveal nothing; the answer that does is *which private
+ * collections this viewer can see*.
+ *
+ * 🔴 WHY A DISTINCT-ID CAP AND NOT A TIME WINDOW. A time-based rate limit slows
+ * enumeration; it does not stop it — an attacker with a background tab has all
+ * the time there is, and a window also gives them a clean "wait and retry"
+ * signal. Enumeration needs hundreds to millions of ids; legitimate use is the
+ * handful of collections the viewer is actually looking at in this block. A cap
+ * on DISTINCT ids therefore separates the two by their defining property rather
+ * than by their speed, and it cannot be waited out.
+ *
+ * 🔴 WHY THE REFUSAL SHARES `collection-unavailable`. A separate "rate limited"
+ * code would let the block tell "I am capped" from "you cannot see it" — the
+ * exact bit the cap withholds — and in a time-window design it would also tell
+ * an attacker precisely when to back off. What the shared code guarantees is
+ * that a refusal past the cap carries NO FACT ABOUT THE COLLECTION. (It does not
+ * try to hide the cap itself, which would be futile: the cap is deterministic,
+ * so a block counting its own distinct ids can infer where it is. That is
+ * information about the block's own behaviour, not about the viewer's account.)
+ *
+ * ── THE LEDGER ─────────────────────────────────────────────────────────────
+ *
+ * `admit` counts DISTINCT ids, not calls, and remembers every id it admitted:
+ *  - a REPEAT of an already-admitted id is always allowed, forever, even long
+ *    past the cap. Re-following (or unfollowing, or re-following again) a
+ *    collection the viewer has already been asked about must never stop working,
+ *    and a repeat teaches the block nothing it was not already told.
+ *  - a NEW id is admitted only while fewer than `limit` distinct ids have been.
+ *  - admission is charged at ATTEMPT, not at success. Charging only successful
+ *    lookups would leave probing for invisible ids free, which is the entire
+ *    attack.
+ *
+ * 🔴 THE LEDGER MUST BE PER BLOCK INSTANCE — a `useRef` in each host, never
+ * module scope. Module scope would let two blocks (or two hosts) on one page
+ * share and drain each other's budget, and would survive a remount. Per-instance
+ * means the budget resets when the viewer navigates away and back, which is
+ * correct: that is a new block session with fresh viewer intent.
+ *
+ * 🔴 IT DOES NOT — AND MUST NOT — SKIP THE LOOKUP AND SHOW AN OBJECT-LESS
+ * DIALOG. "Over budget ⇒ ask the viewer anyway, without naming the collection"
+ * would resurrect the defect the naming fix closed: a dialog that asserts
+ * nothing about the object cannot contradict whatever card the block drew. Over
+ * budget REFUSES; it never degrades the consent screen.
+ */
+export type CollectionLookupBudget = {
+  /**
+   * May the host resolve this id? `true` also RECORDS the id (idempotently), so
+   * calling it twice for the same id spends one unit, not two.
+   */
+  admit: (collectionId: number) => boolean;
+};
+
+export function createCollectionLookupBudget(
+  limit: number = COLLECTION_LOOKUP_BUDGET
+): CollectionLookupBudget {
+  const admitted = new Set<number>();
+  return {
+    admit: (collectionId: number) => {
+      // Repeat of an id this instance already spent budget on — free, forever.
+      if (admitted.has(collectionId)) return true;
+      if (admitted.size >= limit) return false;
+      admitted.add(collectionId);
+      return true;
+    },
+  };
 }
 
 /**

--- a/src/components/AppBlocks/collectionFollowGate.ts
+++ b/src/components/AppBlocks/collectionFollowGate.ts
@@ -340,6 +340,13 @@ export const COLLECTION_LOOKUP_BUDGET = 20;
  * means the budget resets when the viewer navigates away and back, which is
  * correct: that is a new block session with fresh viewer intent.
  *
+ * 🔴 A BLOCK CANNOT RESET IT BY RELOADING ITSELF. The ref lives on the HOST
+ * component; `PageBlockHost`'s retry path remounts the IFRAME (`key={reloadNonce}`
+ * on the element), not the host, so a block that crashes or reloads in a loop
+ * keeps the same ledger. Only the host component unmounting — viewer navigation —
+ * clears it, and a block cannot cause that. Do not move this ref onto anything
+ * keyed by `reloadNonce`.
+ *
  * 🔴 IT DOES NOT — AND MUST NOT — SKIP THE LOOKUP AND SHOW AN OBJECT-LESS
  * DIALOG. "Over budget ⇒ ask the viewer anyway, without naming the collection"
  * would resurrect the defect the naming fix closed: a dialog that asserts

--- a/src/components/AppBlocks/collectionFollowGate.ts
+++ b/src/components/AppBlocks/collectionFollowGate.ts
@@ -33,31 +33,53 @@ import { sanitizeAppChromeName } from './appChromeName';
  *      private collection the viewer can't follow throws FORBIDDEN). No follow
  *      logic is re-implemented anywhere in this bridge.
  *
- * 🔴 THE FOURTH GUARANTEE IS THE ONE THIS MODULE EXISTS FOR: CONSENT.
+ * 🔴 THE FOURTH THING IS CONSENT — AND ON HTTP THERE WAS NONE. THIS BRIDGE IS A
+ *    TIGHTENING, NOT A LOOSENING.
  *
- * On HTTP the scope `collections:write:self` WAS the consent step — the viewer
- * agreed to that capability before a token carrying it was ever minted. The
- * bridge deliberately removes that requirement (an app using the bridge no
- * longer declares the write scope at all), and the host acts as the signed-in
- * session user. So without a replacement gate ANY block loaded in a host could
- * silently make the viewer follow arbitrary collections, with no consent step
- * the viewer ever saw. That is a real loosening, and it is not acceptable to
- * ship it silently.
+ * ⚠️ RETRACTED CLAIM, recorded so it is not re-derived. Every earlier copy of
+ * this comment (and the PR that introduced it) asserted: *"on HTTP the scope
+ * `collections:write:self` WAS the consent step — the viewer agreed to that
+ * capability before a token carrying it was ever minted."* **That is false.**
+ * `collections:write:self` is listed in `CONSENT_EXEMPT_SCOPES`
+ * (`src/server/services/blocks/scope-grant.service.ts`), commented *"server
+ * visibility/ownership is the gate, not a per-scope consent prompt"*.
+ * `partitionByConsent` puts it straight into `signable`, `consentGatedScopes`
+ * strips it, and NO grant row is ever recorded. `block-scope.constants.ts` says
+ * the same thing at the registry. So the viewer was never prompted, at install
+ * time or ever: on HTTP a block that merely DECLARED the scope could follow
+ * arbitrary collections for the viewer with ZERO prompts.
  *
- * The replacement is the platform's OTHER consent idiom, already used for the
- * strictly more dangerous PUBLISH_GENERATION_OUTPUTS bridge: a HOST-CHROME
+ * What the bridge therefore does is convert a ZERO-prompt path into a
+ * ONE-PROMPT-PER-ACTION path. A reviewer weighing "is this loosening
+ * acceptable?" is answering a question that does not exist.
+ *
+ * WHAT IT DOES COST, precisely: the manifest `scopes` declaration. That string
+ * is the EX-ANTE REVIEWABILITY signal — a moderator sees it in
+ * `OnsiteReviewModal` and the viewer inspects it post-install in
+ * `AppSettingsModal`. An app on the bridge declares no write scope, so its
+ * permissions panel can read EMPTY while it writes to the viewer's collections.
+ * The real trade is:
+ *
+ *     "reviewable before install"  →  "consented at the moment of action"
+ *
+ * The replacement gate is the platform's OTHER consent idiom, already used for
+ * the strictly more dangerous PUBLISH_GENERATION_OUTPUTS bridge: a HOST-CHROME
  * confirm. The host opens its OWN dialog and performs the write only on an
  * explicit click in host chrome — that click IS the consent boundary, and the
  * sandboxed iframe can neither fake it nor restyle it. It is per-action and
- * per-collection, so it is at least as strong as the install-time scope grant it
- * replaces, and unlike that grant it cannot be spent later on a collection the
+ * per-collection, and it names the collection the host itself resolved (see
+ * `resolveCollectionIdentity` below), so it cannot be spent on a collection the
  * viewer never saw.
  *
+ * 🔴 DO NOT "restore" the scope gate as a fix for the retracted claim above, and
+ * do NOT delete this confirm as redundant with a scope grant. There is no scope
+ * grant. The confirm is the ONLY consent this path has ever had.
+ *
  * (The alternative reading — gate the handler on `grantedScopes` containing
- * `collections:write:self` — was rejected deliberately: it would reinstate the
- * exact scope the move exists to remove, leaving the bridge dead for any app
- * that dropped it. Recorded here so a future reader does not re-derive it as an
- * oversight.)
+ * `collections:write:self` — was rejected deliberately: `grantedScopes` never
+ * contains it (it is consent-exempt, so no grant row exists to put it there), so
+ * such a gate would be dead code that refuses every request. Recorded here so a
+ * future reader does not re-derive it as an oversight.)
  *
  * ── WHY A SEPARATE PURE MODULE ──────────────────────────────────────────────
  * The two hosts differ in how they learn the viewer (IframeHost: `useCurrentUser`;
@@ -85,7 +107,28 @@ export type CollectionFollowRefusal =
   | 'invalid-request'
   | 'sign-in-required'
   | 'review-mode'
-  | 'declined';
+  | 'declined'
+  /** The host has not completed the block handshake yet, so there has been no
+   *  user interaction this prompt could plausibly belong to. See `ready` on
+   *  `resolveCollectionFollowRequest`. */
+  | 'not-ready'
+  /** The host could not resolve the collection's identity — it does not exist,
+   *  the viewer may not see it, or the lookup itself failed. 🔴 ONE code for all
+   *  three, DELIBERATELY: a distinct "not found" would let a block enumerate
+   *  private collection ids by asking the host to name them. Existence-leak
+   *  parity with the read path, which 404s a private collection to a non-owner.
+   *
+   *  ⚠️ KNOWN, ACCEPTED SECOND-ORDER CONSEQUENCE, recorded rather than left to be
+   *  rediscovered: because the lookup now happens BEFORE the dialog, a block can
+   *  tell `collection-unavailable` from a dialog-shown outcome WITHOUT the viewer
+   *  clicking anything — i.e. it can probe, per id, "can this viewer see it?".
+   *  Previously that same bit came back only after a confirm, as a FORBIDDEN from
+   *  the mutation. The bit is coarse (visible / not), the read it rides is
+   *  `collection.getById`, and the alternative — showing a consent dialog for a
+   *  collection the host could not name — is a worse failure. If this ever needs
+   *  closing, close it with a RATE LIMIT on the host-side lookup, not by
+   *  splitting the refusal code. */
+  | 'collection-unavailable';
 
 export type CollectionFollowGateResult =
   /** No usable requestId — there is nothing to reply TO, so drop it silently. */
@@ -93,9 +136,10 @@ export type CollectionFollowGateResult =
   /** Refuse WITH a reply. Never a silent drop: a REQUEST-style message that gets
    *  no reply hangs the block to its SDK timeout (gotcha-#73). */
   | { kind: 'refuse'; requestId: string; error: CollectionFollowRefusal }
-  /** Passed every gate — the caller must now open the host-chrome consent
-   *  confirm. `confirm`, not `proceed`: this result NEVER authorises a write on
-   *  its own, and no caller may act on it without the viewer's click. */
+  /** Passed every gate — the caller must now RESOLVE THE COLLECTION'S IDENTITY
+   *  server-side and open the host-chrome consent confirm naming it.
+   *  `confirm`, not `proceed`: this result NEVER authorises a write on its own,
+   *  and no caller may act on it without the viewer's click. */
   | { kind: 'confirm'; request: CollectionFollowRequest };
 
 /**
@@ -108,6 +152,18 @@ export type CollectionFollowGateResult =
  * hold even for a perfectly-formed request from a signed-in viewer.
  *
  * @param raw        the untrusted message payload
+ * @param ready      has the block completed its handshake (host gate status
+ *                   `ready`)? 🔴 A pre-handshake block must not be able to pop a
+ *                   permission modal before the viewer has interacted with it at
+ *                   all — the posture three sibling handlers already document
+ *                   (`IframeHost` REQUEST_SIGN_IN / REQUEST_CONSENT,
+ *                   `PageBlockHost` navigation). Precedent among the REQUEST-style
+ *                   handlers is genuinely MIXED — OPEN_RESOURCE_PICKER,
+ *                   PUBLISH_GENERATION_OUTPUTS and OPEN_IMAGE_UPLOAD are all
+ *                   ungated — so this is not "the house style"; it is gated
+ *                   because this is the only one of them that performs an ACCOUNT
+ *                   WRITE. Refused WITH a reply, never dropped: the ungated
+ *                   siblings can afford silence, a REQUEST-style message cannot.
  * @param signedIn   is a real session user present in the host? (IframeHost:
  *                   `currentUser?.id != null`; PageBlockHost: `viewer != null`)
  * @param reviewNack mod-review sandbox with "run for real" OFF. This op is
@@ -120,10 +176,12 @@ export type CollectionFollowGateResult =
  */
 export function resolveCollectionFollowRequest({
   raw,
+  ready,
   signedIn,
   reviewNack,
 }: {
   raw: unknown;
+  ready: boolean;
   signedIn: boolean;
   reviewNack: boolean;
 }): CollectionFollowGateResult {
@@ -135,6 +193,9 @@ export function resolveCollectionFollowRequest({
   const requestId = obj.requestId;
 
   if (reviewNack) return { kind: 'refuse', requestId, error: 'review-mode' };
+  // Before the viewer, before the payload: `not-ready` is a statement about the
+  // HOST's lifecycle, and a pre-handshake caller has no standing to learn either.
+  if (!ready) return { kind: 'refuse', requestId, error: 'not-ready' };
   if (!signedIn) return { kind: 'refuse', requestId, error: 'sign-in-required' };
 
   // `collectionId` must be a positive integer. Numbers only — a numeric STRING
@@ -153,34 +214,177 @@ export function resolveCollectionFollowRequest({
 }
 
 /**
+ * The collection's identity AS THE HOST RESOLVED IT — never as the block
+ * described it.
+ *
+ * 🔴 THIS IS WHAT MAKES THE CONFIRM A CONSENT SCREEN RATHER THAN A CEREMONY.
+ * The dialog previously named no collection at all, only the app: *"X wants to
+ * follow a collection with your Civitai account."* A block could render its own
+ * card reading "Follow ⭐ Cute Cats", post `collectionId: 900123` for something
+ * else entirely, and the host chrome would assert NOTHING about the object — so
+ * it could not contradict the block, and the module's own per-collection claim
+ * was empty. The host now fetches the identity from the id itself and names
+ * that.
+ *
+ * 🔴 AND IT MUST STAY HOST-FETCHED. Do NOT add a block-supplied `name` to the
+ * wire and render it: that hands the misrepresentation surface straight back,
+ * with the host's own chrome vouching for it. The only trustworthy string is one
+ * the host resolved server-side from the same `collectionId` it is about to act
+ * on.
+ */
+export type CollectionIdentity = {
+  /** Sanitized display name; `null` when absent or when nothing legible remains. */
+  name: string | null;
+  /** Sanitized owner username; `null` when absent or illegible. */
+  ownerUsername: string | null;
+};
+
+export type CollectionIdentityResult =
+  | { kind: 'ok'; identity: CollectionIdentity }
+  /** Not found, not visible to this viewer, or the lookup failed — ONE outcome
+   *  for all three on purpose (see `collection-unavailable`). */
+  | { kind: 'unavailable' };
+
+/**
+ * Read a `collection.getById` result into a display identity.
+ *
+ * Duck-typed over `unknown` rather than typed against the tRPC output on
+ * purpose: this is a display-safety boundary, so a shape that is not what we
+ * expect must land in `unavailable`, not in a render of `undefined`.
+ *
+ * 🔴 EXISTENCE-LEAK PARITY. `getCollectionByIdHandler` already answers a viewer
+ * with no read permission with `{ collection: null }` — the SAME shape a
+ * nonexistent id produces — so mapping "no `collection` object" to `unavailable`
+ * inherits that non-leak instead of inventing a second, weaker rule. A thrown
+ * lookup (NOT_FOUND, feature flag, network) is folded into the same outcome by
+ * the caller.
+ *
+ * Both strings go through `sanitizeAppChromeName`. Despite the name that helper
+ * is the host's generic *chrome text* sanitizer, and the reason applies verbatim
+ * here: these are OTHER USERS' strings rendered in the one place the viewer is
+ * deciding whom to trust, so a bidi override or a Zalgo run must not be able to
+ * reorder or overflow the sentence. Mantine renders `message` as React text, so
+ * this is not about HTML injection.
+ */
+export function resolveCollectionIdentity(raw: unknown): CollectionIdentityResult {
+  if (!raw || typeof raw !== 'object') return { kind: 'unavailable' };
+  const collection = (raw as { collection?: unknown }).collection;
+  if (!collection || typeof collection !== 'object') return { kind: 'unavailable' };
+  const obj = collection as { name?: unknown; user?: unknown };
+  const name = typeof obj.name === 'string' ? sanitizeAppChromeName(obj.name) : null;
+  const user = obj.user;
+  const username =
+    user &&
+    typeof user === 'object' &&
+    typeof (user as { username?: unknown }).username === 'string'
+      ? sanitizeAppChromeName((user as { username: string }).username)
+      : null;
+  return { kind: 'ok', identity: { name, ownerUsername: username } };
+}
+
+/**
+ * Exactly-once reply + CONSENT LATCH for one SET_COLLECTION_FOLLOW request.
+ * Shared by both hosts so the two bridges cannot drift on the invariant below.
+ *
+ * 🔴 `declined` MUST MEAN "NO WRITE OCCURRED". Without the latch it did not.
+ * `ConfirmDialog.handleConfirm` awaits `onConfirm()` BEFORE closing its Modal,
+ * and the Modal keeps `closeOnEscape` / `closeOnClickOutside` live during that
+ * await — so ESC or an overlay click mid-flight ran `onCancel`, won the
+ * exactly-once latch with `{error:'declined'}`, and the mutation completed
+ * anyway. Measured on the real dialog: the follow mutation fired once and the
+ * only reply the block ever saw was `declined`. A block (or a future audit)
+ * reading `declined` as "safe, nothing happened" would then be wrong.
+ *
+ * WHY THIS FIX rather than `closeOnEscape={false}` / `closeOnClickOutside={false}`:
+ * those props would have to be threaded through `ConfirmDialog`, a component
+ * shared by ~100 unrelated call sites, and they only make the dismissal HARDER —
+ * they do not pin the invariant. Trapping the viewer in a modal during a network
+ * call is also worse UX than letting it close. This latch pins the invariant
+ * itself, in the one module both hosts already share, and is directly unit
+ * testable. The dismissal still closes the dialog; it just no longer claims a
+ * write did not happen.
+ */
+export type CollectionFollowSettlement = {
+  /** Called SYNCHRONOUSLY at the top of `onConfirm`, before any `await`. */
+  markConsented: () => void;
+  /** Reply once; every later call is a no-op. */
+  reply: (payload: Record<string, unknown>) => void;
+  /** Dismissal (Cancel / X / ESC / overlay). A no-op once consent was given. */
+  decline: () => void;
+};
+
+export function createCollectionFollowSettlement({
+  requestId,
+  emit,
+}: {
+  requestId: string;
+  emit: (payload: Record<string, unknown>) => void;
+}): CollectionFollowSettlement {
+  let settled = false;
+  let consented = false;
+  const reply = (payload: Record<string, unknown>) => {
+    if (settled) return;
+    settled = true;
+    emit({ requestId, ...payload });
+  };
+  return {
+    markConsented: () => {
+      consented = true;
+    },
+    reply,
+    decline: () => {
+      // Consent already given ⇒ the write is in flight or done and will settle
+      // this request itself. Reporting `declined` here would be a lie.
+      if (consented) return;
+      reply({ error: 'declined' });
+    },
+  };
+}
+
+/**
  * The copy for the host-chrome consent confirm. Shared so both hosts ask the
  * same question — the dialog IS the security boundary, so its wording is part of
  * the guarantee, not decoration.
  *
- * The app name is PUBLISHER-controlled, so it is passed through
- * `sanitizeAppChromeName` (the same anti-spoof used by the visible trust chrome)
- * before being named as the party asking. Mantine renders `message` as React
- * text, so this is not about HTML injection: it is about a bidi override or a
- * control-char run misrepresenting WHO the viewer is granting something to, on
- * the one screen where that matters. Falls back to the literal "This app".
+ * Two untrusted-ish strings appear here and BOTH are host-controlled by the time
+ * they arrive:
+ *  - `appName` is PUBLISHER-controlled and is sanitized here (falls back to the
+ *    literal "This app");
+ *  - `collection` is HOST-FETCHED and already sanitized by
+ *    `resolveCollectionIdentity`. It is never taken from the block.
+ *
+ * 🔴 THE SENTENCE MUST NAME THE OBJECT. When the fetched name is missing or
+ * sanitizes away we fall back to the numeric id (`collection #900123`) rather
+ * than to the old object-less wording — an id the viewer can at least compare
+ * against what the block showed is strictly more than nothing, and it keeps the
+ * host asserting *something* about the thing it is about to follow.
  */
 export function buildCollectionFollowConsentCopy({
   follow,
   appName,
+  collectionId,
+  collection,
 }: {
   follow: boolean;
   appName?: string | null;
+  collectionId: number;
+  collection: CollectionIdentity;
 }): { title: string; message: string; confirmLabel: string } {
   const who = sanitizeAppChromeName(appName) ?? 'This app';
+  const subject = collection.name
+    ? collection.ownerUsername
+      ? `“${collection.name}” by ${collection.ownerUsername}`
+      : `“${collection.name}”`
+    : `collection #${collectionId}`;
   return follow
     ? {
         title: 'Follow this collection?',
-        message: `${who} wants to follow a collection with your Civitai account. It will appear in your collections until you unfollow it.`,
+        message: `${who} wants to follow ${subject} with your Civitai account. It will appear in your collections until you unfollow it.`,
         confirmLabel: 'Follow',
       }
     : {
         title: 'Unfollow this collection?',
-        message: `${who} wants to unfollow a collection with your Civitai account. It will be removed from your collections.`,
+        message: `${who} wants to unfollow ${subject} with your Civitai account. It will be removed from your collections.`,
         confirmLabel: 'Unfollow',
       };
 }

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -86,8 +86,7 @@ export interface MessageSpec {
 // InlineHost is a v1 STUB that throws on render and wires NO message bridge
 // (BlockHost never routes inline installs in v1 — `canUseInline` is always
 // false). So EVERY message is N/A for it today; the shared reason is below.
-export const INLINE_STUB =
-  'InlineHost is a v1 stub (throws on render, no message bridge in v1)';
+export const INLINE_STUB = 'InlineHost is a v1 stub (throws on render, no message bridge in v1)';
 
 export const INVENTORY = {
   // ── Lifecycle / fire-and-forget (no reply ⇒ unhandled never HANGS, but a
@@ -568,6 +567,32 @@ export const INVENTORY = {
     PageBlockHost: 'required',
     InlineHost: INLINE_STUB,
   },
+  // ── Collection follow/unfollow (host bridge) ───────────────────────────────
+  // A block asks the HOST to follow/unfollow a collection as the logged-in
+  // viewer. Replaces the block's own `POST /api/v1/blocks/collections/[id]/follow`
+  // call (which stays live — this bridge does NOT retire it), so an app no longer
+  // needs the `collections:write:self` write scope for an on-site bookmark.
+  //
+  // 🔴 That removal is a real loosening, so the host does NOT just do it: both
+  // hosts open a HOST-CHROME CONSENT CONFIRM first and write only on the viewer's
+  // explicit click — the same boundary PUBLISH_GENERATION_OUTPUTS uses. The full
+  // reasoning (which of the HTTP endpoint's guarantees carry across, and how) is
+  // in `collectionFollowGate.ts`, which both hosts share.
+  //
+  // BOTH real hosts: unlike the page-only affordances above, a collection follow
+  // is a plain on-site bookmark with no page-sized surface behind it — a model-
+  // slot block showing a collection has exactly the same reason to offer it.
+  // REQUEST-style ⇒ an unhandled one HANGS the block. Ahead of the published SDK
+  // dist union (the SDK's `useCollectionFollow` hook is a co-requisite landing in
+  // civitai-app-starters) — forward-looking coverage, allowed by the one-
+  // directional compile-time gate.
+  SET_COLLECTION_FOLLOW: {
+    request: true,
+    reply: 'COLLECTION_FOLLOW_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
 } satisfies Record<string, MessageSpec>;
 
 /**
@@ -594,6 +619,9 @@ type SdkBlockToParentType = BlockToParentMessageType;
 // ─────────────────────────────────────────────────────────────────────────────
 type _SdkCovered = SdkBlockToParentType extends keyof typeof INVENTORY
   ? true
-  : ['INVENTORY missing published SDK message(s):', Exclude<SdkBlockToParentType, keyof typeof INVENTORY>];
+  : [
+      'INVENTORY missing published SDK message(s):',
+      Exclude<SdkBlockToParentType, keyof typeof INVENTORY>
+    ];
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _sdkCovered: _SdkCovered = true;

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -573,11 +573,18 @@ export const INVENTORY = {
   // call (which stays live — this bridge does NOT retire it), so an app no longer
   // needs the `collections:write:self` write scope for an on-site bookmark.
   //
-  // 🔴 That removal is a real loosening, so the host does NOT just do it: both
-  // hosts open a HOST-CHROME CONSENT CONFIRM first and write only on the viewer's
-  // explicit click — the same boundary PUBLISH_GENERATION_OUTPUTS uses. The full
-  // reasoning (which of the HTTP endpoint's guarantees carry across, and how) is
-  // in `collectionFollowGate.ts`, which both hosts share.
+  // 🔴 THIS IS A TIGHTENING, NOT A LOOSENING. ⚠️ An earlier copy of this comment
+  // said the dropped scope "was the viewer's consent step" — RETRACTED, it is
+  // false: `collections:write:self` is in `CONSENT_EXEMPT_SCOPES`
+  // (`src/server/services/blocks/scope-grant.service.ts`), so it mints without any
+  // prompt and no grant row is ever recorded. The HTTP path had ZERO prompts;
+  // both hosts now open a HOST-CHROME CONSENT CONFIRM and write only on the
+  // viewer's explicit click — the same boundary PUBLISH_GENERATION_OUTPUTS uses.
+  // What the bridge actually gives up is the manifest `scopes` DECLARATION, i.e.
+  // ex-ante reviewability (moderator review + the post-install permissions panel),
+  // traded for consent at the moment of action. Full reasoning, and why the
+  // confirm must not be "restored" into a scope gate, is in
+  // `collectionFollowGate.ts`, which both hosts share.
   //
   // BOTH real hosts: unlike the page-only affordances above, a collection follow
   // is a plain on-site bookmark with no page-sized surface behind it — a model-

--- a/src/components/Apps/ReviewPreviewFit.browser.test.tsx
+++ b/src/components/Apps/ReviewPreviewFit.browser.test.tsx
@@ -88,6 +88,13 @@ vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
 vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof TrpcMod>()),
   trpc: {
+    // Collection follow/unfollow host bridge (SET_COLLECTION_FOLLOW). Both
+    // hosts register the handler, so every host-rendering suite needs these
+    // two session-authed mutations present on the mocked client.
+    collection: {
+      follow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      unfollow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
     generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       // The mint the review host fires on mount. Resolves synchronously to a


### PR DESCRIPTION
Adds `SET_COLLECTION_FOLLOW` → `COLLECTION_FOLLOW_RESULT` to the App Blocks host bridge, so a block can follow/unfollow a collection **without declaring the `collections:write:self` write scope**. Host (serving) side only — the SDK message union and the `useCollectionFollow` hook ship separately from `civitai-app-starters`, which the INVENTORY gate explicitly permits (it already carries forward-looking entries for `CANCEL_WORKFLOW`, `REQUEST_SIGN_IN`, `REQUEST_CONSENT`).

**The existing HTTP path is untouched and stays live.** The shipped app still calls it; removing it now would break production.

## 🔴 The security question — and a correction to how this PR originally framed it

⚠️ **The first version of this PR (and six comment copies in the diff — `collectionFollowGate.ts`, `hostHandlerParity.ts`, both hosts, and both browser-test headers) claimed: _"on HTTP the scope `collections:write:self` WAS the consent step — the viewer agreed to that capability before a token carrying it was ever minted."_ That is FALSE, and it has been retracted in every copy.**

`collections:write:self` is listed in `CONSENT_EXEMPT_SCOPES` (`src/server/services/blocks/scope-grant.service.ts`), commented *"server visibility/ownership is the gate, not a per-scope consent prompt"*. `partitionByConsent` puts it straight into `signable`, `consentGatedScopes` strips it, and **no grant row is ever recorded**. `block-scope.constants.ts` says the same thing at the registry. The viewer was never prompted — at install time or ever.

Two consequences, both now written into the code so a future reader cannot re-derive the wrong one:

- **This PR is a TIGHTENING, not a loosening.** It converts a *zero-prompt* path into a one-prompt-per-action path. A reviewer weighing "is this loosening acceptable?" is answering a question that does not exist.
- **What the bridge actually gives up is the manifest `scopes` DECLARATION** — the ex-ante reviewability signal a moderator reads in `OnsiteReviewModal` and the viewer inspects post-install in `AppSettingsModal`. After this PR an app whose permissions panel reads *empty* can write to the viewer's collections. The real trade is **"reviewable before install" → "consented at the moment of action"**.
- 🔴 Therefore: **do not "restore" the scope gate as a fix, and do not delete the confirm as redundant with a scope grant.** There is no scope grant. The confirm is the only consent this operation has ever had. Gating on `grantedScopes` containing `collections:write:self` would be *dead code that refuses every request*, because a consent-exempt scope never appears there.

The endpoint's other three guarantees carry across by construction, unchanged from the original description:

1. **Subject pinned.** The host calls the session-authed `collection.follow`/`unfollow` tRPC procedures, whose handlers pass `ctx.user.id` as *both* actor and target. The block never supplies a user id — there is no field for one on the wire, and the resolver drops it if there were.
2. **Anonymous rejected.** The host refuses with `sign-in-required` **before opening any UI or calling anything**; `protectedProcedure` is the server-side backstop.
3. **Same services, verbatim.** `addContributorToCollection` / `removeContributorFromCollection`, which enforce their own permission gate. No follow logic is reimplemented.

## The consent dialog names the collection — resolved by the HOST

A confirm that says only *"this app wants to follow **a collection**"* asserts nothing about the object, so it cannot contradict the block: a block can render its own card reading *"Follow ⭐ Cute Cats"*, post `collectionId: 900123` for something else, and the viewer confirms the wrong thing.

So the host now **fetches the collection's identity server-side from the same `collectionId` it is about to act on** (`collection.getById`, `staleTime: 0`) and names *that* — `“Cute Cats” by alice`. Both strings are sanitized with the host's chrome-text sanitizer (bidi overrides, control chars, Zalgo runs, length). **A block-supplied name is never rendered and there is no wire field for one** — that would hand back the exact misrepresentation surface, with host chrome vouching for it. When the fetched name is missing or sanitizes away, the message falls back to `collection #900123` — never to an object-less sentence.

**Lookup failure modes all end in a refusal WITH a reply**, never a hang and never a dialog missing its promised name. Not-found, not-visible and network error share one code, `collection-unavailable`, deliberately: a distinct "not found" would let a block enumerate private collection ids by asking the host to name them. That matches `getCollectionByIdHandler`, which already returns the same `{ collection: null }` shape for both.

## 🔴 The bound on the visibility oracle that the lookup opened

Moving the lookup ahead of the dialog is what lets the dialog name its object. It also **hands the block a capability it did not have**, and this PR now closes it rather than accepting it.

**Before:** a block learned "can this viewer see collection N?" only *after* a viewer click, as a post-confirm FORBIDDEN — one click per id.
**After the naming fix:** `collection-unavailable` comes back with **no dialog and no click**. The transport admits 30 messages/second (`RATE_LIMIT_MAX_MESSAGES`, `usePostMessage.ts`), so that is ~1800 probes/minute.

That is a real escalation, not a nit: a sandboxed cross-origin block **cannot make authenticated requests to civitai.com itself**. The host performing an authed `collection.getById` on its behalf lends untrusted third-party code an **authenticated visibility oracle over the collection id space, running in the viewer's session**. Most collections are public and the answer reveals nothing; the sensitive answer is *which private collections this viewer can see*.

**The bound: a per-block-instance cap on DISTINCT collection ids** (`createCollectionLookupBudget`, default **20**), held in a `useRef` by each host and checked before the lookup is spent.

- **Distinct ids, not calls.** An already-admitted id is admitted again **forever**, past the cap — following, unfollowing and re-following one collection must never stop working, and a repeat teaches the block nothing it was not already told.
- **Charged at attempt, not at success.** Charging only successful lookups would leave probing for *invisible* ids free, which is the entire attack.
- 🔴 **A distinct-id cap rather than a time window.** A time-based rate limit only *slows* enumeration — an attacker with a background tab has all the time there is — and a window also hands back a clean "wait and retry" signal. Enumeration needs hundreds to millions of ids; legitimate use is the handful of collections the viewer is actually looking at. A distinct-id cap separates the two by their defining property rather than by their speed, and it cannot be waited out.
- 🔴 **Over budget refuses with the SAME `collection-unavailable` code.** A separate "rate limited" code would let the block tell *"I am capped"* from *"you cannot see it"* — the exact bit the cap withholds. What the shared code guarantees is that a refusal past the cap **carries no fact about the collection**. It does not try to hide the cap itself, which would be futile: the cap is deterministic, so a block counting its own distinct ids can infer where it is — that is information about the block's own behaviour, not about the viewer's account.
- 🔴 **It never degrades the consent screen.** "Over budget ⇒ ask anyway, without naming the collection" would resurrect the defect the naming fix closed. Over budget **refuses**; a legitimate follow still names its object.
- 🔴 **Per block instance, not module scope.** Two blocks (or two hosts) on one page cannot share or drain each other's budget, and a remount starts fresh — a new block session with fresh viewer intent. Pinned by a test that exhausts one instance, remounts, and asserts the new instance performs the lookup.

## Two more gates on the handler

- **Pre-handshake refusal (`not-ready`).** Neither handler used to gate on the host gate status, so a block that had never sent `BLOCK_READY` could pop a permission modal with **zero user interaction** — measured on both hosts. Precedent among REQUEST-style handlers is genuinely mixed (`OPEN_RESOURCE_PICKER`, `PUBLISH_GENERATION_OUTPUTS`, `OPEN_IMAGE_UPLOAD` are also ungated), so this is not "the house style"; it is gated because **it is the only one of them that performs an account WRITE**. Refused *with* a reply, never dropped — an unanswered REQUEST-style message hangs the block.
- **`declined` now means "no write occurred".** `ConfirmDialog.handleConfirm` awaits `onConfirm()` *before* closing its Modal and leaves escape/overlay dismissal live during that await, so ESC mid-flight used to win the exactly-once latch with `{error:'declined'}` while the mutation completed anyway (measured: `followMutate` called once, only reply `declined`). `createCollectionFollowSettlement` — shared by both hosts — takes a consent latch synchronously at the top of `onConfirm`, after which a dismissal is a no-op and the in-flight write reports itself. Chosen over `closeOnEscape={false}`/`closeOnClickOutside={false}` because those would thread new props through a component with ~100 unrelated call sites, only make dismissal *harder*, and would not pin the invariant.
- `dialogStore.trigger` now passes a per-request `id` (`block-collection-follow-<requestId>`), matching the image-upload handler. `dialogStore` drops a duplicate id silently, and a dropped dialog is a request that never replies. **Insurance, not a fix** — the collision could not be reproduced (rendering a Mantine modal costs >1 ms).

## The bug class this is wired against

A request-style block→host message with **no host handler** never gets its `*_RESULT` reply, so the block hangs to its SDK request timeout: **no network call, no console error, UI spins forever.** The dev/live SDK host serves these messages, so authors test green locally and break in production — this exact gap bit `OPEN_CHECKPOINT_PICKER` on pages.

So this adds all three required pieces: the **INVENTORY entry**, handlers in **both** real hosts, and behavioural browser tests **per host**. `InlineHost` is a v2 stub running no message bridge in v1 and is marked N/A with a reason.

## Design

`collectionFollowGate.ts` is a **pure decision layer imported by both hosts**, so the security decision, the consent copy, the identity resolver and the settlement latch exist in one place instead of being open-coded twice and drifting. The hosts differ only in how they learn the viewer (`useCurrentUser` vs a `viewer` prop) and in the page host's mod-review sandbox; everything downstream is identical, lives in the gate, and is unit-tested directly.

## Verification

| tier | runner | result |
|---|---|---|
| typecheck | `node scripts/typecheck.mjs` | **0 errors** (needs `git submodule update --init event-engine-common` in a fresh worktree) |
| **browser (component)** | `node scripts/test-component-run.mjs` | **219 files / 2424 tests passed**, exit 0; ledger `2424 executed, 0 skipped … 0 failed tests` |
| gate unit | `vitest run --project 'unit*' collectionFollowGate.test.ts` | **35 passed** (29 pre-existing + 6 budget) |
| **unit + unit-native (full)** | `node scripts/test-unit-run.mjs` | **1655 files / 38499 tests passed**, 3 files / 33 tests skipped, 0 failures |
| **geometry** | `vitest run --project geometry` | **5 files / 64 tests passed** |
| lint | `eslint <6 changed files>` | exit 0, **0 errors / 0 warnings** |
| format | `node scripts/prettier-changed.mjs check` | clean — **instrument validated the same run**: a deliberate whitespace mutant made it exit 1 naming `collectionFollowGate.ts`, then restored `cmp`-identical |

### Regression matrix — every new test watched RED at the pre-fix tip `c5acf04c24`

Sources reverted to `c5acf04c24` (`git diff --stat` empty against that ref), post-fix tests kept, then restored `cmp`-identical:

| tier at `c5acf04c24` | result |
|---|---|
| both `*CollectionFollow.browser.test.tsx` | **9 failed / 16 passed (25)** — every new test red, every pre-existing test still green |
| same two files at that round's HEAD | **25 passed** (33 today, after the F4 tests below) |

The F3 failure at `c5acf04c24` is the audit's measured defect verbatim: `{ requestId: 'rq_race', error: 'declined' }` where the fixed host replies `{ result: { collectionId: 77, followed: true } }`, after `followMutate` was called once and completed.

**F3 is driven through the REAL rendered Modal** (`<DialogProvider />` mounted beside the host, a real `page.getByRole('button', {name:'Follow'}).click()`, a real `userEvent.keyboard('{Escape}')`), not through `props.onCancel()` — with a positive control asserting that ESC *before* confirming still declines, so the test cannot pass merely because escape never reached the Modal.

The unit halves of F1/F3 test **new exports** (`resolveCollectionIdentity`, `createCollectionFollowSettlement`), so they cannot be red-at-`c5acf04c24` in a meaningful way — the file would fail to import. The browser tier is the red-matrix instrument for all three findings.

### Regression matrix — F4 (the lookup budget), red at `25efb688b2`

Both hosts reverted to `25efb688b2` (`cmp`-verified against `git show HEAD:<path>`), new tests kept, then restored `cmp`-identical:

| suite at `25efb688b2` | result |
|---|---|
| both `*CollectionFollow.browser.test.tsx` | **6 failed / 27 passed (33)** — every pre-existing test still green |
| the same two files at HEAD | **33 passed** |

All six fail on the same assertion, which is the defect stated exactly: `expected "vi.fn()" to be called 20 times, but got 21 times` — at the base the 21st distinct id spends a 21st authenticated lookup.

⚠️ **The fourth new test per host is labelled in-file as a SHAPE GUARD, not counted as regression coverage.** *"the over-budget refusal is INDISTINGUISHABLE from 'you cannot see it'"* is **green at `25efb688b2`**, and necessarily so: with no budget there is no second refusal path to be distinguishable from. It guards the future — a maintainer adding a `lookup-budget-exhausted` code or a `retryAfter` field — and is mutation-checked in that direction instead (mutants 17/18 below).

Reverting only `collectionFollowGate.ts` to `25efb688b2` makes the **6 new unit pins** fail with `TypeError: createCollectionLookupBudget is not a function` while the 29 pre-existing ones stay green (positive control: the file still imports, so this is not a `Tests no tests` vacuum). That is an **absence-of-symbol** red, not a behavioural one — stated rather than counted; their real guard value is the mutation sweep.

### Mutation check — 21 mutants across the two rounds, 21 killed, 0 survivors

Every mutant: anchor asserted to match **exactly once** (harness refuses otherwise), edit `cmp`-verified as a real change before running, restore `cmp`-verified byte-identical after. Both unmutated baselines green (29 unit / 25 browser).

| mutant | anchor | killed by |
|---|---|---|
| gate drops the `!ready` check (unit) | 1 | *"REFUSES a pre-handshake request with `not-ready`"* — `confirm` vs `refuse` |
| gate drops the `!ready` check (browser) | 1 | *"a block that never sent BLOCK_READY gets `not-ready`"*, both hosts |
| `PageBlockHost` hardcodes `ready: true` | 1 | same, page host only |
| `IframeHost` hardcodes `ready: true` | 1 | same, model slot only |
| consent copy drops `${subject}` (unit) | 1 | 3 tests, incl. the whole-sentence pin and the `collection #900123` fallback |
| consent copy drops `${subject}` (browser) | 1 | *"names it in the dialog"*, both hosts |
| identity resolver calls an invisible collection `ok` (unit) | 1 | *"a NONEXISTENT id and a PRIVATE collection resolve IDENTICALLY"* |
| identity resolver calls an invisible collection `ok` (browser) | 1 | *"a collection the viewer cannot see is REFUSED with a reply and NO dialog"*, both hosts |
| settlement latch forgets consent (unit) | 1 | *"a dismissal AFTER consent is a NO-OP"* + the failed-write sibling |
| settlement latch forgets consent (browser) | 1 | *"ESC while the mutation is in flight does NOT report `declined`"* |
| `PageBlockHost` never calls `markConsented()` | 1 | same |

**F4 round — 10 further mutants, 10 killed, 0 survivors.** Same harness discipline: anchor match count printed and the run **refused on ≠ 1**, restore `cmp`-verified byte-identical. Every run's total test count was unchanged (35 unit / 18 page / 15 model slot), so no mutant was scored against a suite that failed to collect.

| # | mutant | anchor | killed by (its own assertion) |
|---|---|---|---|
| 12 | `admitted.has(collectionId)` → `false` (repeats charged) | 1 | 4 unit pins, incl. *"a REPEAT of an admitted id is free FOREVER"* — `expected false to be true` |
| 13 | `admitted.size >= limit` → `> limit` (off-by-one) | 1 | 6 unit pins — `expected true to be false` on the id past the cap |
| 14 | `admitted.add(collectionId)` → no-op (never records) | 1 | 6 unit pins, same assertion |
| 15 | `COLLECTION_LOOKUP_BUDGET` 20 → 200 | 1 | *"the PRODUCTION default admits 20 distinct ids and refuses the 21st"* — and **only** that one, which is what makes it a real pin on the constant |
| 16a/16b | the `admit` guard disabled in `PageBlockHost` / `IframeHost` (`if (false && …)`) | 1 each | the 3 budget browser tests on that host — `expected 20 calls, got 21` |
| 17/18 | over-budget code → `'lookup-budget-exhausted'`, page / model slot | 1 each | the **shape guard** above, plus the whole-payload `toEqual` in *"past the cap the host STOPS LOOKING UP"* |
| 19/20 | the ledger moved from the instance `useRef` to **module scope**, page / model slot | 1 each (2 edits) | *"the budget is PER BLOCK INSTANCE — a remount starts fresh"* |

Mutants 19/20 were re-run **isolated to that one test** (`-t "PER BLOCK INSTANCE"`), because in a full-file run a module-scope ledger is drained by an earlier test and the guard would have died for the wrong reason. Isolated, it fails on its own final assertion — `expected "vi.fn()" to be called 21 times, but got 20 times`, i.e. the remounted instance inherited an exhausted budget.

All four tiers were run locally (`unit`, `unit-native`, `component`, `geometry`) — the browser tier included, which the first version of this PR could not run. 🔴 The `geometry` project is browser-mode too and needs the same Playwright executable override as `component`; without it the run reports 0 failures and still exits 1 on a browser-launch `Unhandled Error`, which is an environment artifact, not a test result.

### Not verified — stated plainly

- The bridge was **not exercised end-to-end against a running host**; no live block was driven through a follow, and no real `collection.getById` response was observed (the browser tier mocks `trpc.useUtils()`).
- The **existence-leak parity** is verified against the *shape* `getCollectionByIdHandler` returns (`{ collection: null }` for both a missing row and an unreadable one), read from its source — not by hitting the live endpoint with a private collection id.

## Scope

- No Prisma migration; no existing field or endpoint changed or removed. The HTTP endpoint, the scope, and feature flagging are all deliberately untouched.
- No file overlap with the other open collection PRs (#4661, #4597); not based on either.

