### PR TITLE
fix(collections): notify collection owners on every submission path

### DIFF
--- a/src/server/services/__tests__/collection-bulk-save-submission-notify.test.ts
+++ b/src/server/services/__tests__/collection-bulk-save-submission-notify.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+const mockDbRead = dbMock.dbRead;
+const mockDbWrite = dbMock.dbWrite;
+
+// `bulkSaveItems` is the wider of the two submit paths (collection "Submit an entry", direct
+// upload, post-publish-into-a-collection) and notified nobody — ClickUp 868m15nne.
+
+const { mockCreateNotification, mockHomeBlockCacheBust, mockQueueUpdate } = vi.hoisted(() => ({
+  mockCreateNotification: vi.fn(),
+  mockHomeBlockCacheBust: vi.fn(),
+  mockQueueUpdate: vi.fn(),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: mockCreateNotification,
+}));
+vi.mock('~/server/services/home-block-cache.service', () => ({
+  homeBlockCacheBust: mockHomeBlockCacheBust,
+}));
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: mockQueueUpdate },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+}));
+
+const { bulkSaveItems } = await import('~/server/services/collection.service');
+
+const COLLECTION_ID = 10;
+const OWNER_ID = 999;
+const MANAGER_ID = 777;
+const SUBMITTER_ID = 555;
+const JUDGE_USER_ID = 6235605;
+const IMAGE_IDS = [42, 43, 44];
+
+function arrangeCollection(overrides: Record<string, unknown> = {}) {
+  mockDbRead.collection.findUnique.mockResolvedValue({
+    id: COLLECTION_ID,
+    name: 'Indie Spotlight',
+    description: null,
+    read: 'Public',
+    write: 'Review',
+    type: 'Image',
+    nsfw: false,
+    nsfwLevel: 0,
+    image: null,
+    mode: null,
+    metadata: {},
+    availability: 'Public',
+    userId: OWNER_ID,
+    tags: [],
+    ...overrides,
+  });
+}
+
+// `isContributor` short-circuits the follow-on-submit branch, which isn't what these tests are about.
+// `writeReview` without `manage`/`isOwner`/`isCollaborator` is what puts the write into REVIEW.
+function reviewPermissions() {
+  return {
+    collectionId: COLLECTION_ID,
+    read: true,
+    write: false,
+    writeReview: true,
+    manage: false,
+    follow: true,
+    isContributor: true,
+    isOwner: false,
+    isCollaborator: false,
+  } as never;
+}
+
+function submit(permissions = reviewPermissions()) {
+  return bulkSaveItems({
+    input: {
+      collectionId: COLLECTION_ID,
+      imageIds: IMAGE_IDS,
+      userId: SUBMITTER_ID,
+      isModerator: false,
+    } as never,
+    permissions,
+  });
+}
+
+describe('bulkSaveItems — submission notification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    arrangeCollection();
+    mockDbRead.collectionItem.findMany.mockResolvedValue([]);
+    mockDbWrite.collectionItem.createMany.mockResolvedValue({ count: IMAGE_IDS.length });
+    mockDbRead.collectionContributor.findMany.mockResolvedValue([]);
+    mockDbRead.challengeJudge.findMany.mockResolvedValue([]);
+  });
+
+  it('notifies the owner and MANAGE holders once for the whole batch', async () => {
+    mockDbRead.collectionContributor.findMany.mockResolvedValue([
+      { collectionId: COLLECTION_ID, userId: MANAGER_ID },
+    ]);
+
+    await submit();
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'collection-submission-received',
+        userIds: expect.arrayContaining([OWNER_ID, MANAGER_ID]),
+        details: { collectionId: COLLECTION_ID, collectionName: 'Indie Spotlight' },
+      })
+    );
+    const { userIds } = mockCreateNotification.mock.calls[0][0] as { userIds: number[] };
+    expect(userIds).not.toContain(SUBMITTER_ID);
+  });
+
+  it('does not notify when the entries were accepted outright rather than queued for review', async () => {
+    await submit({ ...reviewPermissions(), writeReview: true, manage: true } as never);
+
+    expect(mockDbWrite.collectionItem.createMany).toHaveBeenCalled();
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+
+  it('does not notify when every item was already in the collection', async () => {
+    mockDbRead.collectionItem.findMany.mockResolvedValue(IMAGE_IDS.map((imageId) => ({ imageId })));
+    mockDbWrite.collectionItem.createMany.mockResolvedValue({ count: 0 });
+
+    await submit();
+
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+
+  it('drops a challenge judge from the recipients, leaving nothing to send', async () => {
+    arrangeCollection({ userId: JUDGE_USER_ID, mode: null });
+    mockDbRead.challengeJudge.findMany.mockResolvedValue([{ userId: JUDGE_USER_ID }]);
+
+    await submit();
+
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+
+  it('still reports the saved items when notifying throws', async () => {
+    mockDbRead.collectionContributor.findMany.mockRejectedValue(new Error('replica hiccup'));
+
+    await expect(submit()).resolves.toEqual(
+      expect.objectContaining({ count: IMAGE_IDS.length, imageIds: IMAGE_IDS })
+    );
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/collection-submission-notify-failure-isolation.test.ts
+++ b/src/server/services/__tests__/collection-submission-notify-failure-isolation.test.ts
@@ -122,4 +122,15 @@ describe('saveItemInCollections — submission-notify failure isolation', () => 
     const call = mockCreateNotification.mock.calls[0][0] as { userIds: number[] };
     expect(call.userIds).not.toContain(SUBMITTER_ID);
   });
+
+  it('does not notify a re-save of an item already in the collection under the same tag', async () => {
+    mockDbRead.collectionItem.findMany.mockResolvedValue([
+      { id: 1, collectionId: COLLECTION_ID, tagId: null, addedById: SUBMITTER_ID, note: null },
+    ]);
+    mockDbRead.collectionContributor.findMany.mockResolvedValue([]);
+
+    await expect(submit()).resolves.toBe('added');
+
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
 });

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -764,6 +764,65 @@ async function applyCollectionAutoTag(
   }
 }
 
+type SubmissionNotifyCollection = { id: number; name: string; userId: number };
+
+// Callers have already committed the item write, so nothing here may throw: an error for a submit
+// that succeeded gets retried, and double-submits.
+async function notifyCollectionSubmissionReceived({
+  collections,
+  submitterId,
+}: {
+  collections: SubmissionNotifyCollection[];
+  submitterId: number;
+}) {
+  if (collections.length === 0) return;
+  const collectionIds = collections.map((c) => c.id);
+
+  try {
+    const [managers, judges] = await Promise.all([
+      dbRead.collectionContributor.findMany({
+        where: {
+          collectionId: { in: collectionIds },
+          permissions: { has: CollectionContributorPermission.MANAGE },
+        },
+        select: { collectionId: true, userId: true },
+      }),
+      // Every challenge entry collection is owned by a judge's user account
+      // (resolveChallengeCollectionOwnerId), so without this each entry notifies the judge.
+      dbRead.challengeJudge.findMany({ select: { userId: true } }),
+    ]);
+    const judgeUserIds = new Set(judges.map((j) => j.userId));
+
+    await Promise.all(
+      collections.map((collection) => {
+        const recipients = uniq([
+          collection.userId,
+          ...managers.filter((m) => m.collectionId === collection.id).map((m) => m.userId),
+        ]).filter((id) => id !== submitterId && !judgeUserIds.has(id));
+        if (recipients.length === 0) return;
+
+        return createNotification({
+          userIds: recipients,
+          type: 'collection-submission-received',
+          category: NotificationCategory.Update,
+          key: `collection-submission-received:${collection.id}:${uuid()}`,
+          details: { collectionId: collection.id, collectionName: collection.name },
+        });
+      })
+    );
+  } catch (error) {
+    logToAxiom({
+      type: 'error',
+      name: 'collection-submission-notify-failed',
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+      collectionIds,
+    }).catch(() => {
+      // swallow — best-effort logging must never break the submit it is observing
+    });
+  }
+}
+
 export const saveItemInCollections = async ({
   input: {
     collections: upsertCollectionItems,
@@ -992,7 +1051,7 @@ export const saveItemInCollections = async ({
       })
       .filter(isDefined);
 
-    // The "Save to collection" modal is the other door into removal, and a delete through it
+    // The "Add to Collection" modal is the other door into removal, and a delete through it
     // would let the job re-add the image the removal was meant to stop.
     const autoFeatureUserId = await getAutoFeatureUserId();
     const autoFeaturedIds = removeAllowedCollectionItemIds.filter((id) => {
@@ -1062,54 +1121,17 @@ export const saveItemInCollections = async ({
     }
   }
 
+  // Excluding `unwrittenCollectionIds` keeps a no-op re-save from reading as a second submission.
   const reviewCollectionIds = uniq(
-    data.filter((d) => d.status === CollectionItemStatus.REVIEW).map((d) => d.collectionId)
+    data
+      .filter((d) => d.status === CollectionItemStatus.REVIEW)
+      .map((d) => d.collectionId)
+      .filter((id) => !unwrittenCollectionIds.has(id))
   );
-  if (reviewCollectionIds.length > 0) {
-    try {
-      const managers = await dbRead.collectionContributor.findMany({
-        where: {
-          collectionId: { in: reviewCollectionIds },
-          permissions: { has: CollectionContributorPermission.MANAGE },
-        },
-        select: { collectionId: true, userId: true },
-      });
-
-      await Promise.all(
-        reviewCollectionIds.map((collectionId) => {
-          const collection = collections.find((c) => c.id === collectionId);
-          if (!collection) return;
-
-          const recipients = uniq([
-            collection.userId,
-            ...managers.filter((m) => m.collectionId === collectionId).map((m) => m.userId),
-          ]).filter((id) => id !== userId);
-          if (recipients.length === 0) return;
-
-          return createNotification({
-            userIds: recipients,
-            type: 'collection-submission-received',
-            category: NotificationCategory.Update,
-            key: `collection-submission-received:${collectionId}:${uuid()}`,
-            details: { collectionId, collectionName: collection.name },
-          });
-        })
-      );
-    } catch (error) {
-      // The item write above already committed — a failure resolving recipients or notifying
-      // them must not fail the submit itself, or the caller sees an error for an action that
-      // actually succeeded and is likely to retry and double-submit.
-      logToAxiom({
-        type: 'error',
-        name: 'collection-submission-notify-failed',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-        collectionIds: reviewCollectionIds,
-      }).catch(() => {
-        // swallow — best-effort logging must never break the submit it is observing
-      });
-    }
-  }
+  await notifyCollectionSubmissionReceived({
+    collections: collections.filter((c) => reviewCollectionIds.includes(c.id)),
+    submitterId: userId,
+  });
 
   // The feed index carries collection membership for hubs, and nothing about a
   // CollectionItem write reaches it on its own. Covers both directions: the
@@ -3334,6 +3356,14 @@ export const bulkSaveItems = async ({
 
   // Tag AFTER the entry-fee block, so anything rolled back for non-payment is never tagged.
   await applyCollectionAutoTag(metadata, savedImageIds);
+
+  // After the entry-fee block, so an entry rolled back for non-payment is never announced.
+  if (count > 0 && status === CollectionItemStatus.REVIEW) {
+    await notifyCollectionSubmissionReceived({
+      collections: [collection],
+      submitterId: userId,
+    });
+  }
 
   // Bust AFTER the write so a concurrent read can't repopulate the cache with pre-write data.
   await homeBlockCacheBust(HomeBlockType.Collection, collectionId);


### PR DESCRIPTION
## The bug

`collection-submission-received` was only emitted from `saveItemInCollections`, so a collection owner heard about a submission only when the submitter happened to use the **"Add to Collection"** modal on a content card.

Every other door goes through `bulkSaveItems`, which wrote `REVIEW` items and notified nobody:

| Door | Path | Notified before |
|---|---|---|
| "Add to Collection" modal on an image/model card | `saveItemInCollections` | ✅ |
| **Collection page "Submit an entry"** → `AddUserContentModal` | `bulkSaveItems` | ❌ |
| Direct upload into a collection (`addSimpleImagePost`) | `bulkSaveItems` | ❌ |
| Publish a post into a collection | `bulkSaveItems` | ❌ |
| `ChallengeSubmitModal` | `bulkSaveItems` | ❌ |

`Collection.tsx` routes the primary "Submit an entry" button to `AddUserContentModal`, so the most obvious way to submit was the silent one. That is why it read as intermittent rather than broken — it depended on which door the *submitter* used, not on anything the owner did.

## Evidence

Prod main DB against `notification_prod`, over the eleven user-owned `write:Review` collections active since the notification shipped (2026-08-13):

| Collection | Owner | Items | Notifications |
|---|---|---|---|
| The Comedy Club | Eva4321 | 83 | 30 |
| Indie Spotlight | Boerboer (reporter) | 78 | 49 |
| Ellie's Featured | Ellie_TheFoxyPaladin | 49 | 44 |
| BDSM-Community-Choose | nofmegan895 | 41 | 31 |
| Sticker this! | DD13 | 15 | 8 |
| Stuff Dem liked (Q3) | DD13 | 13 | 6 |
| Pokedex (Community) — models | CitronLegacy | 12 | **0** |
| Legend of Zelda Loras — models | CitronLegacy | 11 | **0** |
| Stuff Dem Liked (Lewd) | DD13 | 6 | 3 |
| Daz Suggestionbox | DazMakeArt | 3 | 2 |
| NofMegan-Community-Fav | nofmegan895 | 3 | 2 |
| **Total** | | **314** | **175** |

The two zero rows are model collections whose submissions all arrived via multi-select bulk add — `bulkSaveItems` in isolation, 23 items, no notification ever. On 2026-08-30, the day the report was filed, the reporter's collection took two submissions and sent none.

Ruled out: no `UserNotificationSettings` opt-out rows for any owner checked; the fan-out worker was healthy (`PendingNotification` depth 44, oldest 2 min); every collection post-dates the deploy.

## The change

- **Extract** the recipient fan-out into `notifyCollectionSubmissionReceived`, keeping the existing try/catch isolation and the `collection-submission-notify-failed` Axiom log name.
- **Call it from `bulkSaveItems`**, placed after the entry-fee block so an entry rolled back for non-payment is never announced. Guarded on `count > 0 && status === REVIEW`. One notification per call, not per item — a bulk add of twenty images is one submission to review.
- **Drop challenge judges from the recipients.** Challenge entry collections are owned by a judge's account (`resolveChallengeCollectionOwnerId`) and take thousands of entries a day; CivBot and CivChan already hold 2,654 of the 4,038 notifications of this type sent to date. This is a *recipient* filter, not a contest blocklist — a human-run contest still notifies its owner.
- **Stop notifying a no-op re-save**, where the item is already in the collection under the same tag and the upsert writes nothing.

Coverage is complete: the other three `CollectionItem` insert sites (bookmarks, model-create, auto-feature) cannot produce `REVIEW` — the schema default is `ACCEPTED` and the last sets it explicitly.

## Verification

- Full unit suite: **38,612 passed, 0 failed**
- `test:lint-rules`: 33 files, 482 passed
- `tsc --noEmit`: clean. eslint: one pre-existing `no-unused-vars` warning at `collection.service.ts:464`, identical on the base.
- **Both fixes revert-checked.** Removing the `bulkSaveItems` call → `expected "vi.fn()" to be called 1 times, but got 0 times` in 4ms. Removing the `unwrittenCollectionIds` filter → `expected "vi.fn()" to not be called at all, but actually been called 1 times` in 2ms. Both fail fast and legibly rather than hanging.

Note on the new tests: only one of the five goes red on revert. The other four are negative assertions (accepted-outright, zero-count, judge-filtered, notify-throws) guarding the opposite regression, so they stay green when the feature is removed — deliberate, not coverage theatre.

Also corrects a stale comment at `collection.service.ts:1056` naming a `"Save to collection"` modal that does not exist; the component is `AddToCollectionModal`, titled "Add to Collection".

Fixes ClickUp [868m15nne](https://app.clickup.com/t/8459928/868m15nne).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHVSEawLBsHdPUgeDHPNqR
