### PR TITLE
feat(moderation): dark shadow probe to measure whether a cheaper classifier model agrees

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -685,6 +685,23 @@ export const serverSchema = z
     // to end. `.catch(0)` degrades an unparseable value to OFF, which is the safe direction for a
     // cache in front of a moderation gate.
     EXTERNAL_MODERATION_CACHE_TTL_SECONDS: z.coerce.number().int().min(0).max(3600).catch(0),
+
+    // DARK SHADOW PROBE — compare a CANDIDATE classifier model against the incumbent on a sampled
+    // share of calls, to produce the disagreement rate the "cheaper model?" decision needs. Both
+    // fields are required to arm and neither defaults on; see
+    // src/server/integrations/moderation-shadow-probe.ts.
+    //
+    // 🔴 SAMPLE IS THE SPEND CONTROL, NOT A CONVENIENCE. Every sampled call issues a SECOND billable
+    // classifier request against the production credential, so 1.0 doubles the moderation bill for
+    // as long as it is armed. It is a fraction in [0,1], not a percentage.
+    //
+    // Both use `.catch(...)` rather than `.default(...)`, the same rule the TTL above carries:
+    // `src/env/server.ts` THROWS on an invalid field and env is parsed only at container start, so a
+    // typo would do nothing visible now and CrashLoop the fleet at the next rollout. Degrading to
+    // OFF is the safe direction for a probe that spends money. A non-numeric SAMPLE coerces to NaN,
+    // fails `.min(0)` and lands on 0 = off.
+    EXTERNAL_MODERATION_SHADOW_MODEL: z.string().default('').catch(''),
+    EXTERNAL_MODERATION_SHADOW_SAMPLE: z.coerce.number().min(0).max(1).catch(0),
     BLOCKED_IMAGE_HASH_CHECK: zc.booleanString.optional().default(false),
     MODERATION_KNIGHT_TAGS: commaDelimitedStringArray().default([]),
 

--- a/src/server/integrations/__tests__/moderation-shadow-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-shadow-probe.test.ts
@@ -48,7 +48,7 @@ vi.mock('~/env/server', () => ({ env }));
 import { serverSchema } from '~/env/server-schema';
 import { extModeration } from '~/server/integrations/moderation';
 import {
-  candidateVocabularyCovers,
+  candidateVerdictIsDeterminate,
   classifyShadowOutcome,
 } from '~/server/integrations/moderation-shadow-probe';
 
