### PR TITLE
fix(clickhouse): widen reaction/report enums and guard every tracker enum column

### DIFF
--- a/src/server/clickhouse/__tests__/tracker-enum-drift.test.ts
+++ b/src/server/clickhouse/__tests__/tracker-enum-drift.test.ts
@@ -1,0 +1,422 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { ReactionType, ReportType } from '~/server/clickhouse/tracker';
+import { NsfwLevelDeprecated } from '~/shared/constants/browsingLevel.constants';
+import { ReportEntity } from '~/shared/utils/report-helpers';
+import { ReportReason, ReportStatus, ReviewReactions } from '~/shared/utils/prisma/enums';
+
+/**
+ * Enum drift on every tracker-written column EXCEPT `actions.type`.
+ *
+ * `actions.type` has had a guard since 2026-08-21 (./action-type-enum-drift.test.ts).
+ * Nothing else did — and that narrowness is the entire reason this file exists. A sweep of
+ * tracker rejections over a 2h38m window on 2026-09-07 found three live gaps, none of them
+ * on `actions`:
+ *
+ *   * `reactions.nsfw` lacked 'Blocked' — 7 of 10 rejections in that window, all real
+ *     users, on the order of ~387 rows/day silently discarded.
+ *   * `reports.reason` lacked 'Spam' and 'StickerPlacement'.
+ *   * `reactions.type` lacks 'Post_Create' and 'Post_Delete'.
+ *
+ * A fourth, `reports.entityType`, was found by writing this guard.
+ *
+ * 🔴 WHY NOTHING ELSE CATCHES IT. The rejection is CLIENT-SIDE, inside the tracker service,
+ * while it serializes the batch — the app POSTs fire-and-forget, so the caller sees success,
+ * nothing is logged here, and the row never exists. `SHOW CREATE TABLE` is clean because the
+ * DDL genuinely is. Typecheck was clean too: the reaction controller built its `type` with a
+ * template literal (inferred `string`) and laundered it through `as ReactionType` at the call
+ * site, so the one branch emitting a value the column has never carried type-checked for as
+ * long as it has existed. That cast is gone; this file is what stops the class coming back.
+ *
+ * THE PROPERTY: for every enum column the tracker writes, every value the APP can emit must
+ * be present in the column's effective definition — the newest migration that states it, or,
+ * for a column no migration has touched, the measured production baseline below.
+ *
+ * Containment, not equality: a column is allowed to be WIDER than the app domain
+ * (`reactions.nsfw` carries 'Undefined', which no app value maps to). Narrower is the defect.
+ */
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '../migrations');
+
+const sqlFiles = fs
+  .readdirSync(MIGRATIONS_DIR)
+  .filter((f) => f.endsWith('.sql'))
+  .sort()
+  .map((f) => ({ name: f, raw: fs.readFileSync(path.join(MIGRATIONS_DIR, f), 'utf-8') }));
+
+/**
+ * 🔴 Comments are stripped BEFORE anything is parsed. These migrations carry their values in
+ * prose as well as in DDL — a rationale, a verification snippet, a POST-APPLY block — so a
+ * parser fed the raw file stays green on a migration whose ALTER was deleted and whose
+ * comments were not. Measured on the sibling guard: removing an arm left it passing.
+ */
+const stripComments = (raw: string) =>
+  raw
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('--'))
+    .join('\n');
+
+/**
+ * 🔴 MULTI-LINE BY CONSTRUCTION. Every migration in this directory writes the statement as
+ * `ALTER TABLE default.reactions\n  MODIFY COLUMN ...`, and the enum arms are one per line.
+ * A regex anchored to a single line matches ZERO of them — and a guard built on it scans an
+ * empty set and passes on everything, which is the same reassuring zero this file exists to
+ * stop. `\s+` spans newlines; `parsedBlockCount` below is the control that proves it did.
+ *
+ * Enum8 and Enum16 are both accepted: `actions.type` is Enum16, every column here is Enum8,
+ * and a guard that silently skipped one width would have exactly the blind spot above.
+ */
+const ENUM_COLUMN_RE =
+  /ALTER\s+TABLE\s+([\w.]+)\s+MODIFY\s+COLUMN\s+`?(\w+)`?\s+Enum(?:8|16)\s*\(([^)]*)\)/gi;
+
+type EnumBlock = {
+  file: string;
+  column: string; // "<table>.<column>", lower-cased
+  arms: Map<string, number>;
+  multiLine: boolean;
+};
+
+const enumBlocks: EnumBlock[] = sqlFiles.flatMap(({ name, raw }) =>
+  [...stripComments(raw).matchAll(ENUM_COLUMN_RE)].map((m) => ({
+    file: name,
+    column: `${m[1]}.${m[2]}`.toLowerCase(),
+    arms: new Map<string, number>(
+      [...m[3].matchAll(/'([A-Za-z0-9_]+)'\s*=\s*(\d+)/g)].map((a) => [a[1], Number(a[2])])
+    ),
+    multiLine: m[0].includes('\n'),
+  }))
+);
+
+/**
+ * The `reactions_owner_scores_mv` +1 list. Parsed, not substring-matched, because the
+ * property that matters is set equality against the column's '*_Create' values — see the
+ * coupling test at the bottom of this file for why that is not cosmetic.
+ */
+const MV_QUERY_RE =
+  /ALTER\s+TABLE\s+default\.reactions_owner_scores_mv\s+MODIFY\s+QUERY([\s\S]*?);/gi;
+
+const mvBlocks = sqlFiles.flatMap(({ name, raw }) =>
+  [...stripComments(raw).matchAll(MV_QUERY_RE)].map((m) => {
+    const inList = /type\s+IN\s*\(([^)]*)\)/i.exec(m[1]);
+    return {
+      file: name,
+      plusOne: new Set<string>(
+        inList ? [...inList[1].matchAll(/'([A-Za-z0-9_]+)'/g)].map((a) => a[1]) : []
+      ),
+    };
+  })
+);
+
+/** The newest block wins: `MODIFY COLUMN` replaces the definition, and files are date-named. */
+const lastBlockFor = (column: string) => {
+  const matching = enumBlocks.filter((b) => b.column === column);
+  return matching[matching.length - 1];
+};
+
+type ColumnSpec = {
+  /** "<table>.<column>", lower-cased — the key the parser produces. */
+  column: string;
+  /** Where the app-side domain lives, for the failure message. */
+  domain: string;
+  /** Every value the app can emit into this column. */
+  appValues: readonly string[];
+  /**
+   * The production definition as it stood BEFORE any migration in this directory touched
+   * the column, measured with `SHOW CREATE TABLE` on 2026-09-07.
+   *
+   * 🔴 Do NOT add a name here to silence a failing case. That is the one-line bypass of this
+   * whole guard and it reproduces precisely the "looks instrumented, writes no rows" outcome
+   * the file exists to stop — the value would be in the app and still absent from the column.
+   * A new value belongs in a migration.
+   */
+  baseline: ReadonlyMap<string, number>;
+};
+
+const COLUMNS: readonly ColumnSpec[] = [
+  {
+    column: 'default.reactions.type',
+    domain: 'ReactionType (src/server/clickhouse/tracker.ts)',
+    appValues: ReactionType,
+    baseline: new Map([
+      ['Image_Create', 1],
+      ['Image_Delete', 2],
+      ['Comment_Create', 3],
+      ['Comment_Delete', 4],
+      ['CommentV2_Create', 5],
+      ['CommentV2_Delete', 6],
+      ['Review_Create', 7],
+      ['Review_Delete', 8],
+      ['Question_Create', 9],
+      ['Question_Delete', 10],
+      ['Answer_Create', 11],
+      ['Answer_Delete', 12],
+      ['BountyEntry_Create', 13],
+      ['BountyEntry_Delete', 14],
+      ['Article_Create', 15],
+      ['Article_Delete', 16],
+    ]),
+  },
+  {
+    column: 'default.reactions.reaction',
+    domain: 'ReviewReactions (Prisma)',
+    appValues: Object.values(ReviewReactions),
+    baseline: new Map([
+      ['Like', 1],
+      ['Dislike', 2],
+      ['Laugh', 3],
+      ['Cry', 4],
+      ['Heart', 5],
+    ]),
+  },
+  {
+    column: 'default.reactions.nsfw',
+    // 'Undefined' = 0 has no app counterpart; the column may be wider than the domain.
+    domain: 'NsfwLevelDeprecated (src/shared/constants/browsingLevel.constants.ts)',
+    appValues: Object.values(NsfwLevelDeprecated),
+    baseline: new Map([
+      ['Undefined', 0],
+      ['None', 1],
+      ['Soft', 2],
+      ['Mature', 3],
+      ['X', 4],
+    ]),
+  },
+  {
+    column: 'default.reports.type',
+    domain: 'ReportType (src/server/clickhouse/tracker.ts)',
+    appValues: ReportType,
+    baseline: new Map([
+      ['Create', 1],
+      ['StatusChange', 2],
+    ]),
+  },
+  {
+    column: 'default.reports.entitytype',
+    domain: 'ReportEntity (src/shared/utils/report-helpers.ts)',
+    appValues: Object.values(ReportEntity),
+    baseline: new Map([
+      ['model', 1],
+      ['comment', 2],
+      ['commentV2', 3],
+      ['image', 4],
+      ['resourceReview', 5],
+      ['article', 6],
+      ['post', 7],
+      ['reportedUser', 8],
+      ['collection', 9],
+      ['bounty', 10],
+      ['bountyEntry', 11],
+      ['chat', 12],
+    ]),
+  },
+  {
+    column: 'default.reports.reason',
+    domain: 'ReportReason (Prisma)',
+    appValues: Object.values(ReportReason),
+    baseline: new Map([
+      ['TOSViolation', 1],
+      ['NSFW', 2],
+      ['Ownership', 3],
+      ['AdminAttention', 4],
+      ['Claim', 5],
+      ['CSAM', 6],
+      ['Automated', 7],
+    ]),
+  },
+  {
+    column: 'default.reports.status',
+    domain: 'ReportStatus (Prisma)',
+    appValues: Object.values(ReportStatus),
+    baseline: new Map([
+      ['Pending', 1],
+      ['Processing', 2],
+      ['Actioned', 3],
+      ['Unactioned', 4],
+    ]),
+  },
+];
+
+/** Effective definition: the newest migration that states the column, else the baseline. */
+const effectiveArms = (spec: ColumnSpec) => lastBlockFor(spec.column)?.arms ?? spec.baseline;
+
+describe('tracker enum drift (reactions + reports)', () => {
+  describe('the parser actually parsed something', () => {
+    // 🔴 POSITIVE CONTROLS. Every `it.each` below is driven by parsed data, so a regex that
+    // matches nothing turns the whole file into a green that means "scanned zero columns".
+    // These are the only assertions here that would notice.
+    it('scans the migrations directory', () => {
+      expect(sqlFiles.length, 'no .sql migrations found to scan').toBeGreaterThanOrEqual(8);
+    });
+
+    it('parses multi-line ALTER ... MODIFY COLUMN statements', () => {
+      // Every migration here writes the table and the MODIFY COLUMN on separate lines. If
+      // this is 0 the regex has been narrowed to a single line and covers nothing.
+      const multiLine = enumBlocks.filter((b) => b.multiLine);
+      expect(
+        multiLine.length,
+        'no multi-line enum ALTER parsed — the statements in this directory are all multi-line, ' +
+          'so a zero here means the parser is matching an empty set and every check below is vacuous'
+      ).toBeGreaterThanOrEqual(5);
+    });
+
+    it('found a migration block for every column this change defines', () => {
+      // Named explicitly rather than counted, so a rename or a retargeted ALTER is caught
+      // instead of being absorbed by a total that happens to stay the same.
+      const defined = [
+        'default.reactions.type',
+        'default.reactions.nsfw',
+        'default.reports.reason',
+        'default.reports.entitytype',
+      ];
+      expect(defined.filter((c) => !lastBlockFor(c))).toEqual([]);
+    });
+
+    it('found the reactions_owner_scores_mv MODIFY QUERY', () => {
+      expect(mvBlocks.length, 'no ALTER ... MODIFY QUERY on the MV found').toBeGreaterThanOrEqual(
+        1
+      );
+      expect(mvBlocks[mvBlocks.length - 1].plusOne.size).toBeGreaterThan(0);
+    });
+  });
+
+  it.each(COLUMNS.map((c) => [c.column, c] as const))(
+    '%s baseline matches the production definition it was measured from',
+    (_column, spec) => {
+      // A tripwire on the baseline map itself: growing it is how a value gets exempted from
+      // needing a migration. Change it deliberately, with a fresh SHOW CREATE TABLE, or not
+      // at all.
+      const expected: Record<string, number> = {
+        'default.reactions.type': 16,
+        'default.reactions.reaction': 5,
+        'default.reactions.nsfw': 5,
+        'default.reports.type': 2,
+        'default.reports.entitytype': 12,
+        'default.reports.reason': 7,
+        'default.reports.status': 4,
+      };
+      expect(spec.baseline.size).toBe(expected[spec.column]);
+    }
+  );
+
+  it.each(COLUMNS.map((c) => [c.column, c] as const))(
+    'every %s value the app can emit exists in the column',
+    (column, spec) => {
+      const arms = effectiveArms(spec);
+      const missing = spec.appValues.filter((v) => !arms.has(v));
+      expect(
+        missing,
+        `${column} cannot accept ${missing.length} value(s) the app emits: ${missing.join(
+          ', '
+        )}.\n` +
+          `Source of truth: ${spec.domain}.\n` +
+          `The tracker rejects these CLIENT-SIDE while serializing, so the app sees a successful ` +
+          `send and the rows never exist. Add them in a migration under ` +
+          `src/server/clickhouse/migrations/ that restates the whole enum, then restart the ` +
+          `tracker — the DDL alone is inert against pods that already read the schema.`
+      ).toEqual([]);
+    }
+  );
+
+  it.each(COLUMNS.map((c) => [c.column, c] as const))(
+    'every migration restating %s reproduces the baseline indices exactly',
+    (column, spec) => {
+      // `MODIFY COLUMN` REPLACES the definition. A name left out is DROPPED from a live
+      // column; a name given a different index silently remaps every existing row. Both are
+      // whole-table rewrites the migrations' own headers forbid, and nothing else asserts it.
+      const blocks = enumBlocks.filter((b) => b.column === column);
+      for (const block of blocks) {
+        for (const [name, index] of spec.baseline) {
+          expect(
+            block.arms.get(name),
+            `${block.file}: ${column} restates the enum but ${
+              block.arms.has(name)
+                ? `moves '${name}' from ${index} to ${block.arms.get(name)}`
+                : `drops '${name}'`
+            }`
+          ).toBe(index);
+        }
+      }
+    }
+  );
+
+  it('assigns every value in every parsed enum a distinct index', () => {
+    for (const block of enumBlocks) {
+      const indices = [...block.arms.values()];
+      expect(
+        new Set(indices).size,
+        `${block.file}: ${block.column} reuses an index — two names would collapse onto one value`
+      ).toBe(indices.length);
+    }
+  });
+
+  /**
+   * 🔴 THE COUPLING. `reactions_owner_scores_mv` scores `type IN (<the '*_Create' list>)` as
+   * +1 and EVERYTHING ELSE as -1. There is no unknown arm. So adding a '*_Create' value to
+   * `reactions.type` without adding it to that list does not fail to count the new reaction —
+   * it makes every one of them DECREMENT the owner's score, turning dropped rows (recoverable:
+   * nothing was written) into wrong rows in an aggregate with no source to rebuild from.
+   *
+   * Set EQUALITY in both directions on purpose. A '*_Create' value missing from the list is the
+   * corruption above; a name in the list that the column cannot hold is dead weight that reads
+   * as coverage. If a future '*_Create' type legitimately must not score +1, change this test
+   * deliberately and say why — that is the intended cost of a machine-checkable claim.
+   */
+  it('scores every reactions.type *_Create value +1 in reactions_owner_scores_mv', () => {
+    const reactionsType = COLUMNS.find((c) => c.column === 'default.reactions.type')!;
+    const creates = [...effectiveArms(reactionsType).keys()].filter((t) => t.endsWith('_Create'));
+    const mv = mvBlocks[mvBlocks.length - 1];
+
+    expect(creates.length, 'no *_Create values parsed out of reactions.type').toBeGreaterThan(0);
+    expect(
+      [...mv.plusOne].sort(),
+      `${mv.file}: the reactions_owner_scores_mv +1 list and the reactions.type '*_Create' ` +
+        `values disagree. Anything absent from the list scores -1, so a type in the column but ` +
+        `not in the view actively decrements owner scores on every reaction. The column widening ` +
+        `and the MODIFY QUERY are ONE operation — apply both or neither.`
+    ).toEqual(creates.sort());
+  });
+
+  /**
+   * The same post-apply marker the `actions.type` guard pins, extended to these columns.
+   *
+   * 🔴 The DDL is half the operation. `civitai-clickhouse-tracker` builds its column
+   * serializers from the schema its pods read AT CONNECT TIME and never re-reads them, so a
+   * value added after those pods booted is still rejected client-side: the ALTER verifies
+   * perfectly and the value collects ZERO rows. That has shipped broken twice on `actions`
+   * alone (see ../migrations/README.md).
+   *
+   * 🔴 Pinned as an exact string rather than matched on /restart/i because the artifact under
+   * test is PROSE, and a guard on words is walkable by rewording. A cosmetic reword fails this
+   * on purpose; change the constant, the README and the sibling guard together.
+   */
+  const POST_APPLY_MARKER =
+    '-- POST-APPLY: restart civitai-clickhouse-tracker by pod delete, then confirm with a real event.';
+
+  const trackerEnumMigrations = sqlFiles.filter(({ name }) =>
+    enumBlocks.some((b) => b.file === name && COLUMNS.some((c) => c.column === b.column))
+  );
+
+  it('found migrations touching these columns to check for the marker', () => {
+    expect(
+      trackerEnumMigrations.length,
+      'no migration widening a reactions/reports enum was found — the marker check below ' +
+        'would be vacuously true over an empty set'
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it.each(trackerEnumMigrations.map((m) => m.name))(
+    '%s carries the POST-APPLY tracker-restart marker verbatim',
+    (name) => {
+      const raw = trackerEnumMigrations.find((m) => m.name === name)!.raw;
+      expect(
+        raw.includes(POST_APPLY_MARKER),
+        `${name} widens a tracker-written enum but does not carry the post-apply marker.\n` +
+          `Add this line verbatim to its header:\n  ${POST_APPLY_MARKER}\n` +
+          `Applying the DDL without restarting the tracker ships a value that collects ZERO ` +
+          `rows while every signal says it worked — see migrations/README.md.`
+      ).toBe(true);
+    }
+  );
+});

--- a/src/server/clickhouse/__tests__/tracker-enum-drift.test.ts
+++ b/src/server/clickhouse/__tests__/tracker-enum-drift.test.ts
@@ -36,6 +36,11 @@ import { ReportReason, ReportStatus, ReviewReactions } from '~/shared/utils/pris
  *
  * Containment, not equality: a column is allowed to be WIDER than the app domain
  * (`reactions.nsfw` carries 'Undefined', which no app value maps to). Narrower is the defect.
+ *
+ * 🔴 WHAT THIS FILE STRUCTURALLY CANNOT SEE: it reads migration TEXT, never ClickHouse. A
+ * green means "a migration in this directory STATES the value", never "the live column
+ * accepts it". See the comment on `effectiveArms` below — the gap is live right now, not
+ * hypothetical.
  */
 
 const MIGRATIONS_DIR = path.resolve(__dirname, '../migrations');
@@ -90,20 +95,80 @@ const enumBlocks: EnumBlock[] = sqlFiles.flatMap(({ name, raw }) =>
 );
 
 /**
- * The `reactions_owner_scores_mv` +1 list. Parsed, not substring-matched, because the
- * property that matters is set equality against the column's '*_Create' values — see the
- * coupling test at the bottom of this file for why that is not cosmetic.
+ * The `reactions_owner_scores_mv` MODIFY QUERY. Captured WHOLE, not just its IN list.
+ *
+ * 🔴 THE IN LIST IS THE LEAST DANGEROUS PART OF THIS STATEMENT. `MODIFY QUERY` replaces the
+ * ENTIRE SELECT of a live view that maintains every user's all-time reaction score
+ * (`reactions_owner_scores`, read by `getReactionTasks` in src/server/metrics/user.metrics.ts).
+ * Two edits that leave the IN list untouched, and so pass a parser that reads only the IN list:
+ *
+ *   * swapping the multiIf arms, `, 1, -1)` -> `, -1, 1)`, scores EVERY reaction -1;
+ *   * moving `parseDateTimeBestEffort('2024-04-27')` forward disables the self-reaction
+ *     exclusion, so a user can farm their own score.
+ *
+ * Both were applied as mutations against the IN-list-only version of this guard and the suite
+ * stayed fully green. That is why the whole normalised statement is pinned below.
  */
 const MV_QUERY_RE =
   /ALTER\s+TABLE\s+default\.reactions_owner_scores_mv\s+MODIFY\s+QUERY([\s\S]*?);/gi;
 
+/**
+ * Canonical form for comparing two spellings of one statement: collapse whitespace runs to a
+ * single space, then drop spaces adjacent to `(`, `)` and `,`. That reconciles the migration's
+ * one-arm-per-line layout with ClickHouse's own single-line rendering, so the pre-image can be
+ * recorded here as production printed it rather than reformatted to match the migration.
+ *
+ * This is a blunt normaliser and it does NOT respect quoted literals — a literal containing
+ * whitespace, a paren or a comma would be rewritten. No literal in this statement contains
+ * any of those (they are `'<Type>_Create'` names and one `'2024-04-27'`), so it is safe here
+ * and would need revisiting if one were ever added. It rewrites NOTHING except whitespace and
+ * those three punctuation marks — digits, signs and identifiers are untouched — so both
+ * mutations above survive normalisation and fail the comparison rather than being normalised
+ * away. That is not reasoning: it is the M-A/M-B result recorded in the PR.
+ */
+const normalizeSql = (sql: string) =>
+  sql
+    .replace(/\s+/g, ' ')
+    .replace(/ *([(),]) */g, '$1')
+    .trim();
+
+/**
+ * The live `reactions_owner_scores_mv` SELECT, as read from production with
+ * `SHOW CREATE TABLE` on 2026-09-08 (reproduced verbatim in the section 4 header of
+ * ../migrations/2026-09-07-reaction-report-enum-widening.sql), with `'Post_Create'` appended
+ * to the IN list and NOTHING else changed. That single added value is the entire intended
+ * delta of section 4.
+ *
+ * Written in ClickHouse's own rendering rather than the migration's layout, on purpose: this
+ * is a transcription of production plus one reviewed edit, not a copy of the statement it
+ * checks, and it should be readable as such.
+ *
+ * 🔴 Do NOT edit this to make a failing migration pass. A disagreement means either the
+ * migration is rewriting the view in a way nobody reviewed, or production has moved and the
+ * pre-image in the migration is stale. Both are findings. Re-read `SHOW CREATE TABLE`, update
+ * this constant and the migration's pre-image together, and say why.
+ */
+const EXPECTED_MV_SELECT = `
+  SELECT
+      ownerId,
+      sum(multiIf((type IN ('Image_Create', 'Comment_Create', 'CommentV2_Create', 'Review_Create', 'Question_Create', 'Answer_Create', 'BountyEntry_Create', 'Article_Create', 'Post_Create')), 1, -1)) AS score
+  FROM default.reactions
+  WHERE (time < parseDateTimeBestEffort('2024-04-27')) OR (userId != ownerId)
+  GROUP BY ownerId
+`;
+
 const mvBlocks = sqlFiles.flatMap(({ name, raw }) =>
   [...stripComments(raw).matchAll(MV_QUERY_RE)].map((m) => {
-    const inList = /type\s+IN\s*\(([^)]*)\)/i.exec(m[1]);
+    // 🔴 ALL `type IN (...)` occurrences, not the first. `plusOne` is parsed from the first
+    // one, so a second would decide part of the +1 semantics without ever being checked;
+    // `inListCount` is asserted to be exactly 1 so that stays impossible rather than silent.
+    const inLists = [...m[1].matchAll(/type\s+IN\s*\(([^)]*)\)/gi)];
     return {
       file: name,
+      body: m[1],
+      inListCount: inLists.length,
       plusOne: new Set<string>(
-        inList ? [...inList[1].matchAll(/'([A-Za-z0-9_]+)'/g)].map((a) => a[1]) : []
+        inLists[0] ? [...inLists[0][1].matchAll(/'([A-Za-z0-9_]+)'/g)].map((a) => a[1]) : []
       ),
     };
   })
@@ -238,7 +303,26 @@ const COLUMNS: readonly ColumnSpec[] = [
   },
 ];
 
-/** Effective definition: the newest migration that states the column, else the baseline. */
+/**
+ * Effective definition: the newest migration that states the column, else the baseline.
+ *
+ * 🔴 STATED PLAINLY, BECAUSE EVERY FAILURE MESSAGE BELOW READS LIKE A CLAIM ABOUT PRODUCTION
+ * AND IS NOT ONE. `lastBlockFor` returns the newest migration that STATES the column —
+ * applied or not. Nothing in this file connects to ClickHouse, so it cannot distinguish an
+ * applied migration from a file somebody merely wrote. "the column" in the messages below
+ * means "the column as this repo describes it".
+ *
+ * That is not a theoretical gap. At the time of writing, `reactions.type` gains 'Post_Create'
+ * in the 2026-09-07 migration, section 3 of which is UNAPPLIED — so production rejects that
+ * value client-side, on every post reaction, while this suite is fully green. The guard is
+ * green on the very defect it was written for.
+ *
+ * So: this catches "the app gained a value and nobody wrote a migration". It does NOT catch
+ * "a migration was written and never run", and nothing here can be strengthened to catch it,
+ * because the evidence lives in a system this test does not talk to. The only things that
+ * close that half are applying the DDL and running the positive-control queries in the
+ * migration's POST-APPLY block. Do not read a green here as either of those having happened.
+ */
 const effectiveArms = (spec: ColumnSpec) => lastBlockFor(spec.column)?.arms ?? spec.baseline;
 
 describe('tracker enum drift (reactions + reports)', () => {
@@ -278,6 +362,16 @@ describe('tracker enum drift (reactions + reports)', () => {
         1
       );
       expect(mvBlocks[mvBlocks.length - 1].plusOne.size).toBeGreaterThan(0);
+    });
+
+    it('derives the +1 list from exactly one type IN (...) list', () => {
+      const mv = mvBlocks[mvBlocks.length - 1];
+      expect(
+        mv.inListCount,
+        `${mv.file}: the MODIFY QUERY contains ${mv.inListCount} \`type IN (...)\` lists. ` +
+          `The +1 set is parsed from the FIRST one, so with any other number the coupling ` +
+          `check below is reasoning about part of the statement while the rest goes unread.`
+      ).toBe(1);
     });
   });
 
