### PR TITLE
feat(models): offer Embedding in the model type picker again

### DIFF
--- a/src/shared/constants/__tests__/model-type.constants.test.ts
+++ b/src/shared/constants/__tests__/model-type.constants.test.ts
@@ -15,6 +15,9 @@ import { ModelType } from '~/shared/utils/prisma/enums';
 import { getDisplayName } from '~/utils/string-helpers';
 
 describe('model type picker data', () => {
+  const groupOf = (type: ModelType) =>
+    modelTypeGroups.find(({ types }) => types.includes(type))?.group;
+
   it('covers every ModelType exactly once, as selectable or retired', () => {
     const all = [...selectableModelTypes, ...retiredModelTypes].sort();
 
@@ -22,7 +25,8 @@ describe('model type picker data', () => {
     expect(new Set(all).size).toBe(all.length);
   });
 
-  it('offers only the types the 2026-08-31 cleanup kept, plus Embedding', () => {
+  // The list is what the 2026-08-31 cleanup kept, plus Embedding, restored 2026-09-07.
+  it('offers exactly the picker list, in order', () => {
     expect(selectableModelTypes).toStrictEqual([
       ModelType.Checkpoint,
       ModelType.LORA,
@@ -41,9 +45,6 @@ describe('model type picker data', () => {
   });
 
   it('groups Controlnet with the workflow additives, not the adapters', () => {
-    const groupOf = (type: ModelType) =>
-      modelTypeGroups.find(({ types }) => types.includes(type))?.group;
-
     expect(groupOf(ModelType.Controlnet)).toBe('Workflow additives');
     expect(groupOf(ModelType.LORA)).toBe('Adapters');
   });
@@ -53,9 +54,6 @@ describe('model type picker data', () => {
   // its only option -- the thing the ungrouped lists exist to avoid. Moving it to its own group is a
   // product call, not a tidy-up.
   it('groups Embedding with the adapters rather than in a group of its own', () => {
-    const groupOf = (type: ModelType) =>
-      modelTypeGroups.find(({ types }) => types.includes(type))?.group;
-
     expect(groupOf(ModelType.TextualInversion)).toBe('Adapters');
     expect(
       modelTypeGroups.filter(({ types }) => types.length < 2).map(({ group }) => group)
@@ -212,6 +210,12 @@ describe('model type picker data', () => {
     expect(source).toMatch(/The type has been set to Other/);
     expect(source).not.toContain('getModelTypeSelectData(type)');
     expect(source).not.toContain('resolveModelTypeDefaults(model)');
+  });
+
+  // Retiring the type left this label reachable only on already-saved models; it is now on the
+  // default path for every new model, and getDisplayName is the only thing producing it.
+  it('labels TextualInversion as Embedding, the word the picker actually offers', () => {
+    expect(getDisplayName(ModelType.TextualInversion)).toBe('Embedding');
   });
 
   // Reverted from "Fine-tune" (#4521) after tester complaints that it replaced a term people

--- a/src/shared/constants/__tests__/model-type.constants.test.ts
+++ b/src/shared/constants/__tests__/model-type.constants.test.ts
@@ -22,12 +22,13 @@ describe('model type picker data', () => {
     expect(new Set(all).size).toBe(all.length);
   });
 
-  it('offers only the types the 2026-08-31 cleanup kept', () => {
+  it('offers only the types the 2026-08-31 cleanup kept, plus Embedding', () => {
     expect(selectableModelTypes).toStrictEqual([
       ModelType.Checkpoint,
       ModelType.LORA,
       ModelType.LoCon,
       ModelType.DoRA,
+      ModelType.TextualInversion,
       ModelType.VAE,
       ModelType.TextEncoder,
       ModelType.UNet,
@@ -45,6 +46,20 @@ describe('model type picker data', () => {
 
     expect(groupOf(ModelType.Controlnet)).toBe('Workflow additives');
     expect(groupOf(ModelType.LORA)).toBe('Adapters');
+  });
+
+  // Deliberate, and the reason is not visible from the value: an embedding is not a weight-delta
+  // adapter. It sits under Adapters because the alternative is a group of one whose heading repeats
+  // its only option -- the thing the ungrouped lists exist to avoid. Moving it to its own group is a
+  // product call, not a tidy-up.
+  it('groups Embedding with the adapters rather than in a group of its own', () => {
+    const groupOf = (type: ModelType) =>
+      modelTypeGroups.find(({ types }) => types.includes(type))?.group;
+
+    expect(groupOf(ModelType.TextualInversion)).toBe('Adapters');
+    expect(
+      modelTypeGroups.filter(({ types }) => types.length < 2).map(({ group }) => group)
+    ).toStrictEqual([]);
   });
 
   it('keeps a retired type selectable while it is the current value', () => {
@@ -80,7 +95,6 @@ describe('model type picker data', () => {
     // retiredModelTypes is written out rather than derived as the complement of the selectable set.
     // Derived, a ModelType added later would land in it and this file would stay green.
     expect([...retiredModelTypes]).toStrictEqual([
-      ModelType.TextualInversion,
       ModelType.Hypernetwork,
       ModelType.AestheticGradient,
       ModelType.MotionModule,
@@ -125,26 +139,26 @@ describe('model type picker data', () => {
 
   it('grandfathers a saved model, and offers a template only what is still offered', () => {
     // A saved model keeps a retired type and the picker re-offers it.
-    const saved = resolveModelTypeDefaults({ id: 7, type: ModelType.TextualInversion });
+    const saved = resolveModelTypeDefaults({ id: 7, type: ModelType.Hypernetwork });
     expect(saved).toStrictEqual({
-      grandfatheredType: ModelType.TextualInversion,
-      initialType: ModelType.TextualInversion,
+      grandfatheredType: ModelType.Hypernetwork,
+      initialType: ModelType.Hypernetwork,
       replacedType: null,
     });
     expect(getModelTypeSelectData(saved.grandfatheredType).map(({ value }) => value)).toContain(
-      ModelType.TextualInversion
+      ModelType.Hypernetwork
     );
 
     // A template seeds `type` with no `id`, so it is a NEW model. Dropping the option alone is not
     // enough: the form would still hold the retired value behind a blank required field, and the
     // submit would create a model on it.
     // Falling back to Checkpoint would file it as a fine-tune; Other claims nothing.
-    const fromTemplate = resolveModelTypeDefaults({ type: ModelType.TextualInversion });
+    const fromTemplate = resolveModelTypeDefaults({ type: ModelType.Hypernetwork });
     expect(fromTemplate).toStrictEqual({
       grandfatheredType: null,
       initialType: ModelType.Other,
       // Named so the form can say what it dropped instead of substituting silently.
-      replacedType: ModelType.TextualInversion,
+      replacedType: ModelType.Hypernetwork,
     });
 
     // A template on a type that is still offered is untouched.

--- a/src/shared/constants/__tests__/model-type.constants.test.ts
+++ b/src/shared/constants/__tests__/model-type.constants.test.ts
@@ -26,7 +26,7 @@ describe('model type picker data', () => {
   });
 
   // The list is what the 2026-08-31 cleanup kept, plus Embedding, restored 2026-09-07.
-  it('offers exactly the picker list, in order', () => {
+  it('offers exactly the post-cleanup picker list, in order', () => {
     expect(selectableModelTypes).toStrictEqual([
       ModelType.Checkpoint,
       ModelType.LORA,

--- a/src/shared/constants/model-type.constants.ts
+++ b/src/shared/constants/model-type.constants.ts
@@ -2,7 +2,10 @@ import { ModelType } from '~/shared/utils/prisma/enums';
 import { getDisplayName } from '~/utils/string-helpers';
 
 export const modelTypeGroups = [
-  { group: 'Adapters', types: [ModelType.LORA, ModelType.LoCon, ModelType.DoRA] },
+  {
+    group: 'Adapters',
+    types: [ModelType.LORA, ModelType.LoCon, ModelType.DoRA, ModelType.TextualInversion],
+  },
   {
     group: 'Component replacements',
     types: [ModelType.VAE, ModelType.TextEncoder, ModelType.UNet, ModelType.Upscaler],
@@ -35,7 +38,6 @@ export const selectableModelTypes = [
  * to one keeps the value and keeps displaying it.
  */
 export const retiredModelTypes = [
-  ModelType.TextualInversion,
   ModelType.Hypernetwork,
   ModelType.AestheticGradient,
   ModelType.MotionModule,


### PR DESCRIPTION
Closes ClickUp [868m27td4](https://app.clickup.com/t/868m27td4).

Makes **Embedding** (`ModelType.TextualInversion`) pickable again when creating or editing a model. It moves out of `retiredModelTypes` and into the **Adapters** group in `src/shared/constants/model-type.constants.ts`.

Retired never meant invalid: a model already set to Embedding kept the value and `getModelTypeSelectData` re-offered it under "Currently selected". The only thing that was missing was the ability to choose it for a new model. That is what this restores.

## The decision: Adapters, not a group of its own

**Confirmed by Justin on 2026-09-07** (hub request `2026-09-07-180425-357baff8`), so this is settled rather than proposed. The reasoning is kept because the choice is not recoverable from the value. An embedding is genuinely not an adapter in the LoRA sense — there is no weight delta, it trains new token vectors in the text encoder's embedding table. So the placement is a judgement call, and here is mine with what I rejected.

**Chosen: append to Adapters, after DoRA.** The group heading is a user-facing category, not an architecture taxonomy. Textual inversion is a parameter-efficient adaptation method; it is only "not an adapter" under the narrow weight-delta reading, and nobody choosing a model type is making that distinction. What the grouping actually communicates is *small file you add on top of a checkpoint*, which is exactly what an embedding is.

**Rejected: a group of its own.** The file's own comment above `leadingUngroupedModelTypes` says a group of one repeats its own name as a header — that is precisely why Checkpoint and Other are ungrouped rather than sitting in one-item groups. An "Embeddings" group whose only option is "Embedding" is the exact shape that comment exists to prevent, so taking it would have meant arguing with the code beside it.

**Rejected: a trailing ungrouped slot beside Other.** That position reads as the miscellaneous bucket, and it throws away the one signal the grouping carries.

Pinned by a test named for the decision, `groups Embedding with the adapters rather than in a group of its own`, with a comment addressed at whoever arrives to tidy it up.

Its second assertion -- no group has fewer than two members -- was called redundant by three of the five review lanes, on the grounds that it holds on `main` and so cannot distinguish this change from its revert. That is true as far as it goes, and it was nearly deleted on a 3-1 split. It survives because the fourth lane supplied a mutation only it catches: **redistribute types among the three existing groups so one is left holding a single entry.** Flat order stays byte-identical, group names are unchanged, and `groupOf(TextualInversion)` is still `'Adapters'`, so the ordered pin, the group-name pin and the first assertion all stay green. Run against that mutation it gives `Tests 1 failed | 15 passed (16)` with `expected [ 'Component replacements' ] to strictly equal []`, naming the offending group. It is a standing invariant guard, not a regression test for this diff.

## What moved

Four test cases, not the two the ticket predicted:

- `offers only the types the 2026-08-31 cleanup kept` — `TextualInversion` added to the ordered `toStrictEqual`.
- `lists both partitions explicitly` — `TextualInversion` removed from the retired `toStrictEqual`.
- Both halves of `grandfathers a saved model, and offers a template only what is still offered` — these used `TextualInversion` as their *example of a retired type*, which stops being true here. They are re-pointed at `Hypernetwork`. That case exists to test grandfathering, not to test `TextualInversion` specifically, so it needs a type that is still retired. **No assertion was weakened to get green** — the shape and strength are unchanged, only the type standing in as the example.

The compile-time `_everyModelTypeIsCategorised` check needs no edit: it requires every `ModelType` to sit in exactly one list, and moving the entry between lists satisfies it.

## Verification

Both guards were given a positive control rather than trusted for coming back green.

**Covering file** — `Test Files 1 passed (1)` / `Tests 16 passed (16)`, exit 0.
Control: reverting `model-type.constants.ts` alone gives `Tests 3 failed | 13 passed (16)` with legible assertions naming wrong values, including `expected undefined to be 'Adapters'` from the new pin. The grandfathering cases correctly stay green under that revert, because Hypernetwork is retired either way.

**Typecheck** — `0 type errors in 120s`, exit 0.
Control: dropping `TextualInversion` from both lists gives exit 2 and
`error TS2322: ... missing: "TextualInversion"`.

**A label that nothing covered.** The review found `getDisplayName` is the only thing producing the word "Embedding", and no test reached that path. Deleting `TextualInversion: 'Embedding'` from `src/utils/string-helpers.ts:49` left `Test Files 2 passed (2)` / `Tests 45 passed (45)`, exit 0 -- fully green while the picker would have offered "Textual Inversion", the exact word this PR exists to restore. Retiring the type had hidden it: the label previously surfaced only in the "Currently selected" group on already-saved models, and offering the type again puts it on the default path for every new model. Now pinned; its control gives `expected 'Textual Inversion' to be 'Embedding'`.

**Full unit suite** — `Test Files 1665 passed | 3 skipped (1668)`, `Tests 38607 passed | 35 skipped (38642)`, at `--max-workers=4`. Both dimensions reconcile against the collected totals, and the test count is exactly one above the pre-review run: the assertion added above.

**Typecheck does not cover the test file.** `tsconfig.json:83` excludes `src/**/__tests__/**`, so the green typecheck says nothing about the test changes. Direct `pnpm exec eslint` over both files is exit 0; the covering run and the full suite are what actually cover them.

**Submodule canary** — `src/server/routers/__tests__/blocks.router.workflow.test.ts` collected **370 tests**, checked by running the file directly rather than by grepping the suite log.

**Lint** — repo-wide lint is red on `origin/main` independently of this change: `4525 problems (358 errors, 4167 warnings)`, byte-identical with and without this diff, and neither changed file appears anywhere in its output.

**Prettier** — both files report `All files formatted correctly`.

## Scope

Nothing outside the picker gated embeddings, and that still holds. A `git grep` over `origin/main` for the module path plus all seven exported symbols returns exactly three files: the constants file, `ModelUpsertForm.tsx`, and its test. `ModelUpsertForm.tsx` contains no occurrence of `TextualInversion` or `Embedding` at all. `getDisplayName` already maps the enum to `Embedding` (`src/utils/string-helpers.ts:49`), so the label needs no work, and upload/file handling, generation resource types and AIR mapping were never involved.

No migration. No schema change. Nothing to apply by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbpSJSaJY2QJ5juD5rYY9f
