### PR TITLE
docs(clickhouse): a type enum widening needs a TRACKER RESTART, and now a test says so

### DIFF
--- a/src/server/clickhouse/__tests__/action-type-enum-drift.test.ts
+++ b/src/server/clickhouse/__tests__/action-type-enum-drift.test.ts
@@ -157,6 +157,67 @@ describe('actions.type enum drift', () => {
     }
   });
 
+  /**
+   * 🔴 THE DDL IS ONLY HALF THE OPERATION, AND THE OTHER HALF HAS SHIPPED BROKEN TWICE.
+   *
+   * `civitai-clickhouse-tracker` builds its column serializers from the schema its pods read
+   * AT CONNECT TIME and never re-reads them. A value added to the enum after those pods booted
+   * is rejected CLIENT-SIDE, inside the tracker, before ClickHouse is asked — so the ALTER
+   * verifies perfectly against `system.columns` and the type still collects ZERO rows.
+   *
+   * Measured: `Announcement_Click` (2026-09-04) collected NOTHING for ~2.5 days; its first row
+   * ever landed ten minutes after an unrelated tracker restart on 2026-09-07, then 253 rows
+   * across 170 real users within the day. `App_Open` (2026-09-05) went the same way until it
+   * was caught by hand. Both migrations were CORRECT. Both headers already carried the
+   * "apply the DDL before the emitting code" rule and obeyed it — that rule addresses deploy
+   * ordering and cannot fix a cache predating both the DDL and the deploy.
+   *
+   * 🔴 WHY AN EXACT STRING RATHER THAN A LOOSE MATCH: the artifact under test is PROSE, and a
+   * guard on words is walkable by rewording — /restart/i would pass on any sentence containing
+   * the word. Pinning the whole normalised line makes it a machine-checkable claim. A cosmetic
+   * reword fails this test on purpose; change the constant and the README together.
+   */
+  const POST_APPLY_MARKER =
+    '-- POST-APPLY: restart civitai-clickhouse-tracker by pod delete, then confirm with a real event.';
+
+  /** Every migration file that widens `default.actions.type`, by name, with its raw text. */
+  const actionsMigrations = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .map((f) => ({ name: f, raw: fs.readFileSync(path.join(MIGRATIONS_DIR, f), 'utf-8') }))
+    .filter(({ raw }) =>
+      /ALTER\s+TABLE\s+default\.actions\s+MODIFY\s+COLUMN\s+`?type`?\s+Enum16/i.test(
+        raw
+          .split('\n')
+          .filter((line) => !line.trim().startsWith('--'))
+          .join('\n')
+      )
+    );
+
+  it('found actions migrations to check for the post-apply marker', () => {
+    // The positive control for the case below. Without it, a regex that matches nothing
+    // makes every `every()` assertion vacuously true — a green that means "scanned zero
+    // files", which is exactly the reassuring-zero this whole file exists to prevent.
+    expect(
+      actionsMigrations.length,
+      'no migration widening default.actions.type was found — the marker check below would be vacuous'
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  it.each(actionsMigrations.map((m) => m.name))(
+    '%s carries the POST-APPLY tracker-restart marker verbatim',
+    (name) => {
+      const raw = actionsMigrations.find((m) => m.name === name)!.raw;
+      expect(
+        raw.includes(POST_APPLY_MARKER),
+        `${name} widens actions.type but does not carry the post-apply marker.\n` +
+          `Add this line verbatim to its header:\n  ${POST_APPLY_MARKER}\n` +
+          `Applying the DDL without restarting the tracker ships a type that collects ZERO ` +
+          `rows while every signal says it worked — see migrations/README.md.`
+      ).toBe(true);
+    }
+  );
+
   it('assigns every value a distinct index', () => {
     const indices = [...actionsBlock.arms.values()];
     expect(new Set(indices).size).toBe(indices.length);

--- a/src/server/clickhouse/migrations/2026-08-21-feed-tag-bar-action.sql
+++ b/src/server/clickhouse/migrations/2026-08-21-feed-tag-bar-action.sql
@@ -17,6 +17,15 @@
 -- `system.tables`), so unlike the `views` widening there is no MV whose SELECT also has to be
 -- updated with MODIFY QUERY. If that ever changes, a widened source column with a stale MV
 -- query drops the new value at the MV instead — same silent shape, different place.
+--
+-- 🔴 THE ORDERING RULE ABOVE IS NECESSARY AND INSUFFICIENT — APPLYING THE DDL FIRST DOES NOT
+-- MAKE THIS WORK. `civitai-clickhouse-tracker` builds its column serializers from the schema
+-- its pods read AT CONNECT TIME and never re-reads them, so a value added after those pods
+-- booted is rejected CLIENT-SIDE, inside the tracker, before ClickHouse is asked. The DDL
+-- verifies perfectly and the type still collects ZERO rows. Measured twice: `Announcement_Click`
+-- collected nothing for ~2.5 days, `App_Open` until it was caught by hand. See ./README.md.
+--
+-- POST-APPLY: restart civitai-clickhouse-tracker by pod delete, then confirm with a real event.
 
 ALTER TABLE default.actions
   MODIFY COLUMN `type` Enum16(

--- a/src/server/clickhouse/migrations/2026-09-04-announcement-click-action.sql
+++ b/src/server/clickhouse/migrations/2026-09-04-announcement-click-action.sql
@@ -18,6 +18,15 @@
 -- put a MODIFY QUERY obligation on every future widening of this column, and the read this
 -- feeds does not need it. `actions` is 92.8M rows all-time / 590,896 in the last day, ordered
 -- (time, type), and the per-creator read filters on `type` over ~100 announcements site-wide.
+--
+-- 🔴 THE ORDERING RULE ABOVE IS NECESSARY AND INSUFFICIENT — APPLYING THE DDL FIRST DOES NOT
+-- MAKE THIS WORK. `civitai-clickhouse-tracker` builds its column serializers from the schema
+-- its pods read AT CONNECT TIME and never re-reads them, so a value added after those pods
+-- booted is rejected CLIENT-SIDE, inside the tracker, before ClickHouse is asked. The DDL
+-- verifies perfectly and the type still collects ZERO rows. Measured twice: `Announcement_Click`
+-- collected nothing for ~2.5 days, `App_Open` until it was caught by hand. See ./README.md.
+--
+-- POST-APPLY: restart civitai-clickhouse-tracker by pod delete, then confirm with a real event.
 
 ALTER TABLE default.actions
   MODIFY COLUMN `type` Enum16(

--- a/src/server/clickhouse/migrations/2026-09-05-app-open-action.sql
+++ b/src/server/clickhouse/migrations/2026-09-05-app-open-action.sql
@@ -30,6 +30,15 @@
 --
 -- The emitted `details` carries `{ appBlockId }` — a pure id, never author text — and the
 -- rollup joins it to `app_listings.app_block_id` (which is `@unique`).
+--
+-- 🔴 THE ORDERING RULE ABOVE IS NECESSARY AND INSUFFICIENT — APPLYING THE DDL FIRST DOES NOT
+-- MAKE THIS WORK. `civitai-clickhouse-tracker` builds its column serializers from the schema
+-- its pods read AT CONNECT TIME and never re-reads them, so a value added after those pods
+-- booted is rejected CLIENT-SIDE, inside the tracker, before ClickHouse is asked. The DDL
+-- verifies perfectly and the type still collects ZERO rows. Measured twice: `Announcement_Click`
+-- collected nothing for ~2.5 days, `App_Open` until it was caught by hand. See ./README.md.
+--
+-- POST-APPLY: restart civitai-clickhouse-tracker by pod delete, then confirm with a real event.
 
 ALTER TABLE default.actions
   MODIFY COLUMN `type` Enum16(

--- a/src/server/clickhouse/migrations/README.md
+++ b/src/server/clickhouse/migrations/README.md
@@ -1,0 +1,91 @@
+# ClickHouse migrations — how to apply one without shipping a dead feature
+
+These are applied **manually**. Nothing auto-runs DDL here (same policy as the Postgres
+migrations).
+
+## 🔴 Widening `actions.type` is a TWO-STEP operation. The `ALTER` alone is inert.
+
+**Apply the DDL, then restart the tracker.** Skipping the restart ships a feature that
+collects **zero rows** while every signal you would normally check says it worked.
+
+This is not hypothetical. It has happened **twice**, and both times the migration itself was
+correct:
+
+| type                 | migration                                  | rows collected before a tracker restart |
+| -------------------- | ------------------------------------------ | --------------------------------------- |
+| `Announcement_Click` | `2026-09-04-announcement-click-action.sql` | **0**, for ~2.5 days                    |
+| `App_Open`           | `2026-09-05-app-open-action.sql`           | **0**, until caught manually            |
+
+`Announcement_Click`'s first row _in the type's entire history_ landed ten minutes after an
+unrelated tracker restart on 2026-09-07 — 253 rows across 170 real users followed within the
+day. For the 2.5 days before that, every dashboard over it read a clean, correct-looking zero.
+
+### Why the existing "apply the DDL first" rule does not cover this
+
+Each of these migration headers already says _"apply this BEFORE the app code that emits the
+value is deployed"_, and both migrations obeyed it. **That rule is necessary and insufficient**,
+because it addresses the wrong actor.
+
+`civitai-clickhouse-tracker` builds its column serializers from the schema it reads **when its
+pods connect**, and never re-reads them. A value added to the enum after those pods booted is
+rejected **client-side**, inside the tracker, before ClickHouse is ever asked. So:
+
+- the DDL verifies perfectly — the server-side enum really does carry the value;
+- the app logs nothing — the tracker POST is fire-and-forget and returns success;
+- the tracker's rejection is a single `warn` line in a service nobody tails;
+- and the metric reads `0`, which is indistinguishable from "nobody did this yet".
+
+Deploy ordering cannot fix a cache that predates both the DDL _and_ the deploy.
+
+### The steps
+
+```bash
+# 1. Apply the DDL (metadata-only when appending at an unused index — no data rewrite).
+
+# 2. Restart the tracker so it re-reads the schema. ONE POD AT A TIME; NATS buffers.
+#    🔴 `kubectl rollout restart` does NOT work here — the deployment is Flux-managed
+#    (kustomize-controller owns it) and force server-side apply strips `restartedAt`.
+#    Delete the pods instead.
+kubectl get pods -n civitai-clickhouse-tracker
+kubectl delete pod <pod-1> -n civitai-clickhouse-tracker   # wait for Ready before the next
+kubectl delete pod <pod-2> -n civitai-clickhouse-tracker
+
+# 3. Confirm with a REAL event — not with the DDL, and not with a bare zero.
+#    Trigger the action, then assert BOTH halves:
+#      a) the tracker's flush line reads  poison=0 dlq=0
+#      b) the row is queryable
+kubectl logs -n civitai-clickhouse-tracker <pod> --since=5m | grep 'Flush actions'
+#    then, against ClickHouse:
+#      SELECT count() FROM default.actions WHERE type='<NewType>' AND time > now() - INTERVAL 1 HOUR
+```
+
+🔴 **`poison=0` immediately after a restart proves nothing** — it only says no _rejectable_ row
+was in that batch. Wait for an actual attempt of the new type, or the green is vacuous.
+
+### Detecting it retroactively
+
+If you suspect a type has been silently dropping, compare the earliest row it ever produced
+against when its migration was applied:
+
+```sql
+SELECT min(time) FROM default.actions WHERE type = '<TheType>';
+```
+
+**If that timestamp post-dates a tracker restart rather than the migration, this trap ate
+everything in between.** A `min(time)` of far-future-relative-to-the-migration is the signature.
+
+## The `POST-APPLY:` marker is enforced
+
+Every migration that widens `actions.type` must carry this line verbatim:
+
+```
+-- POST-APPLY: restart civitai-clickhouse-tracker by pod delete, then confirm with a real event.
+```
+
+`__tests__/action-type-enum-drift.test.ts` fails without it. It is pinned as an exact string
+rather than matched loosely on purpose: a guard that accepts any sentence mentioning "restart"
+is walkable by rewording, and the whole point is that the next person copying an existing
+migration inherits the step rather than inheriting only the parts that look important.
+
+Reword it and the test goes red — that is the intended cost of a machine-checkable claim. If
+the wording genuinely must change, change it in the test constant and here in the same commit.


### PR DESCRIPTION
## What this fixes

Applying an `actions.type` enum ALTER **without restarting `civitai-clickhouse-tracker`** ships a type that collects **zero rows** while every signal you would normally check says it worked. This has happened **twice**, and both times the migration itself was correct.

The tracker builds its column serializers from the schema its pods read **at connect time** and never re-reads them. A value added to the enum after those pods booted is rejected **client-side, inside the tracker**, before ClickHouse is ever asked. So the ALTER verifies perfectly against `system.columns` and the type stays empty.

It is invisible from every direction people normally look:

- the DDL verifies — the server-side enum really does carry the value
- the app logs nothing — the tracker POST is fire-and-forget and returns success
- the tracker's rejection is one `warn` line in a service nobody tails
- the metric reads `0`, indistinguishable from "nobody did this yet"

## The measured history

| type | migration | rows before a tracker restart |
|---|---|---|
| `Announcement_Click` | `2026-09-04-announcement-click-action.sql` | **0**, for ~2.5 days |
| `App_Open` | `2026-09-05-app-open-action.sql` | **0**, until caught by hand |

`Announcement_Click`'s first row *in the type's entire history* landed at `2026-09-07 05:04:07` — ten minutes after an unrelated tracker restart at `04:54:27`. 253 rows across **170 distinct real users** followed within the day. For the 2.5 days before that, every dashboard over it read a clean, correct-looking zero.

## Why the rule already in these headers did not prevent it

Both headers already say *"apply this MANUALLY, BEFORE the app code that emits the value is deployed"*, and **both migrations obeyed it**. That rule addresses deploy **ordering**, and it cannot fix a cache predating both the DDL and the deploy. It is necessary and insufficient — correcting that is the point of this change.

## What lands

- **`migrations/README.md`** — the two-step runbook: why the ordering rule does not cover this, one-pod-at-a-time restart (`rollout restart` is **stripped** — `kustomize-controller` owns the deployment, so it must be a pod delete), how to confirm with a real event, and a **retroactive detection query**: a type whose `min(time)` post-dates a tracker restart rather than its own migration lost everything in between.
- **A verbatim `POST-APPLY:` marker** in all three migrations that widen `actions.type`.
- **A guard** in `action-type-enum-drift.test.ts` enforcing it.

## Why the marker is an exact string, not a loose match

The artifact under test is **prose**, and a guard on words is walkable by rewording — `/restart/i` would pass on any sentence containing the word. Pinning the whole normalised line makes it a machine-checkable claim. A cosmetic reword fails the test on purpose; the README says to change the constant and the doc together.

## Mutation results — each mutant dies for its own reason

| mutation | outcome |
|---|---|
| remove the marker from one migration | **KILLED** — that file's case fails with the guard's own message |
| reword the marker by a single hyphen (`pod delete` -> `pod-delete`) | **KILLED** — same case; proves exact-string, not loose matching |
| break the file filter so it matches nothing | **KILLED by the positive control** — and the run drops **10 tests -> 7**, which is exactly the silent green the control exists to catch |

All three files restored and verified byte-identical afterwards.

## Verification

- unit tier `src/server/clickhouse`: **6 files / 35 tests pass**
- `pnpm typecheck`: **OK — 0 type errors** (read from the tool's own marker, not a grep for an absence)
- prettier: clean on both changed files
- browser/geometry tiers are **not runnable on this box** (nix ships `chromium_headless_shell-1228`, Playwright wants `-1200`); this change touches neither.

No production behaviour changes — docs, a marker comment, and a test.