@@ -349,6 +443,36 @@ describe('tracker enum drift (reactions + reports)', () => {
         `${block.file}: ${block.column} reuses an index — two names would collapse onto one value`
       ).toBe(indices.length);
     }
+  });
+
+  /**
+   * 🔴 THE WHOLE STATEMENT, NOT THE IN LIST. The coupling test below pins the +1 list against
+   * `reactions.type`, which is the right property for that one list and says nothing at all
+   * about everything else `MODIFY QUERY` replaces: the multiIf arms, the WHERE, the FROM, the
+   * GROUP BY.
+   *
+   * Measured: inverting the multiIf arms and moving the self-reaction cutoff to 2099, together,
+   * fail THIS assertion and nothing else — every other test in this file, the coupling test
+   * included, stays green under both. Before this assertion existed that was the whole result:
+   * a fully green suite over a statement that silently rewrites every user's all-time score.
+   */
+  it('reactions_owner_scores_mv MODIFY QUERY is the live view plus exactly the one added value', () => {
+    const mv = mvBlocks[mvBlocks.length - 1];
+    expect(
+      normalizeSql(mv.body),
+      `${mv.file}: the reactions_owner_scores_mv MODIFY QUERY does not match the live view ` +
+        `definition with 'Post_Create' added and nothing else changed.\n` +
+        `MODIFY QUERY replaces the WHOLE SELECT of a live view maintaining every user's ` +
+        `all-time reaction score, so an edit anywhere in it — the multiIf arms, the ` +
+        `2024-04-27 self-reaction cutoff, the FROM, the GROUP BY — rewrites that score for ` +
+        `everyone, with nothing about applying it looking wrong. Inverting the multiIf arms ` +
+        `scores every reaction -1; moving the cutoff lets a user farm their own score. ` +
+        `Neither touches the IN list, so the set-equality check below stays green under both ` +
+        `— which is why this assertion exists and why a substring check is not enough.\n` +
+        `The expected text is EXPECTED_MV_SELECT in this file, transcribed from a ` +
+        `SHOW CREATE TABLE read; the same pre-image is recorded in the migration's section 4 ` +
+        `header. If production has legitimately moved, re-read it, update BOTH, and say why.`
+    ).toBe(normalizeSql(EXPECTED_MV_SELECT));
   });
 
   /**

--- a/src/server/clickhouse/__tests__/tracker-enum-drift.test.ts
+++ b/src/server/clickhouse/__tests__/tracker-enum-drift.test.ts
@@ -124,7 +124,7 @@ const MV_QUERY_RE =
  * and would need revisiting if one were ever added. It rewrites NOTHING except whitespace and
  * those three punctuation marks — digits, signs and identifiers are untouched — so both
  * mutations above survive normalisation and fail the comparison rather than being normalised
- * away. That is not reasoning: it is the M-A/M-B result recorded in the PR.
+ * away. That is not reasoning about the regex: it is the measured M11/M12 result in the PR.
  */
 const normalizeSql = (sql: string) =>
   sql

--- a/src/server/clickhouse/__tests__/tracker-enum-drift.test.ts
+++ b/src/server/clickhouse/__tests__/tracker-enum-drift.test.ts
@@ -469,9 +469,14 @@ describe('tracker enum drift (reactions + reports)', () => {
         `scores every reaction -1; moving the cutoff lets a user farm their own score. ` +
         `Neither touches the IN list, so the set-equality check below stays green under both ` +
         `— which is why this assertion exists and why a substring check is not enough.\n` +
-        `The expected text is EXPECTED_MV_SELECT in this file, transcribed from a ` +
-        `SHOW CREATE TABLE read; the same pre-image is recorded in the migration's section 4 ` +
-        `header. If production has legitimately moved, re-read it, update BOTH, and say why.`
+        `The expected text is EXPECTED_MV_SELECT in this file. 🔴 It is the POST-image — the ` +
+        `live view WITH 'Post_Create' added. The migration's section 4 header records the ` +
+        `PRE-image, WITHOUT it, and that copy is the rollback text. They are deliberately ` +
+        `different strings; never sync one from the other. Once section 4 is applied a fresh ` +
+        `SHOW CREATE TABLE returns the POST-image, so pasting that read into the section 4 ` +
+        `header overwrites the rollback text with the state it exists to undo. If production ` +
+        `has legitimately moved: update EXPECTED_MV_SELECT from the read, derive the ` +
+        `pre-image by removing 'Post_Create' from it, and say why in the commit.`
     ).toBe(normalizeSql(EXPECTED_MV_SELECT));
   });
 

--- a/src/server/clickhouse/migrations/2026-09-07-reaction-report-enum-widening.sql
+++ b/src/server/clickhouse/migrations/2026-09-07-reaction-report-enum-widening.sql
@@ -3,9 +3,11 @@
 -- Apply this MANUALLY. We do not auto-run DDL (same policy as the Postgres migrations).
 --
 -- 🔴 THIS FILE IS PART "ALREADY APPLIED", PART "STILL TO APPLY". Read the section headers.
--- Sections 1 and 2 were applied by hand on 2026-09-07 and are recorded here so the history
--- exists in the repo and so the drift guard can see the definitions. Sections 3, 4 and 5
--- have NOT been applied.
+-- Sections 1, 2 and 5 were applied by hand — 1 and 2 on 2026-09-07, 5 on 2026-09-08 — and are
+-- recorded here so the history exists in the repo and so the drift guard can see the
+-- definitions. Sections 3 and 4 have NOT been applied. The sections are numbered in the order
+-- they were WRITTEN, not the order they were applied, so the numbering is not a running order:
+-- each section header carries its own status and that is the only thing to trust here.
 --
 -- WHY THIS FILE EXISTS AT ALL. The enum-drift guard in this directory's sibling test only
 -- ever covered `actions.type`. Every other enum column the tracker writes was unchecked,
@@ -35,7 +37,8 @@
 -- must be restarted so it re-reads the column schema, or the ALTER verifies perfectly and
 -- the value still collects ZERO rows. See ./README.md — this has shipped broken twice.
 --
--- Every section below appends at an unused index, which is a metadata-only ALTER: no data
+-- Every ENUM section below (1, 2, 3, 5 — section 4 is a MODIFY QUERY, not a column change)
+-- appends at an unused index, which is a metadata-only ALTER: no data
 -- is rewritten and no mutation is scheduled. `MODIFY COLUMN` REPLACES the whole enum
 -- definition, so each statement restates every existing value at exactly the index it
 -- already has. Do NOT renumber or rename an existing value; that WOULD rewrite the table
@@ -99,6 +102,21 @@ ALTER TABLE default.reports
 --
 --    If you apply only one of the two, apply NEITHER. Dropping post reactions for another
 --    day is strictly better than corrupting owner scores for an hour.
+--
+-- 🔴 "IN ONE SITTING" IS NOT, BY ITSELF, PROTECTION — the window is opened by a pod restart
+--    you do not control. The tracker builds its serializers from the schema it reads at
+--    connect time, so the moment any tracker pod restarts after section 3 lands it starts
+--    ACCEPTING 'Post_Create', with section 4 still unapplied. That deployment has been
+--    observed replacing its pods on its own, with no human action, on the order of every few
+--    hours — so the interval between the two statements is a live risk window, not a
+--    formality, and working quickly narrows it rather than closing it.
+--
+--    Rows that land in that window are scored -1 by the old view body, and a materialized
+--    view does NOT backfill: section 4 changes what is computed from the moment it is applied
+--    and repairs nothing already written to `reactions_owner_scores`. So apply section 4
+--    IMMEDIATELY after section 3 — and afterwards run the window query in the POST-APPLY
+--    block at the foot of this file to find out whether anything landed in between. That
+--    query is the only way to learn it happened; nothing alerts on it.
 -- =====================================================================================
 
 ALTER TABLE default.reactions
@@ -128,12 +146,45 @@ ALTER TABLE default.reactions
 -- 4. reactions_owner_scores_mv — ⚠️ NOT YET APPLIED. THE OTHER HALF OF SECTION 3.
 --
 --    Adds 'Post_Create' to the +1 list. Everything not in this list scores -1, which is
---    why this cannot lag behind section 3 by even one deploy. The rest of the query —
---    the target table, the 2024-04-27 self-reaction cutoff, the GROUP BY — is restated
---    byte-for-byte from the live definition; MODIFY QUERY replaces the whole SELECT.
+--    why this cannot lag behind section 3 by even one deploy.
 --
 --    'Post_Delete' is deliberately NOT added: a delete is a -1, which is what the
 --    fall-through arm already gives it. Only the '*_Create' half of a pair belongs here.
+--
+-- 🔴 MODIFY QUERY REPLACES THE WHOLE SELECT, AND THIS VIEW MAINTAINS EVERY USER'S ALL-TIME
+--    REACTION SCORE. `reactions_owner_scores` is read by `getReactionTasks` in
+--    src/server/metrics/user.metrics.ts, which is where the number reaches users. So an edit
+--    ANYWHERE in the statement below — the multiIf arms, the 2024-04-27 self-reaction cutoff,
+--    the FROM, the GROUP BY — silently rewrites that score for everyone, and nothing about
+--    applying it would look wrong. Two concrete examples, both of which leave the IN list
+--    untouched and so pass any check that only reads the IN list: swapping the multiIf arms
+--    (`, 1, -1)` -> `, -1, 1)`) scores every reaction -1; moving the cutoff forward disables
+--    the self-reaction exclusion, so a user can farm their own score.
+--
+--    The rest of the query is therefore NOT a claim to take on trust. It is the live
+--    definition, recorded below, and `tracker-enum-drift.test.ts` pins the whole statement
+--    (whitespace-normalised) against that pre-image plus the one added value.
+--
+-- 🔴 THE LIVE PRE-IMAGE — read verbatim from production with
+--    `SHOW CREATE TABLE default.reactions_owner_scores_mv` on 2026-09-08, i.e. after
+--    sections 1, 2 and 5 were applied and while sections 3 and 4 are still unapplied:
+--
+--      CREATE MATERIALIZED VIEW default.reactions_owner_scores_mv TO default.reactions_owner_scores
+--      (
+--          `ownerId` Int32,
+--          `score` Int64
+--      )
+--      AS SELECT
+--          ownerId,
+--          sum(multiIf((type IN ('Image_Create', 'Comment_Create', 'CommentV2_Create', 'Review_Create', 'Question_Create', 'Answer_Create', 'BountyEntry_Create', 'Article_Create')), 1, -1)) AS score
+--      FROM default.reactions
+--      WHERE (time < parseDateTimeBestEffort('2024-04-27')) OR (userId != ownerId)
+--      GROUP BY ownerId
+--
+--    TO ROLL BACK: re-run the MODIFY QUERY below with 'Post_Create' removed from the IN list
+--    and nothing else changed — that is exactly the SELECT above. 🔴 Roll back ONLY together
+--    with reverting section 3; a narrowed view against a widened column is the sign-inversion
+--    corruption described in section 3, arrived at from the other direction.
 -- =====================================================================================
 
 ALTER TABLE default.reactions_owner_scores_mv
@@ -157,14 +208,26 @@ ALTER TABLE default.reactions_owner_scores_mv
 
 
 -- =====================================================================================
--- 5. reports.entityType — ⚠️ NOT YET APPLIED. A FOURTH GAP, found by the new guard.
+-- 5. reports.entityType — ✅ APPLIED TO PRODUCTION 2026-09-08T04:04:14Z. A FOURTH GAP,
+--    found by the new guard, and applied by hand AFTER this file was first written — which
+--    is why it sits below sections 3 and 4 and is nonetheless already live.
 --
 --    The report form accepts every member of the ReportEntity enum
---    (src/shared/utils/report-helpers.ts), but the column stops at 'chat' = 12. Reports
---    filed against a challenge, a comic project, a 3D model or a 3D-model review are
---    therefore dropped by the tracker today, exactly like the three gaps above. The
---    report itself is written to Postgres normally — only the ClickHouse analytics row
---    is lost — so this is under-reporting in moderation analytics, not lost moderation.
+--    (src/shared/utils/report-helpers.ts), but the column stopped at 'chat' = 12. Reports
+--    filed against a challenge, a comic project, a 3D model or a 3D-model review were
+--    therefore dropped by the tracker, exactly like the three gaps above. The COLUMN half of
+--    that was closed at 2026-09-08T04:04:14Z; see the restart caveat below before reading
+--    that as the end of the loss. The report itself is written to Postgres normally — only
+--    the ClickHouse analytics row was lost — so this was under-reporting in moderation
+--    analytics, not lost moderation.
+--
+--    ⚠️ THE TRACKER-RESTART HALF IS NOT RECORDED HERE. Sections 1 and 2 note the restart
+--    explicitly because it was observed; for this section it was not, so treat 'is the
+--    tracker actually writing these four values' as OPEN until the entityType positive
+--    control in the POST-APPLY block below returns non-zero. The DDL landing is not the
+--    same claim — that is this whole file's point.
+--
+--    Recorded here for history; re-applying it is a no-op.
 --
 --    Independent of sections 3 and 4: no materialized view reads `reports`.
 -- =====================================================================================
@@ -204,8 +267,33 @@ ALTER TABLE default.reports
 --     -- `entityType` must show 13..16 added, with 1..12 unchanged.
 --
 --   SHOW CREATE TABLE default.reactions_owner_scores_mv;
---     -- the IN list must contain 'Post_Create'. 🔴 If section 3 is live and this is not,
---     -- STOP: post reactions are actively decrementing owner scores.
+--     -- 🔴 DIFF THE WHOLE STATEMENT against the pre-image recorded in section 4's header.
+--     -- Checking that the IN list contains 'Post_Create' is NOT sufficient and must not be
+--     -- what you do here: MODIFY QUERY replaced the entire SELECT, so a swapped multiIf sign
+--     -- or a moved 2024-04-27 cutoff passes that check while changing every user's all-time
+--     -- reaction score. The ONLY difference from the pre-image you should see is one added
+--     -- element at the end of the IN list:
+--     --     ..., 'Article_Create', 'Post_Create')), 1, -1)) AS score
+--     -- Everything else — `multiIf(..., 1, -1)`, `parseDateTimeBestEffort('2024-04-27')`,
+--     -- `userId != ownerId`, `FROM default.reactions`, `GROUP BY ownerId` — must be
+--     -- character-identical ONCE WHITESPACE IS COLLAPSED. ClickHouse re-renders the statement
+--     -- from its own parse rather than echoing what you sent, so its layout will not match
+--     -- what you pasted; that difference is expected and is the only one that is.
+--     -- 🔴 If section 3 is live and this is not, STOP: post reactions are actively
+--     -- decrementing owner scores.
+--
+--   Did any post reaction land in the gap between section 3 and section 4? Those rows scored
+--   -1, and a materialized view does not backfill, so section 4 does NOT repair them:
+--
+--   SELECT count() FROM default.reactions
+--   WHERE type = 'Post_Create' AND time < '<the UTC instant section 4 was applied>';
+--     -- Write the instant down when you run section 4 rather than reconstructing it later.
+--     -- Non-zero means that many post reactions were scored -1 where they should have scored
+--     -- +1, so each affected owner's all-time score is low by 2 per such reaction.
+--     -- `reactions_owner_scores` is an aggregate with no source of truth to rebuild from, so
+--     -- record the count and the affected ownerIds rather than assuming it washes out.
+--     -- 'Post_Delete' is deliberately excluded: it scores -1 under both the old and the new
+--     -- view body, so it cannot be mis-scored.
 --
 -- Positive control, AFTER the tracker has been restarted — react to a post, then:
 --
@@ -219,3 +307,22 @@ ALTER TABLE default.reports
 --   WHERE nsfw = 'Blocked' AND time > now() - INTERVAL 1 DAY;
 --     -- non-zero since 2026-09-07 confirms section 1 is landing rows rather than merely
 --     -- existing in the schema.
+--
+--   Section 5's positive control — the one that decides whether the tracker restart half of
+--   that section ever happened. The DDL landed 2026-09-08T04:04:14Z; a restart was NOT
+--   recorded, and until this returns rows the four widened values are still capable of being
+--   rejected client-side by pods that connected before the ALTER:
+--
+--   SELECT entityType, count() FROM default.reports
+--   WHERE entityType IN ('challenge', 'comicProject', 'model3d', 'model3dReview')
+--   GROUP BY entityType;
+--     -- No time predicate is needed and none is used: the column could not REPRESENT these
+--     -- four values before 2026-09-08T04:04:14Z, so any row carrying one necessarily postdates
+--     -- the ALTER. (Written this way deliberately — this file has not verified what the
+--     -- `reports` table's timestamp column is called.)
+--     -- 🔴 A zero here is ambiguous and must not be read as "fixed": it is equally consistent
+--     -- with "the tracker was never restarted" and with "nobody has reported one of these
+--     -- four entity types yet". Nobody has measured how often these four are reported, so
+--     -- there is no basis for treating a zero as surprising. To settle it, file one report
+--     -- against a challenge yourself and re-run — that converts an absence, which cannot
+--     -- distinguish those two causes, into a real positive control, which can.

--- a/src/server/clickhouse/migrations/2026-09-07-reaction-report-enum-widening.sql
+++ b/src/server/clickhouse/migrations/2026-09-07-reaction-report-enum-widening.sql
@@ -1,0 +1,221 @@
+-- Reaction + report enum widening — ClickHouse DDL.
+--
+-- Apply this MANUALLY. We do not auto-run DDL (same policy as the Postgres migrations).
+--
+-- 🔴 THIS FILE IS PART "ALREADY APPLIED", PART "STILL TO APPLY". Read the section headers.
+-- Sections 1 and 2 were applied by hand on 2026-09-07 and are recorded here so the history
+-- exists in the repo and so the drift guard can see the definitions. Sections 3, 4 and 5
+-- have NOT been applied.
+--
+-- WHY THIS FILE EXISTS AT ALL. The enum-drift guard in this directory's sibling test only
+-- ever covered `actions.type`. Every other enum column the tracker writes was unchecked,
+-- and three of them had drifted:
+--
+--   * `reactions.nsfw` did not carry 'Blocked', which the app has emitted since
+--     NsfwLevelDeprecated gained that member. Measured over a 2h38m window on 2026-09-07:
+--     7 of 10 tracker rejections were this one value, all from real users — on the order of
+--     ~387 rows/day discarded.
+--   * `reports.reason` did not carry 'Spam' or 'StickerPlacement', both of which exist in
+--     the Prisma ReportReason enum and are reachable from the report form.
+--   * `reactions.type` does not carry 'Post_Create' or 'Post_Delete', which the reaction
+--     controller has constructed in its `case 'post':` branch for as long as that branch
+--     has existed. An `as ReactionType` cast at the call site is why the type system never
+--     saw it; that cast is removed in the same change as this file.
+--
+-- 🔴 THE FAILURE IS SILENT AND CLIENT-SIDE. The app POSTs to the tracker service
+-- fire-and-forget; a value the target column does not carry is rejected THERE, while it is
+-- serializing the batch, before ClickHouse is ever asked. So the caller sees a successful
+-- send, the app logs nothing, `SHOW CREATE TABLE` looks fine, and the rows simply never
+-- exist. A dashboard over them reads a clean zero that is indistinguishable from
+-- "nobody did this".
+--
+-- 🔴 THE DDL IS ONLY HALF THE OPERATION. `civitai-clickhouse-tracker` builds its column
+-- serializers from the schema its pods read AT CONNECT TIME and never re-reads them, so a
+-- value added after those pods booted is still rejected client-side. The tracker service
+-- must be restarted so it re-reads the column schema, or the ALTER verifies perfectly and
+-- the value still collects ZERO rows. See ./README.md — this has shipped broken twice.
+--
+-- Every section below appends at an unused index, which is a metadata-only ALTER: no data
+-- is rewritten and no mutation is scheduled. `MODIFY COLUMN` REPLACES the whole enum
+-- definition, so each statement restates every existing value at exactly the index it
+-- already has. Do NOT renumber or rename an existing value; that WOULD rewrite the table
+-- and silently remap existing rows.
+--
+-- POST-APPLY: restart civitai-clickhouse-tracker by pod delete, then confirm with a real event.
+
+
+-- =====================================================================================
+-- 1. reactions.nsfw — ✅ APPLIED TO PRODUCTION 2026-09-07T23:00:20Z (tracker restarted)
+--
+--    Adds 'Blocked' = 5. Recorded here for history; re-applying it is a no-op.
+--    'Undefined' = 0 has no counterpart in NsfwLevelDeprecated and is kept as-is — the
+--    column is allowed to be wider than the app domain, never narrower.
+-- =====================================================================================
+
+ALTER TABLE default.reactions
+  MODIFY COLUMN `nsfw` Enum8(
+    'Undefined' = 0,
+    'None' = 1,
+    'Soft' = 2,
+    'Mature' = 3,
+    'X' = 4,
+    'Blocked' = 5
+  );
+
+
+-- =====================================================================================
+-- 2. reports.reason — ✅ APPLIED TO PRODUCTION 2026-09-07T23:00:20Z (tracker restarted)
+--
+--    Adds 'Spam' = 8 and 'StickerPlacement' = 9, matching the Prisma ReportReason enum.
+--    Recorded here for history; re-applying it is a no-op.
+-- =====================================================================================
+
+ALTER TABLE default.reports
+  MODIFY COLUMN `reason` Enum8(
+    'TOSViolation' = 1,
+    'NSFW' = 2,
+    'Ownership' = 3,
+    'AdminAttention' = 4,
+    'Claim' = 5,
+    'CSAM' = 6,
+    'Automated' = 7,
+    'Spam' = 8,
+    'StickerPlacement' = 9
+  );
+
+
+-- =====================================================================================
+-- 3. reactions.type — ⚠️ NOT YET APPLIED. Adds 'Post_Create' = 17, 'Post_Delete' = 18.
+--
+-- 🔴🔴 SECTIONS 3 AND 4 ARE ONE OPERATION. APPLY BOTH, IN THIS ORDER, IN ONE SITTING.
+--
+--    `reactions_owner_scores_mv` (section 4) scores a reaction +1 if its type is in an
+--    explicit list of '*_Create' values and **-1 for everything else**. There is no
+--    "unknown" arm. So widening this column WITHOUT widening that list does not merely
+--    fail to count post reactions — it makes every single one of them DECREMENT the
+--    content owner's score. That converts the current, recoverable failure (rows are
+--    dropped) into an unrecoverable one (rows land, carrying the wrong sign, into an
+--    aggregate that has no source of truth to rebuild from).
+--
+--    If you apply only one of the two, apply NEITHER. Dropping post reactions for another
+--    day is strictly better than corrupting owner scores for an hour.
+-- =====================================================================================
+
+ALTER TABLE default.reactions
+  MODIFY COLUMN `type` Enum8(
+    'Image_Create' = 1,
+    'Image_Delete' = 2,
+    'Comment_Create' = 3,
+    'Comment_Delete' = 4,
+    'CommentV2_Create' = 5,
+    'CommentV2_Delete' = 6,
+    'Review_Create' = 7,
+    'Review_Delete' = 8,
+    'Question_Create' = 9,
+    'Question_Delete' = 10,
+    'Answer_Create' = 11,
+    'Answer_Delete' = 12,
+    'BountyEntry_Create' = 13,
+    'BountyEntry_Delete' = 14,
+    'Article_Create' = 15,
+    'Article_Delete' = 16,
+    'Post_Create' = 17,
+    'Post_Delete' = 18
+  );
+
+
+-- =====================================================================================
+-- 4. reactions_owner_scores_mv — ⚠️ NOT YET APPLIED. THE OTHER HALF OF SECTION 3.
+--
+--    Adds 'Post_Create' to the +1 list. Everything not in this list scores -1, which is
+--    why this cannot lag behind section 3 by even one deploy. The rest of the query —
+--    the target table, the 2024-04-27 self-reaction cutoff, the GROUP BY — is restated
+--    byte-for-byte from the live definition; MODIFY QUERY replaces the whole SELECT.
+--
+--    'Post_Delete' is deliberately NOT added: a delete is a -1, which is what the
+--    fall-through arm already gives it. Only the '*_Create' half of a pair belongs here.
+-- =====================================================================================
+
+ALTER TABLE default.reactions_owner_scores_mv
+  MODIFY QUERY
+    SELECT
+      ownerId,
+      sum(multiIf((type IN (
+        'Image_Create',
+        'Comment_Create',
+        'CommentV2_Create',
+        'Review_Create',
+        'Question_Create',
+        'Answer_Create',
+        'BountyEntry_Create',
+        'Article_Create',
+        'Post_Create'
+      )), 1, -1)) AS score
+    FROM default.reactions
+    WHERE (time < parseDateTimeBestEffort('2024-04-27')) OR (userId != ownerId)
+    GROUP BY ownerId;
+
+
+-- =====================================================================================
+-- 5. reports.entityType — ⚠️ NOT YET APPLIED. A FOURTH GAP, found by the new guard.
+--
+--    The report form accepts every member of the ReportEntity enum
+--    (src/shared/utils/report-helpers.ts), but the column stops at 'chat' = 12. Reports
+--    filed against a challenge, a comic project, a 3D model or a 3D-model review are
+--    therefore dropped by the tracker today, exactly like the three gaps above. The
+--    report itself is written to Postgres normally — only the ClickHouse analytics row
+--    is lost — so this is under-reporting in moderation analytics, not lost moderation.
+--
+--    Independent of sections 3 and 4: no materialized view reads `reports`.
+-- =====================================================================================
+
+ALTER TABLE default.reports
+  MODIFY COLUMN `entityType` Enum8(
+    'model' = 1,
+    'comment' = 2,
+    'commentV2' = 3,
+    'image' = 4,
+    'resourceReview' = 5,
+    'article' = 6,
+    'post' = 7,
+    'reportedUser' = 8,
+    'collection' = 9,
+    'bounty' = 10,
+    'bountyEntry' = 11,
+    'chat' = 12,
+    'challenge' = 13,
+    'comicProject' = 14,
+    'model3d' = 15,
+    'model3dReview' = 16
+  );
+
+
+-- =====================================================================================
+-- POST-APPLY verification. Run all of it; a bare zero from any of these proves nothing on
+-- its own, which is the whole failure mode this file documents.
+-- =====================================================================================
+--
+--   SHOW CREATE TABLE default.reactions;
+--     -- `type` must show 'Post_Create' = 17 and 'Post_Delete' = 18, with 1..16 unchanged.
+--     -- `nsfw` must show 'Blocked' = 5.
+--
+--   SHOW CREATE TABLE default.reports;
+--     -- `reason` must show 'Spam' = 8 and 'StickerPlacement' = 9, with 1..7 unchanged.
+--     -- `entityType` must show 13..16 added, with 1..12 unchanged.
+--
+--   SHOW CREATE TABLE default.reactions_owner_scores_mv;
+--     -- the IN list must contain 'Post_Create'. 🔴 If section 3 is live and this is not,
+--     -- STOP: post reactions are actively decrementing owner scores.
+--
+-- Positive control, AFTER the tracker has been restarted — react to a post, then:
+--
+--   SELECT type, count() FROM default.reactions
+--   WHERE type IN ('Post_Create', 'Post_Delete') AND time > now() - INTERVAL 1 HOUR
+--   GROUP BY type;
+--     -- must be non-zero. A zero here means the tracker was not restarted (its serializers
+--     -- predate the ALTER), NOT that the enum is missing — this file rules the enum out.
+--
+--   SELECT count() FROM default.reactions
+--   WHERE nsfw = 'Blocked' AND time > now() - INTERVAL 1 DAY;
+--     -- non-zero since 2026-09-07 confirms section 1 is landing rows rather than merely
+--     -- existing in the schema.

