### PR TITLE
Widen rewards-abuse-prevention so it can see the reward being farmed

### DIFF
--- a/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
+++ b/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
@@ -69,7 +69,13 @@ describe('rewards-abuse-prevention — sysRedis config read (STEP-3 soft-depende
     const result = await rewardsAbusePrevention.run().result;
 
     expect(chQuery).toHaveBeenCalledTimes(1); // detection query ran
-    expect(result).toEqual({ usersDisabled: 0 });
+    expect(result).toEqual({
+      dryRun: false,
+      usersDisabled: 0,
+      wouldDisable: 0,
+      ipsFlagged: 0,
+      sample: [],
+    });
   });
 
   it('treats a Buffer config reply (sentinel mode) as valid JSON', async () => {
@@ -78,7 +84,13 @@ describe('rewards-abuse-prevention — sysRedis config read (STEP-3 soft-depende
     const result = await rewardsAbusePrevention.run().result;
 
     expect(chQuery).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ usersDisabled: 0 });
+    expect(result).toEqual({
+      dryRun: false,
+      usersDisabled: 0,
+      wouldDisable: 0,
+      ipsFlagged: 0,
+      sample: [],
+    });
   });
 
   it('SKIPS the run (no destructive detection) when sysRedis is DOWN (hGet throws)', async () => {
@@ -104,6 +116,8 @@ describe('rewards-abuse-prevention — sysRedis config read (STEP-3 soft-depende
 
 const sqlOf = () => (chQuery.mock.calls[0]?.[0] as string) ?? '';
 type DryRunReport = {
+  dryRun: boolean;
+  usersDisabled: number;
   wouldDisable: number;
   ipsFlagged: number;
   sample: { ip: string; user_count: number; awarded: number; user_ids: number[] }[];
@@ -195,7 +209,22 @@ describe('rewards-abuse-prevention — dry run', () => {
 
     expect(dbQueryRawUnsafe).toHaveBeenCalledTimes(1);
     expect(createNotification).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ usersDisabled: 3 });
+    expect(result).toMatchObject({ dryRun: false, usersDisabled: 3 });
+  });
+
+  it('reports what it found on the live path too, not only in a dry run', async () => {
+    chQuery.mockResolvedValue(abusers);
+    dbQueryRawUnsafe.mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+    const result = (await runWith({ require_exclusive_ip: true })) as DryRunReport;
+
+    // The fields that say WHAT was found have to survive the switch to enforcing, or a live run
+    // that disables nobody cannot be told from one that found nothing.
+    expect(result.ipsFlagged).toBe(1);
+    expect(result.wouldDisable).toBe(3);
+    expect(result.sample).toEqual([
+      { ip: '203.0.113.7', user_count: 3, awarded: 300, user_ids: [1, 2, 3] },
+    ]);
   });
   it('hands back the flagged clusters, not just a count', async () => {
     chQuery.mockResolvedValue(abusers);

--- a/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
+++ b/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
@@ -103,6 +103,11 @@ describe('rewards-abuse-prevention — sysRedis config read (STEP-3 soft-depende
 });
 
 const sqlOf = () => (chQuery.mock.calls[0]?.[0] as string) ?? '';
+type DryRunReport = {
+  wouldDisable: number;
+  ipsFlagged: number;
+  sample: { ip: string; user_count: number; awarded: number; user_ids: number[] }[];
+};
 const runWith = (config: Record<string, unknown>) => {
   hGet.mockResolvedValue(JSON.stringify(config));
   return rewardsAbusePrevention.run().result;
@@ -120,19 +125,19 @@ describe('rewards-abuse-prevention — detection shape', () => {
     expect(sql).not.toContain('user_count <=');
   });
 
-  it('matches a whole award family by prefix', async () => {
+  it('emits a startsWith clause for each award-family prefix', async () => {
     await runWith({ award_types: [], award_type_prefixes: ['encouragement:'] });
 
     expect(sqlOf()).toContain("startsWith(be.type, 'encouragement:')");
   });
 
-  it('matches nothing rather than everything when both type lists are empty', async () => {
+  it('emits an always-false predicate rather than none when both type lists are empty', async () => {
     await runWith({ award_types: [], award_type_prefixes: [] });
 
     expect(sqlOf()).toContain('1 = 0');
   });
 
-  it('requires the IP to carry no other earning users when exclusivity is on', async () => {
+  it('emits the exclusivity aggregates and having-clause when exclusivity is on', async () => {
     await runWith({
       require_exclusive_ip: true,
       award_types: [],
@@ -147,7 +152,7 @@ describe('rewards-abuse-prevention — detection shape', () => {
     expect(sql).not.toContain('AND startsWith');
   });
 
-  it('caps cluster size when max_user_count is set', async () => {
+  it('emits a cluster-size ceiling when max_user_count is set', async () => {
     await runWith({ max_user_count: 5 });
 
     expect(sqlOf()).toContain('AND user_count <= 5');
@@ -156,12 +161,12 @@ describe('rewards-abuse-prevention — detection shape', () => {
   it('rejects a config value that would break out of the SQL string', async () => {
     hGet.mockResolvedValue(JSON.stringify({ award_types: ["dailyBoost') OR 1=1 --"] }));
 
-    await expect(rewardsAbusePrevention.run().result).rejects.toThrow();
+    await expect(rewardsAbusePrevention.run().result).rejects.toThrow(/SQL-significant characters/);
     expect(chQuery).not.toHaveBeenCalled();
   });
 });
 
-describe('rewards-abuse-prevention — report mode', () => {
+describe('rewards-abuse-prevention — dry run', () => {
   const abusers = [
     { ip: '203.0.113.7', user_count: 3, ip_user_count: 3, awarded: 300, user_ids: [1, 2, 3] },
   ];
@@ -169,11 +174,11 @@ describe('rewards-abuse-prevention — report mode', () => {
   it('reports what it would disable without touching a single account', async () => {
     chQuery.mockResolvedValue(abusers);
 
-    const result = await runWith({ mode: 'report', require_exclusive_ip: true });
+    const result = await runWith({ dryRun: true, require_exclusive_ip: true });
 
     expect(chQuery).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({
-      mode: 'report',
+      dryRun: true,
       usersDisabled: 0,
       wouldDisable: 3,
       ipsFlagged: 1,
@@ -191,5 +196,60 @@ describe('rewards-abuse-prevention — report mode', () => {
     expect(dbQueryRawUnsafe).toHaveBeenCalledTimes(1);
     expect(createNotification).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ usersDisabled: 3 });
+  });
+  it('hands back the flagged clusters, not just a count', async () => {
+    chQuery.mockResolvedValue(abusers);
+
+    const result = (await runWith({ dryRun: true })) as DryRunReport;
+
+    expect(result.sample).toEqual([
+      { ip: '203.0.113.7', user_count: 3, awarded: 300, user_ids: [1, 2, 3] },
+    ]);
+  });
+
+  it('caps the sample so a wide run cannot return every cluster it found', async () => {
+    const many = Array.from({ length: 40 }, (_, i) => ({
+      ip: `203.0.113.${i}`,
+      user_count: 2,
+      ip_user_count: 2,
+      awarded: 200,
+      user_ids: [i * 2, i * 2 + 1],
+    }));
+    chQuery.mockResolvedValue(many);
+
+    const result = (await runWith({ dryRun: true })) as DryRunReport;
+
+    expect(result.ipsFlagged).toBe(40);
+    expect(result.sample).toHaveLength(25);
+  });
+
+  it('counts a user flagged on two IPs once', async () => {
+    chQuery.mockResolvedValue([
+      { ip: '203.0.113.7', user_count: 2, ip_user_count: 2, awarded: 200, user_ids: [1, 2] },
+      { ip: '203.0.113.8', user_count: 2, ip_user_count: 2, awarded: 200, user_ids: [2, 3] },
+    ]);
+
+    const result = (await runWith({ dryRun: true })) as DryRunReport;
+
+    expect(result.wouldDisable).toBe(3);
+  });
+});
+
+describe('rewards-abuse-prevention — scan bounds and config safety', () => {
+  it('bounds the scan on the partition-key column, not only on createdDate', async () => {
+    await runWith({});
+
+    const sql = sqlOf();
+    expect(sql).toContain('createdDate > subtractDays(now(), 1)');
+    // `createdDate` is MATERIALIZED and prunes nothing; without this the scan reads the
+    // whole table rather than the window it claims to.
+    expect(sql).toContain('time > subtractDays(now(), 3)');
+  });
+
+  it('rejects an excluded IP that would break out of the SQL string', async () => {
+    hGet.mockResolvedValue(JSON.stringify({ excludedIps: ["1.1.1.1') OR 1=1 --"] }));
+
+    await expect(rewardsAbusePrevention.run().result).rejects.toThrow(/SQL-significant characters/);
+    expect(chQuery).not.toHaveBeenCalled();
   });
 });

--- a/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
+++ b/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
@@ -6,14 +6,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // config read fails — a sysRedis DOWN (hGet throws) or SLOW/half-open (withSysReadDeadline
 // rejects) must return early WITHOUT touching clickhouse/dbWrite.
 
-const { hGet, withSysReadDeadline, chQuery, createNotification, refresh } =
-  vi.hoisted(() => ({
-    hGet: vi.fn(),
-    withSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
-    chQuery: vi.fn(),
-    createNotification: vi.fn(() => Promise.resolve(undefined)),
-    refresh: vi.fn(() => Promise.resolve(undefined)),
-  }));
+const { hGet, withSysReadDeadline, chQuery, createNotification, refresh } = vi.hoisted(() => ({
+  hGet: vi.fn(),
+  withSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+  chQuery: vi.fn(),
+  createNotification: vi.fn(() => Promise.resolve(undefined)),
+  refresh: vi.fn(() => Promise.resolve(undefined)),
+}));
 
 vi.mock('~/server/redis/client', () => ({
   sysRedis: { hGet },
@@ -74,9 +73,7 @@ describe('rewards-abuse-prevention — sysRedis config read (STEP-3 soft-depende
   });
 
   it('treats a Buffer config reply (sentinel mode) as valid JSON', async () => {
-    hGet.mockResolvedValue(
-      Buffer.from(JSON.stringify({ awarded: 5000, user_count: 5 }), 'utf8')
-    );
+    hGet.mockResolvedValue(Buffer.from(JSON.stringify({ awarded: 5000, user_count: 5 }), 'utf8'));
 
     const result = await rewardsAbusePrevention.run().result;
 
@@ -102,5 +99,97 @@ describe('rewards-abuse-prevention — sysRedis config read (STEP-3 soft-depende
     expect(result).toEqual({ usersDisabled: 0, skipped: 'sysRedis-config-read-failed' });
     expect(chQuery).not.toHaveBeenCalled();
     expect(dbQueryRawUnsafe).not.toHaveBeenCalled();
+  });
+});
+
+const sqlOf = () => (chQuery.mock.calls[0]?.[0] as string) ?? '';
+const runWith = (config: Record<string, unknown>) => {
+  hGet.mockResolvedValue(JSON.stringify(config));
+  return rewardsAbusePrevention.run().result;
+};
+
+describe('rewards-abuse-prevention — detection shape', () => {
+  it('adds none of the new clauses when the new options are absent', async () => {
+    await runWith({ award_types: ['dailyBoost'] });
+
+    const sql = sqlOf();
+    expect(sql).toContain("AND be.type IN ('dailyBoost')");
+    expect(sql).not.toContain('uniqIf');
+    expect(sql).not.toContain('ip_user_count = user_count');
+    expect(sql).not.toContain('startsWith');
+    expect(sql).not.toContain('user_count <=');
+  });
+
+  it('matches a whole award family by prefix', async () => {
+    await runWith({ award_types: [], award_type_prefixes: ['encouragement:'] });
+
+    expect(sqlOf()).toContain("startsWith(be.type, 'encouragement:')");
+  });
+
+  it('matches nothing rather than everything when both type lists are empty', async () => {
+    await runWith({ award_types: [], award_type_prefixes: [] });
+
+    expect(sqlOf()).toContain('1 = 0');
+  });
+
+  it('requires the IP to carry no other earning users when exclusivity is on', async () => {
+    await runWith({
+      require_exclusive_ip: true,
+      award_types: [],
+      award_type_prefixes: ['encouragement:'],
+    });
+
+    const sql = sqlOf();
+    expect(sql).toContain('ip_user_count = user_count');
+    expect(sql).toContain("uniqIf(be.toUserId, startsWith(be.type, 'encouragement:'))");
+    // The type filter has to leave the WHERE, or the users it hides are the ones
+    // exclusivity exists to count.
+    expect(sql).not.toContain('AND startsWith');
+  });
+
+  it('caps cluster size when max_user_count is set', async () => {
+    await runWith({ max_user_count: 5 });
+
+    expect(sqlOf()).toContain('AND user_count <= 5');
+  });
+
+  it('rejects a config value that would break out of the SQL string', async () => {
+    hGet.mockResolvedValue(JSON.stringify({ award_types: ["dailyBoost') OR 1=1 --"] }));
+
+    await expect(rewardsAbusePrevention.run().result).rejects.toThrow();
+    expect(chQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe('rewards-abuse-prevention — report mode', () => {
+  const abusers = [
+    { ip: '203.0.113.7', user_count: 3, ip_user_count: 3, awarded: 300, user_ids: [1, 2, 3] },
+  ];
+
+  it('reports what it would disable without touching a single account', async () => {
+    chQuery.mockResolvedValue(abusers);
+
+    const result = await runWith({ mode: 'report', require_exclusive_ip: true });
+
+    expect(chQuery).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      mode: 'report',
+      usersDisabled: 0,
+      wouldDisable: 3,
+      ipsFlagged: 1,
+    });
+    expect(dbQueryRawUnsafe).not.toHaveBeenCalled();
+    expect(createNotification).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: the same finding in enforce mode does disable them', async () => {
+    chQuery.mockResolvedValue(abusers);
+    dbQueryRawUnsafe.mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+    const result = await runWith({ require_exclusive_ip: true });
+
+    expect(dbQueryRawUnsafe).toHaveBeenCalledTimes(1);
+    expect(createNotification).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ usersDisabled: 3 });
   });
 });

--- a/src/server/jobs/rewards-abuse-prevention.ts
+++ b/src/server/jobs/rewards-abuse-prevention.ts
@@ -10,6 +10,8 @@ import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/cl
 import { createNotification } from '~/server/services/notification.service';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 
+const REPORT_SAMPLE_SIZE = 25;
+
 export const rewardsAbusePrevention = createJob(
   'rewards-abuse-prevention',
   '0 3 * * *',
@@ -32,26 +34,66 @@ export const rewardsAbusePrevention = createJob(
         (Buffer.isBuffer(abuseLimitsRaw) ? abuseLimitsRaw.toString('utf8') : abuseLimitsRaw) ?? '{}'
       )
     );
+
+    const matched = buildTypePredicate(abuseLimits);
+    const excludedIps = abuseLimits.excludedIps.map((ip) => `'${ip}'`);
+    const clusterCeiling =
+      abuseLimits.max_user_count !== undefined
+        ? `AND user_count <= ${abuseLimits.max_user_count}`
+        : '';
+
+    // Exclusivity has to count the users the type filter would have hidden, which costs a
+    // whole-day scan — so it moves the filter out of the WHERE only when it is switched on.
+    const exclusivity = abuseLimits.require_exclusive_ip
+      ? {
+          where: '',
+          select: `uniqIf(be.toUserId, ${matched}) as user_count, uniq(be.toUserId) as ip_user_count, sumIf(awardAmount, ${matched}) as awarded`,
+          having: 'AND ip_user_count = user_count',
+        }
+      : {
+          where: `AND ${matched}`,
+          select: `uniq(be.toUserId) as user_count, sum(awardAmount) as awarded`,
+          having: '',
+        };
+
     const abusers = await clickhouse?.$query<Abuser>(`
       SELECT
         ip,
-        uniq(be.toUserId) as user_count,
-        array_agg(distinct be.toUserId) as user_ids,
-        sum(awardAmount) as awarded
+        ${exclusivity.select},
+        array_agg(distinct be.toUserId) as user_ids
       FROM buzzEvents be
       WHERE createdDate > subtractDays(now(), 1)
-      AND be.type IN (${abuseLimits.award_types.map((type) => `'${type}'`)})
-      AND ip NOT IN (${abuseLimits.excludedIps.map((ip) => `'${ip}'`)})
+      ${exclusivity.where}
+      AND ip NOT IN (${excludedIps})
       AND awardAmount > 0
       GROUP BY ip
-      HAVING uniq(be.toUserId) > 1 AND (
+      HAVING user_count > 1 AND (
         awarded >= ${abuseLimits.awarded} AND
         user_count > ${abuseLimits.user_count}
       )
+      ${clusterCeiling}
+      ${exclusivity.having}
       ORDER BY awarded DESC;
     `);
 
     const usersToDisable = abusers?.map((abuser) => abuser.user_ids).flat() ?? [];
+
+    if (abuseLimits.mode === 'report') {
+      return {
+        mode: 'report' as const,
+        usersDisabled: 0,
+        wouldDisable: usersToDisable.length,
+        ipsFlagged: abusers?.length ?? 0,
+        sample:
+          abusers?.slice(0, REPORT_SAMPLE_SIZE).map(({ ip, user_count, awarded, user_ids }) => ({
+            ip,
+            user_count,
+            awarded,
+            user_ids,
+          })) ?? [],
+      };
+    }
+
     let usersDisabled = 0;
     const tasks = chunk(usersToDisable, 500).map((chunk) => async () => {
       const affected = await dbWrite.$queryRawUnsafe<{ id: number }[]>(`
@@ -91,17 +133,44 @@ export const rewardsAbusePrevention = createJob(
   }
 );
 
+// `encouragement` writes one buzzEvent type per entity kind (`encouragement:image`,
+// `:comment`, `:article`, …), so an exact-match list silently stops covering the family
+// the next time an entity kind is added.
+function buildTypePredicate({ award_types, award_type_prefixes }: AbuseLimits) {
+  const clauses: string[] = [];
+  if (award_types.length)
+    clauses.push(`be.type IN (${award_types.map((type) => `'${type}'`).join(',')})`);
+  for (const prefix of award_type_prefixes) clauses.push(`startsWith(be.type, '${prefix}')`);
+
+  if (!clauses.length) return '1 = 0';
+  if (clauses.length === 1) return clauses[0];
+  return `(${clauses.join(' OR ')})`;
+}
+
 type Abuser = {
   ip: string;
   user_count: number;
+  ip_user_count?: number;
   user_ids: number[];
   awarded: number;
 };
 
+// Interpolated into SQL. Operator-authored rather than user input, but a stray quote takes
+// the nightly run down unattended.
+const sqlSafeToken = z
+  .string()
+  .regex(/^[A-Za-z0-9_:.-]*$/, 'must not contain SQL-significant characters');
+
 const abuseLimitsSchema = z.object({
   awarded: z.number().default(3000),
   user_count: z.number().default(10),
-  excludedIps: z.string().array().default(['1.1.1.1', '']), // "10.124.0.14","10.124.0.17","10.124.0.32","10.124.0.70","10.124.0.84","10.124.0.94"
-  award_types: z.string().array().default(['dailyBoost']),
+  max_user_count: z.number().optional(),
+  require_exclusive_ip: z.boolean().default(false),
+  mode: z.enum(['enforce', 'report']).default('enforce'),
+  excludedIps: sqlSafeToken.array().default(['1.1.1.1', '']), // "10.124.0.14","10.124.0.17","10.124.0.32","10.124.0.70","10.124.0.84","10.124.0.94"
+  award_types: sqlSafeToken.array().default(['dailyBoost']),
+  award_type_prefixes: sqlSafeToken.array().default([]),
   user_conditions: z.string().array().optional(),
 });
+
+type AbuseLimits = z.infer<typeof abuseLimitsSchema>;

--- a/src/server/jobs/rewards-abuse-prevention.ts
+++ b/src/server/jobs/rewards-abuse-prevention.ts
@@ -84,21 +84,22 @@ export const rewardsAbusePrevention = createJob(
 
     const usersToDisable = abusers?.map((abuser) => abuser.user_ids).flat() ?? [];
 
-    if (abuseLimits.dryRun) {
-      return {
-        dryRun: true as const,
-        usersDisabled: 0,
-        wouldDisable: new Set(usersToDisable).size,
-        ipsFlagged: abusers?.length ?? 0,
-        sample:
-          abusers?.slice(0, REPORT_SAMPLE_SIZE).map(({ ip, user_count, awarded, user_ids }) => ({
-            ip,
-            user_count,
-            awarded,
-            user_ids,
-          })) ?? [],
-      };
-    }
+    // What it found, reported the same way whether or not it acted on it. A live run that disables
+    // nobody is otherwise indistinguishable from a run that found nothing.
+    const found = {
+      dryRun: abuseLimits.dryRun,
+      wouldDisable: new Set(usersToDisable).size,
+      ipsFlagged: abusers?.length ?? 0,
+      sample:
+        abusers?.slice(0, REPORT_SAMPLE_SIZE).map(({ ip, user_count, awarded, user_ids }) => ({
+          ip,
+          user_count,
+          awarded,
+          user_ids,
+        })) ?? [],
+    };
+
+    if (abuseLimits.dryRun) return { ...found, usersDisabled: 0 };
 
     let usersDisabled = 0;
     const tasks = chunk(usersToDisable, 500).map((chunk) => async () => {
@@ -133,9 +134,7 @@ export const rewardsAbusePrevention = createJob(
     });
     await limitConcurrency(tasks, 3);
 
-    return {
-      usersDisabled,
-    };
+    return { ...found, usersDisabled };
   }
 );
 

--- a/src/server/jobs/rewards-abuse-prevention.ts
+++ b/src/server/jobs/rewards-abuse-prevention.ts
@@ -12,6 +12,11 @@ import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 
 const REPORT_SAMPLE_SIZE = 25;
 
+// `createdDate` is MATERIALIZED, so it prunes no partitions and the scan reads the whole table.
+// `time` is what the partition key is built from; a bound wide enough to sit outside the
+// createdDate window prunes without being able to change which rows match.
+const DATE_BOUND_SLACK_DAYS = 3;
+
 export const rewardsAbusePrevention = createJob(
   'rewards-abuse-prevention',
   '0 3 * * *',
@@ -63,6 +68,7 @@ export const rewardsAbusePrevention = createJob(
         array_agg(distinct be.toUserId) as user_ids
       FROM buzzEvents be
       WHERE createdDate > subtractDays(now(), 1)
+      AND time > subtractDays(now(), ${DATE_BOUND_SLACK_DAYS})
       ${exclusivity.where}
       AND ip NOT IN (${excludedIps})
       AND awardAmount > 0
@@ -78,11 +84,11 @@ export const rewardsAbusePrevention = createJob(
 
     const usersToDisable = abusers?.map((abuser) => abuser.user_ids).flat() ?? [];
 
-    if (abuseLimits.mode === 'report') {
+    if (abuseLimits.dryRun) {
       return {
-        mode: 'report' as const,
+        dryRun: true as const,
         usersDisabled: 0,
-        wouldDisable: usersToDisable.length,
+        wouldDisable: new Set(usersToDisable).size,
         ipsFlagged: abusers?.length ?? 0,
         sample:
           abusers?.slice(0, REPORT_SAMPLE_SIZE).map(({ ip, user_count, awarded, user_ids }) => ({
@@ -166,7 +172,7 @@ const abuseLimitsSchema = z.object({
   user_count: z.number().default(10),
   max_user_count: z.number().optional(),
   require_exclusive_ip: z.boolean().default(false),
-  mode: z.enum(['enforce', 'report']).default('enforce'),
+  dryRun: z.boolean().default(false),
   excludedIps: sqlSafeToken.array().default(['1.1.1.1', '']), // "10.124.0.14","10.124.0.17","10.124.0.32","10.124.0.70","10.124.0.84","10.124.0.94"
   award_types: sqlSafeToken.array().default(['dailyBoost']),
   award_type_prefixes: sqlSafeToken.array().default([]),


### PR DESCRIPTION
Widens the nightly `rewards-abuse-prevention` job so it can see the reward that is actually being farmed, and adds a dry run so the widening can be watched before it disables anyone.

Ticket: [868m28jyp](https://app.clickup.com/t/868m28jyp). Fell out of investigating three linked accounts ([868m1ryk8](https://app.clickup.com/t/868m1ryk8), closed).

## Does merging this change anything in production?

**No — the set of users the job would disable is identical.** Every new option defaults to today's behaviour, and the sysRedis field they are read from, `system:features` → `rewards:abuse-limits`, is **not set**. Evidence for that last claim rather than an assertion of it: `hgetall system:features` returns 8 other populated fields (`generation:status`, `training:status`, `disabled-healthchecks`, …), so the hash exists and this one field genuinely is not in it. Everything falls to the schema defaults in the file.

One correction to an earlier version of this claim, stated plainly so it does not survive anywhere: the **SQL is not unchanged**. It now carries an extra date bound (below) that makes it dramatically cheaper while returning the same rows. Behaviour unchanged; query not.

## Why the job could not see this

Its thresholds blind it three separate ways, each sufficient on its own:

1. `award_types: ['dailyBoost']` — it watches only `dailyBoost`. Last 24h: **23,652** events. `encouragement:image`, the reward being farmed, is **530,341** events across **18,792** users in the same window. It watches the smaller stream and ignores the farmed one by 22x.
2. `user_count > 10` — needs more than ten accounts on one IP. Observed farm clusters are 2-5.
3. `awarded >= 3000` per IP per day — three accounts at the 100 Buzz/day cap earn about 300.

`award_types` also cannot express `encouragement` at all: it matches exactly, and encouragement writes one type per entity kind (`encouragement:image`, `:comment`, `:commentOld`, `:article`, `:bountyEntry`, `:post`). Enumerating the six works until someone adds a seventh.

## What this adds

- **`award_type_prefixes`** — match a whole award family.
- **`require_exclusive_ip`** — keep only IPs whose every *earning* user is in the flagged set. A bare `user_count > N` sweeps up carrier ranges; the busiest IP in August 2026 carried 5,663 legitimate users.
- **`max_user_count`** — a ceiling on cluster size.
- **`dryRun`** — return what would have been disabled, disabling nothing.

## The scan was reading the whole table

`WHERE createdDate > subtractDays(now(), 1)` filters a MATERIALIZED column, which prunes no partitions. Today that is masked: `type` leads the primary key, so `type IN ('dailyBoost')` lets the sparse index skip granules. The exclusivity check moves that filter out of the WHERE, and then nothing is left that intersects the key.

Measured on prod:

| WHERE | rows read | bytes | duration |
|---|---|---|---|
| `createdDate > subtractDays(now(),1)` | 1,477,592,976 | 2.75 GiB | 1,000 ms |
| `+ AND time > subtractDays(now(),3)` | 11,474,679 | 31.00 MiB | 157 ms |

The added bound is **wider** than the existing predicate, so it cannot exclude a row the current one accepts — matching rows 1,415,952 → 1,416,502, taken minutes apart on a live table.

The perf review proposed replacing `createdDate` with `time` outright, which is faster still (2,389,686 rows / 8 ms). **Not taken.** It is a different predicate: `createdDate > subtractDays(now(),1)` is a date comparison covering yesterday plus today so far, `time > now() - INTERVAL 1 DAY` is a rolling 24h. They match **1,415,952** and **1,925,256** rows — 36% apart. Narrowing the detection window of a job that disables accounts is not a performance fix.

### What turning exclusivity on actually costs

Measured separately, because the option changes the cost profile and nothing had priced it before: with `require_exclusive_ip` on there is no type predicate in the WHERE at all, so the scan is a full pruned partition rather than a primary-key-assisted seek.

| shape | rows read | bytes | server time | peak memory |
|---|---|---|---|---|
| default (`type IN (…)` in WHERE) | 221K | 3.4 MiB | 41 ms | — |
| `require_exclusive_ip: true` | 12.6M | 148 MiB | ~260 ms | 210 MiB |

~60x more rows for a once-nightly job, which is inconsequential in absolute terms — but it is triggered purely by a Redis config toggle, with nothing in the job's own code making that cost visible. Worth knowing before flipping it.

The 3-day slack on the date bound was also checked rather than assumed: `createdDate` floors a matching row's `time` at yesterday's midnight, and the cron is `0 3 * * *`, so the widest real window is about **27 hours**. Three days is roughly 2.7x that. Comfortable rather than lucky.

## `max_user_count` is beyond the ticket, and here is why it stayed

The ticket's answer to cluster size was exclusivity, not a ceiling. The intent review flagged the knob as scope creep and was right about the fact.

It stayed because of what happens when you ask whether exclusivity alone holds on a carrier range. If every earning user on a CGNAT IP earns the watched reward, `ip_user_count = user_count` passes and several hundred innocent accounts go through. Measured over the last 24h, top IPs by earner count:

| ip | all earners | encouragement earners | other earners |
|---|---|---|---|
| 185.132.178.126 | 287 | 0 | 287 |
| 137.103.152.37 | 252 | 1 | 251 |
| 190.86.73.255 | 239 | 1 | 239 |
| 2806:250:…:ecab | 219 | 14 | 219 |

**Read that table carefully, because it does not prove what it first appears to.** Exclusivity excludes every one of those IPs — so the table shows the guard *working*, not a case where it fails. It is not evidence for the ceiling.

The argument for the ceiling is what the table's *mechanism* implies. Exclusivity excludes these ranges only because `dailyBoost` reaches nearly every active user daily — 23,652 users, one event each — so anyone earning anything also earns outside the watched family. Exclusivity's strength here is borrowed from an unrelated reward's coverage. Nothing pins that. Narrow `dailyBoost`'s reach and a large legitimate range whose users all earn only the watched reward would satisfy `ip_user_count = user_count` and pass, with no test going red.

That is a hypothesis about a future state, not a measurement of the present one, and it should be read as one. The ceiling is cheap insurance against it and defaults to off. (This distinction was the intent review's finding, not mine — the original wording let the table stand in for proof it was not.)

The ticket has been amended to say all of this, rather than leaving it and the code disagreeing.

## Review lanes

All five ran **twice** — once on the first commit, and again over the whole branch after the fix round, because the first pass had reviewed code that the fix round then changed. The second pass read `origin/main...HEAD` rather than the new commit alone, so nothing fell in the gap between passes.

The second pass found the thing this PR most needed and the first pass could not have: **the dry run reported what it found, and the live path did not.** `ipsFlagged`, `wouldDisable` and the cluster sample existed only in the dry-run branch, so the fields describing what was found disappeared at exactly the moment someone switched enforcement on. Every other job in this directory returns one shape and gates only the write; `auto-feature-images.service.ts` says why in its own comment — a short run is legitimate, the caps doing their job, "but it is otherwise indistinguishable from the job not running at all, which is the shape of a 79-hour outage nobody noticed in August." Both paths now return the same object.

Two pre-existing tests pinned the whole return value with `toEqual` and began failing. They were **widened to the new shape rather than loosened** to `toMatchObject`, so they still fail on an unexpected field.

From the first pass: Findings taken: the `dryRun` rename (reuse — five other jobs in this directory already call it that), the dry-run count dedupe (correctness — a user flagged on two IPs was counted twice, overstating blast radius to whoever reads it before enabling enforcement), the untested sample payload and three over-claiming test names (tests), the scan bound (perf), and `max_user_count` named as out-of-scope (intent).

Not taken: the perf lane's `createdDate` → `time` replacement, for the reason above.

## Tests

18 in the job's file, up from 4.

**Revert control**, against `origin/main` rather than the branch's own HEAD: 11 of 13 new tests go red. The two that stay green do so for stated reasons — the defaults test (old code has none of the new clauses either) and the enforce-mode control (old code always enforces). Discriminating in both directions rather than uniformly angry.

Three tests are named for emitting a SQL clause rather than for filtering behaviour, because ClickHouse is mocked and they cannot observe filtering. That is a limit of the harness, and the names now say so.

## Full suite

One pre-existing failure, and it is not from this change: `src/server/integrations/__tests__/moderation-cache-probe.test.ts` fails with this job change **reverted**, in the same worktree, same node_modules, same collection set.

| arm | SHA | collected | files failed | tests failed | probe |
|---|---|---|---|---|---|
| with this change | `d4490fbe61` | 38,656 | 1 | 1 | FAIL |
| with this change | `bd28ca72a0` | 38,655 | 1 | 1 | FAIL |
| job file reverted to `origin/main` | `bd28ca72a0` tree | 38,655 | 2 | 12 | FAIL |

The control pair is the second and third rows — same tree, same node_modules, identical collected counts, only the job file differing. The extra failing file in the reverted arm is this PR's own test file losing 11 of its new tests, which is the revert control working rather than a second problem. The first row is the current SHA; its one extra test is the live-path reporting test added in the third commit.

It passes 22/22 in isolation. This shows it fails *independently of this change* — not that it fails on `origin/main` generally, which I have not established.

## Deploy

Code-only, no migration. It does not take effect in production until it ships **and** someone sets `rewards:abuse-limits`. Two separate events, neither automatic, and I have not set that field.

Docs: nothing was made stale, and no doc is added. Thresholds and carve-outs for an anti-abuse detector are what this repo's security guidance keeps out of a public tree. The absence is deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbTHWSRzK8asgVTBLP3UiP
