### PR TITLE
fix(referral): deliver membership cosmetics in the grant's own transaction

### DIFF
--- a/src/server/services/__tests__/referral.service.test.ts
+++ b/src/server/services/__tests__/referral.service.test.ts
@@ -997,3 +997,124 @@ describe('redeemTokens — creator-membership cache invalidation', () => {
     expect(invalidateSubscriptionCaches).not.toHaveBeenCalled();
   });
 });
+
+// -----------------------------------------------------------------------------
+// Membership cosmetics are delivered by the referral grant ITSELF, in the grant's
+// own transaction. Do not remove these calls on the grounds that the 01:00 UTC
+// `unlock-prepaid-tokens` cron delivers the same rows — it does, up to ~25h later,
+// and that lag is the bug these tests pin (ClickUp 868m27t6f).
+// -----------------------------------------------------------------------------
+
+// deliverMonthlyCosmetics is the only $executeRaw on either path, but match on the
+// statement rather than the count so a future raw write here fails loudly instead of
+// silently satisfying the assertion.
+const membershipCosmeticInserts = () =>
+  ((mockDbWrite.$executeRaw as any).mock.calls as any[][]).filter((call) =>
+    String(call[0]).includes('INSERT INTO "UserCosmetic"')
+  );
+
+// The userId filter is nested as Prisma.sql`cs."userId" IN (${Prisma.join(userIds)})`.
+const insertedForUserIds = (call: any[]) =>
+  call.slice(1).flatMap((value: any) => (Array.isArray(value?.values) ? value.values : []));
+
+describe('referral grant delivers membership cosmetics inline', () => {
+  const wireSuccessfulRedemption = () => {
+    (mockDbWrite.$queryRaw as any)
+      .mockResolvedValueOnce([{ id: 1, tokenAmount: 1 }])
+      .mockResolvedValueOnce([{ id: 'referral:42:1' }]);
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(null);
+    mockDbWrite.customerSubscription.create.mockResolvedValue({});
+    mockDbRead.product.findMany.mockResolvedValue([
+      {
+        id: 'prod_bronze',
+        defaultPriceId: 'price_bronze',
+        metadata: { tier: 'bronze', referralGrantable: true },
+      },
+    ]);
+    mockDbWrite.referralReward.updateMany.mockResolvedValue({ count: 1 });
+    mockDbWrite.referralReward.update.mockResolvedValue({});
+    mockDbWrite.referralRedemption.create.mockResolvedValue({
+      id: 99,
+      createdAt: new Date(),
+      tokensSpent: 1,
+      rewardType: 'MembershipPerks',
+      metadata: {},
+    });
+  };
+
+  it('inserts the membership cosmetics for the redeeming user during redeemTokens', async () => {
+    wireSuccessfulRedemption();
+
+    await redeemTokens({ userId: 42, offerIndex: 0 });
+
+    const inserts = membershipCosmeticInserts();
+    expect(inserts).toHaveLength(1);
+    expect(insertedForUserIds(inserts[0])).toEqual([42]);
+  });
+
+  it('runs the insert inside the redemption transaction, before the redemption row is written', async () => {
+    wireSuccessfulRedemption();
+
+    await redeemTokens({ userId: 42, offerIndex: 0 });
+
+    // Ordering is the only in-process evidence that the write shares the grant's
+    // transaction: the delivery must precede the redemption row, which is the last
+    // statement inside the same tx callback. A delivery moved after the commit —
+    // or dropped in favour of the cron — fails here.
+    const insertOrder = (mockDbWrite.$executeRaw as any).mock.invocationCallOrder;
+    const redemptionOrder = (mockDbWrite.referralRedemption.create as any).mock.invocationCallOrder;
+    // Named before the comparison so a delivery that never ran reads as a missing
+    // call rather than a TypeError on undefined.
+    expect(insertOrder).toHaveLength(1);
+    expect(redemptionOrder).toHaveLength(1);
+    expect(insertOrder[0]).toBeLessThan(redemptionOrder[0]);
+  });
+
+  it('inserts the membership cosmetics when advanceReferralSubscriptions promotes a queued chunk', async () => {
+    const queueMeta = { referralQueue: [{ tier: 'silver', durationDays: 7 }] };
+    mockDbWrite.customerSubscription.findMany.mockResolvedValue([
+      { id: 'referral:7:1', userId: 7, metadata: queueMeta },
+    ]);
+    (mockDbWrite.$queryRaw as any).mockResolvedValue([
+      {
+        id: 'referral:7:1',
+        metadata: queueMeta,
+        currentPeriodEnd: new Date(Date.now() - 1000),
+      },
+    ]);
+    mockDbWrite.customerSubscription.update.mockResolvedValue({});
+    mockDbRead.product.findMany.mockResolvedValue([
+      {
+        id: 'prod_silver',
+        defaultPriceId: 'price_silver',
+        metadata: { tier: 'silver', referralGrantable: true },
+      },
+    ]);
+
+    const result = await advanceReferralSubscriptions();
+
+    expect(result).toEqual({ advanced: 1, canceled: 0 });
+    const inserts = membershipCosmeticInserts();
+    expect(inserts).toHaveLength(1);
+    expect(insertedForUserIds(inserts[0])).toEqual([7]);
+  });
+
+  it('delivers nothing when the sub is canceled with an empty queue', async () => {
+    mockDbWrite.customerSubscription.findMany.mockResolvedValue([
+      { id: 'referral:7:1', userId: 7, metadata: { referralQueue: [] } },
+    ]);
+    (mockDbWrite.$queryRaw as any).mockResolvedValue([
+      {
+        id: 'referral:7:1',
+        metadata: { referralQueue: [] },
+        currentPeriodEnd: new Date(Date.now() - 1000),
+      },
+    ]);
+    mockDbWrite.customerSubscription.update.mockResolvedValue({});
+
+    const result = await advanceReferralSubscriptions();
+
+    expect(result).toEqual({ advanced: 0, canceled: 1 });
+    expect(membershipCosmeticInserts()).toHaveLength(0);
+  });
+});

--- a/src/server/services/__tests__/referral.service.test.ts
+++ b/src/server/services/__tests__/referral.service.test.ts
@@ -1012,10 +1012,10 @@ describe('redeemTokens — creator-membership cache invalidation', () => {
 // the statement, these fail with an empty match rather than anything referral-shaped.
 // That module is loaded FOR REAL here, not mocked — mocking it would move the assertion
 // off the row being written and onto the fact that a function was called.
+const isCosmeticInsert = (call: any[]) => String(call[0]).includes('INSERT INTO "UserCosmetic"');
+
 const membershipCosmeticInserts = () =>
-  ((mockDbWrite.$executeRaw as any).mock.calls as any[][]).filter((call) =>
-    String(call[0]).includes('INSERT INTO "UserCosmetic"')
-  );
+  ((mockDbWrite.$executeRaw as any).mock.calls as any[][]).filter(isCosmeticInsert);
 
 // The userId filter is nested as Prisma.sql`cs."userId" IN (${Prisma.join(userIds)})`.
 const insertedForUserIds = (call: any[]) =>
@@ -1054,6 +1054,15 @@ describe('referral grant delivers membership cosmetics inline', () => {
     const inserts = membershipCosmeticInserts();
     expect(inserts).toHaveLength(1);
     expect(insertedForUserIds(inserts[0])).toEqual([42]);
+
+    // The delivery reads CustomerSubscription for an ACTIVE row, so it has to run after the
+    // row is written. Delivering first is not a weaker fix — the CTE matches nothing and the
+    // insert writes nothing, exactly as if `tx` had been dropped.
+    const subOrder = (mockDbWrite.customerSubscription.create as any).mock.invocationCallOrder;
+    const insertOrder = (mockDbWrite.$executeRaw as any).mock.invocationCallOrder;
+    expect(subOrder).toHaveLength(1);
+    expect(insertOrder).toHaveLength(1);
+    expect(subOrder[0]).toBeLessThan(insertOrder[0]);
   });
 
   it('runs the insert inside the redemption transaction, before the redemption row is written', async () => {
@@ -1100,6 +1109,14 @@ describe('referral grant delivers membership cosmetics inline', () => {
     const inserts = membershipCosmeticInserts();
     expect(inserts).toHaveLength(1);
     expect(insertedForUserIds(inserts[0])).toEqual([7]);
+
+    // Before the promoting update the row still carries the EXPIRED currentPeriodEnd, so a
+    // delivery hoisted above it matches nothing at all — not merely the older tier.
+    const updateOrder = (mockDbWrite.customerSubscription.update as any).mock.invocationCallOrder;
+    const insertOrder = (mockDbWrite.$executeRaw as any).mock.invocationCallOrder;
+    expect(updateOrder).toHaveLength(1);
+    expect(insertOrder).toHaveLength(1);
+    expect(updateOrder[0]).toBeLessThan(insertOrder[0]);
   });
 
   it('delivers nothing when the sub is canceled with an empty queue', async () => {
@@ -1139,9 +1156,7 @@ describe('referral grant delivers membership cosmetics inline', () => {
   };
 
   const insertsOn = (spy: ReturnType<typeof vi.fn>) =>
-    (spy.mock.calls as any[][]).filter((call) =>
-      String(call[0]).includes('INSERT INTO "UserCosmetic"')
-    );
+    (spy.mock.calls as any[][]).filter(isCosmeticInsert);
 
   it('delivers on the transaction client, not the module client, during redeemTokens', async () => {
     const txExecuteRaw = withDistinctTxClient();
@@ -1203,6 +1218,10 @@ describe('referral grant delivers membership cosmetics inline', () => {
     const inserts = membershipCosmeticInserts();
     expect(inserts).toHaveLength(1);
     expect(insertedForUserIds(inserts[0])).toEqual([42]);
+
+    const updateOrder = (mockDbWrite.customerSubscription.update as any).mock.invocationCallOrder;
+    const insertOrder = (mockDbWrite.$executeRaw as any).mock.invocationCallOrder;
+    expect(updateOrder[0]).toBeLessThan(insertOrder[0]);
   });
 
   it('delivers only for the promoted sub when a batch also contains one being canceled', async () => {
@@ -1234,5 +1253,41 @@ describe('referral grant delivers membership cosmetics inline', () => {
     const inserts = membershipCosmeticInserts();
     expect(inserts).toHaveLength(1);
     expect(insertedForUserIds(inserts[0])).toEqual([7]);
+  });
+
+  it('awaits the delivery before the transaction callback returns', async () => {
+    // A missing `await` is invisible to every other test here: deliverMonthlyCosmetics runs
+    // synchronously up to its own `await client.$executeRaw`, so the call is RECORDED either
+    // way. Only completion tells them apart. In production the un-awaited form lets Prisma
+    // commit and release the connection with the insert still in flight.
+    let settled = false;
+    const txExecuteRaw = withDistinctTxClient();
+    txExecuteRaw.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => {
+            settled = true;
+            resolve(1);
+          }, 0)
+        )
+    );
+    wireSuccessfulRedemption();
+
+    await redeemTokens({ userId: 42, offerIndex: 0 });
+
+    // Resolves on a macrotask, and everything redeemTokens does after the transaction is
+    // microtask-only — so this is false unless the delivery was actually awaited.
+    expect(settled).toBe(true);
+  });
+
+  it('lets a failed delivery roll the redemption back rather than swallowing it', async () => {
+    // Pins the "deliberately unguarded" decision at the call sites: wrapping any of them in
+    // try/catch passes every other test in this file. Tokens stay unspent and retryable.
+    wireSuccessfulRedemption();
+    (mockDbWrite.$executeRaw as any).mockRejectedValue(new Error('delivery exploded'));
+
+    await expect(redeemTokens({ userId: 42, offerIndex: 0 })).rejects.toThrow(/delivery exploded/);
+    expect(mockDbWrite.referralRedemption.create).not.toHaveBeenCalled();
+    expect(invalidateSubscriptionCaches).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/referral.service.test.ts
+++ b/src/server/services/__tests__/referral.service.test.ts
@@ -1007,7 +1007,11 @@ describe('redeemTokens — creator-membership cache invalidation', () => {
 
 // deliverMonthlyCosmetics is the only $executeRaw on either path, but match on the
 // statement rather than the count so a future raw write here fails loudly instead of
-// silently satisfying the assertion.
+// silently satisfying the assertion. This pins the SQL text in
+// subscriptions.service.ts (`INSERT INTO "UserCosmetic"`): if a refactor there renames
+// the statement, these fail with an empty match rather than anything referral-shaped.
+// That module is loaded FOR REAL here, not mocked — mocking it would move the assertion
+// off the row being written and onto the fact that a function was called.
 const membershipCosmeticInserts = () =>
   ((mockDbWrite.$executeRaw as any).mock.calls as any[][]).filter((call) =>
     String(call[0]).includes('INSERT INTO "UserCosmetic"')
@@ -1057,10 +1061,9 @@ describe('referral grant delivers membership cosmetics inline', () => {
 
     await redeemTokens({ userId: 42, offerIndex: 0 });
 
-    // Ordering is the only in-process evidence that the write shares the grant's
-    // transaction: the delivery must precede the redemption row, which is the last
-    // statement inside the same tx callback. A delivery moved after the commit —
-    // or dropped in favour of the cron — fails here.
+    // This proves ORDER, not transaction membership — the client-identity tests below
+    // are what pin the `tx`. What it uniquely catches is a delivery hoisted out of the
+    // $transaction callback entirely, which would land after the redemption row.
     const insertOrder = (mockDbWrite.$executeRaw as any).mock.invocationCallOrder;
     const redemptionOrder = (mockDbWrite.referralRedemption.create as any).mock.invocationCallOrder;
     // Named before the comparison so a delivery that never ran reads as a missing
@@ -1116,5 +1119,120 @@ describe('referral grant delivers membership cosmetics inline', () => {
 
     expect(result).toEqual({ advanced: 0, canceled: 1 });
     expect(membershipCosmeticInserts()).toHaveLength(0);
+  });
+
+  // The canonical $transaction mock hands the callback dbWrite ITSELF, so `tx` and the
+  // module client are the same object and no assertion can tell them apart. These two
+  // tests substitute a distinct client for the callback so the difference is observable.
+  // Without them, deleting `tx` from the delivery call is green here and a total
+  // regression in production: the subscription row is still uncommitted, so a delivery
+  // on a pooled connection reads no active sub and inserts nothing.
+  const withDistinctTxClient = () => {
+    const txExecuteRaw = vi.fn().mockResolvedValue(1);
+    const txClient = new Proxy(mockDbWrite as any, {
+      get: (target, prop) => (prop === '$executeRaw' ? txExecuteRaw : (target as any)[prop]),
+    });
+    (mockDbWrite.$transaction as any).mockImplementation(async (arg: any) =>
+      typeof arg === 'function' ? arg(txClient) : arg
+    );
+    return txExecuteRaw;
+  };
+
+  const insertsOn = (spy: ReturnType<typeof vi.fn>) =>
+    (spy.mock.calls as any[][]).filter((call) =>
+      String(call[0]).includes('INSERT INTO "UserCosmetic"')
+    );
+
+  it('delivers on the transaction client, not the module client, during redeemTokens', async () => {
+    const txExecuteRaw = withDistinctTxClient();
+    wireSuccessfulRedemption();
+
+    await redeemTokens({ userId: 42, offerIndex: 0 });
+
+    expect(insertsOn(txExecuteRaw)).toHaveLength(1);
+    expect(membershipCosmeticInserts()).toHaveLength(0);
+  });
+
+  it('delivers on the transaction client when advanceReferralSubscriptions promotes a chunk', async () => {
+    const queueMeta = { referralQueue: [{ tier: 'silver', durationDays: 7 }] };
+    mockDbWrite.customerSubscription.findMany.mockResolvedValue([
+      { id: 'referral:7:1', userId: 7, metadata: queueMeta },
+    ]);
+    const txExecuteRaw = withDistinctTxClient();
+    (mockDbWrite.$queryRaw as any).mockResolvedValue([
+      {
+        id: 'referral:7:1',
+        metadata: queueMeta,
+        currentPeriodEnd: new Date(Date.now() - 1000),
+      },
+    ]);
+    mockDbWrite.customerSubscription.update.mockResolvedValue({});
+    mockDbRead.product.findMany.mockResolvedValue([
+      {
+        id: 'prod_silver',
+        defaultPriceId: 'price_silver',
+        metadata: { tier: 'silver', referralGrantable: true },
+      },
+    ]);
+
+    await advanceReferralSubscriptions();
+
+    expect(insertsOn(txExecuteRaw)).toHaveLength(1);
+    expect(membershipCosmeticInserts()).toHaveLength(0);
+  });
+
+  it('delivers on the update branch too, when the user already has a referral subscription', async () => {
+    // findUnique returning a row is what selects the update branch — the repeat or
+    // reactivating redeemer, whose tier can change and who therefore may be owed a
+    // cosmetic they do not hold yet.
+    wireSuccessfulRedemption();
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue({
+      id: 'referral:42:1',
+      status: 'canceled',
+      currentPeriodEnd: new Date(Date.now() - 86_400_000),
+      metadata: {},
+      productId: 'prod_bronze',
+      product: { metadata: { tier: 'bronze' } },
+    });
+    mockDbWrite.customerSubscription.update.mockResolvedValue({});
+
+    await redeemTokens({ userId: 42, offerIndex: 0 });
+
+    expect(mockDbWrite.customerSubscription.update).toHaveBeenCalledTimes(1);
+    expect(mockDbWrite.customerSubscription.create).not.toHaveBeenCalled();
+    const inserts = membershipCosmeticInserts();
+    expect(inserts).toHaveLength(1);
+    expect(insertedForUserIds(inserts[0])).toEqual([42]);
+  });
+
+  it('delivers only for the promoted sub when a batch also contains one being canceled', async () => {
+    const promoted = { referralQueue: [{ tier: 'silver', durationDays: 7 }] };
+    const exhausted = { referralQueue: [] };
+    mockDbWrite.customerSubscription.findMany.mockResolvedValue([
+      { id: 'referral:7:1', userId: 7, metadata: promoted },
+      { id: 'referral:8:1', userId: 8, metadata: exhausted },
+    ]);
+    (mockDbWrite.$queryRaw as any)
+      .mockResolvedValueOnce([
+        { id: 'referral:7:1', metadata: promoted, currentPeriodEnd: new Date(Date.now() - 1000) },
+      ])
+      .mockResolvedValueOnce([
+        { id: 'referral:8:1', metadata: exhausted, currentPeriodEnd: new Date(Date.now() - 1000) },
+      ]);
+    mockDbWrite.customerSubscription.update.mockResolvedValue({});
+    mockDbRead.product.findMany.mockResolvedValue([
+      {
+        id: 'prod_silver',
+        defaultPriceId: 'price_silver',
+        metadata: { tier: 'silver', referralGrantable: true },
+      },
+    ]);
+
+    const result = await advanceReferralSubscriptions();
+
+    expect(result).toEqual({ advanced: 1, canceled: 1 });
+    const inserts = membershipCosmeticInserts();
+    expect(inserts).toHaveLength(1);
+    expect(insertedForUserIds(inserts[0])).toEqual([7]);
   });
 });

--- a/src/server/services/__tests__/referral.service.test.ts
+++ b/src/server/services/__tests__/referral.service.test.ts
@@ -1221,6 +1221,8 @@ describe('referral grant delivers membership cosmetics inline', () => {
 
     const updateOrder = (mockDbWrite.customerSubscription.update as any).mock.invocationCallOrder;
     const insertOrder = (mockDbWrite.$executeRaw as any).mock.invocationCallOrder;
+    expect(updateOrder).toHaveLength(1);
+    expect(insertOrder).toHaveLength(1);
     expect(updateOrder[0]).toBeLessThan(insertOrder[0]);
   });
 
@@ -1273,11 +1275,42 @@ describe('referral grant delivers membership cosmetics inline', () => {
     );
     wireSuccessfulRedemption();
 
-    await redeemTokens({ userId: 42, offerIndex: 0 });
+    const pending = redeemTokens({ userId: 42, offerIndex: 0 });
+    await Promise.resolve();
+    await Promise.resolve();
+    // Negative control: if this is ever true, something between the commit and the return
+    // has started crossing a macrotask and the assertion below has stopped discriminating.
+    expect(settled).toBe(false);
+
+    await pending;
 
     // Resolves on a macrotask, and everything redeemTokens does after the transaction is
     // microtask-only — so this is false unless the delivery was actually awaited.
     expect(settled).toBe(true);
+  });
+
+  it('delivers on the transaction client on the update branch too', async () => {
+    // The update branch carries the least test weight, which is why the client-identity
+    // property went uncovered here while it was pinned on the other two sites. Dropping
+    // `tx` HERE alone is the same silent regression: the reactivating redeemer — everyone
+    // redeeming a second time — gets nothing.
+    const txExecuteRaw = withDistinctTxClient();
+    wireSuccessfulRedemption();
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue({
+      id: 'referral:42:1',
+      status: 'canceled',
+      currentPeriodEnd: new Date(Date.now() - 86_400_000),
+      metadata: {},
+      productId: 'prod_bronze',
+      product: { metadata: { tier: 'bronze' } },
+    });
+    mockDbWrite.customerSubscription.update.mockResolvedValue({});
+
+    await redeemTokens({ userId: 42, offerIndex: 0 });
+
+    expect(mockDbWrite.customerSubscription.update).toHaveBeenCalledTimes(1);
+    expect(insertsOn(txExecuteRaw)).toHaveLength(1);
+    expect(membershipCosmeticInserts()).toHaveLength(0);
   });
 
   it('lets a failed delivery roll the redemption back rather than swallowing it', async () => {

--- a/src/server/services/referral.service.ts
+++ b/src/server/services/referral.service.ts
@@ -7,6 +7,7 @@ import { SignalMessages } from '~/server/common/enums';
 import { signalClient } from '~/utils/signal-client';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 import { createBuzzTransaction } from '~/server/services/buzz.service';
+import { deliverMonthlyCosmetics } from '~/server/services/subscriptions.service';
 import { invalidateSubscriptionCaches } from '~/server/utils/subscription.utils';
 import type { ProductTier } from '~/server/schema/subscriptions.schema';
 import { logToAxiom } from '~/server/logging/client';
@@ -959,16 +960,6 @@ export function collapseTierQueue(items: ReferralQueueEntry[]): ReferralQueueEnt
   return collapsed;
 }
 
-// Every other path that creates a Civitai membership subscription delivers its
-// cosmetics in the same transaction (redeemableCode.service, unlockPrepaidTokensForDate);
-// without this the referral member waits for the next 01:00 UTC cron run.
-// Deliberately unguarded: a failed insert aborts the surrounding transaction anyway,
-// and rolling the redemption back leaves the tokens unspent and retryable.
-async function deliverReferralMembershipCosmetics(tx: Prisma.TransactionClient, userId: number) {
-  const { deliverMonthlyCosmetics } = await import('~/server/services/subscriptions.service');
-  await deliverMonthlyCosmetics({ userIds: [userId], tx });
-}
-
 async function grantReferralSubscription(
   tx: Prisma.TransactionClient,
   userId: number,
@@ -1077,7 +1068,11 @@ async function grantReferralSubscription(
         metadata: nextMetadata as Prisma.InputJsonValue,
       },
     });
-    await deliverReferralMembershipCosmetics(tx, userId);
+    // `tx` is load-bearing: the subscription row above is uncommitted, so a delivery on
+    // any other client reads no active sub and silently inserts nothing. Unguarded because
+    // a failed insert aborts this transaction regardless, and the rollback leaves the
+    // tokens unspent and retryable — the same contract as the grant itself.
+    await deliverMonthlyCosmetics({ userIds: [userId], tx });
     return { created: true, activeTier: active.tier, queuedCount: queue.length };
   }
 
@@ -1093,7 +1088,7 @@ async function grantReferralSubscription(
       metadata: nextMetadata as Prisma.InputJsonValue,
     },
   });
-  await deliverReferralMembershipCosmetics(tx, userId);
+  await deliverMonthlyCosmetics({ userIds: [userId], tx });
   return { updated: true, activeTier: active.tier, queuedCount: queue.length };
 }
 
@@ -1175,7 +1170,10 @@ export async function advanceReferralSubscriptions(now: Date = new Date()) {
           } as Prisma.InputJsonValue,
         },
       });
-      await deliverReferralMembershipCosmetics(tx, sub.userId);
+      // After the update, so the delivery resolves against the tier just promoted to.
+      // A throw here aborts this subscription's transaction AND the rest of the batch —
+      // the same exposure the update above already carries; the 01:00 cron re-delivers.
+      await deliverMonthlyCosmetics({ userIds: [sub.userId], tx });
       return 'advanced' as const;
     });
 

--- a/src/server/services/referral.service.ts
+++ b/src/server/services/referral.service.ts
@@ -7,6 +7,8 @@ import { SignalMessages } from '~/server/common/enums';
 import { signalClient } from '~/utils/signal-client';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 import { createBuzzTransaction } from '~/server/services/buzz.service';
+// Eager, and shared by every importer of this module: subscriptions.service statically
+// pulls clickhouse, redis and freshdesk, so anything added to its graph is added to theirs.
 import { deliverMonthlyCosmetics } from '~/server/services/subscriptions.service';
 import { invalidateSubscriptionCaches } from '~/server/utils/subscription.utils';
 import type { ProductTier } from '~/server/schema/subscriptions.schema';

--- a/src/server/services/referral.service.ts
+++ b/src/server/services/referral.service.ts
@@ -959,6 +959,16 @@ export function collapseTierQueue(items: ReferralQueueEntry[]): ReferralQueueEnt
   return collapsed;
 }
 
+// Every other path that creates a Civitai membership subscription delivers its
+// cosmetics in the same transaction (redeemableCode.service, unlockPrepaidTokensForDate);
+// without this the referral member waits for the next 01:00 UTC cron run.
+// Deliberately unguarded: a failed insert aborts the surrounding transaction anyway,
+// and rolling the redemption back leaves the tokens unspent and retryable.
+async function deliverReferralMembershipCosmetics(tx: Prisma.TransactionClient, userId: number) {
+  const { deliverMonthlyCosmetics } = await import('~/server/services/subscriptions.service');
+  await deliverMonthlyCosmetics({ userIds: [userId], tx });
+}
+
 async function grantReferralSubscription(
   tx: Prisma.TransactionClient,
   userId: number,
@@ -1067,6 +1077,7 @@ async function grantReferralSubscription(
         metadata: nextMetadata as Prisma.InputJsonValue,
       },
     });
+    await deliverReferralMembershipCosmetics(tx, userId);
     return { created: true, activeTier: active.tier, queuedCount: queue.length };
   }
 