--- a/src/server/clickhouse/migrations/README.md
+++ b/src/server/clickhouse/migrations/README.md
@@ -3,6 +3,26 @@
 These are applied **manually**. Nothing auto-runs DDL here (same policy as the Postgres
 migrations).
 
+## 🔴 This applies to EVERY enum column the tracker writes, not just `actions.type`
+
+The rest of this file is written around `actions.type` because that is where the trap was
+first measured. **The mechanism is not specific to that column**, and reading it as if it
+were is what let three other columns drift unnoticed until 2026-09-07:
+
+| column               | missing value(s)             | found                                            |
+| -------------------- | ---------------------------- | ------------------------------------------------ |
+| `reactions.nsfw`     | `Blocked`                    | 7 of 10 rejections in a 2h38m window, real users |
+| `reports.reason`     | `Spam`, `StickerPlacement`   | same sweep                                       |
+| `reactions.type`     | `Post_Create`, `Post_Delete` | same sweep                                       |
+| `reports.entityType` | `challenge` + 3 more         | while writing the guard below                    |
+
+`__tests__/tracker-enum-drift.test.ts` now checks each of those columns against its
+app-side domain, and enforces the same `POST-APPLY:` marker on any migration that widens
+one. `2026-09-07-reaction-report-enum-widening.sql` is the worked example — read its
+section 3/4 pair before widening `reactions.type` again: that column has a dependent
+materialized view whose scoring list must be widened in the same operation, and applying
+one without the other turns dropped rows into wrongly-signed rows.
+
 ## 🔴 Widening `actions.type` is a TWO-STEP operation. The `ALTER` alone is inert.
 
 **Apply the DDL, then restart the tracker.** Skipping the restart ships a feature that
@@ -76,13 +96,15 @@ everything in between.** A `min(time)` of far-future-relative-to-the-migration i
 
 ## The `POST-APPLY:` marker is enforced
 
-Every migration that widens `actions.type` must carry this line verbatim:
+Every migration that widens `actions.type`, or any of the `reactions`/`reports` enum columns
+listed at the top of this file, must carry this line verbatim:
 
 ```
 -- POST-APPLY: restart civitai-clickhouse-tracker by pod delete, then confirm with a real event.
 ```
 
-`__tests__/action-type-enum-drift.test.ts` fails without it. It is pinned as an exact string
+`__tests__/action-type-enum-drift.test.ts` and `__tests__/tracker-enum-drift.test.ts` fail
+without it — they pin the same constant. It is pinned as an exact string
 rather than matched loosely on purpose: a guard that accepts any sentence mentioning "restart"
 is walkable by rewording, and the whole point is that the next person copying an existing
 migration inherits the step rather than inheriting only the parts that look important.

--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -20,6 +20,7 @@ import type {
 } from '~/server/schema/track.schema';
 import type { ProhibitedSources } from '~/server/schema/user.schema';
 import type { NsfwLevelDeprecated } from '~/shared/constants/browsingLevel.constants';
