### PR TITLE
fix(search): delete collection documents that no longer qualify for the index

### DIFF
--- a/src/server/search-index/__tests__/collections-index-prune.test.ts
+++ b/src/server/search-index/__tests__/collections-index-prune.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as MeiliClient from '~/server/meilisearch/client';
+import type * as MeiliUtil from '~/server/meilisearch/util';
+import type * as RedisCaches from '~/server/redis/caches';
+
+const updateDocs = vi.fn();
+const onSearchIndexDocumentsCleanup = vi.fn();
+
+vi.mock('~/server/meilisearch/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof MeiliClient>()),
+  updateDocs: (...args: unknown[]) => updateDocs(...args),
+}));
+
+vi.mock('~/server/meilisearch/util', async (importOriginal) => ({
+  ...(await importOriginal<typeof MeiliUtil>()),
+  onSearchIndexDocumentsCleanup: (...args: unknown[]) => onSearchIndexDocumentsCleanup(...args),
+}));
+
+vi.mock('~/server/redis/caches', async (importOriginal) => ({
+  ...(await importOriginal<typeof RedisCaches>()),
+  tagIdsForImagesCache: { fetch: async () => ({}) },
+}));
+
+const { pullData, transformData, pushData } = await import(
+  '~/server/search-index/collections.search-index'
+);
+
+/** Partial on purpose: only the fields `transformData` reads have to be real. */
+const collectionRow = (id: number) => ({
+  id,
+  name: `collection ${id}`,
+  imageId: null,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  userId: 100,
+  type: 'Model',
+  read: 'Public',
+  write: 'Private',
+  mode: null,
+  nsfwLevel: 1,
+  metrics: null,
+  image: null,
+  user: { id: 100, username: 'someone', deletedAt: null, image: null, profilePictureId: null },
+  cosmetics: null,
+});
+
+const run = async (
+  batch: Parameters<typeof pullData>[1],
+  rows: ReturnType<typeof collectionRow>[]
+) => {
+  const db = {
+    // The second $queryRaw is the item-image lookup — the fixture carries no image, so it runs.
+    $queryRaw: vi.fn().mockResolvedValueOnce(rows).mockResolvedValue([]),
+    image: { findMany: vi.fn().mockResolvedValue([]) },
+  };
+  const ctx = {
+    db,
+    indexName: 'collections_v3',
+    logger: () => undefined,
+  } as unknown as Parameters<typeof pullData>[0];
+
+  const pulled = await pullData(ctx, batch);
+  const transformed = await transformData(pulled);
+  await pushData(ctx, transformed);
+
+  return transformed;
+};
+
+beforeEach(() => {
+  updateDocs.mockReset();
+  onSearchIndexDocumentsCleanup.mockReset();
+});
+
+describe('collections search index :: documents whose collection no longer qualifies', () => {
+  it('deletes the document of a requested collection that the index filter no longer matches', async () => {
+    await run({ type: 'update', ids: [1, 2, 3] }, [collectionRow(1)]);
+
+    expect(onSearchIndexDocumentsCleanup).toHaveBeenCalledWith(
+      expect.objectContaining({ indexName: 'collections_v3', ids: [2, 3] })
+    );
+  });
+
+  it('deletes every requested id when the batch comes back empty', async () => {
+    await run({ type: 'update', ids: [7, 8] }, []);
+
+    expect(onSearchIndexDocumentsCleanup).toHaveBeenCalledWith(
+      expect.objectContaining({ ids: [7, 8] })
+    );
+  });
+
+  it('deletes nothing when every requested collection still qualifies', async () => {
+    await run({ type: 'update', ids: [1, 2] }, [collectionRow(1), collectionRow(2)]);
+
+    expect(onSearchIndexDocumentsCleanup).not.toHaveBeenCalled();
+  });
+
+  it('deletes nothing on a range batch, where absence is the normal case', async () => {
+    await run({ type: 'new', startId: 1, endId: 1000 }, [collectionRow(4)]);
+
+    expect(onSearchIndexDocumentsCleanup).not.toHaveBeenCalled();
+  });
+
+  it('still upserts the collections it did pull', async () => {
+    await run({ type: 'update', ids: [1, 2] }, [collectionRow(1)]);
+
+    expect(updateDocs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indexName: 'collections_v3',
+        documents: [expect.objectContaining({ id: 1 })],
+      })
+    );
+  });
+});