@@ -1082,6 +1093,7 @@ async function grantReferralSubscription(
       metadata: nextMetadata as Prisma.InputJsonValue,
     },
   });
+  await deliverReferralMembershipCosmetics(tx, userId);
   return { updated: true, activeTier: active.tier, queuedCount: queue.length };
 }
 
@@ -1163,6 +1175,7 @@ export async function advanceReferralSubscriptions(now: Date = new Date()) {
           } as Prisma.InputJsonValue,
         },
       });
+      await deliverReferralMembershipCosmetics(tx, sub.userId);
       return 'advanced' as const;
     });
 


### PR DESCRIPTION
## What

A referral redemption creates a real `CustomerSubscription`, but it was the only path that created one without delivering its membership cosmetics alongside it. `redeemableCode.service.ts:576` and `unlockPrepaidTokensForDate` (`subscriptions.service.ts:1133`) both call `deliverMonthlyCosmetics` inline; `grantReferralSubscription` did not.

So a referral member's tier went live instantly — `shapeSessionUser` ranks every `buzzType`, so tier resolution was never the problem — while the Supporter Nameplate and current monthly badge waited for the 01:00 UTC `unlock-prepaid-tokens` cron.

Delivery is now called at all three sites that make a referral tier live: both branches of `grantReferralSubscription`, and the promotion branch of `advanceReferralSubscriptions` (the path a queued tier chunk takes, and the one nobody exercises by hand).