+import type { ReportEntity } from '~/shared/utils/report-helpers';
 import dayjs from '~/shared/utils/dayjs';
 import type {
   ArticleEngagementType,
@@ -833,9 +834,18 @@ export class Tracker {
     return this.track('prohibitedRequests', values);
   }
 
+  /**
+   * 🔴 `entityType` is `ReportEntity`, not `string`. It was `string`, which is the same
+   * type-laundering this change removes from the reaction path: a bare `string` here means
+   * every value the app can invent type-checks against a column that is an Enum8 of a fixed
+   * set of names, and the tracker rejects anything outside it CLIENT-SIDE, silently. The
+   * drift guard names `ReportEntity` as the source of truth for `reports.entityType`; the
+   * parameter has to agree with the guard or the guard is checking a domain the code does not
+   * actually constrain.
+   */
   public report(values: {
     type: ReportType;
-    entityType: string;
+    entityType: ReportEntity;
     entityId: number;
     reason: ReportReason;
     status: ReportStatus;

--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -93,24 +93,44 @@ export type ModelActivty =
   | 'PermanentDelete'
   | 'Transfer';
 export type ResourceReviewType = 'Create' | 'Delete' | 'Exclude' | 'Include' | 'Update';
-export type ReactionType =
-  | 'Image_Create'
-  | 'Image_Delete'
-  | 'Comment_Create'
-  | 'Comment_Delete'
-  | 'CommentV2_Create'
-  | 'CommentV2_Delete'
-  | 'Review_Create'
-  | 'Review_Delete'
-  | 'Question_Create'
-  | 'Question_Delete'
-  | 'Answer_Create'
-  | 'Answer_Delete'
-  | 'BountyEntry_Create'
-  | 'BountyEntry_Delete'
-  | 'Article_Create'
-  | 'Article_Delete';
-export type ReportType = 'Create' | 'StatusChange';
+/**
+ * The `reactions.type` Enum8, in index order.
+ *
+ * 🔴 A runtime array rather than a bare union ON PURPOSE, and the order is the column's
+ * index order. `__tests__/tracker-enum-drift.test.ts` enumerates this at runtime and
+ * checks every member against the migrations that define the column — a union cannot be
+ * enumerated, so as a union this domain was structurally unguardable and drifted unseen.
+ *
+ * 🔴 `Post_Create`/`Post_Delete` are NOT YET in the production column: they need
+ * `migrations/2026-09-07-reaction-report-enum-widening.sql`, whose reactions.type section
+ * is COUPLED to a `reactions_owner_scores_mv` change in the same file. Applying the column
+ * widening without the view turns every post reaction into a -1 on the owner's score.
+ */
+export const ReactionType = [
+  'Image_Create',
+  'Image_Delete',
+  'Comment_Create',
+  'Comment_Delete',
+  'CommentV2_Create',
+  'CommentV2_Delete',
+  'Review_Create',
+  'Review_Delete',
+  'Question_Create',
+  'Question_Delete',
+  'Answer_Create',
+  'Answer_Delete',
+  'BountyEntry_Create',
+  'BountyEntry_Delete',
+  'Article_Create',
+  'Article_Delete',
+  'Post_Create',
+  'Post_Delete',
+] as const;
+export type ReactionType = (typeof ReactionType)[number];
+
+/** The `reports.type` Enum8. Runtime array for the same reason as `ReactionType` above. */
+export const ReportType = ['Create', 'StatusChange'] as const;
+export type ReportType = (typeof ReportType)[number];
 export type ModelEngagementType = 'Hide' | 'Favorite' | 'Delete' | 'Notify';
 export type TagEngagementType = 'Hide' | 'Allow';
 export type UserEngagementType = 'Follow' | 'Hide' | 'Delete';

--- a/src/server/controllers/reaction.controller.ts
+++ b/src/server/controllers/reaction.controller.ts
@@ -23,7 +23,29 @@ import { dbRead } from '../db/client';
 import { toggleReaction } from './../services/reaction.service';
 import { hasEntityAccess } from '~/server/services/common.service';
 
-async function getTrackerEvent(input: ToggleReactionInput, result: 'removed' | 'created') {
+/**
+ * The exact payload `Tracker.reaction` accepts.
+ *
+ * 🔴 THIS ANNOTATION IS THE GUARD, NOT DOCUMENTATION. Every `type` below is built as
+ * `` `<Entity>_${action}` ``, and a template-literal expression is inferred as plain
+ * `string` unless something contextually types it. Without this return type the switch
+ * produced `string`, the call site laundered it through `as ReactionType`, and the
+ * `Post_*` arm — a value `reactions.type` does not carry — type-checked for as long as
+ * it has existed while the tracker dropped every row it produced client-side. Do not
+ * re-add a cast at the call site; fix the union or the branch instead.
+ */
+type ReactionTrackerEvent = {
+  type: ReactionType;
+  entityId: number;
+  ownerId: number;
+  reaction: ReviewReactions;
+  nsfw: NsfwLevelDeprecated;
+};
+
+async function getTrackerEvent(
+  input: ToggleReactionInput,
+  result: 'removed' | 'created'
+): Promise<ReactionTrackerEvent | undefined> {
   const shared = {
     entityId: input.entityId,
     reaction: input.reaction,
@@ -232,12 +254,7 @@ export const toggleReactionHandler = async ({
     });
     const trackerEvent = result === 'noop' ? undefined : await getTrackerEvent(input, result);
     if (trackerEvent) {
-      await ctx.track
-        .reaction({
-          ...trackerEvent,
-          type: trackerEvent.type as ReactionType,
-        })
-        .catch(handleLogError);
+      await ctx.track.reaction(trackerEvent).catch(handleLogError);
     }
 
     if (input.entityType === 'image' && result !== 'noop') {


### PR DESCRIPTION
## The class

The ClickHouse tracker rejects a row **client-side**, while serializing the batch, when the target column's enum does not carry the value. The app POSTs fire-and-forget, so:

- the caller sees a successful send,
- nothing is logged app-side,
- `SHOW CREATE TABLE` is clean, because the DDL genuinely is correct,
- and the metric reads `0` — indistinguishable from "nobody did this".

`actions.type` has had a drift guard since 2026-08-21. **Nothing else did**, and that narrowness is why the gaps below survived.

## What was found (measured on production, 2026-09-07)

| column | missing | evidence |
|---|---|---|
| `reactions.nsfw` | `Blocked` | **7 of 10 tracker rejections in a 2h38m window, all real users** — on the order of ~387 rows/day discarded |
| `reports.reason` | `Spam`, `StickerPlacement` | same sweep; both reachable from the report form |
| `reactions.type` | `Post_Create`, `Post_Delete` | same sweep; emitted by the reaction controller's `case 'post':` branch |
| `reports.entityType` | `challenge`, `comicProject`, `model3d`, `model3dReview` | **found while writing the new guard** — not in the original sweep |

## 🔴 Production state — what is applied and what is not

**Already applied by hand on 2026-09-07T23:00:20Z, tracker restarted** (recorded in the migration for history; re-applying is a no-op):

- section 1 — `reactions.nsfw` += `'Blocked' = 5`
- section 2 — `reports.reason` += `'Spam' = 8`, `'StickerPlacement' = 9`

**Also already applied — `2026-09-08T04:04:14Z`, i.e. AFTER this PR was first written:**

- section 5 — `reports.entityType` += `'challenge' = 13` … `'model3dReview' = 16`

  ⚠️ Corrected in `b45986c91d`. An earlier revision of this PR body and of the migration's section 5 header said this was unapplied and that reports on those four entity types "are dropped by the tracker today". **That is no longer true.** The DDL in the file matches live byte-for-byte, so nothing about the statement changed — only its stated status. A tracker restart after that ALTER was **not** observed, so whether the tracker is actually writing those four values is still open; the migration carries a positive-control query for it rather than assuming.

**NOT applied. Needs a human to run it, then restart the tracker service so it re-reads the column schema:**

- section 3 — `reactions.type` += `'Post_Create' = 17`, `'Post_Delete' = 18`
- section 4 — `reactions_owner_scores_mv` `MODIFY QUERY`

The sections are numbered in the order they were written, not the order they were applied, which is why an applied section sits below two unapplied ones. Each section header carries its own status.

This PR applies **no** DDL. Nothing auto-runs it.

## 🔴🔴 Sections 3 and 4 are ONE operation. Apply both or neither.

`reactions_owner_scores_mv` scores `type IN (<the '*_Create' list>)` as **+1 and everything else as −1**. There is no unknown arm.

So widening `reactions.type` **without** widening that list does not merely fail to count post reactions — **every post reaction would DECREMENT the content owner's score.** That converts the current, recoverable failure (rows are dropped; nothing was written) into an unrecoverable one (rows land with the wrong sign into an aggregate with no source of truth to rebuild from).

If you can only do one, do **neither**. Another day of dropped post reactions is strictly better than an hour of corrupted owner scores.

**"In one sitting" is not, by itself, protection.** The tracker rebuilds its column serializers from the schema it reads at connect time, so the moment any tracker pod restarts after section 3 lands it starts *accepting* `Post_Create` with section 4 still unapplied — and that deployment has been observed replacing its pods unprompted on the order of every few hours. So the interval between the two statements is a real window, and working quickly narrows it rather than closing it. A materialized view does not backfill: rows landing in that window are scored −1 **permanently**, and section 4 repairs none of them. The migration's POST-APPLY block now carries the query that detects it.

The two statements sit next to each other in the migration file, and `tracker-enum-drift.test.ts` asserts **set equality** between the column's `*_Create` values and the view's +1 list, in both directions.

### The MV statement is pinned WHOLE, not through its IN list

`MODIFY QUERY` replaces the **entire SELECT** of a live view maintaining every user's all-time reaction score (`reactions_owner_scores`, read by `getReactionTasks` in `src/server/metrics/user.metrics.ts`). The set-equality check above covers the IN list and nothing else — and the two most damaging edits both leave the IN list untouched:

- swapping the `multiIf` arms, `, 1, -1)` → `, -1, 1)`, scores **every** reaction −1;
- moving `parseDateTimeBestEffort('2024-04-27')` forward disables the self-reaction exclusion, so a user can farm their own score.

Applied together, those two left the suite **fully green**. So `b45986c91d` adds three things: the live pre-image is recorded verbatim in the migration's section 4 header (giving a rollback text, and making the former "restated byte-for-byte from the live definition" comment a checkable claim instead of load-bearing prose); the post-apply step is a **full diff against that pre-image** rather than a grep for one value; and the guard pins the **whole whitespace-normalised statement** against that pre-image plus the single added value. A companion assertion requires the +1 list to come from exactly one `type IN (...)` occurrence. ⚠️ Corrected after review: pinning the statement makes that assertion **strictly dominated**, not newly reachable — a body with more than one `type IN (...)` list also differs from `EXPECTED_MV_SELECT`, so the pin fires on it too (re-running M14 without skipping the pin fails **2** tests, not 1). It is kept for a specific, actionable failure message rather than for unique coverage.

## Why the type system never saw the `reactions.type` gap

`getTrackerEvent` builds its `type` as `` `Post_${action}` ``. A template-literal expression infers as plain `string` unless something contextually types it — and the call site laundered it through `as ReactionType`. So the one branch emitting a value the column has never carried type-checked for as long as it has existed.

The cast is removed and `getTrackerEvent` now carries an explicit return type, which contextually types every branch's constructed string against the union. All eight branches were enumerated (`image`, `post`, `article`, `commentOld`, `comment`, `question`, `answer`, `bountyEntry` × `Create`/`Delete`); `post` was the only one outside the union.

`ReactionType` and `ReportType` changed from bare unions to `as const` arrays (the `ActionType` pattern already in this file). A union cannot be enumerated at runtime, which is exactly why those domains were structurally unguardable.

## The durable fix

New `src/server/clickhouse/__tests__/tracker-enum-drift.test.ts` — **31 tests** — checks **seven** columns, each against the app-side domain that feeds it:

| column | domain |
|---|---|
| `reactions.type` | `ReactionType` (tracker) |
| `reactions.reaction` | `ReviewReactions` (Prisma) |
| `reactions.nsfw` | `NsfwLevelDeprecated` |
| `reports.type` | `ReportType` (tracker) |
| `reports.entityType` | `ReportEntity` |
| `reports.reason` | `ReportReason` (Prisma) |
| `reports.status` | `ReportStatus` (Prisma) |

Per column it asserts: every app value is in the effective definition (newest migration that states the column, else the measured production baseline); every migration restating the column reproduces the baseline names **at their existing indices** (a `MODIFY COLUMN` replaces the definition — a dropped name deletes a live value, a moved index silently remaps rows); indices are distinct; and the same verbatim `POST-APPLY:` marker the `actions.type` guard pins.

Positive controls, because every `it.each` here is driven by parsed data and a regex that matches nothing would make the whole file a green meaning "scanned zero columns": the directory has ≥8 `.sql` files; ≥5 **multi-line** `ALTER … MODIFY COLUMN` blocks parsed (these statements span two lines — a single-line regex matches zero of them); a block exists for each column this change defines, named explicitly rather than counted; the MV `MODIFY QUERY` was found; and ≥1 migration exists for the marker check to run over.

## Red-at-base / green-at-HEAD

`origin/main` @ `14302e9a9d`.

**Environmental control first** (a fresh worktree has neither `node_modules` nor the `event-engine-common` submodule; both were installed/initialised before anything below was believed): after `pnpm install` + `git submodule update --init event-engine-common`, `pnpm typecheck` on the **unmodified** tree reports `typecheck: OK — 0 type errors`. Every result below is against that baseline.

| state | result |
|---|---|
| base code + new test file only | **10 failed / 18 passed (28)** |
| base code + the `as const` conversion (16 values, no `Post_*`), no migration file | **8 failed / 20 passed (28)** |
| HEAD | **31 passed (31)**; whole `src/server/clickhouse` dir 7 files / **66 passed**; `typecheck: OK — 0 type errors` |

(The `29`/`64` figures were HEAD before `b45986c91d`, which added two assertions.)

The three live gaps red at base with their own messages, independent of any other part of this change:

```
default.reactions.nsfw cannot accept 1 value(s) the app emits: Blocked.
default.reports.reason cannot accept 2 value(s) the app emits: Spam, StickerPlacement.
default.reports.entitytype cannot accept 4 value(s) the app emits: challenge, comicProject, model3d, model3dReview.
```

**Stated honestly:** `reactions.type` and `reports.type` are **green at base**, and that is correct — at base those unions were fully covered by the live column, so there was no drift to see. Their guards are exercised by mutation instead (M1, M3, M10 below). In the first state, those two columns fail with `Cannot read properties of undefined` rather than an assertion, because `ReactionType`/`ReportType` are type-only exports at base; that is a red for the wrong reason and is not counted as evidence.

## Mutation matrix

Every mutation was applied to the real tree, run, and reverted. Harness control: unmutated → `29 passed`, no failures.

| # | mutation | killed by | isolated? |
|---|---|---|---|
| M1 | drop `Post_Create`/`Post_Delete` from the `ReactionType` array | `pnpm typecheck` → `reaction.controller.ts(89,11): error TS2322: Type '"Post_Create" \| "Post_Delete"' is not assignable to …` — **1 type error**, at the `post` branch | yes |
| M2 | drop `'Post_Create'` from the MV +1 list | `scores every reactions.type *_Create value +1 in reactions_owner_scores_mv` → "the +1 list and the reactions.type '*_Create' values disagree … apply both or neither" | 1 failed / 28 passed |
| M3 | drop `'Post_Delete' = 18` from the `reactions.type` ALTER | `every default.reactions.type value the app can emit exists in the column` → "cannot accept 1 value(s) the app emits: Post_Delete." | 1 failed / 28 passed |
| M4 | renumber `'Image_Create' = 1` → `= 99` | `every migration restating default.reactions.type reproduces the baseline indices exactly` → "moves 'Image_Create' from 1 to 99" | 1 failed / 28 passed |
| M5 | drop `'Blocked' = 5` from the `nsfw` ALTER | `every default.reactions.nsfw value …` → "cannot accept 1 value(s) the app emits: Blocked." | 1 failed / 28 passed |
| M6 | drop `'StickerPlacement' = 9` from the `reason` ALTER | `every default.reports.reason value …` → "cannot accept 1 value(s) the app emits: StickerPlacement." | co-run with M7 |
| M7 | reword the `POST-APPLY:` line to a sentence that still says "restart" | `… carries the POST-APPLY tracker-restart marker verbatim` → "widens a tracker-written enum but does not carry the post-apply marker." | co-run with M6 |
| M8 | narrow the parser's `\s+` to `[ \t]+` (the single-line-regex trap) | `parses multi-line ALTER ... MODIFY COLUMN statements` → "expected 0 to be greater than or equal to 5", plus 7 downstream | control, not isolated — by design |
| M9 | add `Widget = 'widget'` to `ReportEntity` | `every default.reports.entitytype value …` → "cannot accept 1 value(s) the app emits: widget." | co-run with M10 |
| M10 | add `'Reopened'` to the `ReportType` array | `every default.reports.type value …` → "cannot accept 1 value(s) the app emits: Reopened." | co-run with M9 |

M10 matters specifically: `reports.type` is a column **no migration touches**, so it is checked purely against the recorded baseline. The mutation proves that path is live rather than vacuous.

M8 is the positive control for the multi-line trap. Under it the suite reports **28** tests rather than 29, because the marker `it.each` is driven by parsed files and had zero cases — which is exactly what the "found migrations touching these columns to check for the marker" assertion exists to catch, and it fired.

### Mutation matrix — round 2 (`b45986c91d`)

Run in a `cp -a` copy with its `.git` removed, against a **31-pass harness control**. M1–M10 above predate these assertions and were not re-run.

| # | mutation | killed by | result |
|---|---|---|---|
| M11 | `multiIf(…, 1, -1)` → `multiIf(…, -1, 1)` in the MV `MODIFY QUERY` | `reactions_owner_scores_mv MODIFY QUERY is the live view plus exactly the one added value` → "does not match the live view definition with 'Post_Create' added and nothing else changed" | **1 failed / 30 passed** — isolated |
| M12 | `parseDateTimeBestEffort('2024-04-27')` → `('2099-01-01')` | same assertion, same message | **1 failed / 30 passed** — isolated |
| M13 | M11 **and** M12 together — the exact pair that was previously fully green | same assertion | **1 failed / 30 passed** |
| M14 | add a second `type IN (…)` list to the MV `WHERE`, **with the statement pin skipped** so it cannot shadow | `derives the +1 list from exactly one type IN (...) list` → "the MODIFY QUERY contains 2 `type IN (...)` lists" | **1 failed / 29 passed / 1 skipped** — reachable on its own |
| M15 | pass `entityType: 'widget'` (outside `ReportEntity`) at the only `Tracker.report` call site | `pnpm typecheck` → `report.controller.ts(49,9): error TS2322: Type '"widget"' is not assignable to type 'ReportEntity'` | **1 type error** |
| M15-control | the identical mutation with `entityType` reverted to the old bare `string` | nothing | **`typecheck: OK — 0 type errors`** |

M11–M13 matter most: under every one of them the **pre-existing coupling test stayed green**, alongside all 29 other assertions. That is the measurement showing the IN-list-only guard could not see any of these changes, and it is why the pin is a whole-statement equality rather than a wider regex.

M15-control is the negative control for the `ReportEntity` change: the same out-of-domain value is **silently accepted** under the old typing and rejected under the new one, which is the type-laundering this PR removes from the reaction path, left on the report path.

## Not verified

- **This PR runs no DDL.** Sections 3 and 4 are unapplied by design; nobody has observed a `Post_Create` row land, or the widened MV recompute. Sections 1, 2 and 5 were applied by hand outside this PR and are asserted here only as history.
- **Section 5's tracker restart was not observed.** The ALTER landed `2026-09-08T04:04:14Z`; whether the tracker has re-read the schema and is actually writing `challenge` / `comicProject` / `model3d` / `model3dReview` is **open**. The migration carries a query for it, and states why a zero from that query would be ambiguous rather than reassuring.
- The enum definitions and the MV pre-image were transcribed from live `SHOW CREATE TABLE` reads (`2026-09-07`, MV re-read `2026-09-08`). They should be re-read immediately before applying rather than trusted from this file.
- **The suite cannot see production, and is green on the very defect it was written for.** It reads migration *text*: `effectiveArms` returns the newest migration that **states** a column, applied or not. Right now `Post_Create` is stated, unapplied, and rejected in production, and every assertion passes. The `effectiveArms` docstring says this plainly. It is a **disclosure, not a repair** — no change to this file could close it, because the evidence lives in a system the test does not talk to.
- No integration test exercises the tracker's serializer. If production drifts by some path other than a migration in this directory, the baselines here go stale silently.
- The claim that the tracker deployment rolls its pods unprompted "every few hours" comes from operational observation, not from a measured distribution over time.


