### PR TITLE
fix(models): stop the collection showcase from walking whole collections

### DIFF
--- a/src/components/Model/CollectionShowcase/CollectionShowcase.browser.test.tsx
+++ b/src/components/Model/CollectionShowcase/CollectionShowcase.browser.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { IntersectionObserverProvider } from '~/components/IntersectionObserver/IntersectionObserverProvider';
+import type * as ModelUtils from '~/components/Model/model.utils';
+import { LOADABLE_IMAGE_DATA_URI, renderWithProviders } from '../../../../test/component-setup';
+
+const useModelShowcaseCollection = vi.fn();
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+vi.mock('~/components/Model/model.utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModelUtils>()),
+  useModelShowcaseCollection: (args: { modelId: number }) => useModelShowcaseCollection(args),
+}));
+
+const { CollectionShowcase } = await import('./CollectionShowcase');
+
+type Overrides = Partial<ReturnType<typeof useModelShowcaseCollection>>;
+
+function showcaseState(overrides: Overrides = {}) {
+  return {
+    items: [],
+    isLoading: false,
+    isError: false,
+    hasNextPage: true,
+    fetchNextPage: vi.fn(),
+    isFetching: false,
+    isRefetching: false,
+    pageCount: 1,
+    refetch: vi.fn(),
+    ...overrides,
+  };
+}
+
+function item(id: number) {
+  return {
+    id,
+    name: `Model ${id}`,
+    type: 'Checkpoint',
+    images: [
+      { id, url: LOADABLE_IMAGE_DATA_URI, name: `image-${id}`, type: 'image', nsfwLevel: 1 },
+    ],
+    rank: undefined,
+    version: { id, name: 'v1', baseModel: 'SDXL 1.0' },
+  };
+}
+
+// `ShowcaseItem` renders `ElementInView`, which throws without this provider.
+function render(modelId = 1) {
+  return renderWithProviders(
+    <IntersectionObserverProvider id="collection-showcase-test">
+      <CollectionShowcase modelId={modelId} />
+    </IntersectionObserverProvider>
+  );
+}
+
+beforeEach(() => {
+  useModelShowcaseCollection.mockReset();
+});
+
+describe('CollectionShowcase auto-loading', () => {
+  test('below the page cap it keeps the in-view loader', async () => {
+    useModelShowcaseCollection.mockReturnValue(
+      showcaseState({ items: [item(1)], pageCount: 4 })
+    );
+    render();
+
+    await expect.element(page.getByText('Model 1')).toBeInTheDocument();
+    expect(page.getByRole('button', { name: 'Load more' }).elements()).toHaveLength(0);
+  });
+
+  test('at the page cap it stops auto-loading and offers a manual Load more', async () => {
+    const fetchNextPage = vi.fn();
+    useModelShowcaseCollection.mockReturnValue(
+      showcaseState({ items: [item(1)], pageCount: 5, fetchNextPage })
+    );
+    render();
+
+    const button = page.getByRole('button', { name: 'Load more' });
+    await expect.element(button).toBeInTheDocument();
+    await button.click();
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  test('a failed fetch stops auto-loading rather than retrying on a timer', async () => {
+    useModelShowcaseCollection.mockReturnValue(
+      showcaseState({ items: [item(1)], pageCount: 1, isError: true })
+    );
+    render();
+
+    await expect.element(page.getByRole('button', { name: 'Load more' })).toBeInTheDocument();
+  });
+});
+
+describe('CollectionShowcase error state', () => {
+  test('an errored first page reads as a failure, not as an empty collection', async () => {
+    const refetch = vi.fn();
+    useModelShowcaseCollection.mockReturnValue(
+      showcaseState({ items: [], pageCount: 0, isError: true, refetch })
+    );
+    render();
+
+    await expect.element(page.getByText(/Couldn.t load this collection/)).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain('There are no items for this collection');
+
+    await page.getByRole('button', { name: 'Try again' }).click();
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('an empty collection still reads as empty', async () => {
+    useModelShowcaseCollection.mockReturnValue(showcaseState({ items: [], hasNextPage: false }));
+    render();
+
+    await expect
+      .element(page.getByText('There are no items for this collection'))
+      .toBeInTheDocument();
+  });
+});

--- a/src/components/Model/CollectionShowcase/CollectionShowcase.browser.test.tsx
+++ b/src/components/Model/CollectionShowcase/CollectionShowcase.browser.test.tsx
@@ -60,9 +60,7 @@ beforeEach(() => {
 
 describe('CollectionShowcase auto-loading', () => {
   test('below the page cap it keeps the in-view loader', async () => {
-    useModelShowcaseCollection.mockReturnValue(
-      showcaseState({ items: [item(1)], pageCount: 4 })
-    );
+    useModelShowcaseCollection.mockReturnValue(showcaseState({ items: [item(1)], pageCount: 4 }));
     render();
 
     await expect.element(page.getByText('Model 1')).toBeInTheDocument();

--- a/src/components/Model/CollectionShowcase/CollectionShowcase.tsx
+++ b/src/components/Model/CollectionShowcase/CollectionShowcase.tsx
@@ -1,6 +1,6 @@
 import {
-  ActionIcon,
   Badge,
+  Button,
   Group,
   Loader,
   LoadingOverlay,
@@ -31,15 +31,27 @@ import { AnimatedCount, Metrics } from '~/components/Metrics';
 import { getModelUrl } from '~/utils/string-helpers';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 
+/**
+ * `InViewLoader` re-arms 500ms after each load for as long as it stays on screen, and a
+ * list this short keeps it there — so uncapped it walks the whole collection, thousands
+ * of models on the largest showcases, one rate-limited request at a time.
+ */
+const MAX_AUTO_LOADED_PAGES = 5;
+
 export function CollectionShowcase({ modelId, loading }: Props) {
   const {
     items = [],
     isLoading,
+    isError,
     hasNextPage,
     fetchNextPage,
     isFetching,
     isRefetching,
+    pageCount,
+    refetch,
   } = useModelShowcaseCollection({ modelId });
+
+  const autoLoad = !isError && pageCount < MAX_AUTO_LOADED_PAGES;
 
   return (
     <div className="relative">
@@ -54,18 +66,37 @@ export function CollectionShowcase({ modelId, loading }: Props) {
             {items.map((model) => (
               <ShowcaseItem key={model.id} {...model} />
             ))}
-            {hasNextPage && (
-              <InViewLoader
-                loadFn={fetchNextPage}
-                loadCondition={!isFetching}
-                style={{ gridColumn: '1/-1' }}
-              >
+            {hasNextPage &&
+              (autoLoad ? (
+                <InViewLoader
+                  loadFn={fetchNextPage}
+                  loadCondition={!isFetching}
+                  style={{ gridColumn: '1/-1' }}
+                >
+                  <div className="flex items-center justify-center px-4 py-2">
+                    <Loader type="bars" size="sm" />
+                  </div>
+                </InViewLoader>
+              ) : (
                 <div className="flex items-center justify-center px-4 py-2">
-                  <Loader type="bars" size="sm" />
+                  <Button
+                    variant="subtle"
+                    size="compact-sm"
+                    loading={isFetching}
+                    onClick={() => fetchNextPage()}
+                  >
+                    Load more
+                  </Button>
                 </div>
-              </InViewLoader>
-            )}
+              ))}
           </>
+        ) : isError ? (
+          <div className="flex flex-col items-center justify-center gap-2 p-2">
+            <Text c="dimmed">Couldn&rsquo;t load this collection</Text>
+            <Button variant="light" size="compact-sm" onClick={() => refetch()}>
+              Try again
+            </Button>
+          </div>
         ) : (
           <div className="flex items-center justify-center p-2">
             <Text c="dimmed">There are no items for this collection</Text>

--- a/src/components/Model/model.utils.ts
+++ b/src/components/Model/model.utils.ts
@@ -174,10 +174,13 @@ export const useQueryModels = (
       // cast: v5 InfiniteData pageParams typing (bigint vs string|number) is stricter here.
       (oldData) => oldData ?? (data as typeof oldData)
     );
+    const message = getQueryErrorMessage(error);
     showErrorNotification({
-      id: 'model-get-all-error',
+      // Keyed by message, not by the query: a retry storm repeats one message and collapses,
+      // while a second feed failing differently still gets its own toast.
+      id: `model-get-all-error:${message}`,
       title: 'Failed to fetch data',
-      error: new Error(getQueryErrorMessage(error)),
+      error: new Error(message),
     });
   }, [error]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/Model/model.utils.ts
+++ b/src/components/Model/model.utils.ts
@@ -24,6 +24,7 @@ import {
   ModelStatus,
   ModelType,
 } from '~/shared/utils/prisma/enums';
+import { getQueryErrorMessage } from '~/utils/errorHandling';
 import { showErrorNotification } from '~/utils/notifications';
 import { removeEmpty } from '~/utils/object-helpers';
 import { postgresSlugify } from '~/utils/string-helpers';
@@ -174,8 +175,9 @@ export const useQueryModels = (
       (oldData) => oldData ?? (data as typeof oldData)
     );
     showErrorNotification({
+      id: 'model-get-all-error',
       title: 'Failed to fetch data',
-      error: new Error(`Something went wrong: ${error.message}`),
+      error: new Error(getQueryErrorMessage(error)),
     });
   }, [error]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -226,6 +228,13 @@ export const useToggleCheckpointCoverageMutation = () => {
   return { ...toggleMutation, toggle: handleToggle };
 };
 
+/**
+ * `model.getAll` is rate limited at the edge, and the 300px list shows under four rows —
+ * a page of 10 ran out in a couple of flicks and spent a request on each one. The feed
+ * itself runs at the handler default of 100.
+ */
+const SHOWCASE_PAGE_SIZE = 50;
+
 export const useModelShowcaseCollection = ({ modelId }: { modelId: number }) => {
   const queryUtils = trpc.useUtils();
 
@@ -243,7 +252,7 @@ export const useModelShowcaseCollection = ({ modelId }: { modelId: number }) => 
       sort: ModelSort.Newest,
       period: MetricTimeframe.AllTime,
       periodMode: 'published',
-      limit: 10,
+      limit: SHOWCASE_PAGE_SIZE,
     },
     { enabled: !loadingCollection && !!showcase?.id, keepPreviousData: true }
   );
@@ -267,6 +276,7 @@ export const useModelShowcaseCollection = ({ modelId }: { modelId: number }) => 
     ...rest,
     collection: showcase,
     items: models,
+    pageCount: data?.pages.length ?? 0,
     isLoading: loadingCollection || loadingModels,
     setShowcaseCollection: handleSetShowcaseCollection,
     settingShowcase: setShowcaseMutation.isPending,

--- a/src/components/Model/model.utils.ts
+++ b/src/components/Model/model.utils.ts
@@ -174,13 +174,9 @@ export const useQueryModels = (
       // cast: v5 InfiniteData pageParams typing (bigint vs string|number) is stricter here.
       (oldData) => oldData ?? (data as typeof oldData)
     );
-    const message = getQueryErrorMessage(error);
     showErrorNotification({
-      // Keyed by message, not by the query: a retry storm repeats one message and collapses,
-      // while a second feed failing differently still gets its own toast.
-      id: `model-get-all-error:${message}`,
       title: 'Failed to fetch data',
-      error: new Error(message),
+      error: new Error(getQueryErrorMessage(error)),
     });
   }, [error]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/utils/__tests__/errorHandling.getQueryErrorMessage.test.ts
+++ b/src/utils/__tests__/errorHandling.getQueryErrorMessage.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getQueryErrorMessage } from '~/utils/errorHandling';
+
+describe('getQueryErrorMessage', () => {
+  // Verbatim messages from a non-JSON body reaching `res.json()`.
+  it.each([
+    `Unexpected token '<', "<!doctype "... is not valid JSON`,
+    'JSON.parse: unexpected character at line 1 column 1 of the JSON data',
+    'Unexpected end of JSON input',
+  ])('replaces the raw parse failure %#', (message) => {
+    const result = getQueryErrorMessage({ message });
+
+    expect(result).not.toContain('doctype');
+    expect(result).not.toContain('JSON');
+    expect(result).toBe("Couldn't reach the server — it may be busy. Please try again in a moment.");
+  });
+
+  it('names the limit when the server was able to report one', () => {
+    expect(getQueryErrorMessage({ message: 'RATE_LIMIT', data: { httpStatus: 429 } })).toBe(
+      'Too many requests. Please wait a moment and try again.'
+    );
+  });
+
+  it('passes a real server message through untouched', () => {
+    expect(
+      getQueryErrorMessage({ message: 'No Model with id 1', data: { httpStatus: 404 } })
+    ).toBe('No Model with id 1');
+  });
+});

--- a/src/utils/__tests__/errorHandling.getQueryErrorMessage.test.ts
+++ b/src/utils/__tests__/errorHandling.getQueryErrorMessage.test.ts
@@ -2,17 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { getQueryErrorMessage } from '~/utils/errorHandling';
 
 describe('getQueryErrorMessage', () => {
-  // Verbatim messages from a non-JSON body reaching `res.json()`.
-  it.each([
-    `Unexpected token '<', "<!doctype "... is not valid JSON`,
-    'JSON.parse: unexpected character at line 1 column 1 of the JSON data',
-    'Unexpected end of JSON input',
-  ])('replaces the raw parse failure %#', (message) => {
-    const result = getQueryErrorMessage({ message });
+  it('replaces the raw parse failure a non-JSON body produces', () => {
+    // What `TRPCClientError.from` builds when `res.json()` rejects: the SyntaxError's own
+    // text as the message, the SyntaxError itself as the cause, and no `data`.
+    const cause = new SyntaxError(
+      `Failed to execute 'json' on 'Response': Unexpected token '<', "<!doctype "... is not valid JSON`
+    );
 
-    expect(result).not.toContain('doctype');
-    expect(result).not.toContain('JSON');
-    expect(result).toBe("Couldn't reach the server — it may be busy. Please try again in a moment.");
+    const result = getQueryErrorMessage({ message: cause.message, cause });
+
+    expect(result).toBe(
+      "Couldn't reach the server — it may be busy. Please try again in a moment."
+    );
   });
 
   it('names the limit when the server was able to report one', () => {
@@ -22,8 +23,16 @@ describe('getQueryErrorMessage', () => {
   });
 
   it('passes a real server message through untouched', () => {
-    expect(
-      getQueryErrorMessage({ message: 'No Model with id 1', data: { httpStatus: 404 } })
-    ).toBe('No Model with id 1');
+    expect(getQueryErrorMessage({ message: 'No Model with id 1', data: { httpStatus: 404 } })).toBe(
+      'No Model with id 1'
+    );
+  });
+
+  it('does not fire on a server message that merely reads like a parse failure', () => {
+    const message = 'Unexpected token in your prompt template';
+
+    expect(getQueryErrorMessage({ message, cause: new Error('upstream'), data: null })).toBe(
+      message
+    );
   });
 });

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -34,3 +34,22 @@ export function withRetries<T>(
     }
   });
 }
+
+const jsonParseFailure = /is not valid JSON|Unexpected token|JSON\.parse|Unexpected end of/i;
+
+/**
+ * tRPC drops the `Response` when `res.json()` throws, so an HTML body — an edge
+ * rate-limit page, a gateway error — reaches the client as a bare `SyntaxError`
+ * with no status to branch on.
+ */
+export function getQueryErrorMessage(error: {
+  message: string;
+  data?: { httpStatus?: number } | null;
+}) {
+  if (error.data?.httpStatus === 429)
+    return 'Too many requests. Please wait a moment and try again.';
+  if (jsonParseFailure.test(error.message))
+    return "Couldn't reach the server — it may be busy. Please try again in a moment.";
+
+  return error.message;
+}

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -35,20 +35,19 @@ export function withRetries<T>(
   });
 }
 
-const jsonParseFailure = /is not valid JSON|Unexpected token|JSON\.parse|Unexpected end of/i;
-
 /**
  * tRPC drops the `Response` when `res.json()` throws, so an HTML body — an edge
- * rate-limit page, a gateway error — reaches the client as a bare `SyntaxError`
- * with no status to branch on.
+ * rate-limit page, a gateway error — arrives with no `data.httpStatus` to branch
+ * on, carrying the raw `SyntaxError` as its cause.
  */
 export function getQueryErrorMessage(error: {
   message: string;
+  cause?: unknown;
   data?: { httpStatus?: number } | null;
 }) {
   if (error.data?.httpStatus === 429)
     return 'Too many requests. Please wait a moment and try again.';
-  if (jsonParseFailure.test(error.message))
+  if (error.cause instanceof SyntaxError)
     return "Couldn't reach the server — it may be busy. Please try again in a moment.";
 
   return error.message;

--- a/src/utils/notifications.tsx
+++ b/src/utils/notifications.tsx
@@ -15,15 +15,11 @@ export function showErrorNotification({
   reason,
   title,
   autoClose = 3000,
-  id,
 }: {
   error: Error | { message: string } | { message: string }[];
   reason?: string;
   title?: string;
   autoClose?: number | false;
-  /** Mantine ignores a `show` whose id is already showing or queued — pass one where the
-   * same failure can repeat, or the user gets a toast per attempt. */
-  id?: string;
 }) {
   const message = Array.isArray(error) ? (
     <ul>
@@ -36,7 +32,6 @@ export function showErrorNotification({
   );
 
   showNotification({
-    id,
     icon: <IconX size={18} />,
     color: 'red',
     message,

--- a/src/utils/notifications.tsx
+++ b/src/utils/notifications.tsx
@@ -15,11 +15,15 @@ export function showErrorNotification({
   reason,
   title,
   autoClose = 3000,
+  id,
 }: {
   error: Error | { message: string } | { message: string }[];
   reason?: string;
   title?: string;
   autoClose?: number | false;
+  /** Mantine ignores a `show` whose id is already showing or queued — pass one where the
+   * same failure can repeat, or the user gets a toast per attempt. */
+  id?: string;
 }) {
   const message = Array.isArray(error) ? (
     <ul>
@@ -32,6 +36,7 @@ export function showErrorNotification({
   );
 
   showNotification({
+    id,
     icon: <IconX size={18} />,
     color: 'red',
     message,


### PR DESCRIPTION
Fixes the model-page collection showcase over-fetching `model.getAll` until the edge rate-limits the reader.

Reported in Freshdesk #70347 (Derfuu, user 240455). Tracked as [868m0ewug](https://app.clickup.com/t/868m0ewug).

## What happens today

The showcase renders `useModelShowcaseCollection` → `useQueryModels({ collectionId, limit: 10 })`, i.e. it pages the collection through `model.getAll`, and auto-paginates with `InViewLoader`. That loader re-arms 500ms after each load for as long as it stays on screen. The list is a `ScrollArea.Autosize mah={300}` and a row is ~80px, so it shows under four rows — a reader who scrolls to the bottom of the list keeps the loader in view and the widget fetches a page roughly every 700ms until the collection is exhausted.

Measured on production against model `2920517`, whose showcase collection has **2,145 items**:

| Scenario | `model.getAll` requests |
|---|---|
| Page open, idle 45s | 1 |
| Showcase panel on screen, inner list not scrolled | 0 — the `ScrollArea` clip keeps the loader out of view |
| Inner list held at its bottom, 48s | **65**, list grew 10 → 650+ items, no ceiling short of 215 |
| 40 rapid `model.getAll` | 30×200, **10×429**, `content-type: text/html`, `server: cloudflare` |

## Where the 429 comes from

Not our middleware. `model.getAll` is `publicProcedure` + `skipEdgeCache` + `edgeCacheIt` with **no `rateLimit()`**, and `publicProcedure` has none either — the limiter is Cloudflare, confirmed by the `server: cloudflare` header on the 429. (The original ticket attributed it to `middleware.trpc.ts`; that part of the report is wrong.) `skipEdgeCache` also means an authenticated reader hits origin on every page, which is the worst case and the one the reporter was in.

Because the limit is at the edge, there is no server-side knob to raise. The only fix is fewer requests.

## Why the user saw a `!doctype` popup

Cloudflare's 429 has an HTML body. tRPC assigns `meta.response` and *then* awaits `res.json()` (`httpUtils`), so when parsing throws, `meta` is never assigned and `TRPCClientError` arrives with no `data.httpStatus` — just a bare `SyntaxError`. `useQueryModels` passed `error.message` straight into a toast, so the user got:

> Unexpected token '<', "&lt;!doctype "... is not valid JSON

once per attempt, since `InViewLoader` kept retrying and `showErrorNotification` had no id to dedupe on. A page load inside the ~60s block window failed its first fetch and rendered "There are no items for this collection" — the wrong message for a failure.

## Changes

- **`model.utils.ts`** — showcase page size `10 → 50` (the model feed already runs at the handler default of 100); hook returns `pageCount`; the error toast goes through `getQueryErrorMessage` with a stable notification id.
- **`CollectionShowcase.tsx`** — auto-loading capped at 5 pages, then a manual **Load more**; auto-loading stops once a fetch has failed; a real error state with **Try again** replaces the empty-collection copy on failure.
- **`errorHandling.ts`** — new `getQueryErrorMessage`, maps a non-JSON transport failure to readable copy.
- **`notifications.tsx`** — `showErrorNotification` accepts an `id`; Mantine ignores a `show` whose id is already showing or queued.

Net effect for that 2,145-item collection: **215 unthrottled requests → 5**, then it waits for a click.

## Tests

10 new tests (5 browser, 5 unit). Each was checked against a revert rather than only for passing:

- `autoLoad = true` (cap removed) → 2 failures
- error branch deleted → 1 failure

`isError` genuinely flips on a failed `fetchNextPage` — query-core 5.101.0 sets `status: "error"` unconditionally, even with data present — so the stop-on-error guard is not dead code.

Full unit suite: 1665 files / 38,591 tests, exit 0. Typecheck 0 errors, eslint clean, `test:lint-rules` 482/482.

## Notes for review

- The `error.data?.httpStatus === 429` branch in `getQueryErrorMessage` is **unreachable for this bug** — a Cloudflare 429 has no parseable body, so it always takes the regex path. It is there for a tRPC-shaped 429 from our own server.
- This reduces request volume; it does not add a server-side limit. Whether `model.getAll` should carry a `rateLimit()` of its own is worth deciding separately — today Cloudflare is the only thing in front of it.
- A lighter collection-items endpoint would help further: `model.getAll` returns the full model-card payload (versions, images, metrics, per-user flag reads) and runs `skipBatch`, where the showcase needs id/name/type/baseModel/one image/three counters. Not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136mxXcaad7gHQLHfGNPD4M
