### PR TITLE
fix(post-editor): surface a failed image scan instead of a stale spinner

### DIFF
--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import handler from '~/pages/api/webhooks/image-scan-result';
 import { processImageScanWorkflow } from '~/server/services/image-scan-result.service';
+import { signalClient } from '~/utils/signal-client';
 import type * as ClickhouseClient from '~/server/clickhouse/client';
 import { TagSource, ImageIngestionStatus } from '~/shared/utils/prisma/enums';
 import { NsfwLevel } from '~/server/common/enums';
@@ -611,7 +612,7 @@ describe('image-scan-result webhook - pipeline tests', () => {
         if (text.includes('INSERT INTO "Tag"')) throw new Error('Raw query failed. Code: `23502`.');
         if (text.includes('UPDATE "Image"') && text.includes("'{retryCount}'")) {
           markedError = renderSql(strings, values);
-          return [{ retryCount: 1, mediaType: 'image' }];
+          return [{ retryCount: 1, mediaType: 'image', userId: 55 }];
         }
         return passthrough(query, ...values);
       });
@@ -675,6 +676,33 @@ describe('image-scan-result webhook - pipeline tests', () => {
         return strings.join('').includes("'{retryCount}'");
       });
       expect(errorFlips).toHaveLength(0);
+    });
+
+    it('signals the Error state so the editor stops showing "Analyzing image"', async () => {
+      const passthrough = mockDbWrite.$queryRaw.getMockImplementation();
+      mockDbWrite.$queryRaw.mockImplementation(async (query: any, ...values: any[]) => {
+        const strings = Array.isArray(query) ? query : query.strings;
+        const text = strings.join('');
+        if (text.includes('INSERT INTO "Tag"')) throw new Error('Raw query failed. Code: `23502`.');
+        if (text.includes('UPDATE "Image"') && text.includes("'{retryCount}'"))
+          return [{ retryCount: 1, mediaType: 'image', userId: 55 }];
+        return passthrough(query, ...values);
+      });
+
+      await processImageScanWorkflow({
+        workflowId: 'workflow-whose-processing-fails',
+        status: 'succeeded',
+        imageId: 14,
+        steps: scanSteps('another tag that cannot be created'),
+      });
+
+      // Without this the editor keeps rendering Pending until the page is reloaded.
+      expect(vi.mocked(signalClient.send)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 55,
+          data: expect.objectContaining({ imageId: 14, ingestion: ImageIngestionStatus.Error }),
+        })
+      );
     });
 
     it('still surfaces a deleted image so the webhook can ACK it as skipped', async () => {

--- a/src/components/Post/EditV2/PostImageCards/AddedImage.tsx
+++ b/src/components/Post/EditV2/PostImageCards/AddedImage.tsx
@@ -105,8 +105,8 @@ type State = {
   isBlocked: boolean;
   isScanned: boolean;
   isPending: boolean;
-  scanFailed: boolean;
-  scanNotFound: boolean;
+  isScanFailed: boolean;
+  isScanNotFound: boolean;
   canAdd: boolean;
   otherImages: PostEditImageDetail[];
   allowedResources: AllowedResource[];
@@ -205,8 +205,8 @@ export function AddedImage({ image }: { image: PostEditImageDetail }) {
   // const isBlocked = ingestion === ImageIngestionStatus.Blocked;
   const isScanned = ingestion === ImageIngestionStatus.Scanned;
   const isPendingManualAssignment = ingestion === ImageIngestionStatus.PendingManualAssignment;
-  const scanFailed = ingestion === ImageIngestionStatus.Error;
-  const scanNotFound = ingestion === ImageIngestionStatus.NotFound;
+  const isScanFailed = ingestion === ImageIngestionStatus.Error;
+  const isScanNotFound = ingestion === ImageIngestionStatus.NotFound;
   const isBlocked = false;
   const isMinor = minor && !needsReview;
   const canAdd = canAddFunc(type, meta);
@@ -301,8 +301,8 @@ export function AddedImage({ image }: { image: PostEditImageDetail }) {
         isBlocked,
         isPending,
         isScanned,
-        scanFailed,
-        scanNotFound,
+        isScanFailed,
+        isScanNotFound,
         canAdd,
         otherImages,
         allowedResources,
@@ -613,8 +613,8 @@ function EditDetail() {
     isBlocked,
     isPending,
     isScanned,
-    scanFailed,
-    scanNotFound,
+    isScanFailed,
+    isScanNotFound,
     onEditMetaClick,
     isDeleting,
     isUpdating,
@@ -1152,7 +1152,7 @@ function EditDetail() {
             </Text>
           </Alert>
         )}
-        {scanFailed && (
+        {isScanFailed && (
           <Alert
             color="red"
             w="100%"
@@ -1167,7 +1167,7 @@ function EditDetail() {
             </Text>
           </Alert>
         )}
-        {scanNotFound && (
+        {isScanNotFound && (
           <Alert
             color="red"
             w="100%"

--- a/src/components/Post/EditV2/PostImageCards/AddedImage.tsx
+++ b/src/components/Post/EditV2/PostImageCards/AddedImage.tsx
@@ -105,6 +105,8 @@ type State = {
   isBlocked: boolean;
   isScanned: boolean;
   isPending: boolean;
+  scanFailed: boolean;
+  scanNotFound: boolean;
   canAdd: boolean;
   otherImages: PostEditImageDetail[];
   allowedResources: AllowedResource[];
@@ -203,6 +205,8 @@ export function AddedImage({ image }: { image: PostEditImageDetail }) {
   // const isBlocked = ingestion === ImageIngestionStatus.Blocked;
   const isScanned = ingestion === ImageIngestionStatus.Scanned;
   const isPendingManualAssignment = ingestion === ImageIngestionStatus.PendingManualAssignment;
+  const scanFailed = ingestion === ImageIngestionStatus.Error;
+  const scanNotFound = ingestion === ImageIngestionStatus.NotFound;
   const isBlocked = false;
   const isMinor = minor && !needsReview;
   const canAdd = canAddFunc(type, meta);
@@ -297,6 +301,8 @@ export function AddedImage({ image }: { image: PostEditImageDetail }) {
         isBlocked,
         isPending,
         isScanned,
+        scanFailed,
+        scanNotFound,
         canAdd,
         otherImages,
         allowedResources,
@@ -607,6 +613,8 @@ function EditDetail() {
     isBlocked,
     isPending,
     isScanned,
+    scanFailed,
+    scanNotFound,
     onEditMetaClick,
     isDeleting,
     isUpdating,
@@ -1141,6 +1149,35 @@ function EditDetail() {
             <Text align="center">
               Analyzing image. Image will not be visible to other people while analysis is in
               progress.
+            </Text>
+          </Alert>
+        )}
+        {scanFailed && (
+          <Alert
+            color="red"
+            w="100%"
+            radius={0}
+            className="rounded-lg p-2"
+            classNames={{ message: 'flex items-center justify-center gap-2' }}
+          >
+            <Text align="center">
+              We couldn&apos;t finish analyzing this image, so it won&apos;t be visible to others.
+              We&apos;ll keep retrying for a while — if this message is still here later, remove the
+              image and upload it again, or contact support.
+            </Text>
+          </Alert>
+        )}
+        {scanNotFound && (
+          <Alert
+            color="red"
+            w="100%"
+            radius={0}
+            className="rounded-lg p-2"
+            classNames={{ message: 'flex items-center justify-center gap-2' }}
+          >
+            <Text align="center">
+              We couldn&apos;t load this image to analyze it, so it won&apos;t be visible to others.
+              Remove it and upload it again.
             </Text>
           </Alert>
         )}

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -245,7 +245,7 @@ export async function processImageScanWorkflow({
     const failureType =
       status === 'expired' ? 'expired' : status === 'canceled' ? 'canceled' : 'workflow-failed';
     const reason = await readJobFailureReason(workflowId);
-    const { retryCount, mediaType, failureClass } = await markImageScanError({
+    const { retryCount, mediaType, userId, failureClass } = await markImageScanError({
       workflowId,
       imageId,
       status,
@@ -271,6 +271,7 @@ export async function processImageScanWorkflow({
       },
       'webhooks'
     ).catch(() => null);
+    await sendIngestionSignal({ imageId, userId, ingestion: ImageIngestionStatus.Error });
     if (articleImageScanning) await fanOutArticleImageUpdates(imageId);
     return;
   }
@@ -284,7 +285,7 @@ export async function processImageScanWorkflow({
     parsed = parseScanSteps({ steps, workflowId });
   } catch (error) {
     const reason = error instanceof Error ? error.message : 'Unknown error';
-    const { retryCount, mediaType, failureClass } = await markImageScanError({
+    const { retryCount, mediaType, userId, failureClass } = await markImageScanError({
       workflowId,
       imageId,
       status,
@@ -308,6 +309,7 @@ export async function processImageScanWorkflow({
       },
       'webhooks'
     ).catch(() => null);
+    await sendIngestionSignal({ imageId, userId, ingestion: ImageIngestionStatus.Error });
     if (articleImageScanning) await fanOutArticleImageUpdates(imageId);
     return;
   }
@@ -380,7 +382,7 @@ export async function processImageScanWorkflow({
       return;
     }
 
-    const { retryCount, mediaType, failureClass } = await markImageScanError({
+    const { retryCount, mediaType, userId, failureClass } = await markImageScanError({
       workflowId,
       imageId,
       status,
@@ -406,6 +408,7 @@ export async function processImageScanWorkflow({
       },
       'webhooks'
     ).catch(() => null);
+    await sendIngestionSignal({ imageId, userId, ingestion: ImageIngestionStatus.Error });
     if (articleImageScanning) await fanOutArticleImageUpdates(imageId);
     return;
   }
@@ -452,11 +455,37 @@ export async function processImageScanWorkflow({
 
   // Last step, after everything is committed — throwing here would 400 a finished webhook
   // and make the orchestrator re-run it.
+  await sendIngestionSignal({
+    imageId: image.id,
+    userId: image.userId,
+    ingestion: outcome.ingestion,
+    blockedFor: outcome.blockedFor,
+  });
+}
+
+/**
+ * Push the resolved ingestion state to the uploader's open editor. Every terminal
+ * state has to send: the editor renders Pending as an in-progress spinner, so an
+ * image that stops at Error or NotFound without a signal sits there claiming to be
+ * analyzing until the page is reloaded.
+ */
+async function sendIngestionSignal({
+  imageId,
+  userId,
+  ingestion,
+  blockedFor,
+}: {
+  imageId: number;
+  userId: number | null;
+  ingestion: ImageIngestionStatus;
+  blockedFor?: string | null;
+}) {
+  if (!userId) return;
   await signalClient
     .send({
       target: SignalMessages.ImageIngestionStatus,
-      data: { imageId: image.id, ingestion: outcome.ingestion, blockedFor: outcome.blockedFor },
-      userId: image.userId,
+      data: { imageId, ingestion, blockedFor },
+      userId,
     })
     .catch((error) =>
       logToAxiom(
@@ -466,7 +495,7 @@ export async function processImageScanWorkflow({
           message: `signal send failed: ${
             error instanceof Error ? error.message : 'Unknown error'
           }`,
-          imageId: image.id,
+          imageId,
           source: 'image-scan-result.service',
         },
         'webhooks'
@@ -705,6 +734,7 @@ async function markImageScanError({
 }): Promise<{
   retryCount: number | null;
   mediaType: string | null;
+  userId: number | null;
   failureClass: string;
 }> {
   const failureClass = classifyImageScanFailure({ reason, failureType, middleware, failedSteps });
@@ -719,7 +749,9 @@ async function markImageScanError({
     failureClass,
     at: new Date().toISOString(),
   });
-  const rows = await dbWrite.$queryRaw<{ retryCount: number | null; mediaType: string | null }[]>`
+  const rows = await dbWrite.$queryRaw<
+    { retryCount: number | null; mediaType: string | null; userId: number | null }[]
+  >`
     UPDATE "Image"
     SET
       "ingestion" = ${ImageIngestionStatus.Error}::"ImageIngestionStatus",
@@ -737,11 +769,13 @@ async function markImageScanError({
         ${errorJson}::jsonb
       )
     WHERE id = ${imageId}
-    RETURNING ("scanJobs"->>'retryCount')::int as "retryCount", type as "mediaType"
+    RETURNING ("scanJobs"->>'retryCount')::int as "retryCount", type as "mediaType",
+      "userId"
   `;
   return {
     retryCount: rows[0]?.retryCount ?? null,
     mediaType: rows[0]?.mediaType ?? null,
+    userId: rows[0]?.userId ?? null,
     failureClass,
   };
 }

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -464,10 +464,10 @@ export async function processImageScanWorkflow({
 }
 
 /**
- * Push the resolved ingestion state to the uploader's open editor. Every terminal
- * state has to send: the editor renders Pending as an in-progress spinner, so an
- * image that stops at Error or NotFound without a signal sits there claiming to be
- * analyzing until the page is reloaded.
+ * Push the resolved ingestion state to the uploader's open editor. The editor renders
+ * Pending as an in-progress spinner, so any state that LEAVES Pending has to send —
+ * Error included, retryable though it is — or the card goes on claiming to analyze
+ * until the page is reloaded.
  */
 async function sendIngestionSignal({
   imageId,


### PR DESCRIPTION
Follow-up to #4671. That PR stopped images being stranded on `Pending` and gave a failed scan a bounded, countable path. This one makes the failure visible to the person who uploaded the image.

## Problem

`AddedImage.tsx` rendered an alert for exactly two states — `Pending` ("Analyzing image…") and `PendingManualAssignment`. There was no branch for `Error` or `NotFound`, so an image that stopped in either one showed **no alert at all**: the yellow banner vanished and the card looked like a finished image.

It isn't finished. Without a rating the image has `nsfwLevel = 0` and stays invisible to everyone, and the uploader has no way to tell whether to keep waiting or ask for help. Arguably worse than the original bug, where at least the spinner said something was happening.

## Why the copy is shaped the way it is

`Error` is not necessarily terminal — the `ingest-images` cron retries it under a class-based ceiling (9 attempts for the `unknown` class a processing failure lands in, roughly an hour apart), and only then gives up. The client can't tell which side of that it's on: `scanJobs.retryCount` isn't in `editPostImageSelect`, and adding it would ship raw scanner error text to end users.

Rather than widen the payload, the copy commits only to what's true in both cases — we keep retrying for a while, and if the message is still there later the image needs re-uploading or support. That gives the reader the decision rule without asserting a retry that may already be spent.

`NotFound` gets its own copy, since re-uploading is the only thing that helps there.

## The other half: the error paths never signalled

There was exactly one `signalClient.send` in the service, in the success tail. The non-succeeded branch and both `processing-failed` branches returned before it, so an image flipping to `Error` pushed nothing to the client and the editor kept rendering `Pending` until a reload — which would have made the new alert unreliable exactly when someone is watching the page.

Extracted as `sendIngestionSignal` and called from all three `markImageScanError` paths. `markImageScanError` now also returns `userId` (one extra column on its existing `RETURNING`) so the signal can address the uploader without another query.

## Deliberate gap

The rating-hard-block branch does not signal. `userId` isn't in scope there and fetching it would add a query to an error path, and that branch ends at `Blocked` — which the editor doesn't surface at all today (`isBlocked` is hardcoded `false`). Worth revisiting if blocked-state UI ever lands.

## Tests

Added a case asserting the `Error` signal reaches the uploader with the right image id and state. Revert-checked: removing the `sendIngestionSignal` calls fails it in about four seconds on the `toHaveBeenCalledWith`.

Note the existing `processing-failed` test's `$queryRaw` fake needed `userId` added to its returned row — without it `sendIngestionSignal` short-circuits, which is the correct behaviour for a deleted image and exactly the trap this test would otherwise have hidden.

No component test for the alert itself. It's a plain conditional render, and a test would need the whole post-edit store and provider to assert what amounts to Mantine rendering a string; the part that can break silently is the signal, and that's covered.

Verified: `pnpm run typecheck` clean, `pnpm run lint` 0 errors, `pnpm run test:lint-rules` 492 passing, full unit suite 38,656 passing / 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UTFCuxwiWGYP7469Ju3SY
