### PR TITLE
feat(apps): drop the store card author chip; move reviews + plays below the CTA (4/4)

### DIFF
--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -53,8 +53,15 @@ import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema
  * P2b AppListingCard component tests (REPORT-ONLY — the browser project is
  * non-blocking; the blocking gate is appListingCardView.test.ts). These pin the
  * rendered kind badge, recommend label, and kind-aware CTA affordance for a few
- * representative cards, PLUS the owner "Edit" deep-link gating (Item 2) and the
- * long-username tooltip fallback (Item 1).
+ * representative cards, PLUS the owner "Edit" deep-link gating (Item 2), the
+ * clamped-title tooltip fallback, the card's LAYOUT contract (a two-line reserved
+ * title, a 46px action row, and the stats line BELOW that row) and the play
+ * count's null-vs-zero rule.
+ *
+ * ⚠️ "PLUS the long-username tooltip fallback (Item 1)" USED TO BE THE LAST CLAUSE
+ * HERE. That test is deleted with its subject — the card no longer renders an
+ * author chip (2026-09-06) — and the surviving tooltip coverage is the TITLE's, so
+ * the sentence is re-derived rather than trimmed.
  */
 
 const mocks = vi.hoisted(() => ({
@@ -338,12 +345,22 @@ function actionRow(ctaName: string) {
 
 /** The recommend rollup, wherever it is. Used for BOTH presence and absence. */
 const ROLLUP_SELECTOR = '[data-testid="apps-listing-recommend-rollup"]';
+/** The play count, wherever it is. Used for BOTH presence and absence. */
+const PLAY_COUNT_SELECTOR = '[data-testid="apps-listing-play-count"]';
 
 /**
- * The card's META BLOCK — the `Stack` holding title / creator / rollup / badges,
- * reached from the title's own `Anchor`. Located structurally rather than by a
- * test id so a change that MOVES the rollup out of it cannot be papered over by
- * moving an id with it.
+ * The card's META BLOCK — the `Stack` holding the title and the two conditional
+ * badges, reached from the title's own `Anchor`. Located structurally rather than
+ * by a test id so a change that MOVES something out of it cannot be papered over
+ * by moving an id with it.
+ *
+ * 🔴 THE LOCATOR IS UNCHANGED BY THE ROLLUP'S SECOND MOVE, and that is exactly
+ * what the structural resolution bought. The block used to hold title / creator /
+ * rollup / badges; the creator chip is deleted and the rollup now renders below the
+ * action row, so today it holds title + badges. Walking from the title's `<a>` to
+ * `anchor.parentElement` still lands on the same `Stack` either way — which is why
+ * the guard below can assert the rollup is OUTSIDE it without the block having to
+ * be re-located.
  */
 function metaBlock(titleText: string): HTMLElement {
   const title = page.getByText(titleText, { exact: true }).element() as HTMLElement;
@@ -379,7 +396,6 @@ describe('AppListingCard', () => {
   test('on-site page app + canOpenPage → Open link to the run route', async () => {
     renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
     await expect.element(page.getByText('My App')).toBeInTheDocument();
-    await expect.element(page.getByText('by alice')).toBeInTheDocument();
     const open = page.getByRole('link', { name: 'Open' });
     await expect.element(open).toBeInTheDocument();
     await expect.element(open).toHaveAttribute('href', '/apps/run/my-app');
@@ -696,11 +712,26 @@ describe('AppListingCard', () => {
    * ALIGNMENT claim between two cards, not as a style read on one.
    *
    * The defect this fixes is only visible in a ROW: a one-line title is 24px and a
-   * wrapped one is 48px, so the creator chip — and everything under it — lands at a
-   * different y on every card. A `min-height` on a single card is a fact about that
-   * card; "the chips line up" is the property a shopper actually sees, and it is a
+   * wrapped one is 48px, so everything under it lands at a different y on every
+   * card. A `min-height` on a single card is a fact about that card; "the lines up
+   * under the title line up" is the property a shopper actually sees, and it is a
    * RELATIONSHIP, so it has to be measured across two cards in one flex row rather
    * than inferred from a computed style.
+   *
+   * 🔴 THE PROBE MOVED FROM THE CREATOR CHIP TO THE TAGLINE, AND THAT IS A
+   * NARROWING OF THE CLAIM, NOT A SUBSTITUTION OF CONVENIENCE. This suite used to
+   * measure two cards' `a[href^="/user/"]` chips. The store card no longer renders
+   * an author chip at all, and the recommend rollup left the meta block in the same
+   * change — so the only content still positioned by the title's height is the two
+   * conditional badges and the tagline. The action row and the stats line below it
+   * are bottom-pinned by `mt="auto"`, so measuring THEM would pass with the
+   * reservation deleted and would be a guard on nothing. The tagline is the
+   * shallowest thing the reservation still moves, so it is what this measures.
+   *
+   * 🔴 THE FIXTURES THEREFORE CARRY A TAGLINE, unlike `base()`'s default use
+   * elsewhere in this file — one that is SHORT enough to occupy one line under the
+   * `line-clamp-3`, and IDENTICAL on both cards, so a difference in its `top` can
+   * only come from the title box above it.
    *
    * 🔴 THE FIXTURES ARE PAIRWISE DISTINCT AND OFF THE BOUNDARY, deliberately. A
    * 1-line title against a 2-line one would sit exactly ON the reservation and the
@@ -709,26 +740,37 @@ describe('AppListingCard', () => {
    * width, which is asserted below rather than assumed, so the clamp is doing real
    * work and the short card is genuinely a line short of the reservation.
    */
-  describe('🔴 the title reserves its two lines, so creator chips align', () => {
+  describe('🔴 the title reserves its two lines, so the rows under it align', () => {
     /** One line at the width used below. */
     const SHORT_TITLE = 'Ink';
     /** Long enough to wrap past the clamp — proven, not assumed, in the test. */
     const LONG_TITLE =
       'Procedurally Generated Landscape Compositor With Depth Aware Relighting And Batch Export';
+    /**
+     * The probe. IDENTICAL on both cards and short enough to be one line under the
+     * `line-clamp-3`, so its `top` is a function of the title box alone.
+     */
+    const TAGLINE = 'Quick tools';
 
     /** The two cards' roots, in DOM order: [short-title card, long-title card]. */
     function cardRoots(): HTMLElement[] {
       return Array.from(document.querySelectorAll('[class*="Card-root"]')) as HTMLElement[];
     }
 
-    test('a 1-line title and a 3-line title put their creator chips at the SAME y', async () => {
+    test('a 1-line title and a 3-line title put their TAGLINES at the SAME y', async () => {
       renderWithProviders(
         <div style={{ display: 'flex', width: 640, alignItems: 'flex-start' }}>
           <div style={{ width: 320 }}>
-            <AppListingCard card={base({ name: SHORT_TITLE, slug: 'short-title' })} canOpenPage />
+            <AppListingCard
+              card={base({ name: SHORT_TITLE, slug: 'short-title', tagline: TAGLINE })}
+              canOpenPage
+            />
           </div>
           <div style={{ width: 320 }}>
-            <AppListingCard card={base({ name: LONG_TITLE, slug: 'long-title' })} canOpenPage />
+            <AppListingCard
+              card={base({ name: LONG_TITLE, slug: 'long-title', tagline: TAGLINE })}
+              canOpenPage
+            />
           </div>
         </div>
       );
@@ -766,16 +808,69 @@ describe('AppListingCard', () => {
       expect(Math.round(shortTitle.getBoundingClientRect().height)).toBe(48);
 
       // 🔴 THE CLAIM THIS TEST IS FOR. `top`, not centre: a difference here is
-      // exactly the visible defect, and the two chips are the same height so a
+      // exactly the visible defect, and the two taglines are the same height so a
       // centre comparison would say nothing extra.
-      const shortChip = shortCard.querySelector('a[href^="/user/"]') as HTMLElement;
-      const longChip = longCard.querySelector('a[href^="/user/"]') as HTMLElement;
-      expect(shortChip).not.toBeNull();
-      expect(longChip).not.toBeNull();
+      //
+      // 🔴 THE PROBE IS RESOLVED FROM EACH CARD'S OWN SUBTREE, and both are asserted
+      // present BEFORE they are compared — a `null` on either side would otherwise
+      // throw on `.getBoundingClientRect()` and read as a harness fault rather than
+      // as the tagline having stopped rendering.
+      const shortTagline = Array.from(shortCard.querySelectorAll('p')).find(
+        (el) => el.textContent === TAGLINE
+      ) as HTMLElement | undefined;
+      const longTagline = Array.from(longCard.querySelectorAll('p')).find(
+        (el) => el.textContent === TAGLINE
+      ) as HTMLElement | undefined;
+      expect(shortTagline, 'the short-title card rendered no tagline').toBeTruthy();
+      expect(longTagline, 'the long-title card rendered no tagline').toBeTruthy();
+      // NON-VACUITY: the probes are two DIFFERENT elements, one per card. A `find`
+      // that landed on the same node twice would compare a box with itself.
+      expect(shortTagline).not.toBe(longTagline);
       expect(
-        shortChip.getBoundingClientRect().top,
-        'the creator chip must land at the same y whatever the title length'
-      ).toBeCloseTo(longChip.getBoundingClientRect().top, 0);
+        shortTagline!.getBoundingClientRect().top,
+        'the tagline must land at the same y whatever the title length — the title box ' +
+          'reserves LISTING_CARD_TITLE_LINES x LISTING_CARD_TITLE_LINE_HEIGHT for every card'
+      ).toBeCloseTo(longTagline!.getBoundingClientRect().top, 0);
+    });
+
+    /**
+     * 🔴 AND THE AUTHOR CHIP THIS SUITE USED TO MEASURE IS REALLY GONE, asserted
+     * here rather than left implicit in the rewrite above — otherwise "we now
+     * measure the tagline" would be indistinguishable from "we stopped measuring
+     * the chip because it was inconvenient".
+     *
+     * The absence is a `querySelector` returning `null`, NOT
+     * `expect.element(...).not.toBeInTheDocument()`, which is INERT in this repo
+     * (civitai/civitai#4197). It is controlled by a POSITIVE read of the same
+     * shape first: the card's title anchor IS found by an equivalent
+     * `querySelector`, so a `null` for the profile link is a real read of a
+     * rendered card and not a selector that matches nothing anywhere.
+     */
+    test('🔴 the card renders NO author chip — no profile link, no "by <name>"', async () => {
+      renderWithProviders(
+        <Sized width={320} card={base({ creator: { id: 5, username: 'alice', image: null } })} />
+      );
+      await expect.element(page.getByText('My App', { exact: true })).toBeInTheDocument();
+      const [card] = cardRoots();
+      expect(card, 'the card did not render').toBeTruthy();
+
+      // POSITIVE CONTROL, same call shape as the absence below.
+      expect(
+        card.querySelector('a[href^="/apps/store-preview/"]'),
+        'the title anchor is missing — this card did not render, so the absence below is vacuous'
+      ).not.toBeNull();
+
+      expect(
+        card.querySelector('a[href^="/user/"]'),
+        'the author chip is back on the store card — attribution belongs on the DETAIL ' +
+          'surfaces (AppDetailsModal / appDetailAuthorView / AppListingDetailBody), not here'
+      ).toBeNull();
+      // …and not as un-linked text either, which a chip stripped of its Anchor
+      // would be. Read off `textContent`, for the same #4197 reason.
+      expect(
+        card.textContent,
+        'the card still prints a "by <creator>" byline, just without the link'
+      ).not.toContain('by alice');
     });
 
     /**
@@ -816,18 +911,28 @@ describe('AppListingCard', () => {
     });
   });
 
-  test('🔴 S5: the author line is sm/500 and STAYS dimmed (accepted contrast residual)', async () => {
-    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
-    await expect.element(page.getByText('by alice')).toBeInTheDocument();
-    const author = page.getByText('by alice').element() as HTMLElement;
-    const style = author.getAttribute('style') ?? '';
-    expect(style).toContain('--text-fz: var(--mantine-font-size-sm)');
-    expect(style).toContain('font-weight: 500');
-    // 🔴 The accepted trade (decision 3): size + weight only. Taking the author to
-    // white too would flatten the title-over-author hierarchy on a dark-6 body.
-    // If this ever starts asserting white, decision 3 was changed without notice.
-    expect(style).not.toContain('color: var(--mantine-color-white)');
-  });
+  /**
+   * 🔴 THE RETIRED S5 AUTHOR-LINE ASSERTION, AND WHY IT IS DELETED RATHER THAN
+   * RELAXED.
+   *
+   * A test here pinned the author line's typography — `sm` / `fw 500`, and NOT
+   * white — as decision 3 of the S5 chrome pass ("size + weight only; taking both
+   * title and author to white flattens the hierarchy on a dark-6 body"), together
+   * with an ACCEPTED contrast residual of 4.73 (AA pass by 0.23, AAA fail).
+   *
+   * There is no author line on this card any more, so that assertion has no
+   * subject. Leaving it asserting the old typography against a card that renders no
+   * such element would be a test that can only fail; relaxing it into something
+   * that passes either way would be worse — a green claim about a hierarchy that no
+   * longer exists reads as coverage and stops anyone looking. What replaces it is
+   * the ABSENCE guard above ("the card renders NO author chip"), which is the claim
+   * that is now true and is mutation-visible.
+   *
+   * 🔴 THE CONTRAST RESIDUAL IS NOT SILENTLY RESOLVED — IT MOVED. The detail
+   * surfaces still render attribution and are untouched by this change, so if that
+   * 4.73 mattered it matters THERE now (`AppListingDetailBody`'s own `CreatorChip`),
+   * not here. This paragraph exists so nobody reads the deletion as a fix.
+   */
 
   // 🔴 ONE render per test. An earlier version rendered all three variants in a
   // single body and called `.unmount()` between them; that fights the scaffold's
@@ -1567,66 +1672,214 @@ describe('AppListingCard', () => {
     });
 
     /**
-     * 🔴 THE RECOMMEND ROLLUP MOVED — present in the meta block, ABSENT from the
+     * 🔴 THE RECOMMEND ROLLUP MOVED AGAIN — OUTSIDE the meta block, and BELOW the
      * action row.
      *
-     * Both halves in one test on purpose: "it is in the meta block" is also true
-     * of a card that renders it TWICE, and "it is not in the action row" is also
-     * true of a card that does not render it at all.
+     * ⚠️ THIS TEST IS RETARGETED, NOT RELAXED, AND THE DISTINCTION IS THE WHOLE
+     * REASON IT EXISTS. It previously asserted "in the meta block and NOT in the
+     * action row", written specifically so that a change moving the rollup out of
+     * the meta block could not be papered over. This change IS that move, so the
+     * old assertion went red BY DESIGN. The response is a new invariant that is at
+     * least as strong — the rollup is in NEITHER of the two containers, and it is
+     * positioned BELOW the row — and emphatically not an assertion that would pass
+     * under either arrangement.
      *
-     * 🔴 THE ABSENCE IS `querySelector(...) === null` WITHIN THE ROW ELEMENT, NOT
+     * Every half is in one test on purpose: "it is below the action row" is also
+     * true of a card that renders it TWICE (once below, once in the meta block),
+     * and "it is not in the meta block" is also true of a card that does not render
+     * it at all.
+     *
+     * 🔴 EVERY ABSENCE IS `querySelector(...) === null`, NOT
      * `expect.element(...).not.toBeInTheDocument()`. That matcher is INERT in this
      * repo (civitai/civitai#4197) — it passes whether or not the element is there.
-     * The form used here is controlled BOTH ways in the same test: the identical
-     * `querySelector` call against the meta block returns the node, so a `null`
-     * from the row is a real read and not a selector that matches nothing.
+     * The form used here is controlled in the same test: the identical
+     * `querySelector(ROLLUP_SELECTOR)` call against the CARD ROOT returns the node,
+     * so a `null` from the meta block or the row is a real read and not a selector
+     * that matches nothing.
+     *
+     * 🔴 EACH HALF CARRIES ITS OWN MESSAGE, so a mutant rendering the rollup in
+     * BOTH places fails naming which place is wrong rather than on an ambiguous
+     * count.
      */
-    test('🔴 the rollup renders in the meta block and NOT in the action row', async () => {
+    test('🔴 the rollup renders BELOW the action row — not in it, and not in the meta block', async () => {
       mocks.currentUser = OWNER; // the widest row — if it fits anywhere, it fits here
       renderWithProviders(<Sized width={314} card={base({ ...REVIEWED_ROLLUP })} />);
       // 🔴 THE BARRIER IS THE CTA, NOT THE ROLLUP'S OWN TEXT. `getByText` is
-      // strict-mode: a mutation that renders the rollup in BOTH places resolves to
-      // two nodes and THROWS here, so the test goes red for a locator reason
-      // before either assertion below runs. Measured — that is exactly what the
-      // "rollup back in the action row" mutation did on this test's first run, and
-      // a red for the wrong reason proves nothing about the guard.
+      // strict-mode: a mutation that renders the rollup in TWO places resolves to
+      // two nodes and THROWS at the locator, so the test would go red for a locator
+      // reason before any assertion ran — and a red for the wrong reason proves
+      // nothing about the guard. The CTA is unique under every arrangement of the
+      // rollup, so it is the barrier.
       await expect
         .element(page.getByRole('link', { name: 'Open', exact: true }))
         .toBeInTheDocument();
 
       // 🔴 POSITIVE CONTROL FIRST, using the SAME `querySelector(ROLLUP_SELECTOR)`
-      // call shape as the absence below — so a `null` from the row is a real read
-      // and not a selector that matches nothing anywhere.
-      const meta = metaBlock('My App');
-      const inMeta = meta.querySelector(ROLLUP_SELECTOR) as HTMLElement | null;
-      expect(inMeta, 'the rollup is not in the meta block at all').not.toBeNull();
+      // call shape as the two absences below — so a `null` from either container is
+      // a real read and not a selector that matches nothing anywhere.
+      const card = document.querySelector('[class*="Card-root"]') as HTMLElement;
+      expect(card, 'the card did not render').not.toBeNull();
+      const rollup = card.querySelector(ROLLUP_SELECTOR) as HTMLElement | null;
+      expect(
+        rollup,
+        'the recommend rollup is not on the card at all — either it stopped rendering or ' +
+          'ROLLUP_SELECTOR matches nothing, and both absences below would then be vacuous'
+      ).not.toBeNull();
 
       const { row } = actionRow('Open');
       assertLayoutIsReal(row);
+      const meta = metaBlock('My App');
 
-      // 🔴 THE CLAIM THIS TEST EXISTS FOR, asserted BEFORE the count below so a
-      // mutation that renders the rollup in BOTH places fails on THIS message
-      // rather than on a duplicate-count assertion that would mask it.
+      // 🔴 THE TWO CLAIMS THIS TEST EXISTS FOR, each with its own message.
+      expect(
+        meta.querySelector(ROLLUP_SELECTOR),
+        'the recommend rollup is back in the META BLOCK — the operator moved it below the CTA'
+      ).toBeNull();
       expect(
         row.querySelector(ROLLUP_SELECTOR),
-        'the recommend rollup is back in the action row'
+        'the recommend rollup is inside the ACTION ROW — that row holds the CTA and the ⋮ ' +
+          'trigger and nothing else, and sharing it is what cost a min-width floor, a ' +
+          '@container breakpoint and a derived threshold constant last time'
       ).toBeNull();
-      expect(row.contains(inMeta!)).toBe(false);
+      expect(meta.contains(rollup!)).toBe(false);
+      expect(row.contains(rollup!)).toBe(false);
       // The row is exactly the CTA + the trigger's box, nothing else.
       expect(row.children).toHaveLength(2);
 
-      // …and exactly ONE in the whole document — not zero (which would satisfy the
-      // absence vacuously) and not two (a copy left behind in the row).
+      // …and exactly ONE in the whole document — not zero (which would satisfy both
+      // absences vacuously) and not two (a copy left behind in either container).
       expect(document.querySelectorAll(ROLLUP_SELECTOR)).toHaveLength(1);
-      const rollup = inMeta!;
 
-      // It sits BELOW the creator chip (the meta block's reading order), not above
-      // the title — a position claim a containment check alone cannot make.
-      const creator = meta.querySelector('a[href^="/user/"]') as HTMLElement;
-      expect(creator).not.toBeNull();
-      expect(rollup.getBoundingClientRect().top).toBeGreaterThan(
-        creator.getBoundingClientRect().top
+      // 🔴 AND IT IS *BELOW* THE ROW, not merely outside it — a position claim no
+      // containment check can make, and the half of the operator's ask ("move
+      // reviews + plays below the CTA") that containment alone does not express.
+      // `top` against the row's `bottom`, so "below" means genuinely after it in
+      // the block flow rather than merely lower-topped inside an overlap.
+      expect(
+        rollup!.getBoundingClientRect().top,
+        'the rollup does not start below the action row — "below the CTA" is the ask, and ' +
+          'being outside the row is not the same claim'
+      ).toBeGreaterThanOrEqual(row.getBoundingClientRect().bottom);
+
+      // 🔴 AND `mt="auto"` STILL BOTTOM-PINS THE PAIR. The action row carries the
+      // auto top margin and is no longer the Stack's LAST child, so "the row is at
+      // the bottom" has to be re-measured rather than inherited from before the
+      // move: a column flex container's single auto margin absorbs all free space,
+      // which should push the row AND everything after it down together. What that
+      // means observably is that the STATS LINE — now the last child — ends flush
+      // with the Stack's content box.
+      //
+      // Measured against the Stack rather than the Card, because `Card padding="md"`
+      // sits outside the Stack and would put a constant 16px in the comparison.
+      const stack = row.parentElement as HTMLElement;
+      expect(stack.contains(rollup!), 'the stats line is not a sibling of the action row').toBe(
+        true
       );
+      expect(
+        stack.getBoundingClientRect().bottom - rollup!.getBoundingClientRect().bottom,
+        'the bottom-pinned group is not flush with the bottom of the card body. `mt="auto"` ' +
+          'must stay on the FIRST of the bottom-pinned children (the action row) — moved to a ' +
+          'later one, or removed, a gap opens under the stats line and the CTA floats up.'
+      ).toBeLessThan(1);
+    });
+
+    /**
+     * 🔴 THE PLAY COUNT — RENDERED FOR A MEASURABLE LISTING, OMITTED ENTIRELY WHEN
+     * `openCount === null`. NEVER a `0` for the null case.
+     *
+     * 🔴 THAT OMISSION IS AN OPERATOR OVERRIDE, NOT A DERIVATION. An off-site
+     * listing's CTA is a third-party `target="_blank"` anchor, so nothing
+     * on-platform observes the click and the number is STRUCTURALLY ABSENT; a `0`
+     * would read as "nobody has ever used this app" about an app we cannot measure.
+     * The mirror is equally load-bearing and is asserted below: an ON-SITE listing
+     * with a genuine `0` DOES render "0 plays".
+     *
+     * 🔴 THE FIXTURES ARE PAIRWISE DISTINCT AND DISTINCT FROM EVERY CONSTANT THESE
+     * ASSERTIONS NAME. 4821 is not 0, not 1, not a row/control/gap px value, and
+     * abbreviates to a string ("4.8k") that shares no characters-in-order with the
+     * raw number — so a mutant that printed the raw value, or that hardcoded any
+     * geometry literal, cannot produce it.
+     */
+    describe('🔴 the play count', () => {
+      test('an on-site listing renders it beside the rollup', async () => {
+        renderWithProviders(<Sized width={314} card={base({ openCount: 4821 })} />);
+        await expect
+          .element(page.getByRole('link', { name: 'Open', exact: true }))
+          .toBeInTheDocument();
+        const play = document.querySelector(PLAY_COUNT_SELECTOR) as HTMLElement | null;
+        expect(play, 'the play count did not render for a measurable listing').not.toBeNull();
+        expect(play!.textContent).toContain('4.8k plays');
+        // BESIDE the rollup, i.e. on the SAME line — not a second line, which would
+        // make the card taller than the skeleton reserves.
+        const rollup = document.querySelector(ROLLUP_SELECTOR) as HTMLElement;
+        expect(rollup, 'the rollup did not render').not.toBeNull();
+        expect(
+          sameLine(rollup, play!),
+          'the play count wrapped onto its own line — that makes the card ~17px taller than ' +
+            'AppListingCardSkeleton reserves, on every card in the h-full grid row'
+        ).toBe(true);
+        // …and both sit below the action row.
+        const { row } = actionRow('Open');
+        expect(play!.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+          row.getBoundingClientRect().bottom
+        );
+      });
+
+      test('🔴 a genuine ZERO renders — "0 plays" is a measurement, not an absence', async () => {
+        renderWithProviders(<Sized width={314} card={base({ openCount: 0 })} />);
+        await expect
+          .element(page.getByRole('link', { name: 'Open', exact: true }))
+          .toBeInTheDocument();
+        const play = document.querySelector(PLAY_COUNT_SELECTOR) as HTMLElement | null;
+        expect(
+          play,
+          'an ON-SITE listing with openCount 0 rendered no play count. 0 is a real ' +
+            'measurement ("no plays recorded yet") — only `null` is unmeasurable. A ' +
+            'truthiness test (`card.openCount && …`) instead of `!= null` is the likely cause.'
+        ).not.toBeNull();
+        expect(play!.textContent).toContain('0 plays');
+      });
+
+      test('🔴 openCount === null renders NO play count node — never a 0', async () => {
+        renderWithProviders(
+          <Sized
+            width={314}
+            card={base({
+              kind: 'offsite',
+              openCount: null,
+              kindData: { kind: 'offsite', externalUrl: 'https://ext.app' },
+            })}
+          />
+        );
+        await expect
+          .element(page.getByRole('link', { name: 'Visit', exact: true }))
+          .toBeInTheDocument();
+
+        // 🔴 POSITIVE CONTROL ON THE SELECTOR ITSELF, in this same test. The two
+        // tests above already show `PLAY_COUNT_SELECTOR` CAN match — but a bare
+        // "not found" here would still be worthless if this render produced no card
+        // at all, so the rollup (which always renders) is read with the identical
+        // `querySelector` call shape before the absence is believed.
+        const rollup = document.querySelector(ROLLUP_SELECTOR) as HTMLElement | null;
+        expect(
+          rollup,
+          'the stats line did not render at all — the absence below is vacuous'
+        ).not.toBeNull();
+
+        expect(
+          document.querySelector(PLAY_COUNT_SELECTOR),
+          'an off-site listing rendered a play count. `openCount === null` means the number ' +
+            'is STRUCTURALLY ABSENT (no on-platform request follows a third-party CTA), and ' +
+            'the operator\'s call is to omit the stat entirely — a "0" here is a false claim ' +
+            'about an app we cannot measure.'
+        ).toBeNull();
+        // …and not as bare text either, which a node stripped of its testid would be.
+        const card = document.querySelector('[class*="Card-root"]') as HTMLElement;
+        expect(card.textContent, 'the card prints a play count without its testid').not.toContain(
+          'plays'
+        );
+        expect(card.textContent).not.toContain('0 play');
+      });
     });
 
     /**
@@ -1646,26 +1899,22 @@ describe('AppListingCard', () => {
     });
   });
 
-  test('a long username reveals the full value in a tooltip on hover (clip fallback)', async () => {
-    const longName = 'a-really-long-creator-username-that-will-definitely-overflow-the-card-column';
-    // The tooltip is overflow-GATED (TruncatedText disables it unless the label
-    // actually clips — a runtime scrollWidth/scrollHeight measurement). Constrain
-    // the card to a narrow column so the long username really overflows; without a
-    // width bound the label never clips and the tooltip stays disabled.
-    renderWithProviders(
-      <div style={{ width: 200 }}>
-        <AppListingCard
-          card={base({ creator: { id: 5, username: longName, image: null } })}
-          canOpenPage
-        />
-      </div>
-    );
-    const label = page.getByText(`by ${longName}`);
-    await expect.element(label).toBeInTheDocument();
-    await label.hover();
-    // The Tooltip renders the full username (portal) once the label overflows.
-    await expect.element(page.getByText(longName, { exact: true })).toBeInTheDocument();
-  });
+  /**
+   * 🔴 THE RETIRED LONG-USERNAME TOOLTIP TEST, DELETED WITH ITS SUBJECT.
+   *
+   * A test here rendered a card at 200px with a 76-character creator username and
+   * proved the author chip's `TruncatedText` revealed the full value in a portalled
+   * Tooltip on hover — the overflow-GATED behaviour (a runtime
+   * scrollWidth/scrollHeight measurement, so the tooltip stays disabled unless the
+   * label really clips).
+   *
+   * The card renders no author chip, so there is nothing to clip and nothing to
+   * reveal. The `TruncatedText` component is untouched and is STILL exercised on
+   * this card by the TITLE's own tooltip test above ("a clamped title reveals its
+   * full value in a tooltip on hover"), so deleting this one loses no coverage of
+   * that component's overflow gate — it loses coverage of a chip that no longer
+   * exists.
+   */
 });
 
 /**

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -1784,15 +1784,32 @@ describe('AppListingCard', () => {
     });
 
     /**
-     * 🔴 THE PLAY COUNT — RENDERED FOR A MEASURABLE LISTING, OMITTED ENTIRELY WHEN
-     * `openCount === null`. NEVER a `0` for the null case.
+     * 🔴 THE PLAY COUNT — RENDERED ONLY FOR A COUNT OF ONE OR MORE. BOTH
+     * `openCount === null` AND `openCount === 0` RENDER NOTHING.
      *
-     * 🔴 THAT OMISSION IS AN OPERATOR OVERRIDE, NOT A DERIVATION. An off-site
-     * listing's CTA is a third-party `target="_blank"` anchor, so nothing
-     * on-platform observes the click and the number is STRUCTURALLY ABSENT; a `0`
-     * would read as "nobody has ever used this app" about an app we cannot measure.
-     * The mirror is equally load-bearing and is asserted below: an ON-SITE listing
-     * with a genuine `0` DOES render "0 plays".
+     * 🔴 THAT IS AN OPERATOR OVERRIDE, NOT A DERIVATION — and the two inputs reach
+     * the same pixels for DIFFERENT reasons, which is why they get separate tests
+     * with separate names rather than one "falsy is absent" case:
+     *   · `null` is STRUCTURALLY UNMEASURABLE (an off-site listing's CTA is a
+     *     third-party `target="_blank"` anchor; nothing on-platform observes it);
+     *   · `0` is MEASURED AND EMPTY (an on-site app nobody has opened yet).
+     * Operator, 2026-09-06: "dont show 0 plays (just show nothing)".
+     *
+     * ⚠️ THE ZERO CASE IS INVERTED FROM ROUND 1 OF THIS PR, which asserted here that
+     * an on-site `0` DOES render "0 plays" because a zero is a measurement rather
+     * than an absence. That is still true of the DATA — `cardOpenCount`'s "do not
+     * over-null" rule is untouched — and was only ever wrong about the SCREEN. Said
+     * out loud so the next reader does not read the inversion as a regression.
+     *
+     * 🔴 EVERY ABSENCE TEST BELOW CARRIES ITS OWN POSITIVE CONTROL **ON THE SAME
+     * SELECTOR, IN THE SAME RENDER**, and that is a change forced by this reversal
+     * rather than a stylistic choice. With TWO of the three inputs now rendering
+     * nothing, `document.querySelector(PLAY_COUNT_SELECTOR) === null` is what a
+     * BROKEN SELECTOR looks like as well as what correct behaviour looks like — and
+     * the previous version leaned on a sibling test having shown the selector works,
+     * which is not a control at all once most fixtures produce nothing. So each
+     * absence test renders a `>0` card ALONGSIDE the absent one and proves the
+     * selector matches the former before believing the `null` from the latter.
      *
      * 🔴 THE FIXTURES ARE PAIRWISE DISTINCT AND DISTINCT FROM EVERY CONSTANT THESE
      * ASSERTIONS NAME. 4821 is not 0, not 1, not a row/control/gap px value, and
@@ -1801,13 +1818,28 @@ describe('AppListingCard', () => {
      * geometry literal, cannot produce it.
      */
     describe('🔴 the play count', () => {
-      test('an on-site listing renders it beside the rollup', async () => {
-        renderWithProviders(<Sized width={314} card={base({ openCount: 4821 })} />);
+      /** A card with real plays — the positive arm of every pairing below. */
+      const BUSY = { name: 'Busy App', slug: 'busy-app', openCount: 4821 };
+
+      /**
+       * The one card in `document` whose subtree matches `sel`, or `null`. Used for
+       * BOTH presence and absence, so an absence is always read the same way a
+       * presence is.
+       */
+      function cardNamed(title: string): HTMLElement {
+        const heading = page.getByText(title, { exact: true }).element() as HTMLElement;
+        const card = heading.closest('[class*="Card-root"]') as HTMLElement | null;
+        expect(card, `no card root around the title "${title}"`).not.toBeNull();
+        return card!;
+      }
+
+      test('an on-site listing with plays renders the count beside the rollup', async () => {
+        renderWithProviders(<Sized width={314} card={base(BUSY)} />);
         await expect
           .element(page.getByRole('link', { name: 'Open', exact: true }))
           .toBeInTheDocument();
         const play = document.querySelector(PLAY_COUNT_SELECTOR) as HTMLElement | null;
-        expect(play, 'the play count did not render for a measurable listing').not.toBeNull();
+        expect(play, 'the play count did not render for a listing with plays').not.toBeNull();
         expect(play!.textContent).toContain('4.8k plays');
         // BESIDE the rollup, i.e. on the SAME line — not a second line, which would
         // make the card taller than the skeleton reserves.
@@ -1825,60 +1857,107 @@ describe('AppListingCard', () => {
         );
       });
 
-      test('🔴 a genuine ZERO renders — "0 plays" is a measurement, not an absence', async () => {
-        renderWithProviders(<Sized width={314} card={base({ openCount: 0 })} />);
-        await expect
-          .element(page.getByRole('link', { name: 'Open', exact: true }))
-          .toBeInTheDocument();
-        const play = document.querySelector(PLAY_COUNT_SELECTOR) as HTMLElement | null;
-        expect(
-          play,
-          'an ON-SITE listing with openCount 0 rendered no play count. 0 is a real ' +
-            'measurement ("no plays recorded yet") — only `null` is unmeasurable. A ' +
-            'truthiness test (`card.openCount && …`) instead of `!= null` is the likely cause.'
-        ).not.toBeNull();
-        expect(play!.textContent).toContain('0 plays');
-      });
-
-      test('🔴 openCount === null renders NO play count node — never a 0', async () => {
+      test('🔴 openCount 0 (MEASURED AND EMPTY) renders NO play count — no "0 plays" chip', async () => {
+        // Two cards in ONE render: the control and the case. `Sized` takes a single
+        // card, so they are laid out side by side here.
         renderWithProviders(
-          <Sized
-            width={314}
-            card={base({
-              kind: 'offsite',
-              openCount: null,
-              kindData: { kind: 'offsite', externalUrl: 'https://ext.app' },
-            })}
-          />
+          <div style={{ display: 'flex', width: 640, alignItems: 'flex-start' }}>
+            <div style={{ width: 314 }}>
+              <AppListingCard card={base(BUSY)} canOpenPage />
+            </div>
+            <div style={{ width: 314 }}>
+              <AppListingCard
+                card={base({ name: 'Quiet App', slug: 'quiet-app', openCount: 0 })}
+                canOpenPage
+              />
+            </div>
+          </div>
         );
-        await expect
-          .element(page.getByRole('link', { name: 'Visit', exact: true }))
-          .toBeInTheDocument();
+        await expect.element(page.getByText('Busy App', { exact: true })).toBeInTheDocument();
+        await expect.element(page.getByText('Quiet App', { exact: true })).toBeInTheDocument();
 
-        // 🔴 POSITIVE CONTROL ON THE SELECTOR ITSELF, in this same test. The two
-        // tests above already show `PLAY_COUNT_SELECTOR` CAN match — but a bare
-        // "not found" here would still be worthless if this render produced no card
-        // at all, so the rollup (which always renders) is read with the identical
-        // `querySelector` call shape before the absence is believed.
-        const rollup = document.querySelector(ROLLUP_SELECTOR) as HTMLElement | null;
+        // 🔴 POSITIVE CONTROL, SAME SELECTOR, SAME RENDER, FIRST.
+        const busy = cardNamed('Busy App');
+        const quiet = cardNamed('Quiet App');
+        expect(busy).not.toBe(quiet); // two distinct cards, not one matched twice
         expect(
-          rollup,
-          'the stats line did not render at all — the absence below is vacuous'
+          busy.querySelector(PLAY_COUNT_SELECTOR),
+          'PLAY_COUNT_SELECTOR matched nothing even on a card WITH plays — the absence ' +
+            'assertion below would be a fact about the selector, not about openCount 0'
         ).not.toBeNull();
 
+        // THE CLAIM.
         expect(
-          document.querySelector(PLAY_COUNT_SELECTOR),
-          'an off-site listing rendered a play count. `openCount === null` means the number ' +
-            'is STRUCTURALLY ABSENT (no on-platform request follows a third-party CTA), and ' +
-            'the operator\'s call is to omit the stat entirely — a "0" here is a false claim ' +
-            'about an app we cannot measure.'
+          quiet.querySelector(PLAY_COUNT_SELECTOR),
+          'an on-site listing with openCount 0 rendered a play count. Operator override ' +
+            '2026-09-06: "dont show 0 plays (just show nothing)". The likely cause is ' +
+            '`getPlayCountLabel` guarding on `openCount == null` alone again.'
         ).toBeNull();
         // …and not as bare text either, which a node stripped of its testid would be.
-        const card = document.querySelector('[class*="Card-root"]') as HTMLElement;
-        expect(card.textContent, 'the card prints a play count without its testid').not.toContain(
-          'plays'
+        expect(
+          quiet.textContent,
+          'the zero card prints a play count without its testid'
+        ).not.toContain('play');
+        // Exactly one in the document: the control's. Not zero (which would satisfy
+        // the absence vacuously) and not two.
+        expect(document.querySelectorAll(PLAY_COUNT_SELECTOR)).toHaveLength(1);
+      });
+
+      test('🔴 openCount null (UNMEASURABLE — off-site) renders NO play count either', async () => {
+        renderWithProviders(
+          <div style={{ display: 'flex', width: 640, alignItems: 'flex-start' }}>
+            <div style={{ width: 314 }}>
+              <AppListingCard card={base(BUSY)} canOpenPage />
+            </div>
+            <div style={{ width: 314 }}>
+              <AppListingCard
+                card={base({
+                  name: 'Away App',
+                  slug: 'away-app',
+                  kind: 'offsite',
+                  openCount: null,
+                  kindData: { kind: 'offsite', externalUrl: 'https://ext.app' },
+                })}
+              />
+            </div>
+          </div>
         );
-        expect(card.textContent).not.toContain('0 play');
+        await expect.element(page.getByText('Busy App', { exact: true })).toBeInTheDocument();
+        await expect.element(page.getByText('Away App', { exact: true })).toBeInTheDocument();
+
+        // 🔴 POSITIVE CONTROL, SAME SELECTOR, SAME RENDER, FIRST.
+        const busy = cardNamed('Busy App');
+        const away = cardNamed('Away App');
+        expect(busy).not.toBe(away);
+        expect(
+          busy.querySelector(PLAY_COUNT_SELECTOR),
+          'PLAY_COUNT_SELECTOR matched nothing even on a card WITH plays — the absence ' +
+            'assertion below would be a fact about the selector, not about openCount null'
+        ).not.toBeNull();
+
+        // THE CLAIM.
+        expect(
+          away.querySelector(PLAY_COUNT_SELECTOR),
+          'an off-site listing rendered a play count. `openCount === null` means the number ' +
+            'is STRUCTURALLY UNMEASURABLE (no on-platform request follows a third-party CTA), ' +
+            'so there is nothing honest to print — this is a DIFFERENT reason from the zero ' +
+            'case, with the same rendering.'
+        ).toBeNull();
+        expect(
+          away.textContent,
+          'the off-site card prints a play count without its testid'
+        ).not.toContain('play');
+        expect(document.querySelectorAll(PLAY_COUNT_SELECTOR)).toHaveLength(1);
+
+        // 🔴 AND THE STATS LINE ITSELF IS STILL THERE on the absent card — the rollup
+        // half is unconditional. Without this, "no play count" would also be
+        // satisfied by a card that rendered no stats line at all, which would be a
+        // height regression against the skeleton rather than the behaviour under test.
+        expect(
+          away.querySelector(ROLLUP_SELECTOR),
+          'the off-site card rendered no stats line at all — that is shorter than its ' +
+            'skeleton reserves, not "the play count is omitted"'
+        ).not.toBeNull();
       });
     });
 

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -11,15 +11,15 @@ import {
   Text,
   Tooltip,
 } from '@mantine/core';
-import { IconApps, IconThumbUp } from '@tabler/icons-react';
+import { IconApps, IconPlayerPlay, IconThumbUp } from '@tabler/icons-react';
 import type { Icon } from '@tabler/icons-react';
 import Link from 'next/link';
-import { type MouseEvent, useState } from 'react';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { useState } from 'react';
 import { CATEGORY_ICONS, FALLBACK_CATEGORY_ICON } from '~/components/Apps/marketplaceCategoryIcons';
 import {
   getListingCta,
   getListingDetailHref,
+  getPlayCountLabel,
   getRecommendLabel,
 } from '~/components/Apps/appListingCardView';
 import {
@@ -50,10 +50,21 @@ import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema
  * App Store Listings (W13) — P2b unified store CARD, over BOTH kinds.
  *
  * Renders one `ListingCard` (from `appListings.listAvailable`): cover + app icon
- * + name + tagline + creator chip + the Steam-style recommend rollup + a
- * kind-aware CTA (Open / View details / Visit ↗). Mirrors the visual language of
- * the live `AppBlockCard` (Mantine Card + category-glyph cover placeholder) so
- * listings feel native.
+ * + name + tagline + a kind-aware CTA (Open / View details / Visit ↗) + a stats
+ * line BELOW that CTA carrying the Steam-style recommend rollup and, for a
+ * measurable listing, the play count. Mirrors the visual language of the live
+ * `AppBlockCard` (Mantine Card + category-glyph cover placeholder) so listings
+ * feel native.
+ *
+ * 🔴 THERE IS NO AUTHOR CHIP ON THIS CARD. A "by {creator}" line used to sit
+ * under the title; the operator dropped it from the store card (2026-09-06) —
+ * a grid of ~24 tiles is a browsing surface, and the byline competed with the
+ * title for the one line a shopper actually reads. Attribution is NOT lost: the
+ * DETAIL surfaces carry it independently and are untouched by that decision —
+ * `AppDetailsModal`, `appDetailAuthorView` and `AppListingDetailBody` (which has
+ * its own, separate `CreatorChip`). `ListingCard.creator` is still on the DTO and
+ * still read here for the owner test (`isOwner`), so this is a rendering change,
+ * not a schema one.
  *
  * 🔴 THE CARD'S GEOMETRY IS NOT SPELLED HERE — it is READ from
  * `appListingCardGeometry.ts`: cover ratio, icon size, reserved title lines and
@@ -70,15 +81,31 @@ import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema
  * rather than a hand-maintained list, so the claim cannot quietly outgrow the code
  * again.
  *
- * 🔴 THE RECOMMEND ROLLUP LIVES IN THE META BLOCK, NOT THE ACTION ROW. It used to
- * sit opposite the CTA under `justify="space-between"`, which cost an enforced
- * `min-width` floor, a `@container` breakpoint that hid it entirely below 264px,
- * and a derived threshold constant with its own drift guard — all of it apparatus
- * for making two things share a row that did not need to. As a dimmed line under
- * the creator chip it has the meta block's full width, never competes with the
- * CTA, and the row is left holding only the CTA + the `⋮` trigger. Whether a
- * viewer gets a `⋮` no longer has any geometry consequence beyond the trigger's
- * own 36px, so the card no longer computes that predicate at all.
+ * 🔴 THE RECOMMEND ROLLUP IS IN NEITHER THE META BLOCK NOR THE ACTION ROW — IT IS
+ * A LINE OF ITS OWN, BELOW THE ROW. Its history is two moves, and both are worth
+ * knowing because each deleted apparatus that must not come back:
+ *   1. It first sat OPPOSITE the CTA inside the action row under
+ *      `justify="space-between"`, which cost an enforced `min-width` floor, a
+ *      `@container` breakpoint that hid it entirely below 264px, and a derived
+ *      threshold constant with its own drift guard. All of that is deleted.
+ *   2. It then sat in the META BLOCK, under the author chip. The operator moved
+ *      it below the CTA (2026-09-06), in the same pass that dropped the author.
+ * What it keeps from move 1 is the property that mattered: it does not share a
+ * flex line with the CTA, so it needs no floor, no breakpoint and no threshold —
+ * the action row still holds exactly the CTA + the `⋮` trigger. Whether a viewer
+ * gets a `⋮` still has no geometry consequence beyond the trigger's own 36px, so
+ * the card still does not compute that predicate.
+ *
+ * 🔴 THE PLAY COUNT SITS BESIDE THE ROLLUP, AND `openCount === null` RENDERS
+ * NOTHING AT ALL — NOT A `0`. That is an OPERATOR OVERRIDE recorded as a decision,
+ * not a formatting derivation: an off-site listing's CTA is a third-party
+ * `target="_blank"` anchor, so no on-platform request follows the click and the
+ * number is STRUCTURALLY ABSENT. A `0` would read as "nobody has ever used this
+ * app" about an app we cannot measure. The mirror is equally deliberate — an
+ * ON-SITE listing with a genuine `0` DOES render "0 plays", because there the
+ * zero is a measurement. The DTO makes the same distinction at
+ * `app-listing-read.schema.ts`'s `openCount` and at `app-listing.service.ts`'s
+ * `cardOpenCount`; this component is the renderer those two comments promise.
  *
  * 🔴 THERE IS NO KIND BADGE ON THIS CARD. This line used to claim "a kind badge
  * (App / Connect app / Off-site)" — doubly wrong: two of those labels no longer
@@ -215,53 +242,24 @@ function ListingCover({
 }
 
 /**
- * "by {creator}" chip — restores the attribution line AppBlockCard dropped. Uses
- * the public creator chip (id / username / image). Links to the creator profile.
- * (UserAvatarSimple wants a rich `ProfileImage` + cosmetics object; the DTO only
- * carries a bare `image` string, so we render a lightweight avatar here — noted
- * as a reuse tradeoff in the PR.)
+ * ── WHERE THE AUTHOR CHIP WENT ──────────────────────────────────────────────
+ *
+ * A `CreatorChip` used to live here: a 20px avatar plus a dimmed "by {username}"
+ * `TruncatedText`, linking to `/user/<username>`. It is DELETED rather than left
+ * unreferenced, because an exported-but-uncalled component is the shape that gets
+ * wired back in by the next person who wants a byline.
+ *
+ * 🔴 IT WAS NOT A SHARED COMPONENT, so nothing else broke: the name is spelled in
+ * four places in this codebase and they are four INDEPENDENT things —
+ * `AppListingDetailBody` declares its own local `CreatorChip` over
+ * `ListingDetail['creator']`, and `AppDetailsModal` / `appDetailAuthorView` only
+ * MENTION the name in prose while rendering their own attribution. Checked by
+ * grep before deleting, not assumed.
+ *
+ * The detail surfaces are deliberately untouched: dropping the byline is a
+ * decision about a DENSE BROWSING GRID, not about attribution, and an app's
+ * author is still one click away on every card (the title links to the detail).
  */
-function CreatorChip({ creator }: { creator: ListingCard['creator'] }) {
-  if (!creator || !creator.username) return null;
-  const avatarSrc = creator.image ? getEdgeUrl(creator.image, { width: 64 }) : undefined;
-  return (
-    <Anchor
-      component={Link}
-      href={`/user/${encodeURIComponent(creator.username)}`}
-      underline="never"
-      c="dimmed"
-      onClick={(e: MouseEvent) => e.stopPropagation()}
-    >
-      <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
-        <Avatar src={avatarSrc} alt="" radius="xl" size={20} style={{ flexShrink: 0 }}>
-          {creator.username.charAt(0).toUpperCase()}
-        </Avatar>
-        {/* Tuned to fit in the common case; the Tooltip reveals a long username
-            only when it would still clip. */}
-        {/* 🔴 S5 — AUTHOR is size + weight ONLY: 12px/400 -> 14px/500, matching the
-            `/models` author line. `c="dimmed"` is KEPT deliberately (Zach's call):
-            taking BOTH title and author to white flattens the title-over-author
-            hierarchy on a `dark-6` card body, and `/models` needs white there only
-            because its author line is overlaid on media.
-
-            🔴 ACCEPTED RESIDUAL, on the record rather than an oversight: this leaves
-            the author line at contrast 4.73 — AA pass by 0.23, AAA fail. Do not
-            "fix" it to white in a later PR without revisiting that decision; the
-            verification asserts the colour did NOT change. */}
-        <TruncatedText
-          size="sm"
-          fw={500}
-          c="dimmed"
-          lineClamp={1}
-          tooltipLabel={creator.username}
-          style={{ minWidth: 0 }}
-        >
-          {`by ${creator.username}`}
-        </TruncatedText>
-      </Group>
-    </Anchor>
-  );
-}
 
 export interface AppListingCardProps {
   card: ListingCard;
@@ -298,6 +296,14 @@ export function AppListingCard({
   const CtaGlyph = ACTION_GLYPH_ICONS[cardActionGlyph(cta.action)];
   const detailHref = getListingDetailHref(card.slug);
   const recommendLabel = getRecommendLabel(card.recommend, card.reviewCount);
+  // 🔴 THE NULL-VS-ZERO DECISION IS **NOT** MADE HERE — `getPlayCountLabel` owns it
+  // and returns `null` for an unmeasurable listing. That is deliberate: this
+  // component is covered only by the REPORT-ONLY browser project, while the pure
+  // view-model is covered by the node `unit` project that reddens a `main` push. A
+  // `card.openCount != null && …` written into the JSX below would put the rule in
+  // the one tier that never goes red on its own. All this line does is carry the
+  // answer to the render, and all the render does is omit a `null`.
+  const playCountLabel = getPlayCountLabel(card.openCount);
 
   const isOwner = !!currentUser?.id && currentUser.id === card.creator?.id;
 
@@ -325,8 +331,8 @@ export function AppListingCard({
 
   // 🔴 `@container` IS GONE, AND SO IS THE `hasMenu` PREDICATE THAT DROVE IT.
   // The card declared itself a query container for exactly ONE consumer: the
-  // recommend rollup's `hidden @[264px]:flex`. With the rollup relocated to the
-  // meta block there is no container query left on this card, so keeping
+  // recommend rollup's `hidden @[264px]:flex`. With the rollup on a line of its
+  // own below the action row there is no container query left on this card, so keeping
   // `container-type: inline-size` would be an unread containment declaration
   // that a later reader has to prove unused before touching. Nothing else on the
   // card is size-queried; re-add it WITH its consumer if that changes.
@@ -432,18 +438,30 @@ export function AppListingCard({
                   🔴 THE TITLE BOX RESERVES ITS FULL TWO LINES WHETHER OR NOT IT
                   NEEDS THEM. `min-height` = lines x line-height, in `em` so it
                   tracks the title's own font-size. Without it a one-line title is
-                  24px and a wrapped one is 48px, so the creator chip — and every
-                  row of the meta block under it — lands at a DIFFERENT y on every
-                  card in a grid row, which reads as sloppy alignment rather than
-                  as variable content. It adds NO truncation: the title already
-                  clamped at two lines, and the clamp is still two lines because
-                  both numbers are now the same constant.
+                  24px and a wrapped one is 48px, so everything under the title
+                  lands at a DIFFERENT y on every card in a grid row, which reads
+                  as sloppy alignment rather than as variable content. It adds NO
+                  truncation: the title already clamped at two lines, and the clamp
+                  is still two lines because both numbers are now the same constant.
+
+                  🔴 WHAT "EVERYTHING UNDER THE TITLE" MEANS NOW IS NARROWER THAN
+                  IT WAS, AND SAYING SO IS THE POINT. This sentence used to name the
+                  creator chip "and every row of the meta block under it". The chip
+                  is gone and the rollup moved out, so the meta block below the
+                  title holds only the two conditional badges — the rows the
+                  reservation actually aligns today are those badges and the
+                  TAGLINE below the block. The action row and the stats line under
+                  it are bottom-pinned by `mt="auto"`, so they were never affected
+                  by title length and are not evidence for this reservation. The
+                  guard in `AppListingCard.browser.test.tsx` measures the TAGLINE
+                  for exactly this reason.
 
                   🔴 `TruncatedText` REPLACES the `line-clamp-2` utility class, and
                   the swap is not cosmetic. (a) The class would be a SECOND copy of
                   the line count that `min-height` derives from — exactly the drift
                   this PR's geometry module exists to remove. (b) It buys the
-                  hover fallback the creator chip already has: a name clamped at
+                  hover fallback the retired creator chip used to have: a name
+                  clamped at
                   two lines is unreadable, and `TruncatedText` reveals it in a
                   Tooltip ONLY when it actually clips (a runtime scrollHeight
                   measurement, not a guess). `clampLines` selects that component's
@@ -461,42 +479,6 @@ export function AppListingCard({
                 {card.name}
               </TruncatedText>
             </Anchor>
-            <CreatorChip creator={card.creator} />
-            {/* ── THE RECOMMEND ROLLUP ────────────────────────────────────────
-                "N% recommend (M)", or "No reviews yet" when there are none.
-
-                🔴 IT ALWAYS RENDERS, AND THAT IS THE POINT. A card with no reviews
-                still gets the line — dropping it would make card heights depend on
-                review state inside an `h-full` grid row, which is the same class of
-                misalignment the title's reserved lines above fix.
-
-                🔴 IT MOVED HERE FROM THE ACTION ROW, and what it left behind is the
-                headline of this change. Opposite the CTA it needed an enforced
-                `min-width` floor (so a growing CTA could not starve it), a
-                `@container` query hiding it below 264px (so a narrow card did not
-                render a two-character stub), and a derived threshold constant with
-                a drift guard asserting the Tailwind class spelled the same number.
-                All three are DELETED: as a meta-block line it has the block's full
-                width, competes with nothing, and truncates against the card body
-                rather than against a button.
-
-                Dimmed + `xs`, i.e. quieter than the creator line above it: it is
-                corroboration, not identity. */}
-            <Group
-              gap={4}
-              wrap="nowrap"
-              style={{ minWidth: 0 }}
-              data-testid="apps-listing-recommend-rollup"
-            >
-              <IconThumbUp
-                size={13}
-                style={{ flexShrink: 0 }}
-                className={card.recommend.recommendPct == null ? 'text-gray-500' : 'text-green-500'}
-              />
-              <Text size="xs" c="dimmed" truncate>
-                {recommendLabel}
-              </Text>
-            </Group>
             {/* AUTHOR-DECLARED beta label. Matches the `Incomplete` badge's shape directly
                 below, with two deliberate differences: it is PUBLIC (that one is owner-only
                 — `showOwnerIncomplete`), and it carries no tooltip, because the card DTO
@@ -550,9 +532,9 @@ export function AppListingCard({
             stepping up the size scale again — see the CTA's own note below.
 
             🔴 THE ROW HOLDS THE CTA AND THE `⋮` TRIGGER, AND NOTHING ELSE. The
-            recommend rollup used to sit opposite them; it is now a meta-block
-            line (see its note above). Three pieces of apparatus died with the
-            move, and none of them should come back with it:
+            recommend rollup used to sit opposite them; it is now the stats line
+            BELOW this row (see its note there). Three pieces of apparatus died
+            with the first move, and none of them should come back with it:
               - `justify="space-between"` — moot with one growing child, and it
                 was the reason a lone item could jump to flex-START;
               - `marginLeft: 'auto'` on the action cluster — it existed as a
@@ -571,6 +553,18 @@ export function AppListingCard({
             would put the `⋮` on its own row, and a card WITH a menu would then be
             taller than one without — inside an `h-full` grid row that grows every
             card in the row across the store.
+
+            🔴 `mt="auto"` STILL BOTTOM-PINS, AND IT NOW PINS A PAIR. The stats
+            line renders AFTER this row, so this Group is no longer the Stack's
+            last child. That does not weaken the pin: `margin-top: auto` on a
+            column flex item absorbs ALL the free space above it, so the row and
+            everything after it are pushed to the bottom together. The thing to
+            re-check on any future insertion is the same one: the auto margin must
+            stay on the FIRST of the bottom-pinned children, or a gap opens between
+            them. The `actionRow()` helper in `AppListingCard.browser.test.tsx`
+            still discriminates on that `mt="auto"`, so it keeps landing here — but
+            two geometry helpers that walked to the Stack's LAST child did have to
+            move (`ctaWidths()` in `AppListingCardSkeleton.geometry.test.tsx`).
 
             🔴 ROW HEIGHT IS A CONSTANT 46px AND MUST STAY ONE, and it is now
             DERIVED rather than asserted: `LISTING_ACTION_ROW_HEIGHT_PX` =
@@ -745,6 +739,76 @@ export function AppListingCard({
             triggerTooltip
             stopPropagation
           />
+        </Group>
+
+        {/* ── THE STATS LINE ───────────────────────────────────────────────
+            Reviews, then plays — BELOW the CTA, which is the operator's ask
+            (2026-09-06) and the reason the author chip above it is gone.
+
+            🔴 THE ROLLUP HALF ALWAYS RENDERS, AND THAT IS THE POINT. A card with
+            no reviews still gets "No reviews yet" — dropping the line would make
+            card heights depend on review state inside an `h-full` grid row, which
+            is the same class of misalignment the title's reserved lines fix, and
+            it is what lets `AppListingCardSkeleton` reserve this line
+            unconditionally.
+
+            🔴 THE PLAY HALF IS CONDITIONAL, AND ITS ABSENCE COSTS NO HEIGHT. It
+            shares this ONE flex line with the rollup rather than taking a line of
+            its own, so `openCount === null` changes the card's width usage and
+            nothing else. That is what keeps the skeleton exact without the
+            skeleton having to know the listing's kind — a loading state cannot
+            know whether the card it is reserving for is on-site or off-site.
+
+            🔴 `wrap="nowrap"` IS LOAD-BEARING, NOT TIDINESS. A wrapped stats line
+            is a SECOND line, i.e. a card taller than its skeleton by one `xs` line
+            box on every card in that `h-full` grid row. (That is ~17px — DERIVED
+            from the 16.8px figure `AppListingCardSkeleton.geometry.test.tsx`
+            measured for this type token, not re-measured here.) The rollup absorbs
+            any deficit
+            (`minWidth: 0` + `truncate`); the play count is `flexShrink: 0`
+            because it is short, bounded by `abbreviateNumber` (never more than
+            ~6 characters) and useless truncated.
+
+            Dimmed + `xs` — corroboration, not identity, same as when this line
+            lived in the meta block. */}
+        <Group gap="sm" wrap="nowrap" data-testid="apps-listing-card-stats">
+          <Group
+            gap={4}
+            wrap="nowrap"
+            style={{ minWidth: 0 }}
+            data-testid="apps-listing-recommend-rollup"
+          >
+            <IconThumbUp
+              size={13}
+              style={{ flexShrink: 0 }}
+              className={card.recommend.recommendPct == null ? 'text-gray-500' : 'text-green-500'}
+            />
+            <Text size="xs" c="dimmed" truncate>
+              {recommendLabel}
+            </Text>
+          </Group>
+          {/* 🔴 RENDERED ONLY WHEN THE COUNT IS MEASURABLE. `playCountLabel` is
+              `null` exactly when `card.openCount` is `null`, i.e. off-site — the
+              rule and its OPERATOR OVERRIDE live in `getPlayCountLabel`, not here.
+              An on-site `0` yields "0 plays" and must keep rendering.
+
+              🔴 `!= null`, NOT `{playCountLabel && …}`. The label is a string, and
+              the empty string is falsy — so a truthiness test would silently
+              suppress a legitimately empty label if the copy ever changed shape.
+              The type is `string | null`; test for the `null`. */}
+          {playCountLabel != null && (
+            <Group
+              gap={4}
+              wrap="nowrap"
+              style={{ flexShrink: 0 }}
+              data-testid="apps-listing-play-count"
+            >
+              <IconPlayerPlay size={13} style={{ flexShrink: 0 }} className="text-gray-500" />
+              <Text size="xs" c="dimmed">
+                {playCountLabel}
+              </Text>
+            </Group>
+          )}
         </Group>
       </Stack>
     </Card>

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -96,16 +96,24 @@ import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema
  * gets a `⋮` still has no geometry consequence beyond the trigger's own 36px, so
  * the card still does not compute that predicate.
  *
- * 🔴 THE PLAY COUNT SITS BESIDE THE ROLLUP, AND `openCount === null` RENDERS
- * NOTHING AT ALL — NOT A `0`. That is an OPERATOR OVERRIDE recorded as a decision,
- * not a formatting derivation: an off-site listing's CTA is a third-party
- * `target="_blank"` anchor, so no on-platform request follows the click and the
- * number is STRUCTURALLY ABSENT. A `0` would read as "nobody has ever used this
- * app" about an app we cannot measure. The mirror is equally deliberate — an
- * ON-SITE listing with a genuine `0` DOES render "0 plays", because there the
- * zero is a measurement. The DTO makes the same distinction at
- * `app-listing-read.schema.ts`'s `openCount` and at `app-listing.service.ts`'s
- * `cardOpenCount`; this component is the renderer those two comments promise.
+ * 🔴 THE PLAY COUNT SITS BESIDE THE ROLLUP, AND IT RENDERS ONLY FOR A COUNT OF ONE
+ * OR MORE. Both `openCount === null` and `openCount === 0` render NOTHING AT ALL.
+ * That is an OPERATOR OVERRIDE recorded as a decision, not a formatting derivation
+ * — and the two inputs reach the same pixels for DIFFERENT reasons:
+ *   · `null` is STRUCTURALLY UNMEASURABLE (an off-site CTA is a third-party
+ *     `target="_blank"` anchor; nothing on-platform observes the click);
+ *   · `0` is MEASURED AND EMPTY (an on-site app nobody has opened yet).
+ * The DTO keeps those apart deliberately — see `app-listing-read.schema.ts`'s
+ * `openCount` and `app-listing.service.ts`'s `cardOpenCount`, whose "do not
+ * over-null" paragraph must keep holding — and this card is where the operator's
+ * choice to render them IDENTICALLY lives. The rule itself is in
+ * `getPlayCountLabel`, not here.
+ *
+ * ⚠️ THE ZERO HALF REVERSES THE FIRST ROUND OF THIS PR, which rendered "0 plays"
+ * and argued that it must. Operator, 2026-09-06: "dont show 0 plays (just show
+ * nothing)". Flagged rather than quietly rewritten, because the earlier argument
+ * (a zero is a measurement, not an absence) is still right about the DATA and was
+ * only ever wrong about the SCREEN.
  *
  * 🔴 THERE IS NO KIND BADGE ON THIS CARD. This line used to claim "a kind badge
  * (App / Connect app / Off-site)" — doubly wrong: two of those labels no longer
@@ -787,15 +795,20 @@ export function AppListingCard({
               {recommendLabel}
             </Text>
           </Group>
-          {/* 🔴 RENDERED ONLY WHEN THE COUNT IS MEASURABLE. `playCountLabel` is
-              `null` exactly when `card.openCount` is `null`, i.e. off-site — the
-              rule and its OPERATOR OVERRIDE live in `getPlayCountLabel`, not here.
-              An on-site `0` yields "0 plays" and must keep rendering.
+          {/* 🔴 RENDERED ONLY FOR A COUNT OF ONE OR MORE. `playCountLabel` is
+              `null` for BOTH `card.openCount === null` (off-site, unmeasurable)
+              and `card.openCount === 0` (on-site, measured and empty) — two
+              different facts the operator chose to render identically. The rule and
+              its OPERATOR OVERRIDE live in `getPlayCountLabel`, not here; this
+              component only omits a `null`.
 
               🔴 `!= null`, NOT `{playCountLabel && …}`. The label is a string, and
               the empty string is falsy — so a truthiness test would silently
               suppress a legitimately empty label if the copy ever changed shape.
-              The type is `string | null`; test for the `null`. */}
+              The type is `string | null`; test for the `null`. (Note the asymmetry
+              on purpose: a truthiness test is refused HERE, on the label, and used
+              — spelled out as `=== 0` — THERE, on the count. Different values,
+              different reasons.) */}
           {playCountLabel != null && (
             <Group
               gap={4}

--- a/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
@@ -40,16 +40,31 @@
  * 🔴 THE FIXTURE IS PART OF THE CLAIM — READ THIS BEFORE QUOTING A RESULT
  * ─────────────────────────────────────────────────────────────────────────────
  * The skeleton reserves the card's INVARIANT parts: the 16:9 cover, the icon, the
- * two RESERVED title lines, the creator line and the always-rendered recommend
- * rollup line, plus the 46px action row. A card can also render a `line-clamp-3`
- * tagline, a Beta badge and an owner-only "Incomplete" badge — none of which a
- * loading state can predict.
+ * two RESERVED title lines, the 46px action row, and the always-rendered stats line
+ * BELOW that row. A card can also render a `line-clamp-3` tagline, a Beta badge and
+ * an owner-only "Incomplete" badge — none of which a loading state can predict.
  *
- * So the fixture below is a listing of exactly that invariant shape: a creator, no
- * tagline, not beta, viewed signed-out. What this file proves is "the invariant box
- * matches EXACTLY", NOT "no card ever moves". A listing carrying a tagline is
- * taller than its skeleton and the grid still resizes — stated in the component's
- * header and in the PR body rather than papered over here.
+ * So the fixture below is a listing of exactly that invariant shape: no tagline, not
+ * beta, viewed signed-out. What this file proves is "the invariant box matches
+ * EXACTLY", NOT "no card ever moves". A listing carrying a tagline is taller than
+ * its skeleton and the grid still resizes — stated in the component's header and in
+ * the PR body rather than papered over here.
+ *
+ * 🔴 TWO THINGS THAT USED TO BE PART OF "THE INVARIANT SHAPE" NO LONGER ARE, AND
+ * THAT IS THIS CHANGE'S WHOLE EFFECT ON THIS FILE (2026-09-06):
+ *   · THE CREATOR. This paragraph used to open the fixture list with "a creator",
+ *     because the skeleton reserved an author line the card only sometimes rendered
+ *     — the one DOWNWARD variance axis. The card renders no author chip now, the
+ *     skeleton reserves no such line, and `creator` no longer moves the box in
+ *     either direction. Pinned as an equality by the retargeted "a card with NO
+ *     CREATOR is EXACTLY its skeleton" test below.
+ *   · THE KIND. The stats line carries a PLAY COUNT that an off-site listing omits
+ *     (`openCount === null` — nothing on-platform observes a third-party CTA). That
+ *     omission shares the rollup's flex line, so it costs WIDTH and not height —
+ *     which is what lets the skeleton reserve one line without knowing a kind it
+ *     structurally cannot know. Pinned by "an OFF-SITE card (no play count) is
+ *     EXACTLY its skeleton too" below, because "it costs no height" is a
+ *     measurement, not a promise.
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { cleanup } from 'vitest-browser-react';
@@ -264,6 +279,20 @@ const q = (n: number) => Math.round(n * 100) / 100;
  * Resolved structurally because `AppListingCard` puts no testid on the CTA, and
  * VALIDATED rather than trusted: a silently mis-resolved element would make the
  * comparison below compare the wrong boxes and pass.
+ *
+ * 🔴 THE WALK NO LONGER ENDS AT THE STACK'S **LAST** CHILD, AND THAT IS A REAL
+ * BREAK THIS CHANGE CAUSED RATHER THAN A REFACTOR. It used to be
+ * `card.lastElementChild` → `stack.lastElementChild` → `firstElementChild`, on the
+ * premise that the action row is the last thing in the card's `Stack`. The stats
+ * line (recommend rollup + play count) now renders AFTER that row, so
+ * `lastElementChild` resolves to the stats line, its first child is the rollup
+ * `Group`, and the `BUTTON`/`A` check would throw on every call — loudly, which is
+ * the one mercy of having built the check.
+ *
+ * The row is located by `mt="auto"` instead: it is the only bottom-pinned element
+ * on the card, and it is the SAME discriminator `AppListingCard.browser.test.tsx`'s
+ * `actionRow()` and `__tests__/appListingCardView.test.ts`'s prop-ledger test use.
+ * A positional index would have to move again on the next insertion; this does not.
  */
 function ctaWidths(): number[] {
   const cells = Array.from(
@@ -272,8 +301,16 @@ function ctaWidths(): number[] {
   return cells.map((cell) => {
     const card = cell.firstElementChild as HTMLElement | null;
     const stack = card?.lastElementChild as HTMLElement | null;
-    const actionRow = stack?.lastElementChild as HTMLElement | null;
-    const cta = actionRow?.firstElementChild as HTMLElement | null;
+    const actionRow = Array.from(stack?.children ?? []).find(
+      (el) => (el as HTMLElement).style.marginTop === 'auto'
+    ) as HTMLElement | undefined;
+    if (!actionRow) {
+      throw new Error(
+        `no bottom-pinned (mt="auto") action row among the card stack's children: ` +
+          `${stack?.outerHTML.slice(0, 200) ?? 'null'}`
+      );
+    }
+    const cta = actionRow.firstElementChild as HTMLElement | null;
     if (!cta || !(cta.tagName === 'BUTTON' || cta.tagName === 'A')) {
       throw new Error(
         `the walk did not land on the CTA control: ${cta?.outerHTML.slice(0, 200) ?? 'null'}`
@@ -551,38 +588,51 @@ describe('🔴 a skeleton cell occupies EXACTLY the box the card cell will', () 
   });
 
   /**
-   * 🔴 THE FOURTH CONTENT-VARIANCE AXIS, AND THE ONLY ONE THAT RUNS **DOWNWARD**.
+   * 🔴 THE FOURTH CONTENT-VARIANCE AXIS — THE ONLY ONE THAT RAN **DOWNWARD** — IS
+   * GONE, AND THIS TEST PINS THE ABSENCE RATHER THAN BEING DELETED WITH IT.
    *
-   * `ListingCard.creator` is nullable and `AppListingCard`'s `CreatorChip` returns
-   * `null` for a listing without one, while this skeleton reserves that line
-   * unconditionally. So such a card is SHORTER than its skeleton — the opposite
-   * direction from the tagline and the two badges, and it went undocumented for a
-   * round while the header and the PR body both said only "taller". It is not
-   * hypothetical: this PR's own `keepPreviousData` fixture uses `creator: null`.
+   * ⚠️ RETARGETED, AND THE OLD CLAIM IS RECORDED SO THE CHANGE IS LEGIBLE. This test
+   * used to be "a card with NO CREATOR is SHORTER than its skeleton, by exactly the
+   * reserved line": `ListingCard.creator` is nullable, `AppListingCard`'s
+   * `CreatorChip` returned `null` for a listing without one, and this skeleton
+   * reserved that line unconditionally — so such a card was shorter by the creator
+   * line plus the meta stack's gap (measured −22.29px at 1376/4, −22.30px at 2450/5).
    *
-   * 🔴 THE DELTA IS DERIVED FROM THE RENDER, NOT RESTATED. Asserting "−22.29px" would
-   * pin a number nobody could check; asserting that the shortfall equals the skeleton's
-   * own creator line plus the meta stack's gap — both measured off the live tree — says
-   * WHY it is what it is, and stays true if the type scale moves.
+   * The store card renders NO author chip at all now (2026-09-06, operator's call)
+   * and the skeleton reserves no creator line, so the two arms are the SAME height
+   * and the downward axis has no subject. Asserting the old delta would be a test
+   * that can only fail; deleting it silently would drop the only guard that would
+   * notice the chip coming back. So it asserts EQUALITY — with the same two arms,
+   * the same fixtures and the same non-vacuity control — and it is mutation-visible
+   * in exactly the direction that matters: restore `CreatorChip` to the card and arm
+   * B (creator: null) goes short of arm A again.
+   *
+   * 🔴 THE `keepPreviousData` FIXTURE THAT MOTIVATED THE ORIGINAL IS STILL
+   * `creator: null`, which is now simply fine rather than a documented shortfall.
    */
-  test('🔴 a card with NO CREATOR is SHORTER than its skeleton, by exactly the reserved line', async () => {
+  test('🔴 a card with NO CREATOR is EXACTLY its skeleton — the downward variance axis is gone', async () => {
     const GRID_WIDTH = 1376;
 
-    // The skeleton, and the two meta lines it reserves.
     const skel = await renderStore(GRID_WIDTH, { loading: true });
-    const creatorLine = box(
-      document.querySelector('[data-testid="apps-listing-skeleton-creator"]') as HTMLElement
-    );
-    const rollupLine = box(
-      document.querySelector('[data-testid="apps-listing-skeleton-rollup"]') as HTMLElement
-    );
-    // The meta `Stack`'s gap, measured rather than spelled: the card writes `gap={2}`
-    // and so does the skeleton, and neither number is in the geometry module.
-    const metaGap = q(rollupLine.top - creatorLine.bottom);
     const skeletonHeight = skel.boxes[0].height;
 
+    // 🔴 NON-VACUITY ON THE SKELETON ITSELF, FIRST. The retired creator line's
+    // testid must be GONE — if it still rendered, both arms would be equally
+    // over-reserved and the equality below would hold for the wrong reason.
+    expect(
+      document.querySelectorAll('[data-testid="apps-listing-skeleton-creator"]'),
+      'the skeleton still reserves a creator line, but the card renders no author chip — ' +
+        'every card in the store is then SHORTER than its skeleton by that whole line'
+    ).toHaveLength(0);
+    // …and the line it DOES still reserve is there, so the count above is a real read
+    // and not a query against a tree that never rendered.
+    expect(
+      document.querySelectorAll('[data-testid="apps-listing-skeleton-rollup"]').length,
+      'the skeleton reserved no stats line at all — the absence above is vacuous'
+    ).toBe(skel.cells.length);
+
     // Arm A — WITH a creator. This is the parity fixture, and the parity test above
-    // already pins it equal to the skeleton; re-read here so the subtraction below is
+    // already pins it equal to the skeleton; re-read here so the comparison below is
     // between two numbers this test measured itself.
     const withCreator = await renderStore(GRID_WIDTH, {
       loading: false,
@@ -596,30 +646,111 @@ describe('🔴 a skeleton cell occupies EXACTLY the box the card cell will', () 
       items: POOL.slice(0, skel.cells.length).map((c) => ({ ...c, creator: null })),
     });
 
-    // NON-VACUITY: the chip really is gone, so the height change has a named cause.
+    // NON-VACUITY: no profile link on EITHER arm — arm A because the card no longer
+    // renders one at all, arm B because its fixture has no creator to render. The
+    // first of those is the claim; the second is what the original test checked.
     expect(
       document.querySelectorAll('[data-testid="apps-listing-grid-col"] a[href^="/user/"]'),
-      'the creator chip still rendered — the fixture did not actually drop it'
+      'a creator profile link rendered on the store card — the author chip is back'
     ).toHaveLength(0);
+    // …and the cards really did render, so that zero is about the chip.
+    expect(withoutCreator.cells.length).toBe(skel.cells.length);
 
-    const shortfall = q(withCreator.boxes[0].height - withoutCreator.boxes[0].height);
-    const reserved = q(creatorLine.height + metaGap);
-    // 🔴 A SUB-PIXEL TOLERANCE, AND WHY IT DOES NOT WEAKEN THE CLAIM. Both sides are
-    // fractional layouts rounded independently (measured: 22.29 vs 20.3 + 2 = 22.30),
-    // so exact equality pins float noise rather than the reservation. 0.1px is far
-    // below the smallest thing that could be wrongly reserved here — the meta lines are
-    // 16.8 and 20.3 tall and the title box is 48 — so no incorrect reservation fits
-    // inside it.
+    const delta = q(withCreator.boxes[0].height - withoutCreator.boxes[0].height);
     expect(
-      Math.abs(shortfall - reserved),
-      `a creator-less card is ${shortfall}px shorter than its skeleton, which should be ` +
-        `the reserved creator line (${creatorLine.height}) plus the meta stack gap ` +
-        `(${metaGap}) = ${reserved}. If these disagree by more than sub-pixel rounding, ` +
-        'the skeleton is reserving something else too.'
-    ).toBeLessThan(0.1);
+      delta,
+      `a creator-less card is ${delta}px off a card with a creator. The store card renders ` +
+        'no author chip, so `creator` must not move its box at all — a non-zero delta here ' +
+        'means a byline came back, and the skeleton (which reserves nothing for one) is ' +
+        'then wrong for every listing that has a creator.'
+    ).toBe(0);
+    // …and both are EXACTLY the skeleton, stated as its own assertion because
+    // "the two arms agree" is also true of two arms that are equally wrong.
+    expect(withoutCreator.boxes[0].height).toBe(skeletonHeight);
+  });
 
-    // …and state the DIRECTION explicitly, because that is the half the docs got wrong.
-    expect(withoutCreator.boxes[0].height).toBeLessThan(skeletonHeight);
+  /**
+   * 🔴 THE PLAY COUNT'S OMISSION COSTS NO HEIGHT — MEASURED, BECAUSE THE SKELETON'S
+   * LICENCE TO IGNORE THE LISTING'S KIND RESTS ON IT.
+   *
+   * The card's stats line renders the recommend rollup always and the play count only
+   * when `openCount != null`. `null` means the number is structurally unmeasurable —
+   * an off-site listing's CTA is a third-party `target="_blank"` anchor, so nothing
+   * on-platform observes the click — and the operator's call (2026-09-06) is to omit
+   * the stat entirely rather than print a `0` about an app we cannot measure.
+   *
+   * A loading state cannot know whether the card it is reserving for is on-site or
+   * off-site, so the skeleton reserves ONE stats line for both. That is only correct
+   * while the omission changes WIDTH and not HEIGHT — i.e. while the two halves share
+   * a `wrap="nowrap"` flex line. This measures exactly that, at a real grid width,
+   * rather than trusting the `nowrap`.
+   *
+   * 🔴 THE FIXTURE IS A GENUINE OFF-SITE LISTING, not an on-site one with `openCount`
+   * nulled: `cardOpenCount` discriminates on `kind`, so an on-site card can never
+   * produce `null` in production and a fixture that forced it would be testing a
+   * state the DTO cannot emit. Off-site also changes the CTA (an external `Visit`
+   * anchor), which is part of what makes this a worthwhile second shape.
+   */
+  test('🔴 an OFF-SITE card (no play count) is EXACTLY its skeleton too', async () => {
+    const GRID_WIDTH = 1376;
+
+    const skel = await renderStore(GRID_WIDTH, { loading: true });
+    const skeletonHeight = skel.boxes[0].height;
+
+    const onsite = await renderStore(GRID_WIDTH, {
+      loading: false,
+      items: POOL.slice(0, skel.cells.length),
+    });
+    // 🔴 READ NOW, NOT LATER. `renderStore` cleans the document before each render,
+    // so a count taken after the off-site arm would be a count of the off-site tree.
+    // This is the POSITIVE half of the control: the selector CAN match.
+    const onsitePlayCounts = document.querySelectorAll(
+      '[data-testid="apps-listing-play-count"]'
+    ).length;
+
+    const offsite = await renderStore(GRID_WIDTH, {
+      loading: false,
+      items: POOL.slice(0, skel.cells.length).map(
+        (c): ListingCard => ({
+          ...c,
+          kind: 'offsite',
+          openCount: null,
+          kindData: { kind: 'offsite', externalUrl: `https://${c.slug}.example` },
+        })
+      ),
+    });
+
+    // 🔴 NON-VACUITY, BOTH DIRECTIONS, before any height is compared. The play count
+    // must be PRESENT on the on-site arm (read above, while that tree existed) and
+    // ABSENT here — otherwise "the heights agree" is a fact about two identical
+    // renders, and a `0` from a selector that matches nothing anywhere would look
+    // exactly like the behaviour under test.
+    expect(
+      onsitePlayCounts,
+      'the ON-SITE arm rendered no play count, so the absence on the off-site arm is a ' +
+        'fact about the selector rather than about `openCount === null`'
+    ).toBe(onsite.cells.length);
+    expect(
+      document.querySelectorAll('[data-testid="apps-listing-play-count"]'),
+      'an off-site card rendered a play count — `openCount === null` must omit the stat'
+    ).toHaveLength(0);
+    // The rollup half DID render, so the zero above is about the play count and not
+    // about a stats line that failed to render at all.
+    expect(
+      document.querySelectorAll('[data-testid="apps-listing-recommend-rollup"]').length,
+      'the off-site cards rendered no stats line at all — the absence above is vacuous'
+    ).toBe(offsite.cells.length);
+
+    expect(
+      offsite.boxes[0].height,
+      'an off-site card is not the height its skeleton reserves. The play count is ' +
+        'supposed to share the rollup\'s `wrap="nowrap"` flex line, so omitting it costs ' +
+        'WIDTH and nothing else — if that is no longer true, the skeleton cannot reserve ' +
+        'one box for both kinds and it would have to know a kind it cannot know.'
+    ).toBe(skeletonHeight);
+    // …and the on-site arm, which DOES render the play count, is the same height.
+    expect(onsite.boxes[0].height).toBe(skeletonHeight);
+    expect(offsite.boxes).toEqual(onsite.boxes);
   });
 
   /**

--- a/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
@@ -59,8 +59,10 @@
  *     either direction. Pinned as an equality by the retargeted "a card with NO
  *     CREATOR is EXACTLY its skeleton" test below.
  *   · THE KIND. The stats line carries a PLAY COUNT that an off-site listing omits
- *     (`openCount === null` — nothing on-platform observes a third-party CTA). That
- *     omission shares the rollup's flex line, so it costs WIDTH and not height —
+ *     (`openCount === null`, unmeasurable — nothing on-platform observes a
+ *     third-party CTA — and `openCount === 0`, measured and empty; the operator
+ *     renders both as nothing). That omission shares the rollup's flex line, so it
+ *     costs WIDTH and not height —
  *     which is what lets the skeleton reserve one line without knowing a kind it
  *     structurally cannot know. Pinned by "an OFF-SITE card (no play count) is
  *     EXACTLY its skeleton too" below, because "it costs no height" is a
@@ -87,8 +89,17 @@ import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema
  * accidentally uniform in a way that could hide a width bug, and no field spells
  * 2, 10, 36, 40, 46, 16 or 9 — a fixture that can only ever produce a constant's
  * own value cannot see a mutant that hardcodes the literal.
+ *
+ * 🔴 `openCount` IS NON-ZERO, AND THAT IS LOAD-BEARING RATHER THAN INCIDENTAL. It
+ * was `0` for every card in this pool, which was fine while an on-site zero
+ * rendered "0 plays". It no longer does — the operator's 2026-09-06 override omits
+ * the chip for `0` as well as for `null` — so a pool of zeroes would render NO play
+ * count on ANY arm, and the off-site parity test below would be comparing two cards
+ * that both omit it. Its positive control (the on-site arm must actually show a
+ * play count) is what catches that, and a non-zero pool is what satisfies it.
+ * Derived per card so the values stay pairwise distinct.
  */
-function makeCard(id: string, name: string, creator: string): ListingCard {
+function makeCard(id: string, name: string, creator: string, openCount: number): ListingCard {
   return {
     id,
     slug: `slug-${id}`,
@@ -105,7 +116,7 @@ function makeCard(id: string, name: string, creator: string): ListingCard {
     creator: { id: 7331, username: creator, image: null },
     recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
     reviewCount: 0,
-    openCount: 0,
+    openCount,
     kindData: {
       kind: 'onsite',
       appBlockId: `blk-${id}`,
@@ -115,20 +126,29 @@ function makeCard(id: string, name: string, creator: string): ListingCard {
   };
 }
 
-/** Enough distinct listings to fill two rows at the widest count measured here. */
+/**
+ * Enough distinct listings to fill two rows at the widest count measured here.
+ *
+ * 🔴 EVERY `openCount` IS ≥ 1 AND ALL TWELVE ARE DISTINCT. ≥ 1 because that is the
+ * only band that RENDERS a play count (see `makeCard`'s note); distinct so no
+ * assertion can be green by two cards happening to print the same string. They also
+ * span three magnitude bands — three-digit, four-digit ("k") and seven-digit ("m") —
+ * so the row is not uniform in rendered WIDTH either, which is what a parity test
+ * comparing boxes should be exercised against.
+ */
 const POOL: ListingCard[] = [
-  makeCard('u1', 'Prompt Vault', 'ashling'),
-  makeCard('u2', 'Gen Matrix Studio', 'bertrand'),
-  makeCard('u3', 'Palette', 'cyd'),
-  makeCard('u4', 'Frame Weaver Pro', 'delphine'),
-  makeCard('u5', 'Nudge', 'esben'),
-  makeCard('u6', 'Contour Lab', 'fitzgerald'),
-  makeCard('u7', 'Stipple', 'greta'),
-  makeCard('u8', 'Rehearsal Room', 'hollis'),
-  makeCard('u9', 'Kerf', 'imogen'),
-  makeCard('u10', 'Sable Notebook', 'jarrah'),
-  makeCard('u11', 'Tessellate', 'kestrel'),
-  makeCard('u12', 'Overtone Bench', 'linnea'),
+  makeCard('u1', 'Prompt Vault', 'ashling', 317),
+  makeCard('u2', 'Gen Matrix Studio', 'bertrand', 4821),
+  makeCard('u3', 'Palette', 'cyd', 59),
+  makeCard('u4', 'Frame Weaver Pro', 'delphine', 1_234_567),
+  makeCard('u5', 'Nudge', 'esben', 7),
+  makeCard('u6', 'Contour Lab', 'fitzgerald', 88_402),
+  makeCard('u7', 'Stipple', 'greta', 1),
+  makeCard('u8', 'Rehearsal Room', 'hollis', 2_603),
+  makeCard('u9', 'Kerf', 'imogen', 143),
+  makeCard('u10', 'Sable Notebook', 'jarrah', 970_311),
+  makeCard('u11', 'Tessellate', 'kestrel', 26),
+  makeCard('u12', 'Overtone Bench', 'linnea', 55_118),
 ];
 
 const mocks = vi.hoisted(() => ({
@@ -673,11 +693,20 @@ describe('🔴 a skeleton cell occupies EXACTLY the box the card cell will', () 
    * 🔴 THE PLAY COUNT'S OMISSION COSTS NO HEIGHT — MEASURED, BECAUSE THE SKELETON'S
    * LICENCE TO IGNORE THE LISTING'S KIND RESTS ON IT.
    *
-   * The card's stats line renders the recommend rollup always and the play count only
-   * when `openCount != null`. `null` means the number is structurally unmeasurable —
-   * an off-site listing's CTA is a third-party `target="_blank"` anchor, so nothing
-   * on-platform observes the click — and the operator's call (2026-09-06) is to omit
-   * the stat entirely rather than print a `0` about an app we cannot measure.
+   * The card's stats line renders the recommend rollup always, and the play count only
+   * for a count of ONE OR MORE. Two inputs omit it, for different reasons the operator
+   * chose to render identically (2026-09-06): `null` — structurally unmeasurable, an
+   * off-site CTA is a third-party `target="_blank"` anchor nothing on-platform
+   * observes — and `0` — measured and empty. This test uses the `null` arm; what it is
+   * really measuring is "the play count's box is absent", which is the same geometry
+   * either way.
+   *
+   * ⚠️ THE POOL'S `openCount` HAD TO MOVE OFF ZERO FOR THIS TEST TO STILL MEAN
+   * ANYTHING. Every fixture was `openCount: 0`, which rendered "0 plays" when this
+   * test was written and renders nothing now. The on-site arm would have omitted the
+   * chip too, so both arms would agree trivially and the positive control below —
+   * "the ON-SITE arm rendered no play count" — is exactly what fires on that. The pool
+   * now carries distinct non-zero counts; see its note.
    *
    * A loading state cannot know whether the card it is reserving for is on-site or
    * off-site, so the skeleton reserves ONE stats line for both. That is only correct

--- a/src/components/Apps/AppListingCardSkeleton.ssr.browser.test.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.ssr.browser.test.tsx
@@ -131,9 +131,19 @@ describe('🔴 the server emits a real skeleton grid, not an empty one', () => {
         'the Skeleton (NOT `component="div"` to the Text — that moves the element the ' +
         'meta line is measured on).'
     ).toBe(0);
-    // The offending elements are still THERE — this is not passing by rendering less.
-    expect(html).toContain('apps-listing-skeleton-creator');
+    // The offending element is still THERE — this is not passing by rendering less.
+    //
+    // ⚠️ THIS USED TO NAME TWO `MetaLineSkeleton`s, and dropping one of them is a
+    // WEAKENING OF THE CONTROL that has to be declared rather than absorbed. The
+    // skeleton reserved a creator line AND a rollup line inside the meta block; the
+    // card dropped its author chip and moved the rollup below the action row, so
+    // `apps-listing-skeleton-creator` no longer exists and asserting it would fail.
+    // One `<p>`-wrapping-a-`Skeleton` pairing still renders per cell, which is all
+    // this control needs: the check below is `toBe(0)` on the whole document, so its
+    // strength does not scale with the number of instances — only its non-vacuity
+    // does, and one instance is enough for that.
     expect(html).toContain('apps-listing-skeleton-rollup');
+    expect(html).not.toContain('apps-listing-skeleton-creator');
     expect(html).toContain('<p');
   });
 

--- a/src/components/Apps/AppListingCardSkeleton.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.tsx
@@ -36,27 +36,35 @@ import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
  * "Zero layout shift" is therefore the wrong claim. "Zero per-card shift" is the
  * right one.
  *
- * 🔴 AND A THIRD: CONTENT VARIANCE, WHICH RUNS IN **BOTH** DIRECTIONS. The skeleton
- * reserves cover, icon, the two RESERVED title lines, a creator line, the always-
- * rendered recommend rollup line, and the 46px action row. Four axes move a real
- * card off that:
+ * 🔴 AND A THIRD: CONTENT VARIANCE — WHICH NOW RUNS IN ONE DIRECTION ONLY. The
+ * skeleton reserves cover, icon, the two RESERVED title lines, the 46px action row,
+ * and the always-rendered stats line BELOW that row. Three axes move a real card off
+ * that, all of them UPWARD:
  *   · a conditional tagline (`line-clamp-3`)      → card TALLER
  *   · an author-declared `Beta` badge             → card TALLER
  *   · an owner-only "Incomplete" badge            → card TALLER
- *   · NO CREATOR — `ListingCard.creator` is nullable and `CreatorChip` returns
- *     `null` for it — → card SHORTER, by the creator line plus the meta stack's gap.
- * ⚠️ THAT LAST ONE WAS MISSING FROM THIS LIST AND FROM THE PR BODY FOR A ROUND, both
- * of which said only "a listing carrying one is TALLER than its skeleton". It is not
- * hypothetical: measured at −22.29px (1376px grid / 4 columns) and −22.30px
- * (2450px / 5), and this PR's own `keepPreviousData` fixture uses `creator: null`.
- * It is pinned rather than merely described — see "a card with NO CREATOR is SHORTER"
- * in `AppListingCardSkeleton.geometry.test.tsx`, which derives the delta from the
- * rendered creator line rather than restating the number above.
  *
- * 🔴 SO "THE INVARIANT SHAPE" INCLUDES HAVING A CREATOR. The parity fixture is a
- * listing WITH a creator and WITHOUT a tagline or badges; that is the shape the
- * skeleton is exact for, and it is a choice (most listings have a creator, so
- * reserving the line is right more often than not), not a discovered invariant.
+ * 🔴 THE FOURTH AXIS — THE ONLY DOWNWARD ONE — IS GONE, AND THAT IS A REAL
+ * IMPROVEMENT RATHER THAN A LINE DELETED FROM A LIST. It read: "NO CREATOR —
+ * `ListingCard.creator` is nullable and `CreatorChip` returns `null` for it —
+ * → card SHORTER, by the creator line plus the meta stack's gap" (measured at
+ * −22.29px on a 1376px grid, −22.30px at 2450px). The store card no longer renders
+ * an author chip at all (2026-09-06, operator's call), so this skeleton reserves no
+ * creator line and a `creator: null` listing — which this suite's own
+ * `keepPreviousData` fixture is — is now EXACTLY its skeleton's height. The geometry
+ * suite pins that as an equality where it used to pin the delta.
+ *
+ * 🔴 SO "THE INVARIANT SHAPE" NO LONGER DEPENDS ON THE CREATOR FIELD. The parity
+ * fixture is a listing WITHOUT a tagline and WITHOUT badges; whether it carries a
+ * creator is now irrelevant to its height, which is one fewer choice the reservation
+ * has to be right about.
+ *
+ * 🔴 THE STATS LINE IS RESERVED UNCONDITIONALLY, AND THE PLAY COUNT COSTS NOTHING
+ * EXTRA. The card renders the recommend rollup and — when `openCount` is not `null`
+ * — the play count on ONE flex line (`wrap="nowrap"`), so an off-site listing that
+ * omits the play count is the same HEIGHT as an on-site one that shows it. That is
+ * what lets this file reserve the line without knowing the listing's kind, which a
+ * loading state structurally cannot.
  *
  * ── EVERY GEOMETRY NUMBER IS READ, NEVER SPELLED ────────────────────────────
  * 🔴 THIS FILE IMPORTS `appListingCardGeometry.ts` AND SO DOES `AppListingCard`.
@@ -67,14 +75,17 @@ import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
  * `Object.keys` and fails if this file stops reading any of them — the same guard
  * `appListingCardView.test.ts` already runs over the card.
  *
- * What is NOT single-sourced is the MARKUP the two files mirror (`gap={2}` on the
- * meta stack, `size="sm"`/`size="xs"` on the meta lines, `padding="md"` on the
- * Card) — plus one deliberate DIVERGENCE: this file adds `flexGrow: 1` to the meta
- * `Stack`, which the card does not have. The card's stack is sized by its real text;
- * this one's content is absolutely-positioned bars over a non-breaking space, so
- * without it the stack shrink-to-fits to almost nothing and the bars (sized in `%`)
- * render as slivers. It changes no height — the title box is `min-height`-pinned and
- * both meta lines are single-line — which is why the parity test stays exact.
+ * What is NOT single-sourced is the MARKUP the two files mirror (`gap="sm"` on the
+ * outer stack, `gap={2}` on the meta stack, `size="xs"` on the stats line,
+ * `padding="md"` on the Card) — plus one deliberate DIVERGENCE: this file adds
+ * `flexGrow: 1` to the meta `Stack`, which the card does not have. The card's stack
+ * is sized by its real text; this one's content is absolutely-positioned bars over a
+ * non-breaking space, so without it the stack shrink-to-fits to almost nothing and
+ * the bars (sized in `%`) render as slivers. It changes no height — the title box is
+ * `min-height`-pinned and the stats line is single-line — which is why the parity
+ * test stays exact. (This sentence used to say "both meta lines are single-line".
+ * There is one line now and it is not in the meta block: the creator line is gone
+ * and the rollup line moved below the action row.)
  * Those are not in the geometry module — the card spells them too — so the
  * thing that pins them is the MEASURED parity test
  * (`AppListingCardSkeleton.geometry.test.tsx`), which renders both grids and
@@ -87,8 +98,8 @@ import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
  *
  * 🔴 THE `<Text>` IS NOT DECORATION — IT IS THE MEASUREMENT. Its content is a
  * non-breaking space, so the element's line box is exactly the line box the real
- * card's `<Text>` of the same `size`/`fw` produces, whatever Mantine's font-size
- * and line-height tokens happen to be. The visible bar is an ABSOLUTELY
+ * card's `<Text>` of the same `size` produces, whatever Mantine's font-size and
+ * line-height tokens happen to be. The visible bar is an ABSOLUTELY
  * positioned `Skeleton` over it, i.e. out of flow, so it contributes no height of
  * its own and cannot change the answer. A bar with a hand-picked pixel height
  * would be a second copy of Mantine's type scale, and would go wrong the day the
@@ -98,12 +109,22 @@ import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
  * IS VALID HTML. Mantine's `Text` renders a `<p>` and Mantine's `Skeleton` renders a
  * `<div>`, and `<div>` may not descend from `<p>`. An HTML parser auto-closes the
  * `<p>` at the `<div>`, so the parsed DOM is `<p></p><div></div>` while React's tree
- * is `<p><div/></p>` — a HYDRATION MISMATCH on every `/apps` load, EXACTLY 16 times:
- * 8 cells (`APP_LISTING_SKELETON_SSR_COLUMNS` x `APP_LISTING_SKELETON_ROWS`) x the two
- * meta lines each. An earlier draft said "16–20"; 20 would need 10 cells, which no
- * server render produces, and the mutation reproducing this observed `expected 16 to
- * be +0`.
- * It shipped in the first round of this PR and was invisible to the parity suite,
+ * is `<p><div/></p>` — a HYDRATION MISMATCH on every `/apps` load, once per rendered
+ * `MetaLineSkeleton`.
+ *
+ * ⚠️ THE COUNT IN THIS PARAGRAPH IS RE-DERIVED, NOT RE-MEASURED, AND IS FLAGGED
+ * RATHER THAN QUIETLY EDITED. It read "EXACTLY 16 times: 8 cells
+ * (`APP_LISTING_SKELETON_SSR_COLUMNS` x `APP_LISTING_SKELETON_ROWS`) x the two meta
+ * lines each", against a measurement of `expected 16 to be +0`. There is ONE
+ * `MetaLineSkeleton` per cell now (the creator line was deleted with the card's
+ * author chip and the rollup line moved below the action row), so the same
+ * arithmetic gives 8 x 1 = 8. Nobody has re-run the mutation to observe an
+ * `expected 8 to be +0` — the browser tiers do not run on the machine this change
+ * was made on — so treat 8 as arithmetic and 16 as the historical measurement.
+ * What is NOT derived and does not need re-measuring is the guard itself: the
+ * assertion is `toBe(0)`, which is independent of how many instances there are.
+ *
+ * It shipped in the first round of that PR and was invisible to the parity suite,
  * because the bar is `position: absolute` and therefore contributes no geometry for
  * a box comparison to see; the only signal was a `validateDOMNesting` warning on a
  * run that reported 7 passed. Both halves are now guarded —
@@ -119,19 +140,23 @@ import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
  * reproduce. `position: absolute` blockifies the span, so nothing about the bar
  * changes either.
  */
+// 🔴 `fw` IS GONE FROM THIS SIGNATURE, NOT LEFT UNUSED. It existed for the `sm`
+// creator line (`fw={500}`, mirroring the retired `CreatorChip`'s `TruncatedText`);
+// the one surviving caller passes no weight. An optional prop nothing supplies is
+// the same shape as the unread `@container` declaration this component family
+// already deleted — it reads as load-bearing to the next person. `size` is kept
+// general because it IS supplied.
 function MetaLineSkeleton({
   size,
-  fw,
   widthPct,
   'data-testid': testId,
 }: {
   size: 'sm' | 'xs';
-  fw?: number;
   widthPct: number;
   'data-testid'?: string;
 }) {
   return (
-    <Text size={size} fw={fw} c="dimmed" style={{ position: 'relative' }} data-testid={testId}>
+    <Text size={size} c="dimmed" style={{ position: 'relative' }} data-testid={testId}>
       {/* 🔴 A NON-BREAKING SPACE, NOT A PLAIN ONE. Whitespace-only text collapses under
           `white-space: normal`, which can leave the element with NO line box and therefore
           zero height — the reservation would then silently be nothing. `\u00A0` never
@@ -226,21 +251,25 @@ export function AppListingCardSkeleton() {
                 />
               ))}
             </Box>
-            {/* The creator chip's line. `size="sm"` / `fw={500}` mirror
-                `CreatorChip`'s `TruncatedText`; the chip's 20px avatar is shorter
-                than that line box, so the text is what sets the row height and the
-                skeleton does not need to reproduce the avatar to match it. */}
-            <MetaLineSkeleton
-              size="sm"
-              fw={500}
-              widthPct={44}
-              data-testid="apps-listing-skeleton-creator"
-            />
-            {/* The recommend rollup's line. It ALWAYS renders on a card — including
-                for a listing with no reviews — which is what makes it safe to
-                reserve unconditionally here. `size="xs"`, and the 13px thumb icon
-                is again shorter than the line box. */}
-            <MetaLineSkeleton size="xs" widthPct={62} data-testid="apps-listing-skeleton-rollup" />
+            {/* 🔴 NOTHING ELSE IS RESERVED IN THIS BLOCK, AND THAT IS THE CHANGE.
+                Two `MetaLineSkeleton`s used to sit here — a `size="sm"` creator
+                line (`apps-listing-skeleton-creator`) and a `size="xs"` recommend
+                rollup line (`apps-listing-skeleton-rollup`). The card dropped the
+                author chip and moved the rollup below the action row, so the
+                creator line is DELETED and the rollup line MOVED (it is rendered
+                after the action row below, keeping its testid). Reserving either
+                one here now would over-reserve the block by a whole line and
+                reflow the grid downward on every query resolve — the exact defect
+                this component exists to remove, in the direction that is easiest
+                to miss.
+
+                ⚠️ THE `gap={2}` ON THIS STACK IS THEREFORE INERT HERE, and it is
+                kept anyway — declared, not overlooked. It mirrors the CARD's meta
+                stack, where it is NOT inert: that stack still renders the title
+                plus up to two conditional badges (`Beta`, owner-only
+                `Incomplete`). Dropping it here would make the two files disagree
+                about a number for no gain, and would silently under-reserve the
+                day this block reserves a second row again. */}
           </Stack>
         </Group>
 
@@ -277,6 +306,28 @@ export function AppListingCardSkeleton() {
             radius="sm"
           />
         </Group>
+
+        {/* THE STATS LINE — the card's recommend rollup and (for a measurable
+            listing) its play count, on ONE `size="xs"` line BELOW the action row.
+
+            🔴 IT IS RESERVED UNCONDITIONALLY, AND BOTH HALVES OF THAT ARE SAFE FOR
+            DIFFERENT REASONS. The rollup half always renders on a card (a listing
+            with no reviews still gets "No reviews yet"), so the LINE always exists.
+            The play half is `openCount != null`-gated — off-site listings omit it —
+            but it shares the rollup's flex line rather than taking one of its own,
+            so its absence changes width and not height. A loading state cannot know
+            a listing's kind, and this is why it does not have to.
+
+            🔴 IT IS A SIBLING OF THE ACTION ROW, NOT A CHILD OF IT, mirroring the
+            card exactly: the row's `mt="auto"` absorbs the free space above it and
+            pushes BOTH to the bottom, and the outer `Stack`'s `gap="sm"` sets the
+            distance between them on both sides. A `pt` here instead would be a
+            second, hand-picked copy of that gap.
+
+            The 13px thumb/play icons are shorter than the `xs` line box, so — as
+            with the meta lines this replaces — the text is what sets the height and
+            the skeleton does not need to reproduce the icons to match it. */}
+        <MetaLineSkeleton size="xs" widthPct={62} data-testid="apps-listing-skeleton-rollup" />
       </Stack>
     </Card>
   );

--- a/src/components/Apps/AppListingsMarketplaceBody.stretch.geometry.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.stretch.geometry.test.tsx
@@ -253,21 +253,44 @@ async function renderAtGridWidth(width: number) {
  * The parts of one rendered card this file measures.
  *
  * 🔴 RESOLVED STRUCTURALLY, AND THEN VALIDATED, because `AppListingCard` carries no
- * `data-testid` on its action row and this file must not add one: that component is owned
- * by a concurrent change, and the coupling under test is pre-existing on `main`. So the
- * resolver walks my own grid cell → the `Card` → the body `Stack` → its LAST child. Each
- * step is then checked against something only the real action row satisfies, and a failed
- * check THROWS with the offending `outerHTML` rather than returning a wrong element — a
- * silently mis-resolved element would make every assertion below compare the wrong boxes
- * and pass.
+ * `data-testid` on its action row and this file does not add one. So the resolver walks my
+ * own grid cell → the `Card` → the body `Stack` → the BOTTOM-PINNED child. Each step is
+ * then checked against something only the real action row satisfies, and a failed check
+ * THROWS with the offending `outerHTML` rather than returning a wrong element — a silently
+ * mis-resolved element would make every assertion below compare the wrong boxes and pass.
+ *
+ * 🔴 "BOTTOM-PINNED", NOT "LAST" — AND THIS RESOLVER REALLY DID BREAK. It used to take
+ * `stack.lastElementChild`, and VALIDATION 2 below used to REQUIRE
+ * `actionRow.nextElementSibling === null`. `AppListingCard` now renders a stats line
+ * (recommend rollup + play count) AFTER the action row, so the last child is that stats
+ * line: the walk would resolve to it, VALIDATION 1 would find no link or button inside it,
+ * and every test in this file would throw. Loud, which is what the validations are for —
+ * but it is a break, not a refactor, and the fix is not to relax the checks.
+ *
+ * `mt="auto"` is the discriminator instead: it is the only bottom-pinned element on the
+ * card, and it is what `AppListingCard.browser.test.tsx`'s `actionRow()`,
+ * `AppListingCardSkeleton.geometry.test.tsx`'s `ctaWidths()` and
+ * `__tests__/appListingCardView.test.ts`'s prop ledger all key on. A positional index would
+ * have to be re-derived on the next insertion; this does not.
  */
 function cardPartsOf(cell: HTMLElement) {
   const card = cell.firstElementChild as HTMLElement | null;
   if (!card) throw new Error(`grid cell has no card child: ${cell.outerHTML.slice(0, 200)}`);
   const stack = card.lastElementChild as HTMLElement | null;
   if (!stack) throw new Error(`card has no body stack: ${card.outerHTML.slice(0, 200)}`);
-  const actionRow = stack.lastElementChild as HTMLElement | null;
-  if (!actionRow) throw new Error(`card body has no last child: ${stack.outerHTML.slice(0, 200)}`);
+  const pinned = Array.from(stack.children).filter(
+    (el) => (el as HTMLElement).style.marginTop === 'auto'
+  ) as HTMLElement[];
+  // VALIDATION 0 — EXACTLY ONE bottom-pinned child. Two auto top margins in one column
+  // flex container SPLIT the free space between them, so "the action row is at the bottom"
+  // would silently stop being true while every element still resolved.
+  if (pinned.length !== 1) {
+    throw new Error(
+      `expected exactly ONE mt="auto" child in the card body, found ${pinned.length}: ` +
+        stack.outerHTML.slice(0, 300)
+    );
+  }
+  const actionRow = pinned[0];
   // VALIDATION 1 — the action row is the one holding the card's controls. The title block
   // above it holds a link too, so this does not identify it alone; it is what rules out
   // having resolved to a `<Text>` tagline.
@@ -277,10 +300,19 @@ function cardPartsOf(cell: HTMLElement) {
         actionRow.outerHTML.slice(0, 300)
     );
   }
-  // VALIDATION 2 — it really is the LAST thing in the card body, which is what makes "its
-  // top" a meaningful proxy for "where the pinned row sits".
-  if (actionRow.nextElementSibling !== null) {
-    throw new Error('resolved "action row" is not the last child of the card body');
+  // VALIDATION 2 — SOMETHING IS ABOVE IT. (This used to demand the action row be the LAST
+  // child of the card body; the stats line now follows it, so that check has no subject —
+  // see the note above. What replaces it is the property the measurements below actually
+  // need.) `contentBottom` is `previousElementSibling`'s bottom and is the NON-VACUITY
+  // CONTROL for the whole file; if the row were the first child that control would be
+  // `null` on every card and `new Set([null,null,…]).size` would be 1, which the control
+  // reports as "the fixtures do not differ" rather than as a broken walk.
+  if (actionRow.previousElementSibling === null) {
+    throw new Error(
+      'resolved "action row" is the card body\'s FIRST child, so there is no content above ' +
+        'it to measure: ' +
+        stack.outerHTML.slice(0, 300)
+    );
   }
   // Where the content ABOVE the action row ends. This is the NON-VACUITY CONTROL: the
   // fixtures must genuinely differ in natural content height, or "the heights are equal"

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -8,6 +8,7 @@ import {
   getListingCta,
   getListingDetailHref,
   getOwnerEditHref,
+  getPlayCountLabel,
   getRecommendLabel,
   isEditableListingStatus,
   safeExternalHref,
@@ -139,6 +140,67 @@ describe('getRecommendLabel', () => {
   });
   it('formats large counts with locale separators', () => {
     expect(getRecommendLabel(roll(1200, 300, 0.8), 1500)).toBe('80% recommend (1,500)');
+  });
+});
+
+/**
+ * 🔴 THE PLAY COUNT'S NULL-VS-ZERO RULE — AND THIS IS THE TIER THAT OWNS IT.
+ *
+ * The rule is an OPERATOR OVERRIDE (2026-09-06), not a formatting derivation:
+ * `openCount === null` means the number is STRUCTURALLY UNMEASURABLE (an off-site
+ * listing's CTA is a third-party `target="_blank"` anchor, so nothing on-platform
+ * observes the click), and such a card renders NO play stat at all — a `0` there
+ * would read as "nobody has ever used this app" about an app we cannot measure.
+ * The mirror is equally deliberate: an ON-SITE listing with a genuine `0` renders
+ * "0 plays", because there the zero IS the measurement.
+ *
+ * 🔴 IT IS TESTED HERE RATHER THAN ONLY IN THE BROWSER TIER BECAUSE OF WHICH TIER
+ * GOES RED. `AppListingCard.browser.test.tsx` renders the real card and asserts the
+ * omission end-to-end, but the browser `component` project never blocks anything;
+ * the node `unit` project at least reddens a `main` push. Expressing the rule as a
+ * pure function is what makes it visible to this tier at all — as JSX
+ * (`card.openCount != null && …`) it would be invisible here. (Neither tier gates a
+ * PR: `lint.yml` marks both `continue-on-error` for `pull_request`. Canonical
+ * statement: `appListingCardGeometry.ts`'s header.)
+ *
+ * 🔴 THE FIXTURES ARE PAIRWISE DISTINCT AND SHARE NOTHING WITH THE STRINGS
+ * ASSERTED. 4821 → "4.8k" and 1_234_567 → "1.2m" are values whose rendered form
+ * contains none of their own digits in order, so a mutant that dropped
+ * `abbreviateNumber` and printed the raw number cannot produce them; and the two
+ * counts differ in magnitude BAND, so a mutant that hardcoded one suffix survives
+ * neither.
+ */
+describe('getPlayCountLabel', () => {
+  it('🔴 null → null, so the caller has no number to print', () => {
+    expect(getPlayCountLabel(null)).toBeNull();
+  });
+
+  it('🔴 a genuine ZERO is a measurement, not an absence → "0 plays"', () => {
+    // The mutation this refuses is `if (!openCount) return null`, which collapses
+    // the unmeasurable case and the measured-as-none case into one.
+    expect(getPlayCountLabel(0)).toBe('0 plays');
+  });
+
+  it('singular at exactly 1, plural either side of it', () => {
+    expect(getPlayCountLabel(1)).toBe('1 play');
+    expect(getPlayCountLabel(2)).toBe('2 plays');
+    expect(getPlayCountLabel(0)).toBe('0 plays');
+  });
+
+  it('abbreviates a large count rather than printing separators', () => {
+    expect(getPlayCountLabel(4821)).toBe('4.8k plays');
+    expect(getPlayCountLabel(1_234_567)).toBe('1.2m plays');
+  });
+
+  /**
+   * 🔴 THE PLURAL READS THE RAW VALUE, NOT THE ABBREVIATED STRING. 1000
+   * abbreviates to "1k", so a pluraliser written against the rendered text
+   * (`label.startsWith('1') ? 'play' : 'plays'`, or anything derived from the
+   * abbreviation) says "1k play". The distinction is unobservable at every count
+   * below 1000, which is why it needs its own fixture.
+   */
+  it('🔴 1000 is "1k plays" — the plural is not derived from the abbreviation', () => {
+    expect(getPlayCountLabel(1000)).toBe('1k plays');
   });
 });
 
@@ -611,6 +673,120 @@ describe('the card geometry module', () => {
     // Positive control: the stripper leaves OTHER literals alone, so the six
     // absences above are about these constructs and not about an empty read.
     expect(code).toContain('line-clamp-3'); // the tagline's clamp, deliberately not geometry
+  });
+
+  /**
+   * 🔴 THE STATS LINE IS BELOW THE ACTION ROW, IN SOURCE ORDER — the node tier's
+   * half of the operator's ask ("move reviews + plays below the CTA").
+   *
+   * ⚠️ STRUCTURAL, AND SAY SO. This reads the SOURCE, so it proves the elements are
+   * written in that order, not that they RENDER in it — a `position: absolute` or an
+   * `order:` property would defeat it, and neither is used here. The RENDERED claim
+   * (the rollup's `top` is at or below the row's `bottom`, measured against the real
+   * cascade) lives in `AppListingCard.browser.test.tsx`. This exists because that
+   * tier never blocks anything, while this one at least reddens a `main` push, and
+   * because "the rollup went back into the meta block" is precisely the regression a
+   * source-order check CAN see.
+   *
+   * 🔴 THE ANCHOR IS `mt="auto"`, THE SAME DISCRIMINATOR the prop-ledger test above
+   * and the browser suite's `actionRow()` use — the only bottom-pinned element on
+   * the card. A positional index would have to be re-derived on every insertion.
+   */
+  it('🔴 the stats line (rollup + play count) is written BELOW the action row', () => {
+    const code = cardCode();
+    const row = code.indexOf('mt="auto"');
+    const stats = code.indexOf('data-testid="apps-listing-card-stats"');
+    const rollup = code.indexOf('data-testid="apps-listing-recommend-rollup"');
+    const play = code.indexOf('data-testid="apps-listing-play-count"');
+
+    // Positive controls FIRST — each element must actually be in the (stripped)
+    // source, or every ordering comparison below is between −1 and a real index and
+    // would read as a confident pass or a confusing fail.
+    expect(row, 'no bottom-pinned action row in AppListingCard.tsx').toBeGreaterThan(-1);
+    expect(stats, 'the card renders no stats line').toBeGreaterThan(-1);
+    expect(rollup, 'the card renders no recommend rollup').toBeGreaterThan(-1);
+    expect(play, 'the card renders no play count').toBeGreaterThan(-1);
+
+    expect(
+      stats,
+      'the stats line is written ABOVE the action row. The operator asked for reviews + ' +
+        'plays BELOW the CTA; above it is where the rollup used to live (in the meta block).'
+    ).toBeGreaterThan(row);
+    // …and both stats are INSIDE that line, not scattered.
+    expect(rollup, 'the recommend rollup is outside the stats line').toBeGreaterThan(stats);
+    expect(play, 'the play count is outside the stats line').toBeGreaterThan(stats);
+    // Reviews before plays — the order the operator named.
+    expect(rollup, 'the play count is written before the recommend rollup').toBeLessThan(play);
+
+    // 🔴 THE STATS LINE MUST NOT WRAP. Two stats on one `nowrap` line is what keeps
+    // an off-site card (which omits the play count) the same HEIGHT as an on-site
+    // one, which is the whole licence for `AppListingCardSkeleton` reserving a
+    // single line without knowing the listing's kind.
+    //
+    // 🔴 READ OFF THAT ELEMENT'S **OWN** OPENING TAG, delimited exactly the way the
+    // prop-ledger test above delimits the action row's — and the first version of
+    // this assertion was a 400-character WINDOW around the testid instead, which
+    // is why the delimiting is spelled out here. Measured: flipping this Group to
+    // `wrap="wrap"` left the window green, because the ROLLUP's own nested
+    // `wrap="nowrap"` sits ~60 characters later and satisfied a `toContain`. A
+    // guard that can be satisfied by a NEIGHBOUR's identical prop is reading the
+    // wrong element, not making a weak claim.
+    const open = code.lastIndexOf('<', stats);
+    const close = code.indexOf('>', stats);
+    expect(open, 'no opening tag found for the stats line').toBeGreaterThan(-1);
+    expect(close, 'unterminated opening tag on the stats line').toBeGreaterThan(stats);
+    const tag = code.slice(open, close + 1);
+    // The slice really is the stats line's own tag, not an enclosing element the
+    // index walk landed on — otherwise the assertion below is about something else.
+    expect(tag.startsWith('<Group')).toBe(true);
+    expect(tag).toContain('data-testid="apps-listing-card-stats"');
+    expect(
+      tag,
+      'the stats line is not `wrap="nowrap"`. A wrapped stats line is a SECOND line, ' +
+        'i.e. every card taller than its skeleton inside an h-full grid row.'
+    ).toContain('wrap="nowrap"');
+  });
+
+  /**
+   * 🔴 THE AUTHOR CHIP IS GONE FROM THE CARD'S CODE, not merely unrendered.
+   *
+   * The operator dropped the "by {creator}" line from the store card (2026-09-06).
+   * A `CreatorChip` left in the file but uncalled is the shape that gets wired back
+   * in by the next person who wants a byline, so the component was deleted; this
+   * asserts that rather than trusting it.
+   *
+   * 🔴 READ OFF THE **STRIPPED** SOURCE, and the distinction is load-bearing here
+   * more than anywhere else in this file: `AppListingCard.tsx` deliberately keeps a
+   * docblock NAMING the retired `CreatorChip` and explaining where attribution went.
+   * An unstripped scan would read that prose and report the component present.
+   */
+  it('🔴 the card declares no CreatorChip and links to no user profile', () => {
+    const code = cardCode();
+    const source = fs.readFileSync(path.resolve(__dirname, '../AppListingCard.tsx'), 'utf8');
+
+    // Positive control on the stripper, in BOTH directions: the prose that names the
+    // retired component is in the file and is NOT in the stripped code, so a green
+    // result below is about code rather than about a scan that ate everything.
+    expect(source, 'the tombstone explaining where the author chip went is gone').toContain(
+      'CreatorChip'
+    );
+    expect(code).not.toContain('CreatorChip');
+    expect(code, 'the stripper ate the component itself').toContain(
+      'export function AppListingCard'
+    );
+
+    // The chip's two other fingerprints — the profile href it built, and the
+    // CDN-avatar helper it was the only consumer of on this card.
+    expect(code, 'the card still builds a /user/<name> profile link').not.toContain('/user/');
+    expect(code, 'getEdgeUrl is still imported — it had no other consumer here').not.toContain(
+      'getEdgeUrl'
+    );
+    // `card.creator` itself is STILL read — for the owner test and the menu target —
+    // so this is a rendering change, not a DTO one. Asserted so the absences above
+    // cannot be satisfied by dropping the field entirely.
+    expect(code, 'the card stopped reading card.creator at all — isOwner is now dead').toContain(
+      'card.creator?.id'
+    );
   });
 });
 

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -144,22 +144,34 @@ describe('getRecommendLabel', () => {
 });
 
 /**
- * 🔴 THE PLAY COUNT'S NULL-VS-ZERO RULE — AND THIS IS THE TIER THAT OWNS IT.
+ * 🔴 THE PLAY COUNT'S ABSENCE RULE — AND THIS IS THE TIER THAT OWNS IT.
  *
- * The rule is an OPERATOR OVERRIDE (2026-09-06), not a formatting derivation:
- * `openCount === null` means the number is STRUCTURALLY UNMEASURABLE (an off-site
- * listing's CTA is a third-party `target="_blank"` anchor, so nothing on-platform
- * observes the click), and such a card renders NO play stat at all — a `0` there
- * would read as "nobody has ever used this app" about an app we cannot measure.
- * The mirror is equally deliberate: an ON-SITE listing with a genuine `0` renders
- * "0 plays", because there the zero IS the measurement.
+ * The rule is an OPERATOR OVERRIDE (2026-09-06), not a formatting derivation. TWO
+ * DIFFERENT INPUTS RENDER NOTHING, FOR TWO DIFFERENT REASONS:
+ *   · `null` — STRUCTURALLY UNMEASURABLE. An off-site listing's CTA is a
+ *     third-party `target="_blank"` anchor, so nothing on-platform observes the
+ *     click. There is no number and there never will be one.
+ *   · `0` — MEASURED AND EMPTY. An on-site app nobody has opened yet. The number
+ *     exists and is trustworthy.
+ * The operator chose the SAME rendering for both: "dont show 0 plays (just show
+ * nothing)". Each has its own named case below precisely because they are not the
+ * same fact — a single "falsy → null" test would let a future reader conclude the
+ * zero case is an accident of truthiness.
+ *
+ * ⚠️ THE ZERO CASE IS A REVERSAL, AND THE OLD ASSERTION IS RECORDED RATHER THAN
+ * DELETED. Round 1 of this PR asserted `getPlayCountLabel(0) === '0 plays'` under
+ * the heading "a genuine ZERO is a measurement, not an absence", with the reasoning
+ * that only `null` may be over-nulled. That reasoning is still correct about the
+ * DTO — `cardOpenCount`'s "do not over-null" rule is untouched and must stay — and
+ * was only ever a claim about the DATA, not about what a browsing grid should
+ * print. The inverted assertion below is what the operator asked for.
  *
  * 🔴 IT IS TESTED HERE RATHER THAN ONLY IN THE BROWSER TIER BECAUSE OF WHICH TIER
  * GOES RED. `AppListingCard.browser.test.tsx` renders the real card and asserts the
  * omission end-to-end, but the browser `component` project never blocks anything;
  * the node `unit` project at least reddens a `main` push. Expressing the rule as a
  * pure function is what makes it visible to this tier at all — as JSX
- * (`card.openCount != null && …`) it would be invisible here. (Neither tier gates a
+ * (`card.openCount ? … : null`) it would be invisible here. (Neither tier gates a
  * PR: `lint.yml` marks both `continue-on-error` for `pull_request`. Canonical
  * statement: `appListingCardGeometry.ts`'s header.)
  *
@@ -171,20 +183,46 @@ describe('getRecommendLabel', () => {
  * neither.
  */
 describe('getPlayCountLabel', () => {
-  it('🔴 null → null, so the caller has no number to print', () => {
+  it('🔴 null (UNMEASURABLE — off-site) → null, so the caller prints nothing', () => {
     expect(getPlayCountLabel(null)).toBeNull();
   });
 
-  it('🔴 a genuine ZERO is a measurement, not an absence → "0 plays"', () => {
-    // The mutation this refuses is `if (!openCount) return null`, which collapses
-    // the unmeasurable case and the measured-as-none case into one.
-    expect(getPlayCountLabel(0)).toBe('0 plays');
+  it('🔴 0 (MEASURED AND EMPTY — on-site, never opened) → null: no "0 plays" chip', () => {
+    // ⚠️ THE INVERTED ASSERTION. Round 1 required `'0 plays'` here. Operator
+    // override 2026-09-06: "dont show 0 plays (just show nothing)". The mutant this
+    // refuses is a restoration of that — `if (openCount == null) return null` alone,
+    // which puts the chip back on every on-site app with no plays yet.
+    expect(getPlayCountLabel(0)).toBeNull();
   });
 
-  it('singular at exactly 1, plural either side of it', () => {
+  /**
+   * 🔴 THE BOUNDARY, AND THE REASON IT NEEDS ITS OWN CASE. The absence rule stops
+   * at 0 and nowhere else: 1 is the smallest count that renders. A mutant widening
+   * the guard (`openCount <= 1`, `openCount < 2`) is invisible to the two cases
+   * above and to every large-count fixture below — this is the only fixture that
+   * sits on it.
+   */
+  it('🔴 1 is the smallest count that RENDERS — the absence stops at 0', () => {
+    expect(getPlayCountLabel(1)).toBe('1 play');
+  });
+
+  /**
+   * ⚠️ THE OFF-BY-ONE PLURALISER IS NO LONGER OBSERVABLE, AND THAT IS RECORDED HERE
+   * SO IT IS NOT RE-DERIVED AS A COVERAGE HOLE. Round 1 of this PR killed the mutant
+   * `openCount > 1 ? 'plays' : 'play'` — via `getPlayCountLabel(0) === '0 plays'`,
+   * since `=== 1` and `> 1`-inverted differ ONLY below 1. With the zero case now
+   * returning `null` before the plural is reached, that mutant is EQUIVALENT on the
+   * reachable domain (`openCount >= 1`) and survives a green suite. Re-measured after
+   * the reversal, not assumed.
+   *
+   * No fixture can fix that — an equivalent mutant has no killing input — so the
+   * honest statement is that the `=== 1` spelling is now a readability choice on this
+   * line rather than a behaviour the suite pins. What IS pinned, and what actually
+   * matters, is the BOUNDARY above: 1 renders and 0 does not.
+   */
+  it('singular at exactly 1, plural above it', () => {
     expect(getPlayCountLabel(1)).toBe('1 play');
     expect(getPlayCountLabel(2)).toBe('2 plays');
-    expect(getPlayCountLabel(0)).toBe('0 plays');
   });
 
   it('abbreviates a large count rather than printing separators', () => {

--- a/src/components/Apps/appListingCardGeometry.ts
+++ b/src/components/Apps/appListingCardGeometry.ts
@@ -144,9 +144,11 @@ export const LISTING_ACTION_ROW_PT_PX = 10;
  * "with the recommend rollup moved up into the meta block". The rollup is no
  * longer in the meta block — it is a line of its own BELOW the action row, beside
  * the play count (2026-09-06). The row still holds exactly the CTA and the `⋮`
- * trigger, and it holds them for the *stronger* reason: the rollup is not a
- * sibling of the CTA in either direction now, so no future move of it back "up"
- * can put it in this row without also deleting the stats line.
+ * trigger; what changed is only WHERE the third thing went, and the two children
+ * that remain are what this subtraction is about. That the row really holds two
+ * and only two is asserted rather than described — `AppListingCard.browser.test.tsx`
+ * checks `row.children` has length 2, and that the rollup is in neither the row
+ * nor the meta block.
  */
 export const LISTING_ACTION_ROW_GAP_PX = 10;
 

--- a/src/components/Apps/appListingCardGeometry.ts
+++ b/src/components/Apps/appListingCardGeometry.ts
@@ -62,7 +62,14 @@
  */
 export const LISTING_CARD_COVER_ASPECT_RATIO = '16 / 9';
 
-// ── The meta block (icon + title + creator + rollup) ─────────────────────────
+// ── The meta block (icon + title + badges) ───────────────────────────────────
+//
+// 🔴 THIS HEADING USED TO READ "(icon + title + creator + rollup)" AND BOTH OF
+// THOSE LEFT THE BLOCK IN ONE CHANGE (2026-09-06): the author chip was dropped
+// from the store card entirely, and the recommend rollup moved to its own line
+// BELOW the action row, where it now sits beside the play count. What the block
+// still holds is the app icon, the two-line reserved title, and the two
+// conditional badges (Beta / owner-only Incomplete).
 
 /** The publisher app-icon avatar's edge length, in px (square). */
 export const LISTING_CARD_ICON_SIZE_PX = 40;
@@ -72,12 +79,19 @@ export const LISTING_CARD_ICON_SIZE_PX = 40;
  * the title clamps to.
  *
  * 🔴 THE TWO ARE ONE NUMBER ON PURPOSE. Reserving fewer lines than the clamp
- * allows lets a long title push the creator line down; reserving more leaves dead
- * space under every short one. Because the reservation is a `min-height` and the
- * clamp is a `-webkit-line-clamp`, the rendered title box is exactly this many
- * lines tall for EVERY listing — which is what puts the creator chip at the same
- * y on every card in a row. Splitting these into two literals is precisely the
+ * allows lets a long title push everything under it down; reserving more leaves
+ * dead space under every short one. Because the reservation is a `min-height` and
+ * the clamp is a `-webkit-line-clamp`, the rendered title box is exactly this many
+ * lines tall for EVERY listing. Splitting these into two literals is precisely the
  * drift this module exists to prevent.
+ *
+ * 🔴 WHAT IT ALIGNS IS NARROWER THAN IT WAS — RE-DERIVED, not edited around. This
+ * used to say "which is what puts the creator chip at the same y on every card in
+ * a row". There is no creator chip on the card any more (2026-09-06) and the
+ * recommend rollup left the meta block in the same change, so what the reservation
+ * aligns today is the two conditional badges and the TAGLINE below the block. The
+ * action row and the stats line under it are bottom-pinned by `mt="auto"` and were
+ * never a function of title length, so they are not what this buys.
  */
 export const LISTING_CARD_TITLE_LINES = 2;
 
@@ -122,9 +136,17 @@ export const LISTING_ACTION_ROW_PT_PX = 10;
 /**
  * The gap between the CTA and the `⋮` trigger, in px — Mantine `gap="xs"`.
  *
- * This is what the CTA's width is the row MINUS: with the recommend rollup moved
- * up into the meta block the row holds only those two children, so
- * `cta = row − trigger − gap`.
+ * This is what the CTA's width is the row MINUS: the row holds only those two
+ * children, so `cta = row − trigger − gap`.
+ *
+ * 🔴 THE ARITHMETIC IS UNCHANGED BUT ITS JUSTIFICATION IS NOT, SO READ THIS RATHER
+ * THAN THE SENTENCE IT REPLACED. That sentence said the row holds two children
+ * "with the recommend rollup moved up into the meta block". The rollup is no
+ * longer in the meta block — it is a line of its own BELOW the action row, beside
+ * the play count (2026-09-06). The row still holds exactly the CTA and the `⋮`
+ * trigger, and it holds them for the *stronger* reason: the rollup is not a
+ * sibling of the CTA in either direction now, so no future move of it back "up"
+ * can put it in this row without also deleting the stats line.
  */
 export const LISTING_ACTION_ROW_GAP_PX = 10;
 

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -46,6 +46,7 @@ import type {
   ListingRecommendRollup,
 } from '~/server/schema/blocks/app-listing-read.schema';
 import { EMBEDDED_KIND_LABEL, STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
+import { abbreviateNumber } from '~/utils/number-helpers';
 import type { AppListingStatus } from '~/server/services/blocks/app-listing-status.constants';
 
 /** Kind badge shown on the card face. */
@@ -86,6 +87,53 @@ export function getRecommendLabel(recommend: ListingRecommendRollup, reviewCount
   if (recommend.recommendPct == null) return 'No reviews yet';
   const pct = Math.round(recommend.recommendPct * 100);
   return `${pct}% recommend (${reviewCount.toLocaleString()})`;
+}
+
+/**
+ * Play count → display label (`0 plays` / `1 play` / `12.4k plays`), or `null` when
+ * there is no honest number to print.
+ *
+ * 🔴 `null` IN, `null` OUT — AND THAT IS AN OPERATOR OVERRIDE RECORDED AS A
+ * DECISION, NOT A FORMATTING DERIVATION. `ListingCard.openCount` is `null` exactly
+ * when the count is STRUCTURALLY UNMEASURABLE: an off-site listing's CTA is a
+ * third-party `target="_blank"` anchor, so no on-platform request follows the click
+ * and nothing observes it. The operator's call (2026-09-06) is that such a card
+ * renders NO play stat at all — a `0` there would read as "nobody has ever used
+ * this app" about an app we simply cannot measure. The DTO says the same thing in
+ * two places (`app-listing-read.schema.ts`'s `openCount`, and
+ * `app-listing.service.ts`'s `cardOpenCount`, whose own comment promises "the
+ * renderer omits the stat row"); this function is where that promise becomes code.
+ *
+ * 🔴 THE DECISION LIVES HERE RATHER THAN IN THE COMPONENT ON PURPOSE, and it is the
+ * same reasoning `appListingStatChips.ts` was extracted for. `AppListingCard` is
+ * only covered by the browser `component` project, which is REPORT-ONLY; the node
+ * `unit` project is the one that reddens a `main` push. A null-vs-zero rule
+ * expressed as JSX (`card.openCount != null && …`) would be invisible to the only
+ * tier that ever goes red on its own. Expressed as this function's return type it
+ * is pinned in `__tests__/appListingCardView.test.ts`, and the component is left
+ * with a branch that has nothing to get wrong.
+ *
+ * 🔴 AND `0` IS A REAL ANSWER — the mirror half, equally load-bearing. An ON-SITE
+ * listing nobody has opened yet is a genuine zero (the COALESCE-to-0 reading
+ * `cardOpenCount` documents), so this returns "0 plays" rather than treating a
+ * falsy value as absence. A truthiness test here (`if (!openCount) return null`)
+ * would collapse the two cases and is exactly what the guard below refuses.
+ *
+ * 🔴 ABBREVIATED, NOT `toLocaleString()`-ED, which is a deliberate DIVERGENCE from
+ * `getRecommendLabel` above rather than an inconsistency. A review count is an
+ * exactness claim inside a parenthetical; a play count is a magnitude on a dense
+ * grid tile, where "12.4k" reads at a glance and "12,431" does not.
+ * `abbreviateNumber` is the repo-wide helper for that (`~/utils/number-helpers`) —
+ * what every other public count on the platform renders through — so this is reuse,
+ * not a second formatter.
+ *
+ * Pluralisation reads the RAW value, not the abbreviated string: exactly 1 is
+ * "1 play"; everything else — including 0, and including 1000 (which abbreviates to
+ * "1k") — is "plays".
+ */
+export function getPlayCountLabel(openCount: number | null): string | null {
+  if (openCount == null) return null;
+  return `${abbreviateNumber(openCount)} ${openCount === 1 ? 'play' : 'plays'}`;
 }
 
 /**

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -90,34 +90,56 @@ export function getRecommendLabel(recommend: ListingRecommendRollup, reviewCount
 }
 
 /**
- * Play count → display label (`0 plays` / `1 play` / `12.4k plays`), or `null` when
- * there is no honest number to print.
+ * Play count → display label (`1 play` / `12.4k plays`), or `null` when the card
+ * should print no play stat at all.
  *
- * 🔴 `null` IN, `null` OUT — AND THAT IS AN OPERATOR OVERRIDE RECORDED AS A
- * DECISION, NOT A FORMATTING DERIVATION. `ListingCard.openCount` is `null` exactly
- * when the count is STRUCTURALLY UNMEASURABLE: an off-site listing's CTA is a
- * third-party `target="_blank"` anchor, so no on-platform request follows the click
- * and nothing observes it. The operator's call (2026-09-06) is that such a card
- * renders NO play stat at all — a `0` there would read as "nobody has ever used
- * this app" about an app we simply cannot measure. The DTO says the same thing in
- * two places (`app-listing-read.schema.ts`'s `openCount`, and
- * `app-listing.service.ts`'s `cardOpenCount`, whose own comment promises "the
- * renderer omits the stat row"); this function is where that promise becomes code.
+ * 🔴 TWO DIFFERENT REASONS FOR ABSENCE, ONE SHARED RENDERING — AND THE SHARING IS
+ * AN OPERATOR OVERRIDE, NOT A DERIVATION. Read this before "fixing" either case.
+ *
+ *   · `null` — STRUCTURALLY UNMEASURABLE. An off-site listing's CTA is a
+ *     third-party `target="_blank"` anchor, so no on-platform request follows the
+ *     click and nothing observes it. There is no number, and there never will be
+ *     one for that listing.
+ *   · `0` — MEASURED, AND EMPTY. An on-site listing nobody has opened yet is a
+ *     genuine zero (the COALESCE-to-0 reading `app-listing.service.ts`'s
+ *     `cardOpenCount` documents). The number exists, is trustworthy, and is zero.
+ *
+ * These are NOT the same fact. The DTO keeps them apart deliberately and must keep
+ * doing so — `cardOpenCount`'s "do not over-null" paragraph exists to stop an
+ * on-site row being reported as unmeasurable. What the operator decided
+ * (2026-09-06) is only what the CARD DOES WITH THEM: **both render nothing**.
+ * "dont show 0 plays (just show nothing)" — a `0 plays` chip is noise on a browsing
+ * grid and reads as a verdict on the app rather than as an empty measurement.
+ *
+ * ⚠️ THIS REVERSES THE FIRST ROUND OF THIS PR, WHICH RENDERED "0 plays" FOR AN
+ * ON-SITE ZERO AND ARGUED AT LENGTH THAT IT MUST. That argument was about TRUTH —
+ * a zero is a measurement, not an absence — and it is still correct about the data
+ * model; it was simply not the call to make about the pixels. Recorded here rather
+ * than deleted, because the next reader will otherwise meet the zero case, think it
+ * is a truthiness accident, and "restore" it.
+ *
+ * 🔴 SO THE ZERO CASE IS SPELLED EXPLICITLY (`openCount === 0`) RATHER THAN LEFT TO
+ * `if (!openCount)`. The two are behaviourally identical here and that is exactly
+ * the problem: a bare falsy check reads as an oversight and carries none of the
+ * decision above. The explicit form is a signpost — anyone changing it has to
+ * notice they are changing something someone chose.
+ *
+ * ⚠️ AND BECAUSE IT IS A SIGNPOST, NO TEST CAN DEFEND IT — SAID PLAINLY RATHER THAN
+ * IMPLIED. `if (!openCount) return null` was MEASURED to survive the whole node
+ * suite (it is an equivalent mutant over `number | null`), so the spelling here is
+ * legibility, not a guarded invariant. Do not read the test file as pinning it. What
+ * the tests DO pin is the boundary either spelling produces: `null` → nothing, `0` →
+ * nothing, `1` → "1 play".
  *
  * 🔴 THE DECISION LIVES HERE RATHER THAN IN THE COMPONENT ON PURPOSE, and it is the
  * same reasoning `appListingStatChips.ts` was extracted for. `AppListingCard` is
  * only covered by the browser `component` project, which is REPORT-ONLY; the node
- * `unit` project is the one that reddens a `main` push. A null-vs-zero rule
- * expressed as JSX (`card.openCount != null && …`) would be invisible to the only
- * tier that ever goes red on its own. Expressed as this function's return type it
- * is pinned in `__tests__/appListingCardView.test.ts`, and the component is left
- * with a branch that has nothing to get wrong.
- *
- * 🔴 AND `0` IS A REAL ANSWER — the mirror half, equally load-bearing. An ON-SITE
- * listing nobody has opened yet is a genuine zero (the COALESCE-to-0 reading
- * `cardOpenCount` documents), so this returns "0 plays" rather than treating a
- * falsy value as absence. A truthiness test here (`if (!openCount) return null`)
- * would collapse the two cases and is exactly what the guard below refuses.
+ * `unit` project is the one that reddens a `main` push. A rule expressed as JSX
+ * (`card.openCount ? … : null`) would be invisible to the only tier that ever goes
+ * red on its own. Expressed as this function's return type it is pinned in
+ * `__tests__/appListingCardView.test.ts` — with `null`, `0` and `>0` as three
+ * separately-named cases — and the component is left with a branch that has nothing
+ * to get wrong.
  *
  * 🔴 ABBREVIATED, NOT `toLocaleString()`-ED, which is a deliberate DIVERGENCE from
  * `getRecommendLabel` above rather than an inconsistency. A review count is an
@@ -128,11 +150,14 @@ export function getRecommendLabel(recommend: ListingRecommendRollup, reviewCount
  * not a second formatter.
  *
  * Pluralisation reads the RAW value, not the abbreviated string: exactly 1 is
- * "1 play"; everything else — including 0, and including 1000 (which abbreviates to
- * "1k") — is "plays".
+ * "1 play"; everything else — including 1000, which abbreviates to "1k" — is
+ * "plays". (0 no longer reaches the plural at all, but the branch is written for
+ * the value rather than for the reachable set, so it stays correct if the zero
+ * decision is ever reversed back.)
  */
 export function getPlayCountLabel(openCount: number | null): string | null {
-  if (openCount == null) return null;
+  // Both arms are absence-on-screen; they are NOT the same fact. See above.
+  if (openCount == null || openCount === 0) return null;
   return `${abbreviateNumber(openCount)} ${openCount === 1 ? 'play' : 'plays'}`;
 }
 

--- a/src/server/metrics/appListing.metrics.ts
+++ b/src/server/metrics/appListing.metrics.ts
@@ -111,13 +111,20 @@ type AffectedListing = { id: string; appBlockId: string | null };
 // AppBlock was deleted" would misfire on ordinary off-site rows. Full statement of
 // both populations is on `AFFECTED_APPROVED_LISTINGS_SQL`.
 //
-// 🔴 `open_count` HAS NO READER AT THIS REF — its consumer lands in STAGE 3. The
-// rule below ("populate with the PR that ships its consumer") is real and this
-// column is a deliberate, argued exception to it, not an oversight and not a
+// ✅ `open_count` NOW HAS ITS READER, END TO END — this paragraph is re-derived, and
+// it was ALREADY stale before the change that rewrote it. It said "`open_count` HAS
+// NO READER AT THIS REF — its consumer lands in STAGE 3", which stopped being true
+// when stage 3 (#4659) projected the column onto the public card DTO
+// (`cardOpenCount`), and stage 4 then made it VISIBLE: `AppListingCard` renders it
+// through `getPlayCountLabel` as the store card's play count.
+//
+// What survives unchanged is the reason the column was populated ahead of its reader
+// at all: the rule below ("populate with the PR that ships its consumer") is real and
+// this column was a deliberate, argued exception to it — not an oversight and not a
 // precedent. The argument in full — trusted server-side source + a derived,
 // idempotent value with no accumulating state and no backfill — is on the SCOPE
 // block in appListing.metrics.sql.ts. Read it before citing this file to populate
-// anything else.
+// anything else; the exception is now spent, not widened.
 //
 // NOT POPULATED (left at their schema default 0 — no reader today, and each maps
 // to a feature that isn't live): `connect_count` (off-site OAuth-connect grants —

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -104,9 +104,7 @@ export const listAllListingsForModerationSchema = z.object({
   cursor: z.string().min(1).max(64).optional(),
   limit: z.number().int().min(1).max(50).default(25),
 });
-export type ListAllListingsForModerationInput = z.infer<
-  typeof listAllListingsForModerationSchema
->;
+export type ListAllListingsForModerationInput = z.infer<typeof listAllListingsForModerationSchema>;
 
 /** Detail lookup by EXACTLY ONE of slug or id (approved listings only). */
 export const getAppListingDetailSchema = z
@@ -246,7 +244,7 @@ export type ListingCard = {
    * 🔴 `null` IS NOT `0`, AND THE DIFFERENCE IS A TRUTH CLAIM RATHER THAN A STYLE ONE.
    * An OFF-SITE listing's CTA is a plain `target="_blank"` anchor to a third party, so
    * no on-platform request follows the click and there is nothing trustworthy to count.
-   * Its play count is ABSENT, not zero — the renderer omits the stat row entirely for
+   * Its play count is ABSENT, not zero — the renderer omits the stat entirely for
    * `null`, whereas a `0` would render as "nobody has ever used this app", a false
    * statement about an app we simply cannot measure. `app_listing_metrics.open_count`
    * is `Int NOT NULL DEFAULT 0`, so an off-site row DOES carry a literal `0` in the
@@ -257,8 +255,20 @@ export type ListingCard = {
    * genuine `0` and must stay `0`. A missing metric row means "no plays recorded yet",
    * which is 0 — the same COALESCE-to-0 reading `installCount` documents.
    *
-   * Reads `0` for every on-site listing until the rollup that populates `open_count`
-   * ships and the events feeding it exist.
+   * ✅ THE RENDERER EXISTS AND THE ROLLUP FEEDS IT — a re-derivation, because the
+   * sentence that used to close this block ("Reads `0` for every on-site listing until
+   * the rollup that populates `open_count` ships and the events feeding it exist") was
+   * true when written and is now false in both halves. `6ff42aed42` records the
+   * App_Open events and `f9f81dcfb5` derives `open_count` from them; the store card
+   * (`AppListingCard` → `getPlayCountLabel`) is what turns the `null` above into an
+   * omitted stat and a number into "N plays". The `null`-vs-`0` distinction this block
+   * describes is therefore live behaviour, not a forward promise.
+   *
+   * ⚠️ Still NOT claimed: that the rollup has already covered any particular listing
+   * in any particular environment. That is a fact about a scheduled job. A listing the
+   * job has not yet reached reads a `0` that is correct by the rule above and stale in
+   * substance; the count is derived all-time on each run, so it self-corrects rather
+   * than needing a backfill.
    */
   openCount: number | null;
   kindData: ListingCardKindData;

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -313,19 +313,36 @@ function cardKindData(row: HydratedListing): ListingCardKindData {
  * `__tests__/app-listing.service.test.ts`; every other fixture there is onsite/offsite
  * and cannot tell this form apart from the fail-OPEN `=== 'offsite'` one.
  *
- * 🔴 MERGE-ORDER CONSTRAINT — READ BEFORE SHIPPING THE RENDERER (Stage 4).
- * NOTHING WRITES `open_count` YET. `appListing.metrics.sql.ts` populates `install_count`
- * only — its own suite asserts `expect(upsert).not.toContain('open_count')` — and no
- * other writer exists, so this function returns a literal `0` for EVERY on-site listing
- * in production today. The DTO has no third state for "measurable but not yet
- * measured": `null` means unmeasurable and `0` means measured-as-none, and the honest
- * answer right now is neither.
+ * ✅ MERGE-ORDER CONSTRAINT — DISCHARGED. THIS PARAGRAPH IS RE-DERIVED, NOT EDITED
+ * AROUND, SO READ IT RATHER THAN THE ONE IT REPLACES.
  *
- * So the renderer MUST NOT merge before the rollup that populates the column (#4653),
- * or must gate the rendered stat row behind a flag until it lands. Shipping it first
- * makes the public `/apps` grid print "0 plays" on every on-site app INCLUDING heavily
- * used ones — by this field's own written standard the worst outcome available, and on
- * the public surface. The flag is deliberately NOT built here.
+ * It used to open "🔴 READ BEFORE SHIPPING THE RENDERER (Stage 4). NOTHING WRITES
+ * `open_count` YET. `appListing.metrics.sql.ts` populates `install_count` only — its
+ * own suite asserts `expect(upsert).not.toContain('open_count')`", and it required the
+ * renderer either to wait for #4653 or to ship behind a flag, on the grounds that a
+ * premature renderer would print "0 plays" on every on-site app INCLUDING heavily used
+ * ones — by this field's own standard the worst outcome available, and on a public
+ * surface.
+ *
+ * Every clause of that is now false, checked rather than assumed:
+ *   · #4653 IS MERGED (`f9f81dcfb5`, "derive app_listing_metrics.open_count from
+ *     App_Open events"), and #4652 before it (`6ff42aed42`) ships the App_Open events
+ *     it derives from;
+ *   · `appListing.metrics.sql.ts` names `open_count` in its INSERT and ON CONFLICT
+ *     lists, and the suite assertion quoted above has INVERTED — the same file now
+ *     asserts `toContain('COALESCE(oc."open_count", 0)')` and
+ *     `toContain('"open_count" = EXCLUDED."open_count"')`;
+ *   · the count is DERIVED from an all-time read on every rollup run rather than
+ *     accumulated, so there is no backfill step gating correctness — a listing's
+ *     number becomes right the first time the job covers it.
+ *
+ * The renderer (stage 4) therefore ships unflagged, and the flag this paragraph
+ * declined to build is still not built and is no longer wanted.
+ *
+ * ⚠️ WHAT IS **NOT** CLAIMED HERE: that the rollup has already RUN over the whole
+ * catalog in any given environment. That is an operational fact about a scheduled
+ * job, not a property of this code — an on-site listing whose row the job has not yet
+ * covered reads a truthful-by-the-DTO's-rule `0` until it does.
  */
 function cardOpenCount(row: HydratedListing): number | null {
   if (row.kind !== 'onsite') return null;


### PR DESCRIPTION
Stage **4 of 4** of the `apps-listing-play-count` arc, and the operator's original ask, verbatim: **drop the author chip**, and **move reviews + plays below the CTA**.

Stages 1–3 are on `main` — `6ff42aed42` (record App_Open events), `f9f81dcfb5` (derive `app_listing_metrics.open_count`), `19210f04ad` (project `openCount` onto the card DTO). This is the renderer.

Based directly on `main`. Not stacked.

---

## What changed, and why

### 1. The author chip is gone from the store card
`CreatorChip` is **deleted**, not left uncalled — an exported-but-uncalled component is the shape that gets wired back in by the next person who wants a byline. Grepped before deleting: it was **not** shared. `AppListingDetailBody` declares its own local `CreatorChip` over `ListingDetail['creator']`, and `AppDetailsModal` / `appDetailAuthorView` only mention the name in prose while rendering their own attribution. **Nothing on the detail side is touched**; a `/apps` shopper still reaches the author in one click, because the card title links to the detail.

`ListingCard.creator` stays on the DTO and is still read for `isOwner` and the `⋮` menu target, so this is a rendering change, not a schema one — asserted, so the new absence guards can't be satisfied by dropping the field.

### 2. Reviews + plays are one line **below** the action row
The recommend rollup leaves the meta block; the play count renders beside it on the same `wrap="nowrap"` flex line. `mt="auto"` stays on the action row, which now bottom-pins a **pair** rather than being the stack's last child.

### 3. The play count renders **only for a count of one or more**

🔴 **This is a recorded OPERATOR OVERRIDE, not a derivation from anything.** Two inputs render nothing, and they are **not the same fact**:

- **`openCount === null` — structurally unmeasurable.** An off-site listing's CTA is a third-party `target="_blank"` anchor, so no on-platform request follows the click. There is no number and there never will be one.
- **`openCount === 0` — measured, and empty.** An on-site app nobody has opened yet. The number exists and is trustworthy.

The DTO keeps these apart deliberately and must keep doing so — `cardOpenCount`'s "do not over-null" rule is untouched. What the operator decided is only **what the card does with them: both render nothing.**

⚠️ **THIS REVERSES ROUND 1 OF THIS PR**, which rendered `"0 plays"` for an on-site zero and argued at length that it must. Operator, 2026-09-06: *"dont show 0 plays (just show nothing)."* The earlier argument — a zero is a measurement, not an absence — is still correct about the **data** and was only ever wrong about the **screen**. It is recorded in `getPlayCountLabel`'s docstring rather than deleted, because the next reader will otherwise meet the zero case, read it as a truthiness accident, and "restore" it. **On screen the zero case is now deliberately indistinguishable from the off-site case.**

The zero is spelled `openCount === 0`, not `!openCount`, as a signpost. ⚠️ **Measured, and stated in the docstring rather than implied: the bare-falsy form is an EQUIVALENT mutant and survives the entire node suite.** The spelling is legibility, not a guarded invariant. What the tests *do* pin is the boundary either spelling produces.

The rule lives in a pure function (`getPlayCountLabel`) rather than in the JSX, for the reason `appListingStatChips.ts` was extracted: the component is covered only by the report-only browser tier, while the pure view-model is covered by the node `unit` tier that reddens a `main` push. As JSX the rule would be invisible to the only tier that ever goes red on its own.

---

## 🔴 The lockstep files, because this is not a one-component change

`AppListingCardSkeleton` explicitly reserved a **creator line** and a **rollup line** in the meta block, and its docstring said it was calibrated "exact for" a card *with* a creator. Both had to move or the grid visibly reflows the moment the query resolves:

- the `apps-listing-skeleton-creator` line is **deleted**;
- the `apps-listing-skeleton-rollup` line **moves below the action row**, keeping its testid;
- `MetaLineSkeleton`'s now-unsupplied `fw` prop is dropped (it existed for the `sm` creator line).

**Two structural walks broke and are retargeted — this is a real break, not a refactor.** Both `ctaWidths()` (`AppListingCardSkeleton.geometry.test.tsx`) and `cardPartsOf()` (`AppListingsMarketplaceBody.stretch.geometry.test.tsx`) walked to the card stack's **last** child on the premise that the action row is last. The stats line now is, so both would have thrown on every call. Both now key on `mt="auto"` — the same discriminator the browser suite's `actionRow()` and the node prop-ledger already use, and one that survives the next insertion. `cardPartsOf`'s "is the LAST child" validation is replaced by "**exactly one** `mt="auto"` child" (two auto margins would split the free space and silently unpin the row) plus "something is above it" (which is what the file's non-vacuity control needs).

**No new geometry constant was added**, so `appListingCardGeometry`'s export count stays 9 and the skeleton's exact-import set is unchanged. The play count costs no height because it shares the rollup's line.

---

## Comments re-derived (a comment is a claim)

Each of these was made false by this change — or was already false — and is re-derived rather than edited around:

| File | Claim that is now false | What it says now |
|---|---|---|
| `appListingCardGeometry.ts` | `LISTING_ACTION_ROW_GAP_PX`: *"with the recommend rollup moved up into the meta block the row holds only those two children"* | Arithmetic `cta = row − trigger − gap` **unchanged**; the justification is now "the rollup is a line **below** the row", which is strictly stronger |
| `appListingCardGeometry.ts` | Section heading *"The meta block (icon + title + creator + rollup)"* | `(icon + title + badges)` |
| `appListingCardGeometry.ts` | `LISTING_CARD_TITLE_LINES`: *"puts the creator chip at the same y on every card in a row"* | The reservation now aligns the **badges and the tagline**. The action row and stats line are bottom-pinned by `mt="auto"` and were never a function of title length — so they are **not** what it buys |
| `AppListingCard.tsx` (4 sites) | header ¶, the `@container` note, the rollup note, the action-row note | Rewritten for the new position; the two moves the rollup has made are recorded, because each deleted apparatus (min-width floor, `@[264px]` query, threshold constant) that must not come back |
| `AppListingCardSkeleton.tsx` | *"CONTENT VARIANCE, WHICH RUNS IN **BOTH** DIRECTIONS"* + the −22.29px / −22.30px creator shortfall | The **downward** axis is **gone** — a `creator: null` listing is now exactly its skeleton. Three upward axes remain (tagline, Beta, Incomplete) |
| `AppListingCardSkeleton.tsx` | *"a HYDRATION MISMATCH … EXACTLY 16 times: 8 cells × the two meta lines each"* | ⚠️ **Flagged, not silently corrected.** One `MetaLineSkeleton` per cell now, so the same arithmetic gives 8. **Nobody re-ran that mutation** — the browser tiers do not run on this box. 8 is arithmetic; 16 was the measurement. The guard itself is `toBe(0)`, so its strength does not depend on the count |
| `app-listing.service.ts` | 🔴 *"MERGE-ORDER CONSTRAINT — READ BEFORE SHIPPING THE RENDERER (Stage 4). NOTHING WRITES `open_count` YET … its own suite asserts `expect(upsert).not.toContain('open_count')`"* | **Discharged, clause by clause.** #4653 (`f9f81dcfb5`) is merged and #4652 (`6ff42aed42`) supplies the events; `appListing.metrics.sql.ts` names `open_count` in its INSERT and ON CONFLICT lists; **the quoted suite assertion has inverted** — the same file now asserts `toContain('COALESCE(oc."open_count", 0)')`. The flag it declined to build is still not built and is no longer wanted |
| `app-listing-read.schema.ts` | *"Reads `0` for every on-site listing until the rollup … ships and the events feeding it exist"* | Both shipped; the renderer named |
| `appListing.metrics.ts` | *"`open_count` HAS NO READER AT THIS REF — its consumer lands in STAGE 3"* | Was **already stale before this PR** (stage 3 landed the DTO projection). Now: reader exists end to end, and the "populate ahead of the consumer" exception is *spent*, not widened |

⚠️ **What is deliberately NOT claimed** in any of the above: that the rollup job has already **run** over the catalog in any environment. That is an operational fact about a scheduled job, not a property of this code. A listing the job has not reached reads a `0` that is correct by the DTO's own rule and stale in substance; the count is derived all-time per run, so it self-corrects without a backfill.

---

## The guard that had to go red — retargeted, not loosened

`AppListingCard.browser.test.tsx`'s `🔴 the rollup renders in the meta block and NOT in the action row` exists **specifically** so a change moving the rollup out of the meta block cannot be papered over. This change *is* that move, so it went red **by design**.

It is now `🔴 the rollup renders BELOW the action row — not in it, and not in the meta block`, asserting a strictly stronger invariant:

- **positive control first**, using the same `querySelector(ROLLUP_SELECTOR)` call from the card root, so a `null` from either container is a real read;
- **two absences, two distinct messages** ("back in the META BLOCK" / "inside the ACTION ROW"), so a mutant rendering it in both places fails naming *which* place;
- exactly **one** in the document — not zero (vacuous) and not two;
- a **position** claim a containment check cannot make: `rollup.top >= row.bottom`;
- **the CTA remains the strict-mode barrier**, not the rollup's own text, for the reason the existing comments give — a double-render would otherwise throw at the locator and go red for the wrong reason;
- **plus a new bottom-alignment assertion**, because `mt="auto"` now pins a pair: the stats line ends flush with the card body's content box. Without it, "the row is at the bottom" would be inherited from before the move rather than measured.

The meta-block locator is unchanged — it walks structurally (title `<a>` → `anchor.parentElement`), which is exactly what that design bought.

**New coverage added:** play count renders for a listing with plays (`4821` → `4.8k plays`) *on the same line* as the rollup; `openCount: 0` renders **no** play-count node; `openCount === null` renders **no** play-count node; the author chip is gone (no `/user/` link, no `by <name>` text);

🔴 **Both absence tests carry a positive control on the SAME selector in the SAME render** — each lays a `>0` card beside the absent one and proves `PLAY_COUNT_SELECTOR` matches the former before believing the `null` from the latter. That is a change forced by the reversal, not a style choice: with **two of three** inputs now rendering nothing, `querySelector(...) === null` is what a *broken selector* looks like as well as what correct behaviour looks like, and leaning on a sibling test having shown the selector works is not a control once most fixtures produce nothing. The null-arm test additionally asserts the **stats line itself is still present**, so "no play count" cannot be satisfied by a card that rendered no stats line at all (which would be a height regression, not the behaviour under test). an **off-site** card is exactly its skeleton's box (the "omitting the play count costs no height" claim, measured rather than promised); a `creator: null` card is exactly its skeleton (the retargeted downward-axis test).

Two tests were **deleted with their subjects**, each with a tombstone saying so: the S5 author-line typography assertion (including its accepted 4.73 contrast residual, which now lives on the detail surfaces, not here — *the deletion is not a fix*), and the long-username tooltip test (the `TruncatedText` overflow gate is still exercised by the title's own tooltip test).

---

## Verification matrix — read the tier column

| Tier | Ran here? | Result |
|---|---|---|
| node `unit`, `src/components/Apps/__tests__/` | ✅ | 71 files / **1561 passed** (baseline on `main`: 71 / 1554) |
| node `unit`, + `src/server/metrics/__tests__/` + `src/server/services/blocks/__tests__/` | ✅ | 241 files / **5519 passed** |
| node `unit`, **whole project** | ✅ | 1648 files / **38327 passed**, 3 skipped |
| `pnpm typecheck` | ✅ | `typecheck: OK — 0 type errors` (the tool's own marker, not a grep) |
| prettier (12 changed files, explicit args) | ✅ | `All matched files use Prettier code style!` — after 3 files needed `--write` |
| eslint (12 changed files) | ✅ | `--format json`: **12 files linted, 0 messages** (count, not exit code) |
| browser `component` (`*.browser.test.tsx`) | ❌ **CANNOT RUN ON THIS BOX** | see below |
| `geometry` (`*.geometry.test.tsx`) | ❌ **CANNOT RUN ON THIS BOX** | see below |

🔴 **The browser tiers were not run, and I am not claiming they pass.** Control established against an **unmodified** spec before attributing anything: `npx vitest run --project component src/components/Apps/AppListingCard.browser.test.tsx` on `origin/main`'s copy fails with

```
browserType.launch: Executable doesn't exist at
/nix/store/…-playwright-browsers/chromium_headless_shell-1200/chrome-headless-shell-linux64/chrome-headless-shell
```

i.e. nix ships a different headless-shell revision than this Playwright wants. That is an environment fault, not a fault in this change. **CI was therefore the first execution of every browser/geometry edit in this PR** — the retargeted rollup guard, the bottom-alignment assertion, the three play-count tests, the author-chip absence test, the retargeted tagline-alignment test, the off-site parity test, and both retargeted structural walks.

### ✅ CI has now run them, and the result is read at STEP level, not from the check conclusion

`Geometry tests` is `continue-on-error: ${{ github.event_name == 'pull_request' }}`, so its **job conclusion is not evidence** — `lint.yml:377` warns about exactly this. Read from the API instead:

```
JOB: Geometry tests => success
    step: Install Chromium for Playwright                     => success
    step: Geometry tests                                      => success
    step: Assert the geometry tier actually collected something => success   <- positive control
JOB: Unit tests (1..4) => success
    step: Unit tests                        => success
    step: Assert this shard actually ran tests => success                    <- positive control
```

and the Tekton commit status carries its own content, not just a state:

```
preview / component-tests => success :: "Component suite passed (report-only)"
preview / auth-tests      => success :: "Auth suites passed (report-only)"
tekton / typecheck        => success :: "typecheck passed (tsc --noEmit …)"
```

So the `geometry` project (both retargeted structural walks, the retargeted creator test, the new off-site parity test) and the `component` project (the retargeted rollup guard, the bottom-alignment assertion, the play-count trio, the author-chip absence test, the retargeted tagline-alignment test) **both executed and passed**.

**Rollup: 19 rows, 18 SUCCESS + 1 SKIPPED, 0 red; `mergeStateStatus: CLEAN`.** Noted plainly: that is 19, not the 20 rows this repo's rollup was expected to settle at — one context this PR's file set evidently does not trigger. Every registered row is terminal and none is red.

🔴 **Still NOT claimed: that the browser-tier guards would go RED under mutation.** They are green; their killing power is unverified, because the mutation battery could only be run against the node tier.

### Mutation checks — node tier only, each observed with **that guard's own message**

| # | Mutation | Result |
|---|---|---|
| M1 | `getPlayCountLabel`: `if (openCount == null)` → `if (!openCount)` | **KILLED** — `🔴 a genuine ZERO is a measurement…`: `expected null to be '0 plays'` |
| M2 | plural from `abbreviateNumber(openCount) === '1'` | **SURVIVED — and it is an EQUIVALENT MUTANT**, reported rather than hidden: `abbreviateNumber(x) === '1'` iff `x === 1`, so it changes no behaviour. Replaced with M2b rather than counted as a hole |
| M2b | plural from `parseFloat(abbreviateNumber(openCount)) === 1` | **KILLED** — and by **exactly one** test, `🔴 1000 is "1k plays"…`: `expected '1k play' to be '1k plays'`. That fixture exists for this mutant and nothing below 1000 can see it |
| M3 | off-by-one pluraliser `openCount > 1 ? 'plays' : 'play'` | **KILLED** — `expected '0 play' to be '0 plays'` |
| M4 | drop `abbreviateNumber`, use `toLocaleString()` | **KILLED** — `expected '4,821 plays' to be '4.8k plays'` |

#### Re-run after the zero reversal (round 2)

| # | Mutation | Result |
|---|---|---|
| **R1** | **restore the reverted behaviour** — guard on `openCount == null` alone, so `0` prints `"0 plays"` again | 🔴 **KILLED** — `🔴 0 (MEASURED AND EMPTY — on-site, never opened) → null: no "0 plays" chip`: `expected '0 plays' to be null`. This is precisely the change the operator reversed, so it is the one most likely to be re-introduced |
| R2 | widen the guard to `openCount <= 1` | **KILLED** — `🔴 1 is the smallest count that RENDERS — the absence stops at 0`: `expected null to be '1 play'`. The boundary case added in this round is the only fixture that can see it |
| R3 | `openCount === 0` → bare `!openCount` | **SURVIVED — EQUIVALENT MUTANT**, reported rather than hidden. Identical behaviour over `number \| null`; the explicit spelling is a signpost the suite cannot defend, and the docstring now says so |
| M2b, M4 | re-run under the new rule | still **KILLED**, same messages |
| M3 (off-by-one pluraliser) | re-run under the new rule | **SURVIVED — now EQUIVALENT.** `=== 1` and `> 1`-inverted differ only *below* 1, and 0 no longer reaches the plural. Round 1 killed it via `getPlayCountLabel(0) === '0 plays'`, which no longer exists. **A consequence of the reversal, not a weakened test** — no fixture can kill an equivalent mutant. Recorded beside the test so it is not re-derived as a coverage hole |
| M5 | stats line `wrap="nowrap"` → `wrap="wrap"` | **SURVIVED on the first version of the guard.** My assertion read a 400-char *window* around the testid and matched the **nested rollup Group's own** `wrap="nowrap"` ~60 chars later. Fixed to delimit that element's own opening tag (the way the action-row prop ledger does), then **KILLED** — `the stats line is not \`wrap="nowrap"\`…` |
| M6 | relocate the whole stats block above the action row | **KILLED** — `the stats line is written ABOVE the action row…`: `expected 7756 to be greater than 8788` |
| M7 | re-add a `/user/<name>` byline to the card | **KILLED** — `the card still builds a /user/<name> profile link` |

Both mutated files were restored from `cp` backups and verified **byte-identical by sha256** afterwards.

🔴 **What this battery does NOT cover:** every guard in the two browser tiers. Their mutation status is **unknown**, because they cannot be executed here. That includes the retargeted rollup guard — the headline test of this PR.

---

## Judgment calls the operator may want to overrule

1. **Icon for the play count**: `IconPlayerPlay` at 13px, dimmed — the same glyph the on-site "Open" CTA carries. Semantically consistent ("plays"), but it does put that glyph on the card twice.
2. **Wording**: `"4.8k plays"` / `"1 play"`. Abbreviated via the repo-wide `abbreviateNumber`, a deliberate divergence from `getRecommendLabel`'s `toLocaleString()` — a review count is an exactness claim inside a parenthetical, a play count is a magnitude on a dense tile. (`"0 plays"` no longer exists — see §3.)
3. **Order and separation**: reviews first, then plays, `gap="sm"` between them, both `size="xs"` dimmed — matching the rollup's previous treatment. No separator dot.
4. **Card height moves.** Removing the author line takes ~22px off; the rollup relocating from the meta stack (`gap={2}`) to the outer stack (`gap="sm"`) adds ~10px. Net: cards are shorter than on `main`. Skeleton parity is preserved by construction and asserted, but the store grid's *row height* changes — a visual review at 4 and 5 columns is worth a look before merge.

## Out of scope, deliberately

`buildListingDetailPreview`'s `installCount: 0` is a false zero of the same class as the `openCount` one the arc already fixed. It is inert on both consumers (`buildListingStatChips` returns `[]` under `preview`, and the detail rail's install row is `!opts.preview`-gated) and its own comment says to fix it with a reader rather than speculatively. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
