### PR TITLE
fix(generation): stop resolveImageMeta throwing on a non-string metadata hash

### DIFF
--- a/src/server/services/__tests__/no-unroled-image-resource-match.test.ts
+++ b/src/server/services/__tests__/no-unroled-image-resource-match.test.ts
@@ -75,4 +75,14 @@ describe('resolveImageMeta (the TypeScript mirror)', () => {
       /mf\.type NOT IN \(\$\{Prisma\.join\(NON_RESOURCE_FILE_TYPES\)\}\)/
     );
   });
+
+  it('reads every hash through the one normalizer, as the SQL does with NULLIF', () => {
+    // The SQL cannot be handed a non-string -- jsonb_each_text yields NULL and LOWER(NULL) is NULL.
+    // Here the metadata is unvalidated, so a stage that lowercases a raw value throws on
+    // {"hashes":{"model":null}}. Counted, not merely present: a fourth stage added without it is
+    // the way this returns. Behaviour is pinned in generation/__tests__/extract-hash-candidates.
+    expect(mirror, 'no normalizeHash helper').toMatch(/const normalizeHash\s*=/);
+    const normalized = mirror.match(/normalizeHash\(/g) ?? [];
+    expect(normalized.length, 'a hash stage does not go through normalizeHash').toBe(3);
+  });
 });

--- a/src/server/services/generation/__tests__/extract-hash-candidates.test.ts
+++ b/src/server/services/generation/__tests__/extract-hash-candidates.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { extractHashCandidates } from '~/server/services/generation/generation.service';
+
+/**
+ * `resolveImageMeta` is a publicProcedure and its schema is `z.record(z.string(), z.unknown())`, so
+ * every value below arrives exactly as an anonymous caller wrote it. The `Record<string, string>`
+ * cast in extractResourceInputFromMeta is unchecked, and get_image_resources.sql — the SQL this
+ * function mirrors — cannot hit any of these, because jsonb_each_text yields NULL where a value is
+ * not text and LOWER(NULL) is NULL.
+ */
+const asInput = (meta: Record<string, unknown>) =>
+  ({
+    resources: Array.isArray(meta.resources)
+      ? (meta.resources as { hash?: string }[]).filter((r) => r.hash)
+      : undefined,
+    hashes: meta.hashes,
+    modelHash: meta['Model hash'],
+    modelName: meta.Model,
+    civitaiResources: undefined,
+  } as Parameters<typeof extractHashCandidates>[0]);
+
+describe('extractHashCandidates', () => {
+  it('does not throw when meta.hashes carries a non-string value', () => {
+    // Reverting the fix throws TypeError: value.toLowerCase is not a function, which surfaces as a
+    // 500 on an unauthenticated procedure rather than as a failed assertion.
+    expect(() => extractHashCandidates(asInput({ hashes: { model: null } }))).not.toThrow();
+    expect(() => extractHashCandidates(asInput({ hashes: { model: 12345 } }))).not.toThrow();
+    expect(() => extractHashCandidates(asInput({ hashes: { model: { a: 1 } } }))).not.toThrow();
+  });
+
+  it('yields no candidate for a non-string or empty hash, in any of the three stages', () => {
+    expect(extractHashCandidates(asInput({ hashes: { model: null } }))).toEqual([]);
+    expect(extractHashCandidates(asInput({ hashes: { model: '' } }))).toEqual([]);
+    expect(extractHashCandidates(asInput({ resources: [{ type: 'model', hash: '' }] }))).toEqual(
+      []
+    );
+    expect(extractHashCandidates(asInput({ 'Model hash': '' }))).toEqual([]);
+    expect(extractHashCandidates(asInput({ 'Model hash': 42 }))).toEqual([]);
+  });
+
+  it('still yields the candidates it should', () => {
+    expect(extractHashCandidates(asInput({ hashes: { model: 'ABC123' } }))).toEqual([
+      { hash: 'abc123', name: 'model', strength: null },
+    ]);
+    expect(
+      extractHashCandidates(asInput({ resources: [{ type: 'model', hash: 'DEF456' }] }))
+    ).toEqual([{ hash: 'def456', name: 'model', strength: null }]);
+    expect(extractHashCandidates(asInput({ 'Model hash': 'FED987', Model: 'thing' }))).toEqual([
+      { hash: 'fed987', name: 'thing', strength: null },
+    ]);
+  });
+
+  it('keeps rejecting the empty-content hash and non-resource roles', () => {
+    expect(extractHashCandidates(asInput({ hashes: { model: 'e3b0c44298fc' } }))).toEqual([]);
+    expect(extractHashCandidates(asInput({ hashes: { llamamodel: 'abc123' } }))).toEqual([]);
+  });
+});