--- a/src/server/search-index/collections.search-index.ts
+++ b/src/server/search-index/collections.search-index.ts
@@ -1,6 +1,10 @@
 import { Prisma } from '@prisma/client';
 import { updateDocs } from '~/server/meilisearch/client';
-import { getOrCreateIndex } from '~/server/meilisearch/util';
+import { getOrCreateIndex, onSearchIndexDocumentsCleanup } from '~/server/meilisearch/util';
+import type {
+  SearchIndexContext,
+  SearchIndexPullBatch,
+} from '~/server/search-index/base.search-index';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
 import type {
   CollectionMode,
@@ -147,13 +151,19 @@ type CollectionPullData = {
   itemImages: CollectionImageRaw[];
   tags: { imageId: number; tagId: number }[];
   profilePictures: ProfileImage[];
+  /**
+   * Requested ids the index filter no longer matches. Empty for range batches — they
+   * enumerate no ids, so absence from one is not evidence of anything.
+   */
+  disqualifiedIds: number[];
 };
 
-const transformData = async ({
+export const transformData = async ({
   collections,
   itemImages,
   tags,
   profilePictures,
+  disqualifiedIds,
 }: CollectionPullData) => {
   const records = collections
     .map(({ cosmetics, user, image, ...collection }) => {
@@ -189,10 +199,255 @@ const transformData = async ({
     })
     .filter(isDefined);
 
-  return records;
+  return { records, disqualifiedIds };
 };
 
-export type CollectionSearchIndexRecord = Awaited<ReturnType<typeof transformData>>[number];
+export type CollectionSearchIndexRecord = Awaited<
+  ReturnType<typeof transformData>
+>['records'][number];
+
+export const pullData = async (
+  { db, logger }: SearchIndexContext,
+  batch: SearchIndexPullBatch
+): Promise<CollectionPullData> => {
+  logger(`PullData :: Pulling data for batch: ${batch}`);
+  const where = [
+    ...WHERE,
+    batch.type === 'update' ? Prisma.sql`c.id IN (${Prisma.join(batch.ids)})` : undefined,
+    batch.type === 'new'
+      ? Prisma.sql`c.id >= ${batch.startId} AND c.id <= ${batch.endId}`
+      : undefined,
+  ].filter(isDefined);
+
+  const requestedIds = batch.type === 'update' ? batch.ids : [];
+
+  const collections = await db.$queryRaw<CollectionForSearchIndex[]>`
+  WITH target AS MATERIALIZED (
+    SELECT
+    c.id,
+    c.name,
+    c."imageId",
+    c."createdAt",
+    c."updatedAt",
+    c."userId",
+    c."type",
+    c."read",
+    c."write",
+    c."mode",
+    c."nsfwLevel"
+    FROM "Collection" c
+    WHERE ${Prisma.join(where, ' AND ')}
+  ), users AS MATERIALIZED (
+    SELECT
+      u.id,
+      jsonb_build_object(
+        'id', u.id,
+        'username', u.username,
+        'deletedAt', u."deletedAt",
+        'image', u.image,
+        'profilePictureId', u."profilePictureId"
+      ) user
+    FROM "User" u
+    WHERE u.id IN (SELECT "userId" FROM target)
+    GROUP BY u.id
+  ), cosmetics AS MATERIALIZED (
+    SELECT
+      uc."userId",
+      jsonb_agg(
+        jsonb_build_object(
+          'data', uc.data,
+          'cosmetic', jsonb_build_object(
+            'id', c.id,
+            'data', c.data,
+            'type', c.type,
+            'source', c.source,
+            'name', c.name,
+            'leaderboardId', c."leaderboardId",
+            'leaderboardPosition', c."leaderboardPosition"
+          )
+        )
+      )  cosmetics
+    FROM "UserCosmetic" uc
+    JOIN "Cosmetic" c ON c.id = uc."cosmeticId"
+    AND "equippedAt" IS NOT NULL
+    WHERE uc."userId" IN (SELECT "userId" FROM target) AND uc."equippedToId" IS NULL
+    GROUP BY uc."userId"
+  ), images AS MATERIALIZED (
+    SELECT
+      i.id,
+      ${collectionIndexImageSql}
+    FROM "Image" i
+    WHERE i.id IN (SELECT "imageId" FROM target)
+      AND i."ingestion" = 'Scanned'
+      AND i."needsReview" IS NULL
+    GROUP BY i.id
+  ), metrics as MATERIALIZED (
+    SELECT
+      cm."collectionId",
+      jsonb_build_object(
+        'followerCount', cm."followerCount",
+        'itemCount', cm."itemCount",
+        'contributorCount', cm."contributorCount"
+      ) metrics
+    FROM "CollectionMetric" cm
+    WHERE cm.timeframe = 'AllTime'
+      AND cm."collectionId" IN (SELECT id FROM target)
+  )
+  SELECT
+    t.*,
+    (SELECT metrics FROM metrics m WHERE m."collectionId" = t.id),
+    (SELECT "image" FROM images i WHERE i.id = t."imageId"),
+    (SELECT "user" FROM users u WHERE u.id = t."userId"),
+    (SELECT cosmetics FROM cosmetics c WHERE c."userId" = t."userId")
+  FROM target t
+  `;
+
+  logger(`PullData :: collections data pulled`);
+  if (collections.length === 0) {
+    logger(`PullData :: no collections found in batch`);
+    return {
+      collections: [],
+      itemImages: [],
+      tags: [],
+      profilePictures: [],
+      disqualifiedIds: requestedIds,
+    };
+  }
+
+  const collectionsNeedingImages = collections.filter((c) => !c.image).map((c) => c.id);
+  let itemImages: CollectionImageRaw[] = [];
+
+  if (collectionsNeedingImages.length > 0) {
+    itemImages = await db.$queryRaw<CollectionImageRaw[]>`
+    WITH target AS MATERIALIZED (
+      SELECT *
+      FROM (
+        SELECT *,
+        ROW_NUMBER() OVER (
+            PARTITION BY ci."collectionId"
+            ORDER BY ci.id
+          ) AS idx
+        FROM "CollectionItem" ci
+        WHERE ci.status = 'ACCEPTED'
+          AND ci."collectionId" IN (${Prisma.join(collectionsNeedingImages)})
+      ) t
+      WHERE idx <= 10
+    ), imageItemImage AS MATERIALIZED (
+      SELECT
+        i.id,
+        ${collectionIndexImageSql}
+      FROM "Image" i
+      WHERE i.id IN (SELECT "imageId" FROM target WHERE "imageId" IS NOT NULL)
+        AND i."ingestion" = 'Scanned'
+        AND i."needsReview" IS NULL
+    ), postItemImage AS MATERIALIZED (
+      SELECT * FROM (
+          SELECT
+            i."postId" id,
+            ${collectionIndexImageSql},
+            ROW_NUMBER() OVER (PARTITION BY i."postId" ORDER BY i.index) rn
+          FROM "Image" i
+          WHERE i."postId" IN (SELECT "postId" FROM target WHERE "postId" IS NOT NULL)
+            AND i."ingestion" = 'Scanned'
+            AND i."needsReview" IS NULL
+      ) t
+      WHERE t.rn = 1
+    ), modelItemImage AS MATERIALIZED (
+      SELECT * FROM (
+          SELECT
+            m.id,
+            ${collectionIndexImageSql},
+            ROW_NUMBER() OVER (PARTITION BY m.id ORDER BY mv.index, i."postId", i.index) rn
+          FROM "Image" i
+          JOIN "Post" p ON p.id = i."postId"
+          JOIN "ModelVersion" mv ON mv.id = p."modelVersionId"
+          JOIN "Model" m ON mv."modelId" = m.id AND m."userId" = p."userId"
+          WHERE m."id" IN (SELECT "modelId" FROM target WHERE "modelId" IS NOT NULL)
+              AND i."ingestion" = 'Scanned'
+              AND i."needsReview" IS NULL
+      ) t
+      WHERE t.rn = 1
+    ), articleItemImage AS MATERIALIZED (
+        SELECT a.id, ${collectionIndexImageSql}
+        FROM "Article" a
+        JOIN "Image" i ON i.id = a."coverId"
+        WHERE a.id IN (SELECT "articleId" FROM target WHERE "articleId" IS NOT NULL)
+          AND i."ingestion" = 'Scanned'
+          AND i."needsReview" IS NULL
+    ), articleItemSrc AS MATERIALIZED (
+        SELECT a.id, a.cover src FROM "Article" a
+        WHERE a.id IN (SELECT "articleId" FROM target WHERE "articleId" IS NOT NULL)
+    ), model3dItemImage AS MATERIALIZED (
+        SELECT m3.id, ${collectionIndexImageSql}
+        FROM "Model3D" m3
+        JOIN "Image" i ON i.id = m3."thumbnailImageId"
+        WHERE m3.id IN (SELECT "model3dId" FROM target WHERE "model3dId" IS NOT NULL)
+          AND i."ingestion" = 'Scanned'
+          AND i."needsReview" IS NULL
+    )
+    SELECT
+        target."collectionId" id,
+        COALESCE(
+          (SELECT image FROM imageItemImage iii WHERE iii.id = target."imageId"),
+          (SELECT image FROM postItemImage pii WHERE pii.id = target."postId"),
+          (SELECT image FROM modelItemImage mii WHERE mii.id = target."modelId"),
+          (SELECT image FROM articleItemImage aii WHERE aii.id = target."articleId"),
+          (SELECT image FROM model3dItemImage m3i WHERE m3i.id = target."model3dId"),
+          NULL
+        ) image,
+        (SELECT src FROM articleItemSrc ais WHERE ais.id = target."articleId") src
+    FROM target
+  `;
+  }
+
+  const collectionImages = collections.map((c) => c.image?.id).filter(isDefined);
+  const imageIds = [
+    ...collectionImages,
+    ...new Set(itemImages.map(({ image }) => image?.id).filter(isDefined)),
+  ];
+
+  logger(`PullData :: Pulled collection images.`);
+
+  // Use Redis cache for tag lookups (much faster than direct DB query)
+  const imageTagsCache = await tagIdsForImagesCache.fetch(imageIds);
+  const tags = Object.entries(imageTagsCache).flatMap(([imageId, cache]) =>
+    cache.tags.map((tagId) => ({ imageId: +imageId, tagId }))
+  );
+
+  const profilePictures = await db.image.findMany({
+    where: { id: { in: collections.map((c) => c.user.profilePictureId).filter(isDefined) } },
+    select: profileImageSelect,
+  });
+
+  logger(`PullData :: Pulled tags & profile pics.`);
+
+  const matched = new Set(collections.map((c) => c.id));
+
+  return {
+    collections,
+    itemImages,
+    tags,
+    profilePictures,
+    disqualifiedIds: requestedIds.filter((id) => !matched.has(id)),
+  };
+};
+
+export const pushData = async (
+  { indexName }: SearchIndexContext,
+  { records, disqualifiedIds }: Awaited<ReturnType<typeof transformData>>
+): Promise<void> => {
+  await updateDocs({
+    indexName,
+    documents: records as any[],
+    batchSize: MEILISEARCH_DOCUMENT_BATCH_SIZE,
+  });
+
+  // `updateDocs` upserts, so a collection that stopped matching the index filter keeps
+  // its stale document unless deleted here.
+  if (disqualifiedIds.length > 0) {
+    await onSearchIndexDocumentsCleanup({ indexName, ids: disqualifiedIds });
+  }
+};
 
 export const collectionsSearchIndex = createSearchIndexUpdateProcessor({
   indexName: INDEX_ID,
@@ -220,227 +475,7 @@ export const collectionsSearchIndex = createSearchIndexUpdateProcessor({
       endId,
     };
   },
-  pullData: async ({ db, logger }, batch, step): Promise<CollectionPullData> => {
-    logger(`PullData :: Pulling data for batch: ${batch}`);
-    const where = [
-      ...WHERE,
-      batch.type === 'update' ? Prisma.sql`c.id IN (${Prisma.join(batch.ids)})` : undefined,
-      batch.type === 'new'
-        ? Prisma.sql`c.id >= ${batch.startId} AND c.id <= ${batch.endId}`
-        : undefined,
-    ].filter(isDefined);
-
-    // When metrics are ready use this one :D
-    const collections = await db.$queryRaw<CollectionForSearchIndex[]>`
-    WITH target AS MATERIALIZED (
-      SELECT
-      c.id,
-      c.name,
-      c."imageId",
-      c."createdAt",
-      c."updatedAt",
-      c."userId",
-      c."type",
-      c."read",
-      c."write",
-      c."mode",
-      c."nsfwLevel"
-      FROM "Collection" c
-      WHERE ${Prisma.join(where, ' AND ')}
-    ), users AS MATERIALIZED (
-      SELECT
-        u.id,
-        jsonb_build_object(
-          'id', u.id,
-          'username', u.username,
-          'deletedAt', u."deletedAt",
-          'image', u.image,
-          'profilePictureId', u."profilePictureId"
-        ) user
-      FROM "User" u
-      WHERE u.id IN (SELECT "userId" FROM target)
-      GROUP BY u.id
-    ), cosmetics AS MATERIALIZED (
-      SELECT
-        uc."userId",
-        jsonb_agg(
-          jsonb_build_object(
-            'data', uc.data,
-            'cosmetic', jsonb_build_object(
-              'id', c.id,
-              'data', c.data,
-              'type', c.type,
-              'source', c.source,
-              'name', c.name,
-              'leaderboardId', c."leaderboardId",
-              'leaderboardPosition', c."leaderboardPosition"
-            )
-          )
-        )  cosmetics
-      FROM "UserCosmetic" uc
-      JOIN "Cosmetic" c ON c.id = uc."cosmeticId"
-      AND "equippedAt" IS NOT NULL
-      WHERE uc."userId" IN (SELECT "userId" FROM target) AND uc."equippedToId" IS NULL
-      GROUP BY uc."userId"
-    ), images AS MATERIALIZED (
-      SELECT
-        i.id,
-        ${collectionIndexImageSql}
-      FROM "Image" i
-      WHERE i.id IN (SELECT "imageId" FROM target)
-        AND i."ingestion" = 'Scanned'
-        AND i."needsReview" IS NULL
-      GROUP BY i.id
-    ), metrics as MATERIALIZED (
-      SELECT
-        cm."collectionId",
-        jsonb_build_object(
-          'followerCount', cm."followerCount",
-          'itemCount', cm."itemCount",
-          'contributorCount', cm."contributorCount"
-        ) metrics
-      FROM "CollectionMetric" cm
-      WHERE cm.timeframe = 'AllTime'
-        AND cm."collectionId" IN (SELECT id FROM target)
-    )
-    SELECT
-      t.*,
-      (SELECT metrics FROM metrics m WHERE m."collectionId" = t.id),
-      (SELECT "image" FROM images i WHERE i.id = t."imageId"),
-      (SELECT "user" FROM users u WHERE u.id = t."userId"),
-      (SELECT cosmetics FROM cosmetics c WHERE c."userId" = t."userId")
-    FROM target t
-    `;
-
-    logger(`PullData :: collections data pulled`);
-    // Avoids hitting the DB without data.
-    if (collections.length === 0) {
-      logger(`PullData :: no collections found in batch`);
-      return { collections: [], itemImages: [], tags: [], profilePictures: [] };
-    }
-
-    const collectionsNeedingImages = collections.filter((c) => !c.image).map((c) => c.id);
-    let itemImages: CollectionImageRaw[] = [];
-
-    if (collectionsNeedingImages.length > 0) {
-      itemImages = await db.$queryRaw<CollectionImageRaw[]>`
-      WITH target AS MATERIALIZED (
-        SELECT *
-        FROM (
-          SELECT *,
-          ROW_NUMBER() OVER (
-              PARTITION BY ci."collectionId"
-              ORDER BY ci.id
-            ) AS idx
-          FROM "CollectionItem" ci
-          WHERE ci.status = 'ACCEPTED'
-            AND ci."collectionId" IN (${Prisma.join(collectionsNeedingImages)})
-        ) t
-        WHERE idx <= 10
-      ), imageItemImage AS MATERIALIZED (
-        SELECT
-          i.id,
-          ${collectionIndexImageSql}
-        FROM "Image" i
-        WHERE i.id IN (SELECT "imageId" FROM target WHERE "imageId" IS NOT NULL)
-          AND i."ingestion" = 'Scanned'
-          AND i."needsReview" IS NULL
-      ), postItemImage AS MATERIALIZED (
-        SELECT * FROM (
-            SELECT
-              i."postId" id,
-              ${collectionIndexImageSql},
-              ROW_NUMBER() OVER (PARTITION BY i."postId" ORDER BY i.index) rn
-            FROM "Image" i
-            WHERE i."postId" IN (SELECT "postId" FROM target WHERE "postId" IS NOT NULL)
-              AND i."ingestion" = 'Scanned'
-              AND i."needsReview" IS NULL
-        ) t
-        WHERE t.rn = 1
-      ), modelItemImage AS MATERIALIZED (
-        SELECT * FROM (
-            SELECT
-              m.id,
-              ${collectionIndexImageSql},
-              ROW_NUMBER() OVER (PARTITION BY m.id ORDER BY mv.index, i."postId", i.index) rn
-            FROM "Image" i
-            JOIN "Post" p ON p.id = i."postId"
-            JOIN "ModelVersion" mv ON mv.id = p."modelVersionId"
-            JOIN "Model" m ON mv."modelId" = m.id AND m."userId" = p."userId"
-            WHERE m."id" IN (SELECT "modelId" FROM target WHERE "modelId" IS NOT NULL)
-                AND i."ingestion" = 'Scanned'
-                AND i."needsReview" IS NULL
-        ) t
-        WHERE t.rn = 1
-      ), articleItemImage AS MATERIALIZED (
-          SELECT a.id, ${collectionIndexImageSql}
-          FROM "Article" a
-          JOIN "Image" i ON i.id = a."coverId"
-          WHERE a.id IN (SELECT "articleId" FROM target WHERE "articleId" IS NOT NULL)
-            AND i."ingestion" = 'Scanned'
-            AND i."needsReview" IS NULL
-      ), articleItemSrc AS MATERIALIZED (
-          SELECT a.id, a.cover src FROM "Article" a
-          WHERE a.id IN (SELECT "articleId" FROM target WHERE "articleId" IS NOT NULL)
-      ), model3dItemImage AS MATERIALIZED (
-          SELECT m3.id, ${collectionIndexImageSql}
-          FROM "Model3D" m3
-          JOIN "Image" i ON i.id = m3."thumbnailImageId"
-          WHERE m3.id IN (SELECT "model3dId" FROM target WHERE "model3dId" IS NOT NULL)
-            AND i."ingestion" = 'Scanned'
-            AND i."needsReview" IS NULL
-      )
-      SELECT
-          target."collectionId" id,
-          COALESCE(
-            (SELECT image FROM imageItemImage iii WHERE iii.id = target."imageId"),
-            (SELECT image FROM postItemImage pii WHERE pii.id = target."postId"),
-            (SELECT image FROM modelItemImage mii WHERE mii.id = target."modelId"),
-            (SELECT image FROM articleItemImage aii WHERE aii.id = target."articleId"),
-            (SELECT image FROM model3dItemImage m3i WHERE m3i.id = target."model3dId"),
-            NULL
-          ) image,
-          (SELECT src FROM articleItemSrc ais WHERE ais.id = target."articleId") src
-      FROM target
-    `;
-    }
-
-    const collectionImages = collections.map((c) => c.image?.id).filter(isDefined);
-    const imageIds = [
-      ...collectionImages,
-      ...new Set(itemImages.map(({ image }) => image?.id).filter(isDefined)),
-    ];
-
-    logger(`PullData :: Pulled collection images.`);
-
-    // Use Redis cache for tag lookups (much faster than direct DB query)
-    const imageTagsCache = await tagIdsForImagesCache.fetch(imageIds);
-    const tags = Object.entries(imageTagsCache).flatMap(([imageId, cache]) =>
-      cache.tags.map((tagId) => ({ imageId: +imageId, tagId }))
-    );
-
-    const profilePictures = await db.image.findMany({
-      where: { id: { in: collections.map((c) => c.user.profilePictureId).filter(isDefined) } },
-      select: profileImageSelect,
-    });
-
-    logger(`PullData :: Pulled tags & profile pics.`);
-
-    return {
-      collections,
-      itemImages,
-      tags,
-      profilePictures,
-    };
-  },
+  pullData,
   transformData,
-  pushData: async ({ indexName, jobContext }, records) => {
-    await updateDocs({
-      indexName,
-      documents: records as any[],
-      batchSize: MEILISEARCH_DOCUMENT_BATCH_SIZE,
-    });
-
-    return;
-  },
+  pushData,
 });


### PR DESCRIPTION
## The defect

`pushData` in the collections index calls `updateDocs`, which is an **upsert**. Nothing in the sync ever deletes a document.

The index's `WHERE` (`collections.search-index.ts`) admits a collection only while it is public, non-system-owned, searchable, and holds at least one `CollectionItem`:

```sql
c."userId" != -1
c.read = 'Public'
EXISTS (SELECT 1 FROM "CollectionItem" ci WHERE ci."collectionId" = c.id)
c."availability" != 'Unsearchable'
```

Stop matching **any** of those and `pullData` returns no row, so `transformData` yields no record, so `pushData` writes nothing — and the document that is already in `collections_v3` stays there permanently.

The enqueues that would trigger a rebuild already exist and already fire. `saveItemInCollections` queues an `Update` for every collection an item was removed from; `upsertCollection` queues one on every edit, privacy changes included. They arrive, find nothing to write, and change nothing.

## Confirmed in production

Collection **16158661** ("UwU") is `read = 'Unlisted'` with 994 items, flipped on 2026-09-07:

```
GET /indexes/collections_v3/documents/16158661  ->  200   # stale document
GET /indexes/collections_v3/documents/8036      ->  200   # positive control
```

An unlisted collection being served by the public search index. The ticket frames this as "last item hard-deleted"; that is one of four ways in, and the privacy leg is the one with a visibility consequence.

## Prevalence — smaller than the ticket estimates, and differently shaped

The ticket quotes *"24.6% of sampled CollectionMetric rows have itemCount = 1"* and flags its own sampling as heap-order. That number bounds the **exposed** population; it does not count broken documents.

Measured index-side instead: **5,000 documents** (ten windows of 500 across offsets 0 → 90,000 of 96,097) checked against all four predicates — **0 violations**. Caveat, stated because the ticket's number failed on exactly this: those are contiguous windows, so it is stratified coverage, not a random sample.

So the standing population is small — order tens, not thousands — with one confirmed instance. `search-index-sync-collections-reset` is `UNRUNNABLE_JOB_CRON`, so nothing sweeps these automatically; they accumulate at whatever rate collections are emptied or privatised.

## The fix

`pullData` returns the requested ids the filter did not match; `pushData` deletes those documents through `onSearchIndexDocumentsCleanup` after upserting the rest.

**Only for targeted batches.** `requestedIds` is `batch.type === 'update' ? batch.ids : []`.

The ticket's AC states the hazard as *"a naive 'no record ⇒ delete' would evict most of the index"*. **That framing is wrong, and I repeated it before checking.** A range batch's query returns *every* qualifying collection in `[startId, endId]`, so a qualifying document is never among the non-returned ids — a naive range-pruner cannot evict a good document. Non-returned ids are either non-qualifying (which *should* go) or non-existent (a Meilisearch no-op).

The real hazard is volume. `update()` runs `*/10 * * * *`, and `prepareBatches` applies its `createdAt >= lastUpdatedAt` filter only when `lastUpdatedAt` is set. On a first run — or any run after that job date is cleared — the span is the whole id space: **3 → 17,904,558**, walked in `READ_BATCH_SIZE` = 1000-wide batches. A naive pruner would push ~17.9M ids of delete traffic per sweep to cull at most a few dozen documents out of 96,097, into a Meilisearch task queue this repo already has trouble with (the `*-reset` jobs die on a busy one). ~99.5% of those deletes name ids that were never in the index.

So the guard is right and the test stays; the reason recorded for it is now the one that survives checking.

`reset()` is safe for a second, independent reason: it queues nothing but range batches **and** writes to a freshly-created, empty `collections_v3_NEW` swap index.

Ids that never existed are a no-op on the Meilisearch side, so an enqueue for a since-hard-deleted collection costs nothing.

## Most of the diff is a mechanical hoist

`pullData`, `transformData` and `pushData` were inline properties of the object literal passed to `createSearchIndexUpdateProcessor`, so nothing could call them. They are now exported consts with explicit `SearchIndexContext` / `SearchIndexPullBatch` annotations (previously supplied contextually), which lets the tests drive the real pull → transform → push pipeline over a fake database rather than asserting on a helper.

That move accounts for ~225 of the ~260 changed lines and alters no behaviour. `transformData` now returns `{ records, disqualifiedIds }` rather than a bare array, so `CollectionSearchIndexRecord` becomes `Awaited<ReturnType<typeof transformData>>['records'][number]`. Its one consumer is a type-only import in `src/components/Search/search.utils2.ts`. `base.search-index.ts`'s `getData` also returns the new shape; nothing calls it.

## Tests

Five tests, each watched failing before the change, driving the real pipeline. Three mutants, each killed by its designated guard:

| Mutation | Killed by |
|---|---|
| set difference inverted (`matched.has` instead of `!matched.has`) | `deletes the document of a requested collection that the index filter no longer matches` **and** `deletes nothing when every requested collection still qualifies` |
| `disqualifiedIds.length > 0` guard dropped in `pushData` | `deletes nothing when every requested collection still qualifies` **and** `deletes nothing on a range batch…` |
| naive "not in this batch ⇒ delete" extended to range batches | `deletes nothing on a range batch, where absence is the normal case` |

Two of the five pass on unchanged code by construction — they are negative controls — which is why each was mutation-checked rather than taken on trust.

No loops in any fake, so a revert fails in under a second rather than wedging the runner.

## Gates

`pnpm typecheck` 0 errors · `pnpm test:lint-rules` 33 files / 482 passed · `eslint` 0 errors (1 pre-existing `no-explicit-any` warning on the untouched `records as any[]`) · full unit suite **1666 files / 38613 passed, 0 failed**. `blocks.router.workflow.test.ts` collected 370 tests, confirming the worktree's submodule is intact.

## Verifier

After this ships, enqueue an `Update` for 16158661 and confirm its document is gone:

```
GET /indexes/collections_v3/documents/16158661  ->  expect 404
GET /indexes/collections_v3/documents/8036      ->  expect 200   # positive control
```

The control matters: an index that is down also 404s.

## Scope

- **Depends on #4661 for the cascade case.** The prune only fires when something enqueues an `Update` for the collection. On `main` today nothing enqueues collections when a model or image is hard-deleted — `image.service.ts` has **0** references to `collectionsSearchIndex`, and `model.service.ts`'s only one is the featured-models path. So on its own this PR fixes the privacy, unsearchable, and removed-via-`saveItemInCollections` cases, but **not** the ticket's headline case (last item hard-deleted, `CollectionItem` cascading away). #4661 supplies exactly that enqueue. Disjoint mechanism and disjoint files, but the two need each other to close the ticket.

- **Why not just enqueue a `Delete` at the call site?** Considered and rejected: it races. `SearchIndexUpdate.queueUpdate` writes `<index>:Update` and `<index>:Delete` as two independent Redis sets with no dedup or ordering, and the entry points resolve a doubly-queued id oppositely — `update()` runs the workers then the cleanup (**Delete wins**), `updateSync()` runs the cleanup then the pulls (**Update wins**). Empty a collection and re-add to it inside the 10-minute cron window and the sweep upserts the document, then deletes it: a live public collection evicted until something else happens to enqueue it. Pulling from the `WHERE` at pull time cannot do that — a re-populated collection comes back in the pull and is simply upserted. `Delete` is right where the disappearance is permanent and the id cannot return, which is why `deleteCollectionById` uses it. Empty, private and unsearchable are all reversible.
- **Does not reverse #4661's "Update, not Delete" decision.** That is right for a collection that still exists and still qualifies. This is the disjoint case where it no longer qualifies at all.
- **No backfill.** This stops new stale documents; it does not repair standing ones. Worth noting for sequencing: once this is in, a single `Update` enqueue sweep over the index repairs **both** backlogs — a still-qualifying collection rebuilds and drops its dead images (#4661's ~850), a disqualified one gets deleted (these). Two backfills collapse into one.
- **Known limitation, not fixed here.** `onSearchIndexDocumentsCleanup` is called without an explicit `client`, so it uses the default `searchClient`. Correct today — the collections processor sets no custom `client` — but it would silently target the wrong Meilisearch host if one were ever added, the way the metrics indexes have. Threading a client through `SearchIndexContext` is a `base.search-index.ts` change and did not belong in this diff.
- **Every other index is upsert-only too.** Same latent defect, scoped out deliberately: each index's `WHERE` has different predicates and a different blast radius if the prune is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbJCjGzmU7SNq9NiW8vjjJ