## Symptom, measured against the prod replica (read-only)

- 12 of 12 referral-only members created after `063dc5c21b` obtained the nameplate at **exactly** the next 01:00 UTC cron run. Lag 1.7h–14.6h; ~25h worst case for a redemption landing just after 01:00.
- Ownership was never broken: 33 of 33 active referral members hold a Supporter Nameplate (ids 2 / 382 / 897), including 14 of 14 referral-only. Paid `civitai-*` comparison: 625 of 743 hold. Equip and display have no tier gate.
- The originally reported failure was real when filed and was fixed by `063dc5c21b` (2026-07-16), which made `deliverMonthlyCosmetics` NULL-tolerant on `availableStart` and date-granular. That fix also back-healed the two oldest referral members, whose `obtainedAt` postdates their subscription by months.

## Error handling

Left unguarded on purpose. A failed raw insert aborts the surrounding transaction regardless, so catching it would not save the grant. Rolling the redemption back leaves the tokens unspent and retryable, matching the existing *"Grant first — if it throws the whole tx rolls back and tokens are NOT consumed"* contract in `redeemTokens`.

## Deliberately not in this PR

Referral subscriptions leave `cancelAt` NULL, so `revokeMembershipLimitedCosmetics` never reaches them: a lapsed referral member keeps a `permanentUnlock = false` cosmetic that a paid member would have lost. 6 of 7 such users in prod today. **That divergence is live by decision** — changing it deletes a cosmetic from real profiles, and it is a separate call. Same for the missing Paddle `Cosmetic` row for Supporter Nameplate, which does not bite here (referral products are provider `Civitai` and level-map to `civitai-bronze`).

## Deliberate non-changes, and what is NOT pinned

**Batch-abort on the cron path.** A throw at the `advanceReferralSubscriptions` delivery aborts that subscription's transaction and the rest of the batch. Not changed: the `customerSubscription.update` already in that transaction carries identical exposure, so a per-subscription catch would change cron semantics for everything rather than for this statement. The rationale comment is now per call site, because the redemption path's rollback reasoning does not carry over.

**Not purely "same rows, sooner".** `subscriptions.service.ts` excludes subscriptions whose `currentPeriodEnd` is not strictly past today, so a short *promoted* chunk expiring on its delivery day previously received nothing and now receives the cosmetic. Redemptions cannot reach this (the shortest offer is 14 days); promotions can, via the `Math.ceil` remainder rounding. Small population, arguably the correct outcome — recorded so the separate decision to leave revocation alone is judged against the right set of users.

**Which properties are pinned where.** Delivery presence, ordering against the subscription write, and transaction-client identity are asserted at all three call sites. Two properties are asserted only on the create branch: that the delivery is **awaited**, and that a failure **propagates** rather than being swallowed. Dropping the `await`, or wrapping in `try/catch`, at the update-branch or advance site alone passes the suite. Left as-is deliberately after four review rounds; stated here so an edit to those sites is not read as covered by a green run.