--- a/src/server/services/generation/generation.service.ts
+++ b/src/server/services/generation/generation.service.ts
@@ -1450,9 +1450,21 @@ function extractResourceInputFromMeta(metadata: Record<string, unknown>) {
 }
 
 /**
+ * Mirrors `NULLIF(LOWER(x), '')` and the empty-content-hash exclusion in the SQL, in one place so
+ * the three stages cannot drift apart. Takes `unknown` because they never had the string the casts
+ * in extractResourceInputFromMeta claim: the procedure is public and its schema is
+ * `z.record(z.string(), z.unknown())`, so a value here is whatever the caller wrote.
+ */
+const normalizeHash = (raw: unknown): string | undefined => {
+  if (typeof raw !== 'string') return undefined;
+  const hash = raw.toLowerCase();
+  return hash && hash !== EMPTY_HASH ? hash : undefined;
+};
+
+/**
  * Extract hash candidates from metadata (mirrors get_image_resources.sql stages 1-3).
  */
-function extractHashCandidates(
+export function extractHashCandidates(
   input: ReturnType<typeof extractResourceInputFromMeta>
 ): HashCandidate[] {
   const candidates: HashCandidate[] = [];
@@ -1460,10 +1472,10 @@ function extractHashCandidates(
   // Stage 1: meta.resources[] — resources with hashes
   if (input.resources) {
     for (const r of input.resources) {
-      if (!r.hash || r.name === 'vae') continue;
+      if (r.name === 'vae') continue;
       if (!isResourceRole(r.type?.toLowerCase())) continue;
-      const hash = r.hash.toLowerCase();
-      if (hash === EMPTY_HASH) continue;
+      const hash = normalizeHash(r.hash);
+      if (!hash) continue;
       candidates.push({
         hash,
         name: r.name ?? r.type ?? 'unknown',
@@ -1477,18 +1489,16 @@ function extractHashCandidates(
     for (const [key, value] of Object.entries(input.hashes)) {
       if (key === 'vae') continue;
       if (!isResourceRole(roleFromHashKey(key))) continue;
-      const hash = value.toLowerCase();
-      if (hash === EMPTY_HASH) continue;
+      const hash = normalizeHash(value);
+      if (!hash) continue;
       candidates.push({ hash, name: key, strength: null });
     }
   }
 
   // Stage 3: Legacy 'Model hash' field (only if no hashes object)
-  if (input.modelHash && !input.hashes) {
-    const hash = input.modelHash.toLowerCase();
-    if (hash !== EMPTY_HASH) {
-      candidates.push({ hash, name: input.modelName ?? 'model', strength: null });
-    }
+  if (!input.hashes) {
+    const hash = normalizeHash(input.modelHash);
+    if (hash) candidates.push({ hash, name: input.modelName ?? 'model', strength: null });
   }
 
   return candidates;


### PR DESCRIPTION
Follow-up to the review on #4665. Copilot flagged that the `meta.hashes` branch of `extractHashCandidates()` did not normalize empty-string hashes the way the SQL does. Checking it turned up something sharper on the same line.

## The bug

`resolveImageMeta` is a `publicProcedure` and its schema is `z.record(z.string(), z.unknown())`, so metadata values arrive exactly as an anonymous caller wrote them. The `Record<string, string>` cast in `extractResourceInputFromMeta` is unchecked, and the stage did:

```ts
const hash = value.toLowerCase();
```

So `{"hashes":{"model":null}}` throws `TypeError: Cannot read properties of null` — a 500 on an unauthenticated route. Confirmed by running the new test against the unfixed code:

```
TypeError: Cannot read properties of null (reading 'toLowerCase')
 ❯ extractHashCandidates src/server/services/generation/generation.service.ts:1480:26
```

Stages 1 and 3 were safe only by accident — their guards (`!r.hash`, `input.modelHash &&`) reject `null` before the call. A number or an object passes both, so all three stages had the same hole.

`get_image_resources.sql`, which this function mirrors, cannot hit any of it: `jsonb_each_text` yields NULL where a value is not text, and `LOWER(NULL)` is NULL. That asymmetry is why the mirror drifted.

## The change

Rather than a guard per stage, all three route through one `normalizeHash()` that takes `unknown` and reproduces the SQL's `NULLIF(LOWER(x), '')` plus the empty-content-hash exclusion. That also closes the original empty-string report: stage 2 pushed `''` into the lookup array where the SQL had normalized it away. Harmless on its own — an empty hash matches no `ModelFileHash` — but it was the visible half of a real defect.

`extractHashCandidates` is exported so it can be tested directly. It is pure, and reaching it through `resolveImageMeta` would mean mocking the query it exists to build.

## Tests

Both were confirmed to fail on a revert, not just to pass now:

| test | on revert |
|---|---|
| `extract-hash-candidates.test.ts` | `TypeError: Cannot read properties of null` |
| `no-unroled-image-resource-match.test.ts` | `a hash stage does not go through normalizeHash: expected 2 to be 3` |

The guard counts `normalizeHash(` call sites rather than asserting presence, because a fourth stage added without it is how this comes back.

## Verification

- full unit suite: 1675 files / 38704 tests, 0 failures
- `test:lint-rules`: 35 files, 498 tests
- `typecheck`: 0 errors
- eslint clean on changed files (one pre-existing unused-import warning, untouched)

No behaviour change for well-formed metadata — the "still yields the candidates it should" case pins that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lhyk1Rk75Gk4DedmnZUGuZ