### PR TITLE
fix(image-scan): supply NOT NULL columns when creating scan tags

### DIFF
--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import handler from '~/pages/api/webhooks/image-scan-result';
+import { processImageScanWorkflow } from '~/server/services/image-scan-result.service';
 import type * as ClickhouseClient from '~/server/clickhouse/client';
 import { TagSource, ImageIngestionStatus } from '~/shared/utils/prisma/enums';
 import { NsfwLevel } from '~/server/common/enums';
@@ -551,6 +552,46 @@ describe('image-scan-result webhook - pipeline tests', () => {
     const updateForImage7 = dbUpdates.find((call: any) => call[0].where.id === 7);
     expect(updateForImage7).toBeDefined();
     expect(updateForImage7[0].data.nsfwLevel).toBeUndefined(); // locked, so undefined (not updated)
+  });
+
+  it('creates a never-before-seen tag with the columns the Tag table requires', async () => {
+    const passthrough = mockDbWrite.$queryRaw.getMockImplementation();
+    let tagInsert: { text: string; params: any[] } | undefined;
+
+    mockDbWrite.$queryRaw.mockImplementation(async (query: any, ...values: any[]) => {
+      const strings = Array.isArray(query) ? query : query.strings;
+      if (!strings.join('').includes('INSERT INTO "Tag"')) return passthrough(query, ...values);
+
+      tagInsert = renderSql(strings, values);
+      // `Tag.updatedAt` and `Tag.target` are NOT NULL with no database default, so an
+      // insert omitting either raises 23502 instead of returning a row.
+      for (const column of ['"updatedAt"', 'target']) {
+        if (!tagInsert.text.includes(column))
+          throw new Error(`Raw query failed. Code: \`23502\`. "Tag" insert omits ${column}`);
+      }
+      return [{ id: 999, name: 'never seen tag', nsfwLevel: 1, type: 'UserGenerated' }];
+    });
+
+    await processImageScanWorkflow({
+      workflowId: 'workflow-with-an-unseen-tag',
+      status: 'succeeded',
+      imageId: 9,
+      steps: [
+        {
+          $type: 'wdTagging',
+          output: { tags: { 'never seen tag': 0.9 }, rating: { general: 0.9 } },
+        },
+        { $type: 'mediaRating', output: { nsfwLevel: 'pg', isBlocked: false } },
+        { $type: 'mediaHash', output: { hashes: { perceptual: '6F51B11C49611E0E' } } },
+      ] as any,
+    });
+
+    expect(tagInsert?.text).toContain('"updatedAt"');
+    expect(tagInsert?.text).toContain('target');
+    expect(tagInsert?.params.some((param) => param instanceof Date)).toBe(true);
+
+    const written = mockInsertTagsOnImageNew.mock.calls.flatMap((call) => call[0]);
+    expect(written.some((tag: any) => tag.imageId === 9 && tag.tagId === 999)).toBe(true);
   });
 
   describe('webhook body strings never reach SQL text', () => {

--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -636,6 +636,47 @@ describe('image-scan-result webhook - pipeline tests', () => {
       expect(stamped).toBeDefined();
     });
 
+    it('leaves a hard-blocked image Blocked rather than flipping it back to Error', async () => {
+      const passthrough = mockDbWrite.$queryRaw.getMockImplementation();
+      mockDbWrite.$queryRaw.mockImplementation(async (query: any, ...values: any[]) => {
+        const strings = Array.isArray(query) ? query : query.strings;
+        if (strings.join('').includes('INSERT INTO "Tag"'))
+          throw new Error('Raw query failed. Code: `23502`.');
+        return passthrough(query, ...values);
+      });
+
+      await expect(
+        processImageScanWorkflow({
+          workflowId: 'workflow-blocked-then-failing',
+          status: 'succeeded',
+          imageId: 13,
+          steps: [
+            {
+              $type: 'wdTagging',
+              output: { tags: { 'a tag that cannot be created': 0.9 }, rating: { general: 0.9 } },
+            },
+            {
+              $type: 'mediaRating',
+              output: { nsfwLevel: 'xxx', isBlocked: true, blockedReason: 'CSAM' },
+            },
+          ] as any,
+        })
+      ).resolves.toBeUndefined();
+
+      // blockImageFromRating already persisted Blocked. markImageScanError is
+      // unconditional, so running it here would un-block the image.
+      const blocked = mockDbWrite.image.updateMany.mock.calls.find(
+        (call: any) => call[0].where.id === 13
+      );
+      expect(blocked?.[0].data.ingestion).toBe(ImageIngestionStatus.Blocked);
+
+      const errorFlips = mockDbWrite.$queryRaw.mock.calls.filter((call: any) => {
+        const strings = Array.isArray(call[0]) ? call[0] : call[0]?.strings ?? [];
+        return strings.join('').includes("'{retryCount}'");
+      });
+      expect(errorFlips).toHaveLength(0);
+    });
+
     it('still surfaces a deleted image so the webhook can ACK it as skipped', async () => {
       mockDbWrite.image.findUnique.mockResolvedValue(null);
 

--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -563,8 +563,7 @@ describe('image-scan-result webhook - pipeline tests', () => {
       if (!strings.join('').includes('INSERT INTO "Tag"')) return passthrough(query, ...values);
 
       tagInsert = renderSql(strings, values);
-      // `Tag.updatedAt` and `Tag.target` are NOT NULL with no database default, so an
-      // insert omitting either raises 23502 instead of returning a row.
+      // Model the real 23502: both columns are NOT NULL with no DB default.
       for (const column of ['"updatedAt"', 'target']) {
         if (!tagInsert.text.includes(column))
           throw new Error(`Raw query failed. Code: \`23502\`. "Tag" insert omits ${column}`);
@@ -592,6 +591,90 @@ describe('image-scan-result webhook - pipeline tests', () => {
 
     const written = mockInsertTagsOnImageNew.mock.calls.flatMap((call) => call[0]);
     expect(written.some((tag: any) => tag.imageId === 9 && tag.tagId === 999)).toBe(true);
+  });
+
+  describe('a throw while the image is still Pending', () => {
+    const scanSteps = (tag: string) =>
+      [
+        { $type: 'wdTagging', output: { tags: { [tag]: 0.9 }, rating: { general: 0.9 } } },
+        { $type: 'mediaRating', output: { nsfwLevel: 'pg', isBlocked: false } },
+        { $type: 'mediaHash', output: { hashes: { perceptual: '6F51B11C49611E0E' } } },
+      ] as any;
+
+    it('terminalizes to Error with a bumped retryCount instead of leaving it Pending', async () => {
+      const passthrough = mockDbWrite.$queryRaw.getMockImplementation();
+      let markedError: { text: string; params: any[] } | undefined;
+
+      mockDbWrite.$queryRaw.mockImplementation(async (query: any, ...values: any[]) => {
+        const strings = Array.isArray(query) ? query : query.strings;
+        const text = strings.join('');
+        if (text.includes('INSERT INTO "Tag"')) throw new Error('Raw query failed. Code: `23502`.');
+        if (text.includes('UPDATE "Image"') && text.includes("'{retryCount}'")) {
+          markedError = renderSql(strings, values);
+          return [{ retryCount: 1, mediaType: 'image' }];
+        }
+        return passthrough(query, ...values);
+      });
+
+      // Must resolve: rejecting 400s the webhook, and the orchestrator redelivers a
+      // workflow that is already terminal.
+      await expect(
+        processImageScanWorkflow({
+          workflowId: 'workflow-whose-processing-fails',
+          status: 'succeeded',
+          imageId: 10,
+          steps: scanSteps('a tag that cannot be created'),
+        })
+      ).resolves.toBeUndefined();
+
+      expect(markedError?.text).toContain(`'{retryCount}'`);
+      expect(markedError?.params).toContain(ImageIngestionStatus.Error);
+      expect(markedError?.params).toContain(10);
+      const stamped = markedError?.params.find(
+        (param) => typeof param === 'string' && param.includes('processing-failed')
+      );
+      expect(stamped).toBeDefined();
+    });
+
+    it('still surfaces a deleted image so the webhook can ACK it as skipped', async () => {
+      mockDbWrite.image.findUnique.mockResolvedValue(null);
+
+      await expect(
+        processImageScanWorkflow({
+          workflowId: 'workflow-for-a-deleted-image',
+          status: 'succeeded',
+          imageId: 11,
+          steps: scanSteps('some tag'),
+        })
+      ).rejects.toThrow(/^image not found/);
+    });
+  });
+
+  it('keeps a persisted verdict when a post-verdict side effect throws', async () => {
+    mockDbWrite.$executeRaw.mockImplementation(async (query: any) => {
+      const strings = Array.isArray(query) ? query : query.strings;
+      if (strings.join('').includes('DELETE FROM "JobQueue"'))
+        throw new Error('job queue delete failed');
+      return 0;
+    });
+
+    await expect(
+      processImageScanWorkflow({
+        workflowId: 'workflow-with-a-failing-side-effect',
+        status: 'succeeded',
+        imageId: 12,
+        steps: [
+          { $type: 'wdTagging', output: { tags: { 'some-tag': 0.9 }, rating: { general: 0.9 } } },
+          { $type: 'mediaRating', output: { nsfwLevel: 'pg', isBlocked: false } },
+        ] as any,
+      })
+    ).resolves.toBeUndefined();
+
+    const errorFlips = mockDbWrite.$queryRaw.mock.calls.filter((call: any) => {
+      const strings = Array.isArray(call[0]) ? call[0] : call[0]?.strings ?? [];
+      return strings.join('').includes("'{retryCount}'");
+    });
+    expect(errorFlips).toHaveLength(0);
   });
 
   describe('webhook body strings never reach SQL text', () => {

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -313,62 +313,117 @@ export async function processImageScanWorkflow({
   }
 
   const { wdTags, mediaRating, mediaHash } = parsed;
-  const pHash = computePerceptualHash(mediaHash?.hashes?.perceptual);
 
-  // Log (don't act on) perceptual-hash matches against known-blocked content.
-  if (!mediaRating.isBlocked && pHash) await logPerceptualHashMatch({ imageId, pHash });
+  // Scope stops at the outcome write: markImageScanError is unconditional, so
+  // widening this catch past it would overwrite a verdict that already landed.
+  let image: ScanImage;
+  let outcome: Awaited<ReturnType<typeof resolveScanOutcome>>;
+  try {
+    const pHash = computePerceptualHash(mediaHash?.hashes?.perceptual);
 
-  // The orchestrator content rating can hard-block the image outright.
-  if (mediaRating.isBlocked) {
-    await blockImageFromRating({ imageId, pHash, blockedReason: mediaRating.blockedReason });
+    // Log (don't act on) perceptual-hash matches against known-blocked content.
+    if (!mediaRating.isBlocked && pHash) await logPerceptualHashMatch({ imageId, pHash });
+
+    // The orchestrator content rating can hard-block the image outright.
+    if (mediaRating.isBlocked) {
+      await blockImageFromRating({ imageId, pHash, blockedReason: mediaRating.blockedReason });
+    }
+
+    image = await loadImageForScan(imageId);
+    const { prompt, negativePrompt } = (image.meta ?? {}) as {
+      prompt?: string;
+      negativePrompt?: string;
+    };
+
+    await buildAndInsertScanTags({
+      imageId: image.id,
+      wdTags,
+      ratingLevel: mediaRating.nsfwLevel,
+      prompt,
+    });
+
+    outcome = await resolveScanOutcome({
+      image,
+      mediaRating,
+      pHash,
+      workflowId,
+      prompt,
+      negativePrompt,
+    });
+  } catch (error) {
+    // Deleted between submit and callback — no row to mark. The handler ACKs it 200.
+    if (error instanceof Error && error.message.startsWith('image not found')) throw error;
+
+    const reason = error instanceof Error ? error.message : 'Unknown error';
+    const { retryCount, mediaType, failureClass } = await markImageScanError({
+      workflowId,
+      imageId,
+      status,
+      failureType: 'processing-failed',
+      failedSteps: extractFailedSteps(steps),
+      reason,
+    });
+    logToAxiom(
+      {
+        name: 'image-scan-result',
+        type: 'error',
+        message: 'failed to process a succeeded workflow',
+        source: 'image-scan-result.service',
+        stack: error instanceof Error ? error.stack : undefined,
+        failureType: 'processing-failed',
+        reason,
+        failureClass,
+        imageId,
+        mediaType,
+        workflowId,
+        status,
+        retryCount,
+      },
+      'webhooks'
+    ).catch(() => null);
+    if (articleImageScanning) await fanOutArticleImageUpdates(imageId);
+    return;
   }
 
-  const image = await loadImageForScan(imageId);
-  const { prompt, negativePrompt } = (image.meta ?? {}) as {
-    prompt?: string;
-    negativePrompt?: string;
-  };
+  // The verdict is persisted; throwing here would 400 a finished webhook and have
+  // the orchestrator re-run it. Log and fall through to the signal send.
+  try {
+    // Terminal outcome reached (resolveScanOutcome only ever returns Scanned or
+    // Blocked) — drop the ImageScan JobQueue row so it doesn't linger as a stale
+    // entry until the ingest-images cron happens to prune it. Error scans take the
+    // early-return branches above and stay queued for retry.
+    await removeImageScanJobQueue([image.id]);
 
-  await buildAndInsertScanTags({
-    imageId: image.id,
-    wdTags,
-    ratingLevel: mediaRating.nsfwLevel,
-    prompt,
-  });
+    await recordImageScan({
+      workflowId,
+      imageId: image.id,
+      mediaRating,
+      startedAt,
+      completedAt,
+    });
 
-  const outcome = await resolveScanOutcome({
-    image,
-    mediaRating,
-    pHash,
-    workflowId,
-    prompt,
-    negativePrompt,
-  });
+    // Fan out to articles for every terminal state (Scanned and Blocked).
+    // Article ingestion must advance on Blocked too, otherwise articles whose last
+    // image blocks stay stuck in Pending/Rescan.
+    if (articleImageScanning) await fanOutArticleImageUpdates(image.id);
 
-  // Terminal outcome reached (resolveScanOutcome only ever returns Scanned or
-  // Blocked) — drop the ImageScan JobQueue row so it doesn't linger as a stale
-  // entry until the ingest-images cron happens to prune it. Error scans take the
-  // early-return branch above and stay queued for retry.
-  await removeImageScanJobQueue([image.id]);
-
-  // --- side effects (run after the image row reflects the resolved outcome) ---
-
-  // Audit-log to scanner_label_results. Fire-and-forget — failures log but
-  // can't block ingestion. Runs for every successful mediaRating output.
-  await recordImageScan({
-    workflowId,
-    imageId: image.id,
-    mediaRating,
-    startedAt,
-    completedAt,
-  });
-
-  // Fan out to articles for every terminal state (Scanned and Blocked).
-  // Article ingestion must advance on Blocked too, otherwise articles whose last
-  // image blocks stay stuck in Pending/Rescan.
-  if (articleImageScanning) await fanOutArticleImageUpdates(image.id);
-
-  await applyIngestionSideEffects({ image, outcome });
+    await applyIngestionSideEffects({ image, outcome });
+  } catch (error) {
+    logToAxiom(
+      {
+        name: 'image-scan-result',
+        type: 'error',
+        message: 'side effects failed after the scan verdict was persisted',
+        source: 'image-scan-result.service',
+        stack: error instanceof Error ? error.stack : undefined,
+        reason: error instanceof Error ? error.message : 'Unknown error',
+        imageId: image.id,
+        workflowId,
+        ingestion: outcome.ingestion,
+      },
+      'webhooks'
+    ).catch(() => null);
+  }
 
   // Last step, after everything is committed — throwing here would 400 a finished webhook
   // and make the orchestrator re-run it.
@@ -815,8 +870,8 @@ async function processTags({
   if (tagsToCreate.length > 0) {
     const tagsToInsert = deduped.filter((x) => tagsToCreate.includes(x.name));
 
-    // `updatedAt` and `target` are NOT NULL with no database default -- Prisma stamps
-    // them client-side, which raw SQL bypasses, so omitting them raises 23502.
+    // Raw SQL bypasses Prisma's @updatedAt stamp, and neither column has a DB
+    // default — both are NOT NULL, so omitting either raises 23502.
     const now = new Date();
     const values = tagsToInsert.map(
       (tag) => Prisma.sql`(${tag.name}, ${now}, ARRAY['Image']::"TagTarget"[])`

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -318,6 +318,9 @@ export async function processImageScanWorkflow({
   // widening this catch past it would overwrite a verdict that already landed.
   let image: ScanImage;
   let outcome: Awaited<ReturnType<typeof resolveScanOutcome>>;
+  // blockImageFromRating lands a verdict partway through the block below, so the
+  // catch has to know whether one is already on the row.
+  let hardBlocked = false;
   try {
     const pHash = computePerceptualHash(mediaHash?.hashes?.perceptual);
 
@@ -327,6 +330,7 @@ export async function processImageScanWorkflow({
     // The orchestrator content rating can hard-block the image outright.
     if (mediaRating.isBlocked) {
       await blockImageFromRating({ imageId, pHash, blockedReason: mediaRating.blockedReason });
+      hardBlocked = true;
     }
 
     image = await loadImageForScan(imageId);
@@ -355,6 +359,27 @@ export async function processImageScanWorkflow({
     if (error instanceof Error && error.message.startsWith('image not found')) throw error;
 
     const reason = error instanceof Error ? error.message : 'Unknown error';
+    // Marking Error here would un-block a hard-blocked image and hand it back to the
+    // retry pipeline. The verdict stands; only the tagging and side-effect work is lost.
+    if (hardBlocked) {
+      logToAxiom(
+        {
+          name: 'image-scan-result',
+          type: 'error',
+          message: 'failed to process a workflow after its rating hard-blocked the image',
+          source: 'image-scan-result.service',
+          stack: error instanceof Error ? error.stack : undefined,
+          reason,
+          imageId,
+          workflowId,
+          status,
+        },
+        'webhooks'
+      ).catch(() => null);
+      if (articleImageScanning) await fanOutArticleImageUpdates(imageId);
+      return;
+    }
+
     const { retryCount, mediaType, failureClass } = await markImageScanError({
       workflowId,
       imageId,

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -815,10 +815,15 @@ async function processTags({
   if (tagsToCreate.length > 0) {
     const tagsToInsert = deduped.filter((x) => tagsToCreate.includes(x.name));
 
-    const values = tagsToInsert.map((tag) => Prisma.sql`(${tag.name})`);
+    // `updatedAt` and `target` are NOT NULL with no database default -- Prisma stamps
+    // them client-side, which raw SQL bypasses, so omitting them raises 23502.
+    const now = new Date();
+    const values = tagsToInsert.map(
+      (tag) => Prisma.sql`(${tag.name}, ${now}, ARRAY['Image']::"TagTarget"[])`
+    );
 
     createdTags = await dbWrite.$queryRaw<TagWithId[]>`
-      INSERT INTO "Tag" (name)
+      INSERT INTO "Tag" (name, "updatedAt", target)
       VALUES ${Prisma.join(values)}
       ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
       RETURNING id, name, "nsfwLevel", type


### PR DESCRIPTION
Two commits: the defect that stranded ~29k images, and the reason a defect like it could strand them permanently rather than being retried and given up on.

## 1. The defect — `Tag` insert violates NOT NULL

`processTags` in `src/server/services/image-scan-result.service.ts` creates never-before-seen tags with a raw INSERT that listed only `name`:

```sql
INSERT INTO "Tag" (name)
VALUES ...
ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
RETURNING id, name, "nsfwLevel", type
```

`Tag.updatedAt` and `Tag.target` are both NOT NULL with no database default. Raw SQL bypasses Prisma's `@updatedAt` stamp, and `target` has no default at either layer, so the statement fails with `23502` (not_null_violation). The error escaped `/api/webhooks/image-scan-result` before any terminal ingestion state was written, leaving the image on `Pending` with nothing recorded.

The branch only runs when a scan returns a tag name not already in `Tag`. That is why the failure is per-image and perfectly reproducible: an image carrying one novel tag fails every time, including on re-upload, while an image whose tags all already exist is unaffected. Reported in #4657 and confirmed by several users.

Fix lists the two columns the table requires, with the `target` convention the other tag-creation paths use:

```sql
INSERT INTO "Tag" (name, "updatedAt", target)
VALUES ($1, $2, ARRAY['Image']::"TagTarget"[])
```

## 2. Why it stranded rather than retried

Everything from the perceptual hash through `resolveScanOutcome` ran unguarded, so any throw there left the image `Pending` with its `JobQueue` row intact. The `ingest-images` cron re-drove it, the same throw repeated, and **nothing counted the attempts** — the Pending lane filters on cooldown alone, unlike the Rescan and Error lanes which both check `retryCount`. The only ceiling was the `createdAt` age-out, so a persistent processing failure could re-drive indefinitely, paying for a fresh orchestrator scan every pass, while the uploader saw "Analyzing image" forever.

The pipeline is now guarded in two halves, split at the point the verdict is written:

- **Before the outcome write** — route the throw through `markImageScanError` with `failureType: 'processing-failed'`, the same path a failed workflow already takes. The image leaves `Pending` on the first failure with a stamped `failureClass` and an incremented `retryCount`, so the capped Error-retry machinery bounds it and eventually terminalizes. `image not found` still propagates, so the webhook keeps ACKing a deleted image as skipped.
- **After the outcome write** — log and continue. The verdict is already persisted, so throwing would 400 a finished webhook and have the orchestrator redeliver a terminal workflow; and `markImageScanError`'s UPDATE is unconditional, so applying it here would overwrite a landed `Scanned`.

## Tests

Three cases added to `src/__tests__/pages/api/webhooks/image-scan-result.test.ts`, driving the exported `processImageScanWorkflow`. The `$queryRaw` fake mirrors the real constraint, raising the same `23502` when the insert omits either column.

Each was revert-checked rather than trusted green — removing the thing it protects produces:

| Removed | Failure |
|---|---|
| the columns in the INSERT | ``Raw query failed. Code: `23502`. "Tag" insert omits "updatedAt"`` |
| the pre-verdict guard | ``promise rejected "Raw query failed. Code: `23502`." instead of resolving`` |
| the post-verdict guard | `promise rejected "job queue delete failed" instead of resolving` |
| the `image not found` rethrow | `rejects.toThrow(/^image not found/)` fails |

All fail in about two seconds; none hangs.

Verified: `pnpm run typecheck` clean, `pnpm run lint` 0 errors, `pnpm run test:lint-rules` 482 passing, full unit suite 38,624 tests with only a known-flaky wall-clock assertion in `moderation.instrumentation.test.ts` (unrelated file, missed by 2.8 ms under load, passes in isolation and on repeat full runs).

## Not in this PR

**The stuck backlog is left to drain on its own.** Every stranded image is still queued and being re-driven, so once this deploys they resolve without a backfill script.

**`IMAGE_SCANNING_PENDING_TIMEOUT` is worth a look.** The age-out that should have flipped these to `Error` within its window plainly did not — production shows far more `Pending` than `Error` for the affected days, with rows days old. The code and its test (`ingest-images-pending-ageout.test.ts`) both look correct, and the env var is wired through with a sane default, so this points at the deployed value rather than at code. It is now a second-line net rather than the only one, but someone with access should check it.

Fixes #4657

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UTFCuxwiWGYP7469Ju3SY