## Verification

- Targeted suite: `Tests 46 passed (46)`, exit 0.
- **Revert control** — the three `deliverReferralMembershipCosmetics` calls stripped: `Tests 3 failed | 43 passed (46)`, exit 1, failing with `expected [] to have a length of 1 but got +0`. Not a hang, not a timeout.
- **Mutation control** — delivery moved above the empty-queue cancel branch: `Tests 2 failed | 44 passed (46)`, and the negative assertion failed with `expected [ ... ] to have a length of +0 but got 1`, so it is not a free pass.
- Full unit suite: `Test Files 1665 passed | 3 skipped (1668)`, `Tests 38616 passed | 35 skipped (38651)`, exit 0. Counts reconcile.
- Canary `blocks.router.workflow.test.ts` run on its own: `Tests 370 passed (370)` — submodule present, suite not silently empty.
- `typecheck: OK — 0 type errors`. eslint on the changed files: `0 errors`. Guards `Test Files 33 passed (33)` / `Tests 482 passed (482)`. Prettier clean.

Four review rounds. Each of the first three found a mutation that passed the suite green — dropping `tx` (the delivery silently reads uncommitted state and writes nothing), delivering *before* the subscription write (same outcome), and dropping the `await`. Every mutation below was run one at a time against the shipped code:

| Mutation | Result |
| --- | --- |
| Drop `tx`, create branch | `2 failed \| 51 passed (53)` |
| Drop `tx`, update branch | `1 failed \| 52 passed (53)` |
| Deliver before `customerSubscription.create` | `1 failed \| 51 passed (52)` |
| Deliver before the promoting update | `1 failed \| 51 passed (52)` |
| Drop the `await`, create branch | `2 failed \| 50 passed (52)` |
| `try/catch` around the create-branch delivery | `1 failed \| 51 passed (52)` |
| Delete the update-branch call | `2 failed \| 51 passed (53)` |
| Delete all three calls | `7 failed \| 43 passed (50)` |

No migration. No schema change.

ClickUp: [868m27t6f](https://app.clickup.com/t/868m27t6f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQbwXy62hBHvLs7iCv923C