@@ -130,6 +130,7 @@ beforeEach(() => {
   // entries, so a case that sets one would otherwise leak into every later case in this file.
   process.env.CACHE_KEY_NAMESPACE = '';
   delete process.env.IS_PREVIEW;
+  delete process.env.NEXT_PUBLIC_IS_PR_PREVIEW;
 });
 
 afterEach(() => {
@@ -296,18 +297,18 @@ describe('shadow probe — vocabulary gate (audit round 1, F1)', () => {
   it('coverage is by OWN property, so a prototype key cannot fake it', () => {
     // `in` walks the prototype chain, so `'toString' in {}` is true and the vocabulary would read
     // as covered on a response carrying nothing of the sort.
-    expect(candidateVocabularyCovers({ categories: {} }, { toString: 'x' })).toBe(false);
-    expect(candidateVocabularyCovers({ categories: { toString: true } }, { toString: 'x' })).toBe(
-      true
-    );
+    expect(candidateVerdictIsDeterminate({ categories: {} }, { toString: 'x' })).toBe(false);
+    expect(
+      candidateVerdictIsDeterminate({ categories: { toString: true } }, { toString: 'x' })
+    ).toBe(true);
   });
 
   it('treats a missing or non-object categories field as not covered', () => {
-    expect(candidateVocabularyCovers({}, PROD_MAP)).toBe(false);
-    expect(candidateVocabularyCovers({ categories: null }, PROD_MAP)).toBe(false);
-    expect(candidateVocabularyCovers({ categories: 'nope' }, PROD_MAP)).toBe(false);
+    expect(candidateVerdictIsDeterminate({}, PROD_MAP)).toBe(false);
+    expect(candidateVerdictIsDeterminate({ categories: null }, PROD_MAP)).toBe(false);
+    expect(candidateVerdictIsDeterminate({ categories: 'nope' }, PROD_MAP)).toBe(false);
     // Threshold mode: no map, nothing to cover.
-    expect(candidateVocabularyCovers({}, undefined)).toBe(true);
+    expect(candidateVerdictIsDeterminate({}, undefined)).toBe(true);
   });
 
   it('is DETERMINACY, not coverage: a present TRUE key settles the verdict despite a missing one', () => {
@@ -316,7 +317,7 @@ describe('shadow probe — vocabulary gate (audit round 1, F1)', () => {
     // makeable and must not be thrown away as `incomparable`. Unreachable on production's
     // single-key map; reachable the moment a second category is configured, which needs no code.
     const twoKeys = { 'sexual/minors': 'a', violence: 'b' };
-    expect(candidateVocabularyCovers({ categories: { 'sexual/minors': true } }, twoKeys)).toBe(
+    expect(candidateVerdictIsDeterminate({ categories: { 'sexual/minors': true } }, twoKeys)).toBe(
       true
     );
   });
@@ -324,12 +325,12 @@ describe('shadow probe — vocabulary gate (audit round 1, F1)', () => {
   it('is INDETERMINATE when nothing present is true and a mapped key is missing', () => {
     // Here the verdict really is unknowable: the absent key might have been the one that flagged.
     const twoKeys = { 'sexual/minors': 'a', violence: 'b' };
-    expect(candidateVocabularyCovers({ categories: { 'sexual/minors': false } }, twoKeys)).toBe(
+    expect(candidateVerdictIsDeterminate({ categories: { 'sexual/minors': false } }, twoKeys)).toBe(
       false
     );
     // All keys present and all false — determinate `flagged: false`, so comparable.
     expect(
-      candidateVocabularyCovers(
+      candidateVerdictIsDeterminate(
         { categories: { 'sexual/minors': false, violence: false } },
         twoKeys
       )
@@ -369,6 +370,40 @@ describe('shadow probe — arming', () => {
     await extModeration.moderatePrompt('a staging rehearsal', 'generate');
     await untilShadowTotal(1);
     expect(await shadowCount('match')).toBe(1);
+  });
+
+  it('refuses when the namespace is whitespace-padded (round 3, F3)', async () => {
+    // 🔴 The `.trim()` was implemented but UNGUARDED — a mutant deleting it passed the whole file.
+    // It is not cosmetic: with a YAML quoting slip like `CACHE_KEY_NAMESPACE=" preview"` and no
+    // trim, the value is neither `'preview'` nor empty, so NEITHER clause fires and the probe arms
+    // in a PR preview — the exact outcome this guard exists to prevent.
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a warmup prompt', 'generate');
+    await untilShadowTotal(1);
+
+    process.env.CACHE_KEY_NAMESPACE = '  preview  ';
+    const fetchSpy = stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('an entirely different prompt', 'generate');
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await shadowTotal()).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses on NEXT_PUBLIC_IS_PR_PREVIEW even if the keyspace scheme changes (round 3, F1)', async () => {
+    // 🔴 The namespace clause alone is coupled to a string chosen in another repo. A per-preview
+    // keyspace (`preview-<PR>`) is a natural evolution and would match NEITHER `'preview'` nor
+    // empty, silently un-refusing every preview. This second signal does not vary with that scheme.
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a warmup prompt', 'generate');
+    await untilShadowTotal(1);
+
+    process.env.CACHE_KEY_NAMESPACE = 'preview-4680';
+    process.env.NEXT_PUBLIC_IS_PR_PREVIEW = 'true';
+    const fetchSpy = stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('an entirely different prompt', 'generate');
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await shadowTotal()).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it('arms in production, where the namespace is empty and IS_PREVIEW is unset', async () => {

--- a/src/server/integrations/__tests__/moderation-shadow-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-shadow-probe.test.ts
@@ -126,6 +126,10 @@ beforeEach(() => {
   env.EXTERNAL_MODERATION_SHADOW_SAMPLE = 1;
   env.EXTERNAL_MODERATION_CATEGORIES = undefined;
   env.EXTERNAL_MODERATION_ENDPOINT = 'https://moderation.example/v1/moderations';
+  // Deployment-identity knobs the arming guard reads. Reset per test: they are real process.env
+  // entries, so a case that sets one would otherwise leak into every later case in this file.
+  process.env.CACHE_KEY_NAMESPACE = '';
+  delete process.env.IS_PREVIEW;
 });
 
 afterEach(() => {
@@ -306,40 +310,89 @@ describe('shadow probe — vocabulary gate (audit round 1, F1)', () => {
     expect(candidateVocabularyCovers({}, undefined)).toBe(true);
   });
 
-  it('requires EVERY mapped key, not merely one of them', () => {
+  it('is DETERMINACY, not coverage: a present TRUE key settles the verdict despite a missing one', () => {
+    // 🔴 ROUND 2, F2. `deriveModerationVerdict` ORs across mapped keys, so one present `true` fixes
+    // the verdict at `flagged: true` whatever the missing key would have said — that comparison is
+    // makeable and must not be thrown away as `incomparable`. Unreachable on production's
+    // single-key map; reachable the moment a second category is configured, which needs no code.
     const twoKeys = { 'sexual/minors': 'a', violence: 'b' };
     expect(candidateVocabularyCovers({ categories: { 'sexual/minors': true } }, twoKeys)).toBe(
+      true
+    );
+  });
+
+  it('is INDETERMINATE when nothing present is true and a mapped key is missing', () => {
+    // Here the verdict really is unknowable: the absent key might have been the one that flagged.
+    const twoKeys = { 'sexual/minors': 'a', violence: 'b' };
+    expect(candidateVocabularyCovers({ categories: { 'sexual/minors': false } }, twoKeys)).toBe(
       false
     );
+    // All keys present and all false — determinate `flagged: false`, so comparable.
     expect(
-      candidateVocabularyCovers({ categories: { 'sexual/minors': true, violence: false } }, twoKeys)
+      candidateVocabularyCovers(
+        { categories: { 'sexual/minors': false, violence: false } },
+        twoKeys
+      )
     ).toBe(true);
   });
 });
 
 describe('shadow probe — arming', () => {
-  it('REFUSES to arm in a PR preview, however the config was inherited (audit round 1, F2)', async () => {
-    // The preview deploy task copies civitai-cfg from civitai-next and rewrites an enumerated key
-    // list, which cannot name fields that did not exist when it was written. So arming on STAGING
-    // would otherwise arm every open preview at its next deploy, each spending the production
-    // classifier credential unattributed. Differential: prove observations land first.
+  it('REFUSES to arm in a PR preview (CACHE_KEY_NAMESPACE=preview)', async () => {
+    // Round 1 F2: the preview deploy task copies civitai-cfg from staging and rewrites an
+    // enumerated key list that cannot name fields which did not exist when it was written, so
+    // arming on staging would otherwise arm every open preview, each spending the production
+    // credential unattributed. Differential: prove observations land in this budget first.
     stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
     await extModeration.moderatePrompt('a warmup prompt', 'generate');
     await untilShadowTotal(1);
 
-    const prev = process.env.IS_PREVIEW;
+    process.env.CACHE_KEY_NAMESPACE = 'preview';
+    const fetchSpy = stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('an entirely different prompt', 'generate');
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(await shadowTotal()).toBe(1);
+    // Refusing to arm must also mean refusing to SPEND: one request, the live one.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('🔴 STILL ARMS on the standing non-production deployment (round 2, F1)', async () => {
+    // 🔴 THE ROUND-2 REGRESSION, PINNED. The first version of this guard used IS_PREVIEW, and
+    // `civitai-next` — the standing non-production deployment, and the config SOURCE the previews
+    // copy from — sets IS_PREVIEW=true itself. So the guard refused the one staging rehearsal it
+    // claimed to protect and left production as the practical arming target. Its namespace is
+    // `next`, so gating on the namespace permits it, which is the whole point of the correction.
+    process.env.CACHE_KEY_NAMESPACE = 'next';
+    process.env.IS_PREVIEW = 'true'; // exactly what that deployment carries
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a staging rehearsal', 'generate');
+    await untilShadowTotal(1);
+    expect(await shadowCount('match')).toBe(1);
+  });
+
+  it('arms in production, where the namespace is empty and IS_PREVIEW is unset', async () => {
+    process.env.CACHE_KEY_NAMESPACE = '';
+    delete process.env.IS_PREVIEW;
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a production call', 'generate');
+    await untilShadowTotal(1);
+    expect(await shadowCount('match')).toBe(1);
+  });
+
+  it('refuses on the TRANSITIONAL preview: namespace unset but IS_PREVIEW=true', async () => {
+    // cache-key-prefix.ts:66-75 warns this state exists. An unset namespace must not fail OPEN.
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a warmup prompt', 'generate');
+    await untilShadowTotal(1);
+
+    process.env.CACHE_KEY_NAMESPACE = '';
     process.env.IS_PREVIEW = 'true';
-    try {
-      const fetchSpy = stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
-      await extModeration.moderatePrompt('an entirely different prompt', 'generate');
-      await new Promise((r) => setTimeout(r, 200));
-      expect(await shadowTotal()).toBe(1);
-      // Refusing to arm must also mean refusing to SPEND: one request, the live one.
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-    } finally {
-      if (prev === undefined) delete process.env.IS_PREVIEW;
-      else process.env.IS_PREVIEW = prev;
-    }
+    const fetchSpy = stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('an entirely different prompt', 'generate');
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await shadowTotal()).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it('is OFF when the model is unset, even with a positive sample', async () => {

--- a/src/server/integrations/__tests__/moderation-shadow-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-shadow-probe.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Contract for the external-moderation SHADOW PROBE.
+ *
+ * WHAT IT IS. A dark instrument that answers one question — "would a CHEAPER classifier model have
+ * returned the same verdict?" — without ever acting on the answer. It runs on the generation
+ * submission path, so like the cache probe beside it, most of these cases are negative constraints:
+ * it must not change the verdict, must not add latency to the live call, must not be able to fail a
+ * generation, must not contaminate the duration histogram, and must not exist at all until armed.
+ *
+ * 🔴 WHY THE TESTS LOOK LIKE THIS. The failure that matters is not "the rate is slightly off". It is
+ * a probe that reports a reassuring agreement rate it did not measure — because it never ran, or
+ * because it compared the wrong two things. Two cases below are the ones that would survive a green
+ * suite if they were dropped, and each pins a claim the metric's own help text makes:
+ *
+ *   - `sends the CANDIDATE model on the PREPARED prompt` — drop it and the probe still records
+ *     `match` for everything, because it would be comparing the incumbent against itself. A 100%
+ *     agreement rate is exactly the result that gets acted on, and nothing else here contradicts it.
+ *   - `splits the two divergence directions` — drop it and permissive/strict fold together, which is
+ *     the one reading the counter exists to prevent: they cancel, so a candidate that is 2% more
+ *     permissive AND 2% stricter is indistinguishable from one that agrees perfectly.
+ *
+ * Absence assertions are structured as DIFFERENTIALS, not bare zeros — the sibling probe's suite
+ * learned that the hard way, when an "asserted zero" passed with the arming guard DELETED because a
+ * lazy import simply had not resolved inside a fixed sleep. Every "records nothing" case here first
+ * demonstrates that observations DO land in the same budget.
+ *
+ * These read back the REAL prom-client registry rather than asserting we called our own wrapper.
+ */
+import promClient from 'prom-client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mutable env mock, overriding the global stub in src/__tests__/setup.ts, so each case can flip the
+// arming inputs. `vi.hoisted` so it exists before the hoisted `vi.mock` factory references it.
+const env = vi.hoisted(() => ({
+  EXTERNAL_MODERATION_ENDPOINT: 'https://moderation.example/v1/moderations' as string,
+  EXTERNAL_MODERATION_TOKEN: 'tok' as string,
+  EXTERNAL_MODERATION_THRESHOLD: 0.5,
+  EXTERNAL_MODERATION_TIMEOUT_MS: 5000,
+  EXTERNAL_MODERATION_CATEGORIES: undefined as Record<string, string> | undefined,
+  EXTERNAL_MODERATION_CACHE_PROBE: '' as string,
+  EXTERNAL_MODERATION_CACHE_NAMESPACE: '' as string,
+  EXTERNAL_MODERATION_CACHE_TTL_SECONDS: 0,
+  EXTERNAL_MODERATION_SHADOW_MODEL: 'cheap-text-model' as string,
+  EXTERNAL_MODERATION_SHADOW_SAMPLE: 1,
+}));
+vi.mock('~/env/server', () => ({ env }));
+
+import { serverSchema } from '~/env/server-schema';
+import { extModeration } from '~/server/integrations/moderation';
+import { classifyShadowOutcome } from '~/server/integrations/moderation-shadow-probe';
+
+const SHADOW = 'civitai_app_external_moderation_shadow_total';
+const HIST = 'civitai_app_external_moderation_duration_seconds';
+
+/** The model the live call always uses. Mirrors MODERATION_MODEL in moderation.ts. */
+const INCUMBENT = 'omni-moderation-latest';
+
+type Sample = { metricName?: string; labels: Record<string, string | number>; value: number };
+type SentBody = { model: string; input: string };
+
+async function samples(name: string): Promise<Sample[]> {
+  const metric = promClient.register.getSingleMetric(name);
+  if (!metric) throw new Error(`metric ${name} is not registered`);
+  return (await metric.get()).values as Sample[];
+}
+
+async function shadowCount(outcome: string, source = 'generate') {
+  const vals = await samples(SHADOW);
+  return vals.find((v) => v.labels.outcome === outcome && v.labels.source === source)?.value ?? 0;
+}
+
+async function shadowTotal() {
+  return (await samples(SHADOW)).reduce((acc, v) => acc + v.value, 0);
+}
+
+async function histTotal() {
+  const vals = await samples(HIST);
+  return vals
+    .filter((v) => String(v.metricName ?? '').endsWith('_count'))
+    .reduce((acc, v) => acc + v.value, 0);
+}
+
+function body(flagged: boolean) {
+  return {
+    results: [
+      {
+        flagged,
+        categories: { violence: flagged },
+        category_scores: { violence: flagged ? 0.9 : 0.1 },
+      },
+    ],
+  };
+}
+
+/**
+ * Stub `fetch` so the LIVE call and the SHADOW call can return DIFFERENT verdicts, keyed on the
+ * `model` field of the request body. Returns the spy so a case can inspect what was actually sent.
+ *
+ * 🔴 This is what makes the fidelity case possible at all. With one canned response for every
+ * request, a probe that shadowed the WRONG model — or never issued a second request and simply
+ * compared the live verdict to itself — would record `match` and pass.
+ */
+function stubFetchByModel(verdicts: Record<string, boolean>) {
+  const spy = vi.fn(async (_url: string, init: { body: string }) => {
+    const parsed = JSON.parse(init.body) as SentBody;
+    const flagged = verdicts[parsed.model];
+    if (flagged === undefined) throw new Error(`unexpected model ${parsed.model}`);
+    return { ok: true, json: async () => body(flagged) };
+  });
+  vi.stubGlobal('fetch', spy);
+  return spy;
+}
+
+/** The probe is fire-and-forget; poll rather than sleeping a fixed amount. */
+async function untilShadowTotal(n: number) {
+  await vi.waitFor(async () => expect(await shadowTotal()).toBe(n));
+}
+
+beforeEach(() => {
+  promClient.register.getSingleMetric(SHADOW)?.reset();
+  promClient.register.getSingleMetric(HIST)?.reset();
+  env.EXTERNAL_MODERATION_SHADOW_MODEL = 'cheap-text-model';
+  env.EXTERNAL_MODERATION_SHADOW_SAMPLE = 1;
+  env.EXTERNAL_MODERATION_CATEGORIES = undefined;
+  env.EXTERNAL_MODERATION_ENDPOINT = 'https://moderation.example/v1/moderations';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('shadow probe — what it compares', () => {
+  it('sends the CANDIDATE model, on the PREPARED prompt, as a SECOND request', async () => {
+    // 🔴 THE FIDELITY CASE. Two independent things could be silently wrong and still yield a clean
+    // 100% `match`: shadowing the incumbent model (comparing it against itself), or shadowing the
+    // RAW prompt while the live call classified the PREPARED one (`removeFalsePositiveTriggers` is
+    // many-to-one, so the two strings genuinely differ). Both would report perfect agreement, which
+    // is the conclusion that gets acted on.
+    const fetchSpy = stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+
+    // 'girl' is rewritten to 'woman' by removeFalsePositiveTriggers, so the prepared string is
+    // observably different from the input.
+    await extModeration.moderatePrompt('a girl in a school uniform', 'generate');
+    await untilShadowTotal(1);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const sent = fetchSpy.mock.calls.map((c) => JSON.parse(c[1].body) as SentBody);
+    const live = sent.find((s) => s.model === INCUMBENT);
+    const shadow = sent.find((s) => s.model === 'cheap-text-model');
+
+    // Asserted as a pair so a missing shadow request fails HERE with a readable message, rather
+    // than as a TypeError on the next line.
+    expect([live?.model, shadow?.model]).toEqual([INCUMBENT, 'cheap-text-model']);
+    // Literal expected value, not derived from the implementation: 'girl'->'woman' and
+    // 'school uniform'->'uniform'.
+    expect(shadow?.input).toBe('a woman in a uniform');
+    // Both models must see the SAME string, or the comparison measures the substitution.
+    expect(shadow?.input).toBe(live?.input);
+  });
+
+  it('splits the two divergence directions into distinct outcomes', async () => {
+    // 🔴 THE DESIGN CASE. permissive and strict must never share a label: folded together they
+    // cancel. Both legs run here so a mutant that collapses them fails on one of the two.
+    stubFetchByModel({ [INCUMBENT]: true, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('incumbent flags this one', 'generate');
+    await untilShadowTotal(1);
+    expect(await shadowCount('candidate_permissive')).toBe(1);
+    expect(await shadowCount('candidate_strict')).toBe(0);
+    expect(await shadowCount('match')).toBe(0);
+
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': true });
+    await extModeration.moderatePrompt('only the candidate flags this one', 'generate');
+    await untilShadowTotal(2);
+    expect(await shadowCount('candidate_strict')).toBe(1);
+    // The permissive count must NOT have moved — that is what "distinct" means.
+    expect(await shadowCount('candidate_permissive')).toBe(1);
+  });
+
+  it('records `match` when the two models agree, in both directions', async () => {
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('both agree this is fine', 'generate');
+    await untilShadowTotal(1);
+
+    stubFetchByModel({ [INCUMBENT]: true, 'cheap-text-model': true });
+    await extModeration.moderatePrompt('both agree this is not', 'generate');
+    await untilShadowTotal(2);
+
+    expect(await shadowCount('match')).toBe(2);
+    expect(await shadowCount('candidate_permissive')).toBe(0);
+    expect(await shadowCount('candidate_strict')).toBe(0);
+  });
+});
+
+describe('shadow probe — arming', () => {
+  it('is OFF when the model is unset, even with a positive sample', async () => {
+    // Differential: prove observations land in this budget first, so the absence is evidence.
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a warmup prompt', 'generate');
+    await untilShadowTotal(1);
+
+    env.EXTERNAL_MODERATION_SHADOW_MODEL = '';
+    const fetchSpy = stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('an entirely different prompt', 'generate');
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(await shadowTotal()).toBe(1);
+    // Not armed must also mean not SPENDING: exactly one request, the live one.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is OFF when the sample rate is zero, even with a model named', async () => {
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a warmup prompt', 'generate');
+    await untilShadowTotal(1);
+
+    env.EXTERNAL_MODERATION_SHADOW_SAMPLE = 0;
+    const fetchSpy = stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('an entirely different prompt', 'generate');
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(await shadowTotal()).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is OFF when the sample rate is NaN — the one case the arming guard uniquely catches', async () => {
+    // 🔴 THIS CASE EXISTS BECAUSE THE `sample > 0` ARMING GUARD IS OTHERWISE REDUNDANT, and a
+    // redundant guard is an untested one. For sample=0 the later `Math.random() >= sample` check
+    // already returns (every random is >= 0), so deleting the arming guard leaves that test green —
+    // it dies to the OTHER guard. NaN is the case only the arming guard catches: `Math.random() >=
+    // NaN` is FALSE, so without it the probe would sail through and issue a billable request with a
+    // nonsense sample. Written as `!(sample > 0)` rather than `sample <= 0` for exactly this reason.
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a warmup prompt', 'generate');
+    await untilShadowTotal(1);
+
+    env.EXTERNAL_MODERATION_SHADOW_SAMPLE = Number.NaN;
+    const fetchSpy = stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('an entirely different prompt', 'generate');
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(await shadowTotal()).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a whitespace-only model name as unset rather than arming on it', async () => {
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a warmup prompt', 'generate');
+    await untilShadowTotal(1);
+
+    env.EXTERNAL_MODERATION_SHADOW_MODEL = '   ';
+    await extModeration.moderatePrompt('an entirely different prompt', 'generate');
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await shadowTotal()).toBe(1);
+  });
+});
+
+describe('shadow probe — it cannot harm the live path', () => {
+  it('returns the INCUMBENT verdict even when the candidate disagrees', async () => {
+    // The gate must be unaffected. The candidate says "fine", the incumbent says "flagged"; the
+    // caller must still see flagged.
+    stubFetchByModel({ [INCUMBENT]: true, 'cheap-text-model': false });
+    const verdict = await extModeration.moderatePrompt('incumbent flags this', 'generate');
+    await untilShadowTotal(1);
+
+    expect(verdict.flagged).toBe(true);
+    expect(await shadowCount('candidate_permissive')).toBe(1);
+  });
+
+  it('records `error` and still returns the live verdict when the shadow request fails', async () => {
+    const spy = vi.fn(async (_url: string, init: { body: string }) => {
+      const parsed = JSON.parse(init.body) as SentBody;
+      if (parsed.model !== INCUMBENT) throw new Error('shadow gateway is down');
+      return { ok: true, json: async () => body(false) };
+    });
+    vi.stubGlobal('fetch', spy);
+
+    const verdict = await extModeration.moderatePrompt('a serene landscape', 'generate');
+    await untilShadowTotal(1);
+
+    expect(verdict.flagged).toBe(false);
+    expect(await shadowCount('error')).toBe(1);
+  });
+
+  it('does NOT observe the shadow request on the duration histogram', async () => {
+    // 🔴 The histogram measures what ONE classifier call costs. A second in-flight request counted
+    // there would drag every quantile and corrupt the instrument the latency case rests on.
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+    await untilShadowTotal(1);
+
+    expect(await histTotal()).toBe(1);
+  });
+
+  it('clamps an out-of-set source, so no caller can mint a label value', async () => {
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a serene landscape', 'not-a-real-source' as never);
+    await untilShadowTotal(1);
+
+    expect(await shadowCount('match', 'other')).toBe(1);
+  });
+});
+
+describe('shadow probe — outcome classification is pure and total', () => {
+  // Direct unit coverage so the mapping is pinned independently of the HTTP path.
+  it('maps the four cases by literal expectation', () => {
+    expect(classifyShadowOutcome({ flagged: false }, { flagged: false })).toBe('match');
+    expect(classifyShadowOutcome({ flagged: true }, { flagged: true })).toBe('match');
+    expect(classifyShadowOutcome({ flagged: true }, { flagged: false })).toBe(
+      'candidate_permissive'
+    );
+    expect(classifyShadowOutcome({ flagged: false }, { flagged: true })).toBe('candidate_strict');
+  });
+
+  it('coerces a truthy non-boolean rather than reporting a false disagreement', () => {
+    // `flagged` comes off an untyped res.json(); a vendor sending 1 and true must not read as a
+    // disagreement between two verdicts that both mean "flagged".
+    expect(classifyShadowOutcome({ flagged: 1 as never }, { flagged: true })).toBe('match');
+    expect(classifyShadowOutcome({ flagged: 0 as never }, { flagged: false })).toBe('match');
+  });
+});
+
+describe('shadow probe — env schema bounds', () => {
+  const field = (name: keyof typeof serverSchema.shape) => serverSchema.shape[name];
+
+  it('degrades an unparseable sample rate to OFF rather than throwing', () => {
+    // `src/env/server.ts` THROWS on an invalid field and env is parsed only at container start, so
+    // a typo must not be able to CrashLoop the fleet at the next rollout.
+    expect(field('EXTERNAL_MODERATION_SHADOW_SAMPLE').parse('off')).toBe(0);
+    expect(field('EXTERNAL_MODERATION_SHADOW_SAMPLE').parse('50%')).toBe(0);
+    // Out of range in either direction also lands on OFF, not on a clamped value.
+    expect(field('EXTERNAL_MODERATION_SHADOW_SAMPLE').parse('2')).toBe(0);
+    expect(field('EXTERNAL_MODERATION_SHADOW_SAMPLE').parse('-1')).toBe(0);
+  });
+
+  it('accepts a fraction in range', () => {
+    expect(field('EXTERNAL_MODERATION_SHADOW_SAMPLE').parse('0.05')).toBe(0.05);
+    expect(field('EXTERNAL_MODERATION_SHADOW_SAMPLE').parse('1')).toBe(1);
+  });
+
+  it('defaults both inputs to OFF when absent', () => {
+    expect(field('EXTERNAL_MODERATION_SHADOW_MODEL').parse(undefined)).toBe('');
+    expect(field('EXTERNAL_MODERATION_SHADOW_SAMPLE').parse(undefined)).toBe(0);
+  });
+});

--- a/src/server/integrations/__tests__/moderation-shadow-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-shadow-probe.test.ts
@@ -47,7 +47,10 @@ vi.mock('~/env/server', () => ({ env }));
 
 import { serverSchema } from '~/env/server-schema';
 import { extModeration } from '~/server/integrations/moderation';
-import { classifyShadowOutcome } from '~/server/integrations/moderation-shadow-probe';
+import {
+  candidateVocabularyCovers,
+  classifyShadowOutcome,
+} from '~/server/integrations/moderation-shadow-probe';
 
 const SHADOW = 'civitai_app_external_moderation_shadow_total';
 const HIST = 'civitai_app_external_moderation_duration_seconds';
@@ -192,7 +195,153 @@ describe('shadow probe — what it compares', () => {
   });
 });
 
+describe('shadow probe — vocabulary gate (audit round 1, F1)', () => {
+  // 🔴 PRODUCTION'S REAL CONFIGURATION. Read live from the dp-prod ConfigMap 2026-09-07:
+  // EXTERNAL_MODERATION_CATEGORIES = 'sexual/minors:inappropriate minor content'. A SINGLE key, so
+  // the app's verdict is exactly `Boolean(result.categories['sexual/minors'])`.
+  const PROD_MAP = { 'sexual/minors': 'inappropriate minor content' };
+
+  /** A response in a DIFFERENT vocabulary: same meaning, different category names. */
+  function bodyForeignVocab(flagged: boolean) {
+    return {
+      results: [
+        {
+          flagged,
+          categories: { csam: flagged, adult: false },
+          category_scores: { csam: flagged ? 0.95 : 0.02, adult: 0.1 },
+        },
+      ],
+    };
+  }
+
+  it('records `incomparable` — NOT a false disagreement — when the candidate lacks the mapped key', async () => {
+    // 🔴 THE FINDING THIS TEST EXISTS FOR. Without the gate, a candidate in PERFECT agreement that
+    // simply names the category differently yields Boolean(undefined) === false on every call, so
+    // every incumbent flag books as `candidate_permissive` at ZERO errors. A blind candidate reads
+    // IDENTICALLY. That is a fully plausible number, unrelated to quality, on a fail-closed gate.
+    env.EXTERNAL_MODERATION_CATEGORIES = PROD_MAP;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: { body: string }) => {
+        const parsed = JSON.parse(init.body) as SentBody;
+        if (parsed.model === INCUMBENT) {
+          // The incumbent DOES flag, in its own vocabulary.
+          return {
+            ok: true,
+            json: async () => ({
+              results: [
+                {
+                  flagged: true,
+                  categories: { 'sexual/minors': true },
+                  category_scores: { 'sexual/minors': 0.95 },
+                },
+              ],
+            }),
+          };
+        }
+        return { ok: true, json: async () => bodyForeignVocab(true) };
+      })
+    );
+
+    const verdict = await extModeration.moderatePrompt('a prompt the incumbent flags', 'generate');
+    await untilShadowTotal(1);
+
+    expect(verdict.flagged).toBe(true); // the gate itself is untouched
+    expect(await shadowCount('incomparable')).toBe(1);
+    // The whole point: it must NOT be booked as the candidate being permissive.
+    expect(await shadowCount('candidate_permissive')).toBe(0);
+    expect(await shadowCount('match')).toBe(0);
+  });
+
+  it('still compares normally when the candidate DOES share the mapped vocabulary', async () => {
+    // The gate must not simply switch the probe off under a category map — that would trade a
+    // wrong number for no number, and production always runs a map.
+    env.EXTERNAL_MODERATION_CATEGORIES = PROD_MAP;
+    const shared = (flagged: boolean) => ({
+      results: [
+        {
+          flagged,
+          categories: { 'sexual/minors': flagged },
+          category_scores: { 'sexual/minors': flagged ? 0.95 : 0.01 },
+        },
+      ],
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: { body: string }) => {
+        const parsed = JSON.parse(init.body) as SentBody;
+        return { ok: true, json: async () => shared(parsed.model === INCUMBENT) };
+      })
+    );
+
+    await extModeration.moderatePrompt('incumbent flags, candidate does not', 'generate');
+    await untilShadowTotal(1);
+    expect(await shadowCount('candidate_permissive')).toBe(1);
+    expect(await shadowCount('incomparable')).toBe(0);
+  });
+
+  it('does not gate in THRESHOLD mode, where the vendor`s own flagged is comparable', async () => {
+    env.EXTERNAL_MODERATION_CATEGORIES = undefined;
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+    await untilShadowTotal(1);
+    expect(await shadowCount('match')).toBe(1);
+    expect(await shadowCount('incomparable')).toBe(0);
+  });
+
+  it('coverage is by OWN property, so a prototype key cannot fake it', () => {
+    // `in` walks the prototype chain, so `'toString' in {}` is true and the vocabulary would read
+    // as covered on a response carrying nothing of the sort.
+    expect(candidateVocabularyCovers({ categories: {} }, { toString: 'x' })).toBe(false);
+    expect(candidateVocabularyCovers({ categories: { toString: true } }, { toString: 'x' })).toBe(
+      true
+    );
+  });
+
+  it('treats a missing or non-object categories field as not covered', () => {
+    expect(candidateVocabularyCovers({}, PROD_MAP)).toBe(false);
+    expect(candidateVocabularyCovers({ categories: null }, PROD_MAP)).toBe(false);
+    expect(candidateVocabularyCovers({ categories: 'nope' }, PROD_MAP)).toBe(false);
+    // Threshold mode: no map, nothing to cover.
+    expect(candidateVocabularyCovers({}, undefined)).toBe(true);
+  });
+
+  it('requires EVERY mapped key, not merely one of them', () => {
+    const twoKeys = { 'sexual/minors': 'a', violence: 'b' };
+    expect(candidateVocabularyCovers({ categories: { 'sexual/minors': true } }, twoKeys)).toBe(
+      false
+    );
+    expect(
+      candidateVocabularyCovers({ categories: { 'sexual/minors': true, violence: false } }, twoKeys)
+    ).toBe(true);
+  });
+});
+
 describe('shadow probe — arming', () => {
+  it('REFUSES to arm in a PR preview, however the config was inherited (audit round 1, F2)', async () => {
+    // The preview deploy task copies civitai-cfg from civitai-next and rewrites an enumerated key
+    // list, which cannot name fields that did not exist when it was written. So arming on STAGING
+    // would otherwise arm every open preview at its next deploy, each spending the production
+    // classifier credential unattributed. Differential: prove observations land first.
+    stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+    await extModeration.moderatePrompt('a warmup prompt', 'generate');
+    await untilShadowTotal(1);
+
+    const prev = process.env.IS_PREVIEW;
+    process.env.IS_PREVIEW = 'true';
+    try {
+      const fetchSpy = stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });
+      await extModeration.moderatePrompt('an entirely different prompt', 'generate');
+      await new Promise((r) => setTimeout(r, 200));
+      expect(await shadowTotal()).toBe(1);
+      // Refusing to arm must also mean refusing to SPEND: one request, the live one.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      if (prev === undefined) delete process.env.IS_PREVIEW;
+      else process.env.IS_PREVIEW = prev;
+    }
+  });
+
   it('is OFF when the model is unset, even with a positive sample', async () => {
     // Differential: prove observations land in this budget first, so the absence is evidence.
     stubFetchByModel({ [INCUMBENT]: false, 'cheap-text-model': false });

--- a/src/server/integrations/__tests__/moderation-shadow-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-shadow-probe.test.ts
@@ -200,7 +200,7 @@ describe('shadow probe — what it compares', () => {
   });
 });
 
-describe('shadow probe — vocabulary gate (audit round 1, F1)', () => {
+describe('shadow probe — determinacy gate (audit round 1 F1, round 2 F2)', () => {
   // 🔴 PRODUCTION'S REAL CONFIGURATION. Read live from the dp-prod ConfigMap 2026-09-07:
   // EXTERNAL_MODERATION_CATEGORIES = 'sexual/minors:inappropriate minor content'. A SINGLE key, so
   // the app's verdict is exactly `Boolean(result.categories['sexual/minors'])`.

--- a/src/server/integrations/__tests__/moderation-verdict-policy.test.ts
+++ b/src/server/integrations/__tests__/moderation-verdict-policy.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Contract for the shared moderation VERDICT POLICY.
+ *
+ * WHY THIS FILE EXISTS. `deriveModerationVerdict` was extracted verbatim out of the inline body of
+ * `extModeration.moderatePrompt` so that the shadow probe applies the SAME reduction to a candidate
+ * model's response that the live path applies to the incumbent's. The extraction is only safe if it
+ * is behaviour-preserving, and "it still compiles" does not establish that.
+ *
+ * 🔴 EVERY EXPECTATION BELOW IS A LITERAL, DERIVED FROM THE POLICY'S STATED CONTRACT — never read
+ * back out of the implementation. That is the point: a test whose expectation is computed the same
+ * way the code computes it passes for any behaviour, including a wrong one.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { deriveModerationVerdict } from '~/server/integrations/moderation-verdict-policy';
+
+const result = (over: Record<string, unknown> = {}) => ({
+  flagged: false,
+  categories: { violence: false, sexual: false, harassment: false },
+  // Deliberately pairwise-distinct and NOT equal to the threshold used below, so a mutant that
+  // hardcodes a literal or flips a comparison cannot land on the same answer by coincidence.
+  category_scores: { violence: 0.42, sexual: 0.81, harassment: 0.07 },
+  ...over,
+});
+
+describe('threshold mode (no category map)', () => {
+  it('reports every category strictly ABOVE the threshold', () => {
+    // 0.81 > 0.5; 0.42 and 0.07 are not. Literal expectation.
+    expect(deriveModerationVerdict(result(), 0.5, undefined).categories).toEqual(['sexual']);
+  });
+
+  it('is strictly greater-than, not greater-or-equal, at the boundary', () => {
+    // A score EXACTLY on the threshold must not be reported. This is the mutant `>=` would survive
+    // if every fixture score sat away from the boundary.
+    expect(deriveModerationVerdict(result(), 0.81, undefined).categories).toEqual([]);
+    expect(deriveModerationVerdict(result(), 0.8, undefined).categories).toEqual(['sexual']);
+  });
+
+  it('passes the classifier`s own `flagged` through UNCHANGED', () => {
+    // In threshold mode the app does not recompute `flagged` — it echoes the vendor. So a result
+    // that the vendor did not flag stays unflagged even though a category cleared the threshold.
+    expect(deriveModerationVerdict(result(), 0.5, undefined).flagged).toBe(false);
+    expect(deriveModerationVerdict(result({ flagged: true }), 0.99, undefined).flagged).toBe(true);
+  });
+});
+
+describe('category-map mode', () => {
+  it('REPLACES the threshold result entirely and renames to the mapped value', () => {
+    const verdict = deriveModerationVerdict(
+      result({ categories: { violence: true, sexual: false, harassment: false } }),
+      // A threshold that would report `sexual` in threshold mode — proving the map replaces rather
+      // than intersects. `sexual` scores 0.81 and is NOT in the output below.
+      0.5,
+      { violence: 'graphic-violence' }
+    );
+    expect(verdict.categories).toEqual(['graphic-violence']);
+    expect(verdict.flagged).toBe(true);
+  });
+
+  it('falls back to the KEY when the mapped value is nullish', () => {
+    const verdict = deriveModerationVerdict(
+      result({ categories: { violence: true } }),
+      0.5,
+      { violence: undefined as never }
+    );
+    expect(verdict.categories).toEqual(['violence']);
+  });
+
+  it('recomputes `flagged` from the matches, overriding the vendor', () => {
+    // The vendor said flagged; no MAPPED category matched; the app un-flags it.
+    const verdict = deriveModerationVerdict(
+      result({ flagged: true, categories: { violence: false, sexual: true } }),
+      0.5,
+      { violence: 'graphic-violence' }
+    );
+    expect(verdict.flagged).toBe(false);
+    expect(verdict.categories).toEqual([]);
+  });
+
+  it('ignores classifier categories that are not in the map', () => {
+    const verdict = deriveModerationVerdict(
+      result({ categories: { violence: false, sexual: true } }),
+      0.5,
+      { violence: 'graphic-violence' }
+    );
+    expect(verdict.flagged).toBe(false);
+  });
+});

--- a/src/server/integrations/__tests__/moderation-verdict-policy.test.ts
+++ b/src/server/integrations/__tests__/moderation-verdict-policy.test.ts
@@ -58,11 +58,9 @@ describe('category-map mode', () => {
   });
 
   it('falls back to the KEY when the mapped value is nullish', () => {
-    const verdict = deriveModerationVerdict(
-      result({ categories: { violence: true } }),
-      0.5,
-      { violence: undefined as never }
-    );
+    const verdict = deriveModerationVerdict(result({ categories: { violence: true } }), 0.5, {
+      violence: undefined as never,
+    });
     expect(verdict.categories).toEqual(['violence']);
   });
 

--- a/src/server/integrations/moderation-shadow-probe.ts
+++ b/src/server/integrations/moderation-shadow-probe.ts
@@ -51,7 +51,13 @@ import {
 export type ShadowComparableVerdict = { flagged: boolean };
 
 /**
- * Can the candidate's response even be REDUCED by the incumbent's policy?
+ * Is the candidate's verdict DETERMINATE under the incumbent's policy?
+ *
+ * ⚠️ RENAMED FROM `candidateVocabularyCovers`, because the earlier name described the earlier test
+ * and stopped being true when the test changed. It does NOT answer "does the candidate share our
+ * vocabulary" — a partially-shared vocabulary is often determinate, and it returns `true` there.
+ * `incomparable == 0` therefore does NOT imply full vocabulary agreement; it implies every counted
+ * comparison was decidable. Read the outcome's doc in `external-moderation.metrics.ts` with this.
  *
  * 🔴 THIS IS THE DIFFERENCE BETWEEN A MEASUREMENT AND A PLAUSIBLE FICTION, and without it the
  * probe's headline number is unrelated to the candidate's quality. When
@@ -72,7 +78,7 @@ export type ShadowComparableVerdict = { flagged: boolean };
  * would report the vocabulary covered on a response that carries nothing of the sort. Same failure
  * shape this codebase has already been bitten by elsewhere.
  */
-export function candidateVocabularyCovers(
+export function candidateVerdictIsDeterminate(
   result: { categories?: unknown },
   categoryMap: Record<string, string> | undefined
 ): boolean {
@@ -148,7 +154,7 @@ export function classifyShadowOutcome(
  * earlier revision of this comment stopped at "guarding it would be ceremony", which primed the
  * reader to treat a zero `error` rate as proof the candidate was working. It is not: a perfectly
  * valid model that answers in a different CATEGORY VOCABULARY produces 200s, zero errors, and a
- * completely fictional agreement rate. That hole is closed by `candidateVocabularyCovers` and the
+ * completely fictional agreement rate. That hole is closed by `candidateVerdictIsDeterminate` and the
  * `incomparable` outcome above, NOT by anything about the model name — read them together.
  *
  * 🔴 AND IT REFUSES TO ARM IN A PR PREVIEW, which is a CONFIG-INHERITANCE guard, not a model guard.
@@ -166,12 +172,31 @@ export function classifyShadowOutcome(
  * rehearsal it promised to protect and left production as the practical arming target, which is
  * backwards for a probe whose whole design is "arm low, read, disarm".
  *
- * This is the exact conflation `@civitai/redis`'s `cache-key-prefix.ts` and `~/env/database-target`
- * were both written to resolve — `IS_PREVIEW` is overloaded across at least two deployment classes
- * — and both resolved it the same way, with an explicit namespace. Following that precedent rather
- * than inventing a third signal. Canonical values, from `cache-key-prefix.ts`: `''`/unset =
- * production, `'preview'` = the ephemeral per-PR deployments, `'next'` = the standing
- * non-production one. Only `'preview'` is refused.
+ * 🔴 RETRACTED CLAIM, KEPT SO NOBODY DERIVES IT AGAIN. A previous revision said this "follows the
+ * precedent" of `cache-key-prefix.ts` and `~/env/database-target`, which resolved the same
+ * `IS_PREVIEW` overload. Those modules DIAGNOSE the overload — accurately, and that half stands —
+ * but each resolved it by introducing ITS OWN DEDICATED VARIABLE, and each says so in terms
+ * (`"the cache namespace gets its own variable"`; `"this describes the DATABASE, and nothing else …
+ * must not become one"`). Reusing one of those variables is the opposite of what they did. The
+ * sibling probe on this very path considered exactly this reuse and rejected it
+ * (`server-schema.ts`, "WHY NOT REUSE CACHE_KEY_NAMESPACE"). **The precedent argument was wrong;
+ * do not restate it, and do not reach for a replacement justification for the same shape.**
+ *
+ * ⚠️ SO WHAT THIS GUARD ACTUALLY RESTS ON, STATED WITHOUT DRESSING IT UP: two signals that are
+ * TRUE OF PREVIEWS TODAY, neither of which this module owns, and neither of which any test or gate
+ * in either repo pins to this use. Canonical namespace values, from `cache-key-prefix.ts`:
+ * `''`/unset = production, `'preview'` = the ephemeral per-PR deployments, `'next'` = the standing
+ * non-production one. The known way this goes stale is a per-preview keyspace
+ * (`CACHE_KEY_NAMESPACE=preview-<PR>`), which is a natural evolution and would silently un-refuse
+ * every preview — which is why `NEXT_PUBLIC_IS_PR_PREVIEW` is checked ALONGSIDE rather than
+ * instead: it is preview-only, is already used for this exact discrimination elsewhere in this repo
+ * (`contest-score.service.ts`), and does not vary with a keyspace scheme.
+ *
+ * 🔴 THE STRUCTURALLY CORRECT FIX IS A DEDICATED VARIABLE — what both precedents above actually
+ * did — and it is NOT TAKEN HERE, deliberately: a new variable is absent from the preview deploy
+ * task's strip filter until an infra change lands, so until then it would FAIL OPEN, which is worse
+ * than a coupling that currently holds. If you are extending this, that is the change to make, in
+ * both repos, together.
  *
  * ⚠️ The `IS_PREVIEW` fallback below is NOT the old guard surviving. It covers ONLY the transitional
  * state `cache-key-prefix.ts:66-75` itself warns about — a deployment carrying `IS_PREVIEW=true`
@@ -187,6 +212,7 @@ export function classifyShadowOutcome(
  * string directly: the parse is total and cannot throw.
  */
 function shadowConfig(): { model: string; sample: number } | null {
+  if (process.env.NEXT_PUBLIC_IS_PR_PREVIEW === 'true') return null;
   const namespace = process.env.CACHE_KEY_NAMESPACE?.trim() ?? '';
   if (namespace === 'preview') return null;
   if (!namespace && process.env.IS_PREVIEW === 'true') return null;
@@ -273,7 +299,7 @@ async function runShadowComparison(
     // 🔴 Vocabulary gate BEFORE the comparison, never after. Reducing an unreadable response would
     // silently produce `flagged:false` and book it as a real disagreement. See the function's own
     // header for why that specific wrong answer is the dangerous one.
-    if (!candidateVocabularyCovers(results[0], env.EXTERNAL_MODERATION_CATEGORIES)) {
+    if (!candidateVerdictIsDeterminate(results[0], env.EXTERNAL_MODERATION_CATEGORIES)) {
       recordExternalModerationShadow(metricSource, 'incomparable');
       return;
     }

--- a/src/server/integrations/moderation-shadow-probe.ts
+++ b/src/server/integrations/moderation-shadow-probe.ts
@@ -75,7 +75,7 @@ export type ShadowComparableVerdict = { flagged: boolean };
  *
  * `hasOwnProperty` rather than `in`, because `in` walks the prototype chain: with a map key of
  * `toString` or `constructor` — operator-controlled, so not untrusted, but free to get right — `in`
- * would report the vocabulary covered on a response that carries nothing of the sort. Same failure
+ * would report a mapped key PRESENT on a response that carries nothing of the sort. Same failure
  * shape this codebase has already been bitten by elsewhere.
  */
 export function candidateVerdictIsDeterminate(
@@ -183,23 +183,37 @@ export function classifyShadowOutcome(
  * do not restate it, and do not reach for a replacement justification for the same shape.**
  *
  * ⚠️ SO WHAT THIS GUARD ACTUALLY RESTS ON, STATED WITHOUT DRESSING IT UP: two signals that are
- * TRUE OF PREVIEWS TODAY, neither of which this module owns, and neither of which any test or gate
- * in either repo pins to this use. Canonical namespace values, from `cache-key-prefix.ts`:
- * `''`/unset = production, `'preview'` = the ephemeral per-PR deployments, `'next'` = the standing
- * non-production one. The known way this goes stale is a per-preview keyspace
- * (`CACHE_KEY_NAMESPACE=preview-<PR>`), which is a natural evolution and would silently un-refuse
- * every preview — which is why `NEXT_PUBLIC_IS_PR_PREVIEW` is checked ALONGSIDE rather than
- * instead: it is preview-only, is already used for this exact discrimination elsewhere in this repo
- * (`contest-score.service.ts`), and does not vary with a keyspace scheme.
+ * TRUE OF PREVIEWS TODAY and that this module does not own. The tests below pin how this module
+ * READS them; nothing on the INFRA side is pinned to keep SUPPLYING them, and that is the exposure.
+ * Canonical namespace values, from `cache-key-prefix.ts`: `''`/unset = production, `'preview'` =
+ * the ephemeral per-PR deployments, `'next'` = the standing non-production one. The known way this
+ * goes stale is a per-preview keyspace (`CACHE_KEY_NAMESPACE=preview-<PR>`), a natural evolution
+ * that would silently un-refuse every preview — which is why `NEXT_PUBLIC_IS_PR_PREVIEW` is checked
+ * ALONGSIDE rather than instead: measured across the infra repo it is set ONLY by the preview
+ * pipeline (as a build arg) and the preview deploy task (in the ConfigMap), is absent from
+ * production, `civitai-next` and `civitai-next-stage`, and does not vary with a keyspace scheme.
+ *
+ * ⚠️ NO PRECEDENT IS CLAIMED FOR THAT CHOICE, deliberately. A previous revision cited
+ * `contest-score.service.ts` as "already used for this exact discrimination"; it is not — that
+ * file reads the variable as an explicitly LEGACY fallback for a DATABASE-class question, gated on
+ * `!isDatabaseEnvironmentConfigured()` and documented as de-authorised once `DATABASE_ENVIRONMENT`
+ * is set. It is a counter-example, and it points at a code path scheduled to die. This module's
+ * read is INDEPENDENT of that one and must survive its deletion. The justification is the measured
+ * fact above and nothing else.
  *
  * 🔴 THE STRUCTURALLY CORRECT FIX IS A DEDICATED VARIABLE — what both precedents above actually
- * did — and it is NOT TAKEN HERE, deliberately: a new variable is absent from the preview deploy
- * task's strip filter until an infra change lands, so until then it would FAIL OPEN, which is worse
- * than a coupling that currently holds. If you are extending this, that is the change to make, in
- * both repos, together.
+ * did — and it is NOT TAKEN HERE, deliberately: a preview would not RECEIVE a brand-new variable at
+ * all, so a probe refusing unless it is set would refuse everywhere, and one refusing only when it
+ * IS set would FAIL OPEN in every preview. 🔴 The change that fixes that is a new `.data.<VAR>`
+ * write in the preview deploy task's **jq override chain** — NOT an entry in its strip filter,
+ * which only removes inherited explicit `env:` entries and is a no-op for a variable that does not
+ * exist yet. A previous revision named the strip filter, and following it would have produced
+ * exactly the fail-open this paragraph warns about. If you are extending this, that is the change
+ * to make, in both repos, together.
  *
  * ⚠️ The `IS_PREVIEW` fallback below is NOT the old guard surviving. It covers ONLY the transitional
- * state `cache-key-prefix.ts:66-75` itself warns about — a deployment carrying `IS_PREVIEW=true`
+ * state `cache-key-prefix.ts` itself warns about (its own transitional-state note) — a deployment
+ * carrying `IS_PREVIEW=true`
  * whose `CACHE_KEY_NAMESPACE` has not been configured yet — where an unset namespace would
  * otherwise fail OPEN and arm a preview. It cannot catch `civitai-next`, whose namespace is `next`,
  * i.e. non-empty.
@@ -296,7 +310,7 @@ async function runShadowComparison(
       recordExternalModerationShadow(metricSource, 'error');
       return;
     }
-    // 🔴 Vocabulary gate BEFORE the comparison, never after. Reducing an unreadable response would
+    // 🔴 Determinacy gate BEFORE the comparison, never after. Reducing an undecidable response would
     // silently produce `flagged:false` and book it as a real disagreement. See the function's own
     // header for why that specific wrong answer is the dangerous one.
     if (!candidateVerdictIsDeterminate(results[0], env.EXTERNAL_MODERATION_CATEGORIES)) {

--- a/src/server/integrations/moderation-shadow-probe.ts
+++ b/src/server/integrations/moderation-shadow-probe.ts
@@ -1,0 +1,178 @@
+// DARK SHADOW PROBE: does a CHEAPER classifier model agree with the one in production?
+//
+// WHY this exists. `MODERATION_MODEL` is `omni-moderation-latest`, the MULTIMODAL model, and these
+// prompts are TEXT. Roughly 175-180 ms of the ~205 ms `moderatePrompt` costs is the model's own
+// inference time, which makes it the largest single component of the call and the only one nobody
+// has tried to move — every infra-side lever (tail clamping, connection reuse, overlapping the
+// submit) was tested against production measurements and all three are dead.
+//
+// 🔴 BUT THE BLOCKER IS NOT LATENCY, IT IS QUALITY, AND THERE WAS NO INSTRUMENT FOR IT. The
+// duration histogram in `~/server/prom/external-moderation.metrics` grades a candidate model's
+// SPEED within one scrape. It cannot express whether that model AGREES with the incumbent — no
+// label, no series, no derivation. So "is a cheaper model acceptable?" was being put to a
+// moderation-quality owner with no data attached, which is why it stayed parked. This module
+// produces that data and nothing else.
+//
+// 🔴 IT IS A MEASUREMENT, NOT A MIGRATION, AND IT MUST NEVER BECOME ONE BY ACCIDENT. The verdict of
+// record is ALWAYS the incumbent model's. Nothing here is awaited, nothing here is returned to a
+// caller, and no code path reads a shadow result back. Switching the gate to a different model is a
+// moderation-policy decision and must be its own change with its own review.
+//
+// 🔴 NO PROMPT IS EVER STORED OR LOGGED. The prompt is passed to the candidate classifier in the
+// request body — exactly as the live call already does, to the same vendor — and is then dropped.
+// Only a bounded outcome label reaches the metric. This is deliberate: the surrounding moderation
+// path is built not to retain prompts (the verdict cache stores only a digest), and a probe that
+// needed a prompt corpus would mean extracting real user prompts to compare offline. This design
+// exists precisely so that is unnecessary.
+import { env } from '~/env/server';
+import { deriveModerationVerdict } from '~/server/integrations/moderation-verdict-policy';
+import {
+  clampExternalModerationSource,
+  recordExternalModerationShadow,
+  type ExternalModerationSource,
+  type ModerationShadowOutcome,
+} from '~/server/prom/external-moderation.metrics';
+
+/** The verdict shape both models are reduced to before comparison. */
+export type ShadowComparableVerdict = { flagged: boolean };
+
+/**
+ * Decide the comparison outcome from the two verdicts.
+ *
+ * 🔴 THE TWO DISAGREEMENT DIRECTIONS ARE NOT INTERCHANGEABLE AND MUST NOT SHARE A LABEL. A bare
+ * `match`/`diverged` split — which is what the sibling `form_graph_shadow_parse_total` uses, and
+ * which is right for THAT cutover because a parse is either correct or it is not — would be
+ * actively misleading here, because the two directions have opposite consequences:
+ *
+ * - `candidate_permissive` — the incumbent flagged and the candidate did NOT. The candidate would
+ *   have let this prompt through a FAIL-CLOSED gate. This is the direction that carries
+ *   trust-and-safety risk, and it is the number the decision actually turns on.
+ * - `candidate_strict` — the candidate flagged and the incumbent did not. A false positive: a user
+ *   is blocked who is not blocked today. Real cost, but a UX cost, not a safety one.
+ *
+ * Averaged into one "divergence rate" those cancel, and a candidate that is 2% more permissive and
+ * 2% stricter reads as identical to one that agrees perfectly. Split, the owner can weigh the two
+ * against each other, which is the whole judgement they are being asked to make.
+ */
+export function classifyShadowOutcome(
+  live: ShadowComparableVerdict,
+  candidate: ShadowComparableVerdict
+): ModerationShadowOutcome {
+  // Coerced HERE rather than in `deriveModerationVerdict`. `flagged` originates from an untyped
+  // `res.json()`, so a vendor sending a truthy non-boolean would make a bare `===` report a
+  // disagreement between two verdicts that both mean "flagged". Normalising in the live derivation
+  // instead would be a behaviour change on the gate itself; normalising in the comparison cannot be.
+  const liveFlagged = Boolean(live.flagged);
+  const candidateFlagged = Boolean(candidate.flagged);
+  if (liveFlagged === candidateFlagged) return 'match';
+  return liveFlagged ? 'candidate_permissive' : 'candidate_strict';
+}
+
+/**
+ * Is the probe armed? BOTH inputs are required, neither defaults on.
+ *
+ * `EXTERNAL_MODERATION_SHADOW_MODEL` names the candidate; `EXTERNAL_MODERATION_SHADOW_SAMPLE` is the
+ * share of calls to duplicate, in [0,1]. Two inputs rather than one because they answer different
+ * questions — WHICH model, and HOW MUCH it costs to ask — and because it mirrors the two-input
+ * arming the verdict cache already uses on this same path, so an operator meets one convention.
+ *
+ * 🔴 THE SAMPLE RATE IS THE SPEND CONTROL, AND IT IS THE REASON THIS IS NOT SIMPLY A BOOLEAN. Every
+ * sampled call is a SECOND billable classifier request against the production credential. At 1.0
+ * this doubles the moderation bill for as long as it is armed. Arm it low, read the rate, disarm.
+ *
+ * ⚠️ NO ALLOWLIST ON THE MODEL NAME, and that is a considered choice rather than an oversight. The
+ * sibling cache probe's namespace IS a closed allowlist, because there a wrong-but-plausible value
+ * silently opens a second keyspace and measures a FICTION that looks like a real reading. This field
+ * has no such failure mode: a model name the vendor does not recognise makes every sampled request
+ * fail, which surfaces as ~100% `error` and zero `match` — a shape no reader can mistake for a
+ * result. The sample rate bounds the wasted spend meanwhile. Guarding it would be ceremony.
+ */
+function shadowConfig(): { model: string; sample: number } | null {
+  const model = env.EXTERNAL_MODERATION_SHADOW_MODEL?.trim();
+  const sample = env.EXTERNAL_MODERATION_SHADOW_SAMPLE;
+  if (!model) return null;
+  if (!(sample > 0)) return null; // also excludes NaN, which `> 0` rejects and `<= 0` would not
+  return { model, sample };
+}
+
+/**
+ * Compare the incumbent's verdict against a candidate model's, on a sampled share of calls.
+ *
+ * 🔴 TOTAL AND FIRE-AND-FORGET. This function returns `void`, never throws, and is never awaited.
+ * It is called AFTER the live verdict is known and after that call's own outcome has been recorded,
+ * so it cannot alter a verdict, cannot add latency to the generation submit, and cannot perturb the
+ * duration histogram that measures what a classifier call costs. A shadow failure is recorded as
+ * `error` and is otherwise invisible.
+ *
+ * @param source        the population label, clamped to the closed set.
+ * @param preparedPrompt the string the LIVE call sent — post-`removeFalsePositiveTriggers`. Passing
+ *                       the raw prompt instead would compare the two models on different inputs and
+ *                       attribute the substitution's effect to the model.
+ * @param live          the verdict the incumbent model produced for this same string.
+ */
+export function probeShadowModel(
+  source: unknown,
+  preparedPrompt: string,
+  live: ShadowComparableVerdict
+): void {
+  const metricSource: ExternalModerationSource = clampExternalModerationSource(source);
+  try {
+    const config = shadowConfig();
+    if (!config) return;
+    if (Math.random() >= config.sample) return;
+
+    const endpoint = env.EXTERNAL_MODERATION_ENDPOINT;
+    const token = env.EXTERNAL_MODERATION_TOKEN;
+    // The live call cannot have happened without these, so this is belt-and-braces rather than a
+    // reachable branch — but it keeps the module independently safe if it is ever called earlier.
+    if (!endpoint || !token) return;
+
+    void runShadowComparison(metricSource, endpoint, token, config.model, preparedPrompt, live);
+  } catch {
+    // Arming/sampling must never be able to break a generation submit. A throw here would propagate
+    // synchronously into `moderatePrompt`'s try, whose catch fails the call SOFT — i.e. a bug in a
+    // dark measurement would silently drop the external moderation layer for that request.
+    recordExternalModerationShadow(metricSource, 'error');
+  }
+}
+
+async function runShadowComparison(
+  metricSource: ExternalModerationSource,
+  endpoint: string,
+  token: string,
+  model: string,
+  preparedPrompt: string,
+  live: ShadowComparableVerdict
+): Promise<void> {
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ input: preparedPrompt, model }),
+      // Same deadline as the live call. A shadow request that outlives the request it shadows would
+      // hold a socket for a result nobody is waiting for.
+      signal: AbortSignal.timeout(env.EXTERNAL_MODERATION_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      recordExternalModerationShadow(metricSource, 'error');
+      return;
+    }
+    const { results } = await res.json();
+    if (!results?.[0]) {
+      recordExternalModerationShadow(metricSource, 'error');
+      return;
+    }
+    // 🔴 The candidate's raw response is reduced by the SAME policy derivation the live verdict went
+    // through — the shared module, not a reimplementation. Reimplementing it here would compare a
+    // policy-applied verdict against a raw one and report the POLICY's effect as the MODEL's
+    // disagreement.
+    const candidate = deriveModerationVerdict(
+      results[0],
+      env.EXTERNAL_MODERATION_THRESHOLD,
+      env.EXTERNAL_MODERATION_CATEGORIES
+    );
+    recordExternalModerationShadow(metricSource, classifyShadowOutcome(live, candidate));
+  } catch {
+    recordExternalModerationShadow(metricSource, 'error');
+  }
+}

--- a/src/server/integrations/moderation-shadow-probe.ts
+++ b/src/server/integrations/moderation-shadow-probe.ts
@@ -77,11 +77,23 @@ export function candidateVocabularyCovers(
   categoryMap: Record<string, string> | undefined
 ): boolean {
   if (!categoryMap) return true;
-  const categories = result?.categories;
+  const categories = result?.categories as Record<string, unknown> | null | undefined;
   if (!categories || typeof categories !== 'object') return false;
-  return Object.keys(categoryMap).every((key) =>
-    Object.prototype.hasOwnProperty.call(categories, key)
-  );
+
+  const keys = Object.keys(categoryMap);
+  const present = (key: string) => Object.prototype.hasOwnProperty.call(categories, key);
+
+  // 🔴 DETERMINACY, NOT COVERAGE — and the difference only shows on a MULTI-KEY map.
+  // `deriveModerationVerdict` ORs across the mapped keys, so ONE present key that is `true` already
+  // fixes the verdict at `flagged: true` no matter what the missing keys would have said. Requiring
+  // every key there would book a comparison we can actually make as `incomparable` and throw it
+  // away. Production is single-key today, where this is identical to requiring all of them, so the
+  // case is currently unreachable — it is written this way so that ADDING a second category, which
+  // needs no code change, does not silently start discarding valid comparisons.
+  if (keys.some((key) => present(key) && Boolean(categories[key]))) return true;
+
+  // Nothing present is true, so the verdict is `false` ONLY if no missing key could have been true.
+  return keys.every(present);
 }
 
 /**
@@ -144,13 +156,40 @@ export function classifyShadowOutcome(
  * list that cannot include fields that did not exist when it was written — so an operator doing the
  * cautious thing and arming on STAGING first would silently arm every open PR preview at its next
  * deploy, each issuing a second billable request per moderation call against the production
- * credential, unattributed and with nobody reading preview metrics. `IS_PREVIEW` is the same signal
- * `~/env/database-target` falls back to. Deliberately NOT `isNonProductionDatabase()`, which is
- * wider: that would also refuse a DELIBERATE staging arm, which is a legitimate operator choice and
- * the exact workflow this guard is meant to keep safe rather than block.
+ * credential, unattributed and with nobody reading preview metrics.
+ *
+ * 🔴 THE DISCRIMINATOR IS `CACHE_KEY_NAMESPACE`, NOT `IS_PREVIEW`, AND THAT IS A CORRECTION.
+ * An earlier revision gated on `IS_PREVIEW === 'true'` and claimed it preserved a deliberate
+ * staging arm. **It did not: `civitai-next` — the standing non-production deployment, and the very
+ * config source the paragraph above names — sets `IS_PREVIEW=true` itself** (a Deployment env
+ * entry, which beats `envFrom`; measured on the live cluster). So that guard refused the one
+ * rehearsal it promised to protect and left production as the practical arming target, which is
+ * backwards for a probe whose whole design is "arm low, read, disarm".
+ *
+ * This is the exact conflation `@civitai/redis`'s `cache-key-prefix.ts` and `~/env/database-target`
+ * were both written to resolve — `IS_PREVIEW` is overloaded across at least two deployment classes
+ * — and both resolved it the same way, with an explicit namespace. Following that precedent rather
+ * than inventing a third signal. Canonical values, from `cache-key-prefix.ts`: `''`/unset =
+ * production, `'preview'` = the ephemeral per-PR deployments, `'next'` = the standing
+ * non-production one. Only `'preview'` is refused.
+ *
+ * ⚠️ The `IS_PREVIEW` fallback below is NOT the old guard surviving. It covers ONLY the transitional
+ * state `cache-key-prefix.ts:66-75` itself warns about — a deployment carrying `IS_PREVIEW=true`
+ * whose `CACHE_KEY_NAMESPACE` has not been configured yet — where an unset namespace would
+ * otherwise fail OPEN and arm a preview. It cannot catch `civitai-next`, whose namespace is `next`,
+ * i.e. non-empty.
+ *
+ * ⚠️ Read from `process.env` rather than importing `CACHE_KEY_NAMESPACE` from `@civitai/redis`, and
+ * the `?.trim() ?? ''` deliberately MIRRORS that module's own normalisation so the two agree. The
+ * exported constant is evaluated at MODULE-EVAL time, which is right for a key table built once but
+ * wrong for a per-call guard, and importing it would also give this deliberately-light module a new
+ * package dependency. Same reasoning `~/env/database-target` records for reading one optional
+ * string directly: the parse is total and cannot throw.
  */
 function shadowConfig(): { model: string; sample: number } | null {
-  if (process.env.IS_PREVIEW === 'true') return null;
+  const namespace = process.env.CACHE_KEY_NAMESPACE?.trim() ?? '';
+  if (namespace === 'preview') return null;
+  if (!namespace && process.env.IS_PREVIEW === 'true') return null;
   const model = env.EXTERNAL_MODERATION_SHADOW_MODEL?.trim();
   const sample = env.EXTERNAL_MODERATION_SHADOW_SAMPLE;
   if (!model) return null;

--- a/src/server/integrations/moderation-shadow-probe.ts
+++ b/src/server/integrations/moderation-shadow-probe.ts
@@ -18,6 +18,20 @@
 // caller, and no code path reads a shadow result back. Switching the gate to a different model is a
 // moderation-policy decision and must be its own change with its own review.
 //
+// ⚠️ "CANNOT ALTER A VERDICT" IS A STATEMENT ABOUT THIS CODE, NOT ABOUT THE VENDOR. There is one
+// indirect path, named here rather than left for someone to rediscover: the probe DOUBLES the
+// request rate against a shared per-organisation quota. Measured on production 2026-09-07 the live
+// call runs ~4.3 req/s, so `SAMPLE=1.0` adds ~4.3 req/s (~371k requests/day). If that were ever
+// enough to provoke vendor 429s they would land on the LIVE calls too — and the live call is
+// FAIL-SOFT, so a rate-limited moderation request proceeds as `flagged:false` and silently drops
+// the external layer. At the measured volume the margin is wide, so this is a mechanism note and
+// not a prediction. It is still the reason to arm at a LOW sample rate rather than at 1.0.
+//
+// 🔴 THERE IS NO IN-PROCESS KILL SWITCH. `env` is parsed once at process start, so disarming needs a
+// POD ROLLOUT — editing the ConfigMap alone changes nothing on already-running pods. Budget for
+// that before arming, not during an incident. (Inherited from the sibling probes on this path,
+// not introduced here.)
+//
 // 🔴 NO PROMPT IS EVER STORED OR LOGGED. The prompt is passed to the candidate classifier in the
 // request body — exactly as the live call already does, to the same vendor — and is then dropped.
 // Only a bounded outcome label reaches the metric. This is deliberate: the surrounding moderation
@@ -35,6 +49,40 @@ import {
 
 /** The verdict shape both models are reduced to before comparison. */
 export type ShadowComparableVerdict = { flagged: boolean };
+
+/**
+ * Can the candidate's response even be REDUCED by the incumbent's policy?
+ *
+ * 🔴 THIS IS THE DIFFERENCE BETWEEN A MEASUREMENT AND A PLAUSIBLE FICTION, and without it the
+ * probe's headline number is unrelated to the candidate's quality. When
+ * `EXTERNAL_MODERATION_CATEGORIES` is configured, `deriveModerationVerdict` computes
+ * `flagged = any MAPPED category the classifier marked true` — and production configures a SINGLE
+ * key (`sexual/minors`). A candidate model that classifies the same content under a different
+ * category name returns a response with no such key, so `Boolean(undefined)` makes its verdict
+ * `false` on EVERY call. It then reads as `candidate_permissive` on every prompt the incumbent
+ * flagged, at zero errors — i.e. a candidate in PERFECT agreement and one that is completely blind
+ * produce the IDENTICAL, entirely reasonable-looking metric, on a decision about a fail-closed gate.
+ *
+ * ⚠️ Threshold mode needs no such check and deliberately returns true: there the verdict is the
+ * classifier's OWN `flagged` boolean, which is model-native and therefore comparable across
+ * vocabularies. The hazard is specific to category-map mode.
+ *
+ * `hasOwnProperty` rather than `in`, because `in` walks the prototype chain: with a map key of
+ * `toString` or `constructor` — operator-controlled, so not untrusted, but free to get right — `in`
+ * would report the vocabulary covered on a response that carries nothing of the sort. Same failure
+ * shape this codebase has already been bitten by elsewhere.
+ */
+export function candidateVocabularyCovers(
+  result: { categories?: unknown },
+  categoryMap: Record<string, string> | undefined
+): boolean {
+  if (!categoryMap) return true;
+  const categories = result?.categories;
+  if (!categories || typeof categories !== 'object') return false;
+  return Object.keys(categoryMap).every((key) =>
+    Object.prototype.hasOwnProperty.call(categories, key)
+  );
+}
 
 /**
  * Decide the comparison outcome from the two verdicts.
@@ -80,14 +128,29 @@ export function classifyShadowOutcome(
  * sampled call is a SECOND billable classifier request against the production credential. At 1.0
  * this doubles the moderation bill for as long as it is armed. Arm it low, read the rate, disarm.
  *
- * ⚠️ NO ALLOWLIST ON THE MODEL NAME, and that is a considered choice rather than an oversight. The
- * sibling cache probe's namespace IS a closed allowlist, because there a wrong-but-plausible value
- * silently opens a second keyspace and measures a FICTION that looks like a real reading. This field
- * has no such failure mode: a model name the vendor does not recognise makes every sampled request
- * fail, which surfaces as ~100% `error` and zero `match` — a shape no reader can mistake for a
- * result. The sample rate bounds the wasted spend meanwhile. Guarding it would be ceremony.
+ * ⚠️ NO ALLOWLIST ON THE MODEL NAME. A name the vendor does not recognise makes every sampled
+ * request fail, surfacing as ~100% `error` and zero `match` — a shape no reader mistakes for a
+ * result — and the sample rate bounds the wasted spend meanwhile.
+ *
+ * 🔴 THAT REASONING IS ABOUT AN UNRECOGNISED NAME AND DOES NOT EXTEND TO A RECOGNISED ONE. An
+ * earlier revision of this comment stopped at "guarding it would be ceremony", which primed the
+ * reader to treat a zero `error` rate as proof the candidate was working. It is not: a perfectly
+ * valid model that answers in a different CATEGORY VOCABULARY produces 200s, zero errors, and a
+ * completely fictional agreement rate. That hole is closed by `candidateVocabularyCovers` and the
+ * `incomparable` outcome above, NOT by anything about the model name — read them together.
+ *
+ * 🔴 AND IT REFUSES TO ARM IN A PR PREVIEW, which is a CONFIG-INHERITANCE guard, not a model guard.
+ * The preview deploy task copies `civitai-cfg` out of `civitai-next` and rewrites an enumerated key
+ * list that cannot include fields that did not exist when it was written — so an operator doing the
+ * cautious thing and arming on STAGING first would silently arm every open PR preview at its next
+ * deploy, each issuing a second billable request per moderation call against the production
+ * credential, unattributed and with nobody reading preview metrics. `IS_PREVIEW` is the same signal
+ * `~/env/database-target` falls back to. Deliberately NOT `isNonProductionDatabase()`, which is
+ * wider: that would also refuse a DELIBERATE staging arm, which is a legitimate operator choice and
+ * the exact workflow this guard is meant to keep safe rather than block.
  */
 function shadowConfig(): { model: string; sample: number } | null {
+  if (process.env.IS_PREVIEW === 'true') return null;
   const model = env.EXTERNAL_MODERATION_SHADOW_MODEL?.trim();
   const sample = env.EXTERNAL_MODERATION_SHADOW_SAMPLE;
   if (!model) return null;
@@ -115,6 +178,12 @@ export function probeShadowModel(
   preparedPrompt: string,
   live: ShadowComparableVerdict
 ): void {
+  // ⚠️ This clamp NARROWS THE TYPE at the boundary (`unknown` in, closed set out) and is
+  // BEHAVIOURALLY REDUNDANT: `recordExternalModerationShadow` clamps again, so replacing this call
+  // with a bare cast leaves the whole suite green — no mutant kills it on its own, and the
+  // "clamps an out-of-set source" test below is satisfied by the metrics-layer clamp, not by this
+  // line. Stated rather than quietly counted as covered. It stays because the parameter is
+  // `unknown` and something must narrow it, not because it is the guard that holds the property.
   const metricSource: ExternalModerationSource = clampExternalModerationSource(source);
   try {
     const config = shadowConfig();
@@ -160,6 +229,13 @@ async function runShadowComparison(
     const { results } = await res.json();
     if (!results?.[0]) {
       recordExternalModerationShadow(metricSource, 'error');
+      return;
+    }
+    // 🔴 Vocabulary gate BEFORE the comparison, never after. Reducing an unreadable response would
+    // silently produce `flagged:false` and book it as a real disagreement. See the function's own
+    // header for why that specific wrong answer is the dangerous one.
+    if (!candidateVocabularyCovers(results[0], env.EXTERNAL_MODERATION_CATEGORIES)) {
+      recordExternalModerationShadow(metricSource, 'incomparable');
       return;
     }
     // 🔴 The candidate's raw response is reduced by the SAME policy derivation the live verdict went

--- a/src/server/integrations/moderation-verdict-policy.ts
+++ b/src/server/integrations/moderation-verdict-policy.ts
@@ -1,0 +1,59 @@
+// The policy that reduces ONE raw classifier result to the verdict this app acts on.
+//
+// 🔴 IT LIVES IN ITS OWN MODULE SO TWO CALLERS CANNOT DRIFT. `moderation.ts` applies it to the
+// incumbent model's response; `moderation-shadow-probe.ts` applies it to a candidate model's. A
+// shadow comparison that re-implemented this would compare a policy-applied verdict against a raw
+// one and report the POLICY's effect as the candidate MODEL's disagreement — a wrong answer that
+// looks entirely plausible. Same rule the model literal already follows in `moderation.ts`: one
+// spelling, one place.
+//
+// A separate module rather than an export from `moderation.ts` because the probe is imported BY
+// `moderation.ts`; importing back would be a cycle, and reaching for a lazy `import()` to dodge the
+// cycle would trade a structural problem for a timing one.
+
+/**
+ * Reduce one raw classifier result to `{ flagged, categories }`.
+ *
+ * Threshold mode (no `categoryMap`): every category whose score exceeds `threshold` is reported,
+ * and `flagged` is whatever the classifier itself said. Category mode (`categoryMap` present):
+ * the map REPLACES that entirely — only mapped categories the classifier marked true are reported,
+ * each renamed to its mapped value, and `flagged` becomes "any of them matched".
+ *
+ * ⚠️ BEHAVIOUR-PRESERVING EXTRACTION FROM `moderation.ts`, NOT A REWRITE. `RawClassifierResult`
+ * is a COMPILE-TIME shape only: the value arrives from `res.json()`, so at runtime `flagged` is
+ * whatever the vendor actually sent and nothing here coerces or validates it. The annotation
+ * describes the contract, it does not enforce it — a consumer that needs a strict boolean must
+ * coerce at its own comparison site (`moderation-shadow-probe.ts` does exactly that, and says why).
+ * If you are tempted to tighten this into real validation, read the header on
+ * `extModeration.moderatePrompt` first: widening this return type is how a real bug was once found,
+ * and narrowing it again is how one would be reintroduced. Consumers that need a strict boolean
+ * should coerce at their own comparison site.
+ */
+export type RawClassifierResult = {
+  flagged: boolean;
+  categories: Record<string, boolean>;
+  category_scores: Record<string, number>;
+};
+
+export function deriveModerationVerdict(
+  result: RawClassifierResult,
+  threshold: number,
+  categoryMap: Record<string, string> | undefined
+): { flagged: boolean; categories: string[] } {
+  let flagged = result.flagged;
+  let categories = Object.entries(result.category_scores)
+    .filter(([, v]) => (v as number) > threshold)
+    .map(([k]) => k);
+
+  // If we have categories
+  // Only flag if any of them are found in the results
+  if (categoryMap) {
+    categories = [];
+    for (const [k, v] of Object.entries(categoryMap)) {
+      if (result.categories[k]) categories.push(v ?? k);
+    }
+    flagged = categories.length > 0;
+  }
+
+  return { flagged, categories };
+}

--- a/src/server/integrations/moderation.ts
+++ b/src/server/integrations/moderation.ts
@@ -1,5 +1,7 @@
 import { env } from '~/env/server';
 import { probeModerationCacheRepeat } from '~/server/integrations/moderation-cache-probe';
+import { probeShadowModel } from '~/server/integrations/moderation-shadow-probe';
+import { deriveModerationVerdict } from '~/server/integrations/moderation-verdict-policy';
 import {
   type ModerationVerdict,
   policyDigest,
@@ -173,26 +175,34 @@ async function moderatePrompt(
         }
 
         const { results } = await res.json();
-        let flagged = results[0].flagged;
-        let categories = Object.entries(results[0].category_scores)
-          .filter(([, v]) => (v as number) > env.EXTERNAL_MODERATION_THRESHOLD)
-          .map(([k]) => k);
-
-        // If we have categories
-        // Only flag if any of them are found in the results
-        if (env.EXTERNAL_MODERATION_CATEGORIES) {
-          categories = [];
-          for (const [k, v] of Object.entries(env.EXTERNAL_MODERATION_CATEGORIES)) {
-            if (results[0].categories[k]) categories.push(v ?? k);
-          }
-          flagged = categories.length > 0;
-        }
+        const { flagged, categories } = deriveModerationVerdict(
+          results[0],
+          env.EXTERNAL_MODERATION_THRESHOLD,
+          env.EXTERNAL_MODERATION_CATEGORIES
+        );
 
         recordOutcome(metricSource, 'ok', elapsedSeconds());
         // Store ONLY here, on the `ok` path. A failure must cost a retry every time — see the
         // module header on why caching one transient error would be TTL-long under-moderation.
         // Fire-and-forget: nothing waits on the write.
         writeCachedVerdict(preparedPrompt, policy, { flagged, categories });
+
+        // Dark shadow comparison: would a CHEAPER model have returned the same verdict? Off by
+        // default, fire-and-forget, and the verdict of record is never affected — this call reads
+        // nothing back.
+        //
+        // 🔴 PLACED HERE, ON THE `ok` PATH AND AFTER `recordOutcome`, FOR THREE REASONS. (1) It needs
+        // the incumbent's verdict to compare against, which does not exist earlier. (2) After the
+        // histogram observation, so a second in-flight request can never be attributed to the
+        // instrument that measures what ONE classifier call costs. (3) On `ok` only — a live call
+        // that failed has no verdict to compare, and shadowing it would spend a billable request to
+        // learn nothing.
+        //
+        // 🔴 It is NOT placed above the cache read. A cache hit returns before this point, so the
+        // shadow rate is measured over classifier calls that actually happened — which is the
+        // population the model decision is about. If the cache is ever armed alongside this, the
+        // denominator narrows but stays honest.
+        probeShadowModel(metricSource, preparedPrompt, { flagged });
         return { flagged, categories };
       } catch (e) {
         // Exactly one observation per call — here on the throw path, XOR on the resolve path above.

--- a/src/server/prom/external-moderation.metrics.ts
+++ b/src/server/prom/external-moderation.metrics.ts
@@ -309,11 +309,21 @@ export function recordExternalModerationSkipped(source: ExternalModerationSource
  * blocked today, a UX cost rather than a safety one. Folded into one label they CANCEL, and a
  * candidate that is 2% more permissive and 2% stricter becomes indistinguishable from one that
  * agrees perfectly. `error` is the shadow request itself failing and says nothing about either model.
+ *
+ * 🔴 `incomparable` IS NOT A KIND OF ERROR AND MUST NOT BE FOLDED INTO ONE. It means the two models
+ * answered in DIFFERENT VOCABULARIES, so no verdict comparison was attempted. When
+ * `EXTERNAL_MODERATION_CATEGORIES` is configured the app's verdict is `any mapped category the
+ * classifier marked true` — production maps a single key — so a candidate whose response simply
+ * does not carry that key yields `false` on EVERY call and reads as flagging NOTHING. Without this
+ * outcome a candidate in PERFECT agreement is indistinguishable from one that is completely blind:
+ * both report `candidate_permissive` on every incumbent flag, with zero errors. On a fail-closed
+ * gate that is the most dangerous shape a measurement can have, because the number looks fine.
  */
 export type ModerationShadowOutcome =
   | 'match'
   | 'candidate_permissive'
   | 'candidate_strict'
+  | 'incomparable'
   | 'error';
 
 const shadowCounter = registerCounterWithLabels({
@@ -327,8 +337,13 @@ const shadowCounter = registerCounterWithLabels({
     'the candidate did not, i.e. the candidate would have let it through a fail-closed gate); ' +
     'candidate_strict is the reverse and is a false-positive/UX cost. Do NOT sum the two into one ' +
     'divergence rate — they cancel, and that is the one reading this metric exists to prevent. ' +
-    'outcome=error is the shadow request failing and is evidence about neither model. 🔴 Every ' +
-    'counted comparison is a SECOND billable classifier request; the sample rate is the spend control.',
+    'outcome=error is the shadow request failing and is evidence about neither model. 🔴 ' +
+    'outcome=incomparable means the candidate did not answer in the vocabulary the configured ' +
+    'EXTERNAL_MODERATION_CATEGORIES map reads, so no comparison was attempted — a NON-ZERO ' +
+    'incomparable rate INVALIDATES the permissive/strict split for that candidate; pick a candidate ' +
+    'that shares the incumbent`s category names, do not reason around it. 🔴 Every counted ' +
+    'comparison is a SECOND billable classifier request; the sample rate is the spend control, and ' +
+    'disarming takes a POD ROLLOUT because env is parsed once at process start.',
   labelNames: ['source', 'outcome'] as const,
 });
 

--- a/src/server/prom/external-moderation.metrics.ts
+++ b/src/server/prom/external-moderation.metrics.ts
@@ -298,3 +298,51 @@ export function recordExternalModerationSkipped(source: ExternalModerationSource
     // Observability must never break the moderation path. Swallow any prom-client error.
   }
 }
+
+/**
+ * How a shadow comparison against a CANDIDATE classifier model settled.
+ *
+ * 🔴 THE TWO DISAGREEMENT DIRECTIONS ARE SEPARATE OUTCOMES ON PURPOSE — they are not two spellings
+ * of "diverged". `candidate_permissive` means the incumbent flagged and the candidate did not, i.e.
+ * the candidate would have let a prompt through a FAIL-CLOSED gate: that is the trust-and-safety
+ * number the model decision turns on. `candidate_strict` is the reverse — a user blocked who is not
+ * blocked today, a UX cost rather than a safety one. Folded into one label they CANCEL, and a
+ * candidate that is 2% more permissive and 2% stricter becomes indistinguishable from one that
+ * agrees perfectly. `error` is the shadow request itself failing and says nothing about either model.
+ */
+export type ModerationShadowOutcome =
+  | 'match'
+  | 'candidate_permissive'
+  | 'candidate_strict'
+  | 'error';
+
+const shadowCounter = registerCounterWithLabels({
+  name: 'external_moderation_shadow_total',
+  help:
+    'Shadow comparisons between the production prompt classifier and a candidate model, by outcome ' +
+    'and source. DARK AND OFF BY DEFAULT: it requires BOTH EXTERNAL_MODERATION_SHADOW_MODEL and a ' +
+    'positive EXTERNAL_MODERATION_SHADOW_SAMPLE, so NO SERIES AT ALL means "not armed" — never "the ' +
+    'models agree". The verdict of record is always the incumbent`s; nothing reads a shadow result ' +
+    'back. outcome=candidate_permissive is the safety-relevant direction (the incumbent flagged and ' +
+    'the candidate did not, i.e. the candidate would have let it through a fail-closed gate); ' +
+    'candidate_strict is the reverse and is a false-positive/UX cost. Do NOT sum the two into one ' +
+    'divergence rate — they cancel, and that is the one reading this metric exists to prevent. ' +
+    'outcome=error is the shadow request failing and is evidence about neither model. 🔴 Every ' +
+    'counted comparison is a SECOND billable classifier request; the sample rate is the spend control.',
+  labelNames: ['source', 'outcome'] as const,
+});
+
+/**
+ * Record ONE shadow comparison. Cheap + TOTAL (never throws) — it runs on the generation hot path
+ * behind a fire-and-forget call, so a metrics-layer hiccup must not be able to fail a generation.
+ */
+export function recordExternalModerationShadow(
+  source: ExternalModerationSource,
+  outcome: ModerationShadowOutcome
+): void {
+  try {
+    shadowCounter.inc({ source: clampExternalModerationSource(source), outcome });
+  } catch {
+    // Observability must never break the moderation path. Swallow any prom-client error.
+  }
+}

--- a/src/server/prom/external-moderation.metrics.ts
+++ b/src/server/prom/external-moderation.metrics.ts
@@ -310,8 +310,15 @@ export function recordExternalModerationSkipped(source: ExternalModerationSource
  * candidate that is 2% more permissive and 2% stricter becomes indistinguishable from one that
  * agrees perfectly. `error` is the shadow request itself failing and says nothing about either model.
  *
- * 🔴 `incomparable` IS NOT A KIND OF ERROR AND MUST NOT BE FOLDED INTO ONE. It means the two models
- * answered in DIFFERENT VOCABULARIES, so no verdict comparison was attempted. When
+ * 🔴 `incomparable` IS NOT A KIND OF ERROR AND MUST NOT BE FOLDED INTO ONE. It means the candidate's
+ * verdict was NOT DECIDABLE under the configured policy, so no comparison was attempted.
+ *
+ * ⚠️ THAT IS NARROWER THAN "THE TWO MODELS ANSWERED IN DIFFERENT VOCABULARIES", which is what this
+ * paragraph said for one commit and is no longer the test. A PARTIALLY shared vocabulary is often
+ * decidable — the policy ORs across mapped categories, so one shared category the candidate marked
+ * true settles the verdict whatever the missing ones would have said, and that comparison IS
+ * counted. **So `incomparable == 0` does NOT mean the vocabularies agree**; it means every counted
+ * comparison was decidable. Only the converse below is safe to act on. When
  * `EXTERNAL_MODERATION_CATEGORIES` is configured the app's verdict is `any mapped category the
  * classifier marked true` — production maps a single key — so a candidate whose response simply
  * does not carry that key yields `false` on EVERY call and reads as flagging NOTHING. Without this
@@ -338,10 +345,13 @@ const shadowCounter = registerCounterWithLabels({
     'candidate_strict is the reverse and is a false-positive/UX cost. Do NOT sum the two into one ' +
     'divergence rate — they cancel, and that is the one reading this metric exists to prevent. ' +
     'outcome=error is the shadow request failing and is evidence about neither model. 🔴 ' +
-    'outcome=incomparable means the candidate did not answer in the vocabulary the configured ' +
-    'EXTERNAL_MODERATION_CATEGORIES map reads, so no comparison was attempted — a NON-ZERO ' +
+    'outcome=incomparable means the candidate verdict was not DECIDABLE under the configured ' +
+    'EXTERNAL_MODERATION_CATEGORIES policy, so no comparison was attempted — a NON-ZERO ' +
     'incomparable rate INVALIDATES the permissive/strict split for that candidate; pick a candidate ' +
-    'that shares the incumbent`s category names, do not reason around it. 🔴 Every counted ' +
+    "that shares the incumbent's category names, do not reason around it. 🔴 The converse does NOT " +
+    'hold: incomparable=0 means every counted comparison was decidable, NOT that the vocabularies ' +
+    'agree — the policy ORs across categories, so one shared category can settle a verdict while ' +
+    'others are absent. 🔴 Every counted ' +
     'comparison is a SECOND billable classifier request; the sample rate is the spend control, and ' +
     'disarming takes a POD ROLLOUT because env is parsed once at process start.',
   labelNames: ['source', 'outcome'] as const,

--- a/src/server/prom/external-moderation.metrics.ts
+++ b/src/server/prom/external-moderation.metrics.ts
@@ -350,8 +350,9 @@ const shadowCounter = registerCounterWithLabels({
     'incomparable rate INVALIDATES the permissive/strict split for that candidate; pick a candidate ' +
     "that shares the incumbent's category names, do not reason around it. 🔴 The converse does NOT " +
     'hold: incomparable=0 means every counted comparison was decidable, NOT that the vocabularies ' +
-    'agree — the policy ORs across categories, so one shared category can settle a verdict while ' +
-    'others are absent. 🔴 Every counted ' +
+    'agree IN FULL — the policy ORs across categories, so one shared category can settle a verdict ' +
+    'while others are absent. Under a SINGLE-key policy (production today) the two do coincide. ' +
+    '🔴 Every counted ' +
     'comparison is a SECOND billable classifier request; the sample rate is the spend control, and ' +
     'disarming takes a POD ROLLOUT because env is parsed once at process start.',
   labelNames: ['source', 'outcome'] as const,


### PR DESCRIPTION
feat(moderation): dark shadow probe to measure whether a cheaper classifier model agrees

The prompt classifier costs ~205ms of wall time on every generation submit and is
78-88% of the app-side time of orchestrator.generateFromGraph. Roughly 175-180ms of
that is the model's own inference, which makes it the largest single component and
the only one nobody has tried to move — every infra-side lever (tail clamping,
connection reuse, overlapping the submit) was measured and all three are dead.

The blocker on trying a cheaper model was never latency, it was quality, and there
was no instrument for it. The duration histogram grades a candidate's SPEED within
one scrape but cannot express whether it AGREES with the incumbent, so the question
kept being put to a moderation-quality owner with no data attached. This produces
that data and nothing else.

On a sampled share of calls it issues a second, non-blocking request to a candidate
model and records how the two verdicts compare. The verdict of record is always the
incumbent's; nothing reads a shadow result back.

The two disagreement directions are separate outcomes rather than one "diverged"
label, and that is the main design decision here. candidate_permissive means the
incumbent flagged and the candidate did not — the candidate would have let a prompt
through a fail-closed gate, which is the number the decision actually turns on.
candidate_strict is the reverse and is a false-positive cost. Folded into one label
they cancel: a candidate 2% more permissive and 2% stricter would read as agreeing
perfectly.

Off by default and inert on merge. It needs both EXTERNAL_MODERATION_SHADOW_MODEL
and a positive EXTERNAL_MODERATION_SHADOW_SAMPLE; neither alone does anything. No
series at all therefore means "not armed", never "the models agree". The sample rate
is the spend control, because every counted comparison is a second billable request.

No prompt is stored or logged. The prompt goes to the candidate in the request body
exactly as the live call already sends it to the same vendor, and is then dropped;
only a bounded outcome label reaches the metric. This shape was chosen specifically
so that comparing models does not require building a prompt corpus.

The verdict derivation moves into its own module so both callers share it. A shadow
comparison that reimplemented that reduction would compare a policy-applied verdict
against a raw one and report the policy's effect as the model's disagreement — a
wrong answer that looks entirely plausible. It is a behaviour-preserving extraction;
the separate module avoids an import cycle, since the probe is imported by
moderation.ts.

Verification. 91 tests pass across the six moderation suites, including the four
pre-existing ones. Typecheck 0 errors, lint 0 problems. Eight mutants were run and
all eight were killed by a named test: sending the incumbent model instead of the
candidate, shadowing the raw prompt instead of the prepared one, collapsing the two
divergence directions, deleting either arming guard, observing the shadow request on
the duration histogram, and two on the extracted policy. The sample-arming guard is
worth a note — it is redundant against sample=0, since Math.random() >= 0 is always
true, so deleting it leaves that test green. NaN is the only case it uniquely catches,
and there is a test for exactly that, which is what kills the mutant.

