### PR TITLE
feat(app-blocks): project the viewer own browsing level into BLOCK_INIT (effectiveBrowsingLevel)

### DIFF
--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -103,6 +103,10 @@ interface IframeHostProps {
    *  values mirrored from the token mint — the host forwards, never derives. */
   domain?: 'green' | 'blue' | 'red' | null;
   maxBrowsingLevel?: number;
+  /** The domain ceiling intersected with the VIEWER's own browsing level (see
+   *  `projectBlockInitMaturity`). Absent → the block falls back to
+   *  `maxBrowsingLevel`, i.e. the pre-field behaviour. */
+  effectiveBrowsingLevel?: number;
   /** Re-mint the block token after a consent grant so it carries the newly
    *  granted scopes (pushed to the iframe via TOKEN_REFRESH). */
   onConsentGranted?: () => void;
@@ -1103,6 +1107,7 @@ export function IframeHost({
   missingScopes,
   domain,
   maxBrowsingLevel,
+  effectiveBrowsingLevel,
   onConsentGranted,
 }: IframeHostProps) {
   // Treat the slot context as ModelSlotContext when the optional viewer/theme
@@ -1496,7 +1501,7 @@ export function IframeHost({
     theme: activeTheme,
     renderMode: install.renderMode,
     // Advisory maturity signal — server-authoritative values from the mint.
-    ...projectBlockInitMaturity({ domain, maxBrowsingLevel }),
+    ...projectBlockInitMaturity({ domain, maxBrowsingLevel, effectiveBrowsingLevel }),
   });
 
   // Keep the controller's interval posting the freshest payload. buildInitPayload

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -538,6 +538,10 @@ export interface PageBlockHostProps {
    *  values from the token mint — forwarded, never derived client-side. */
   domain?: 'green' | 'blue' | 'red' | null;
   maxBrowsingLevel?: number;
+  /** The domain ceiling intersected with the VIEWER's own browsing level (see
+   *  `projectBlockInitMaturity`). Absent → the block falls back to
+   *  `maxBrowsingLevel`, i.e. the pre-field behaviour. */
+  effectiveBrowsingLevel?: number;
   viewer: { id: number; username: string | null } | null;
   theme: 'light' | 'dark';
   /** Re-mint the page token after a consent grant so it carries the newly
@@ -695,6 +699,7 @@ export function PageBlockHost({
   tokenTerminal = false,
   domain,
   maxBrowsingLevel,
+  effectiveBrowsingLevel,
   viewer,
   theme,
   onConsentGranted,
@@ -1153,7 +1158,7 @@ export function PageBlockHost({
       theme,
       renderMode: 'iframe',
       // Advisory maturity signal — server-authoritative values from the mint.
-      ...projectBlockInitMaturity({ domain, maxBrowsingLevel }),
+      ...projectBlockInitMaturity({ domain, maxBrowsingLevel, effectiveBrowsingLevel }),
     }),
     [
       appId,
@@ -1167,6 +1172,7 @@ export function PageBlockHost({
       theme,
       domain,
       maxBrowsingLevel,
+      effectiveBrowsingLevel,
     ]
   );
   buildInitPayloadRef.current = buildInitPayload;

--- a/src/components/AppBlocks/__tests__/projectBlockInit.test.ts
+++ b/src/components/AppBlocks/__tests__/projectBlockInit.test.ts
@@ -203,7 +203,10 @@ describe('projectBlockInitViewer (BLOCK_INIT viewer allowlist)', () => {
     // Anonymous is the ABSENCE of the object, never `{ signedIn: false }` — the
     // deployed guard accepts only `null` or an object with a numeric `id`.
     expect(
-      projectBlockInitViewer({ slotId: 'model.sidebar_top', viewerUserId: null } as ModelSlotContext)
+      projectBlockInitViewer({
+        slotId: 'model.sidebar_top',
+        viewerUserId: null,
+      } as ModelSlotContext)
     ).toBeNull();
     expect(projectBlockInitViewer({ slotId: 'model.sidebar_top' })).toBeNull();
     // A non-numeric id must NOT slip through as a signed-in viewer: a string id
@@ -378,5 +381,170 @@ describe('projectBlockInitMaturity', () => {
         maxBrowsingLevel: 'x' as unknown as number,
       }).maxBrowsingLevel
     ).toBeUndefined();
+  });
+});
+
+/**
+ * 🔴 `effectiveBrowsingLevel` — THE PER-VIEWER NARROWING OF `maxBrowsingLevel`.
+ *
+ * `maxBrowsingLevel` is a property of the DOMAIN: every viewer on `civitai.red`
+ * receives the identical, maximally-wide ceiling, so it cannot answer "may I
+ * show THIS person mature content". `effectiveBrowsingLevel` is that ceiling
+ * intersected with the viewer's own browsing level, computed at mint by
+ * `resolveEffectiveBrowsingLevel` on top of `getServerBrowsingLevel`.
+ *
+ * The property under test is ONE-WAY: the projection may only ever NARROW. A
+ * block must not be able to widen its own ceiling by reading this field, no
+ * matter what the mint sends.
+ *
+ * 🔴 EVERY FIXTURE BELOW MAKES THE TWO INPUTS DISAGREE, AND IN BOTH DIRECTIONS.
+ * A fixture where domain and viewer agree cannot distinguish "returns the
+ * intersection" from "returns the domain ceiling" from "returns the viewer
+ * level" — all three produce the same number — so an agreeing fixture would
+ * pass against an implementation that ignores the viewer entirely. The bits
+ * used are therefore chosen so the intersection differs from BOTH operands
+ * wherever that is possible.
+ *
+ * PG=1 PG13=2 R=4 X=8 XXX=16 (`NsfwLevel`, mirrored in the SDK's
+ * `BrowsingLevel`). SFW = PG|PG13 = 3, all = 31.
+ */
+describe('projectBlockInitMaturity — effectiveBrowsingLevel (per-viewer ceiling)', () => {
+  it('🔴 a viewer WIDER than the domain cannot widen it: blue domain (SFW=3) + an R/X viewer (7) → 3', () => {
+    // The real blue-domain footgun: `domainBrowsingCeiling('blue')` is SFW for
+    // App Blocks while the viewer's saved level carries R. Projecting the raw
+    // viewer level here would hand a publisher `7` — i.e. R — on a domain whose
+    // whole point is that R is not allowed.
+    const out = projectBlockInitMaturity({
+      domain: 'blue',
+      maxBrowsingLevel: 3, // PG | PG13
+      effectiveBrowsingLevel: 7, // PG | PG13 | R  ← wider than the domain
+    });
+    expect(out.effectiveBrowsingLevel).toBe(3);
+    // Not the raw viewer value, and specifically not carrying the R bit.
+    expect(out.effectiveBrowsingLevel).not.toBe(7);
+    expect((out.effectiveBrowsingLevel as number) & 4).toBe(0);
+    // The domain ceiling itself is untouched by the narrowing.
+    expect(out.maxBrowsingLevel).toBe(3);
+  });
+
+  it('🔴 a viewer NARROWER than the domain DOES narrow it: red domain (31) + a PG-only viewer (1) → 1', () => {
+    // The direction the feature exists for. If the implementation returned the
+    // domain ceiling (ignoring the viewer) this reads 31; if it returned the
+    // viewer level unclamped it also reads 1 — which is why the widening case
+    // above is the other half of the pair and both are required.
+    const out = projectBlockInitMaturity({
+      domain: 'red',
+      maxBrowsingLevel: 31,
+      effectiveBrowsingLevel: 1, // PG only
+    });
+    expect(out.effectiveBrowsingLevel).toBe(1);
+    expect(out.maxBrowsingLevel).toBe(31);
+  });
+
+  it('🔴 intersects rather than picking a side: domain 11 (PG|PG13|X) ∩ viewer 22 (PG13|R|XXX) → 2', () => {
+    // Chosen so the answer equals NEITHER operand: 11 & 22 = 2. An
+    // implementation that returns `maxBrowsingLevel`, or `effectiveBrowsingLevel`,
+    // or `Math.min` (→ 11), or a bitwise OR (→ 31) all fail here. The three
+    // values are pairwise distinct and none is a multiple of another.
+    const out = projectBlockInitMaturity({
+      domain: 'red',
+      maxBrowsingLevel: 11,
+      effectiveBrowsingLevel: 22,
+    });
+    expect(out.effectiveBrowsingLevel).toBe(2);
+  });
+
+  it('is always a SUBSET of the projected domain ceiling, across the level lattice', () => {
+    // Exhaustive over the 5-bit level space rather than a spot check: whatever
+    // pair the mint sends, `effective & ~max` must be empty.
+    for (let max = 0; max < 32; max++) {
+      for (let eff = 0; eff < 32; eff++) {
+        const { effectiveBrowsingLevel } = projectBlockInitMaturity({
+          domain: 'red',
+          maxBrowsingLevel: max,
+          effectiveBrowsingLevel: eff,
+        });
+        expect(effectiveBrowsingLevel).not.toBeUndefined();
+        expect((effectiveBrowsingLevel as number) & ~max).toBe(0);
+      }
+    }
+  });
+
+  it('omits the field when the mint did not send one (legacy server → pre-field behaviour)', () => {
+    const out = projectBlockInitMaturity({ domain: 'red', maxBrowsingLevel: 31 });
+    expect(out.effectiveBrowsingLevel).toBeUndefined();
+    // The domain ceiling still ships, so an existing block is unaffected.
+    expect(out.maxBrowsingLevel).toBe(31);
+  });
+
+  it('🔴 omits the field when there is NO projected ceiling to bound it against', () => {
+    // Nothing would clamp the value here, so forwarding it on trust is the one
+    // path by which a block could see a level the host never sanctioned.
+    expect(
+      projectBlockInitMaturity({ domain: 'green', effectiveBrowsingLevel: 31 })
+        .effectiveBrowsingLevel
+    ).toBeUndefined();
+    // Same when the ceiling was PRESENT but junk — it is dropped upstream, so
+    // there is still nothing to intersect with.
+    expect(
+      projectBlockInitMaturity({
+        domain: 'green',
+        maxBrowsingLevel: NaN,
+        effectiveBrowsingLevel: 31,
+      }).effectiveBrowsingLevel
+    ).toBeUndefined();
+  });
+
+  it('fails closed on a malformed effective level (null / NaN / string)', () => {
+    const base = { domain: 'red' as const, maxBrowsingLevel: 31 };
+    expect(
+      projectBlockInitMaturity({ ...base, effectiveBrowsingLevel: null }).effectiveBrowsingLevel
+    ).toBeUndefined();
+    expect(
+      projectBlockInitMaturity({ ...base, effectiveBrowsingLevel: NaN }).effectiveBrowsingLevel
+    ).toBeUndefined();
+    expect(
+      projectBlockInitMaturity({
+        ...base,
+        effectiveBrowsingLevel: '31' as unknown as number,
+      }).effectiveBrowsingLevel
+    ).toBeUndefined();
+    expect(
+      projectBlockInitMaturity({ ...base, effectiveBrowsingLevel: Infinity }).effectiveBrowsingLevel
+    ).toBeUndefined();
+  });
+
+  it('🔴 rejects a NEGATIVE effective level instead of masking it (−1 & 31 === 31 — the widest viewer)', () => {
+    // Two's complement has every high bit set, so masking junk would resolve to
+    // the FULL domain ceiling — junk reading as the most permissive possible
+    // viewer, which is the exact inversion this guard exists to prevent.
+    const out = projectBlockInitMaturity({
+      domain: 'red',
+      maxBrowsingLevel: 31,
+      effectiveBrowsingLevel: -1,
+    });
+    expect(out.effectiveBrowsingLevel).toBeUndefined();
+    expect(out.effectiveBrowsingLevel).not.toBe(31);
+  });
+
+  it('projects an EMPTY effective level (0) as 0, not as absent', () => {
+    // 0 is a real answer — "this viewer may be shown nothing here" — and is
+    // falsy, so an `if (effective)` style implementation would drop it to
+    // `undefined` and the SDK would then fall back to the WIDE domain ceiling.
+    const out = projectBlockInitMaturity({
+      domain: 'red',
+      maxBrowsingLevel: 31,
+      effectiveBrowsingLevel: 0,
+    });
+    expect(out.effectiveBrowsingLevel).toBe(0);
+    expect(out.effectiveBrowsingLevel).not.toBeUndefined();
+  });
+
+  it('emits exactly the three maturity keys — the projection stays an allowlist', () => {
+    expect(
+      Object.keys(
+        projectBlockInitMaturity({ domain: 'red', maxBrowsingLevel: 31, effectiveBrowsingLevel: 5 })
+      ).sort()
+    ).toEqual(['domain', 'effectiveBrowsingLevel', 'maxBrowsingLevel']);
   });
 });

--- a/src/components/AppBlocks/projectBlockInit.ts
+++ b/src/components/AppBlocks/projectBlockInit.ts
@@ -28,6 +28,7 @@
  * These are pure functions (no React, no postMessage) so the allowlist is
  * unit-testable in isolation — see __tests__/projectBlockInit.test.ts.
  */
+import { Flags } from '~/shared/utils/flags';
 import type {
   BlockCheckpointInfo,
   BlockInitPayload,
@@ -105,11 +106,49 @@ export function projectBlockInitContext(
  * Defaults are FAIL-CLOSED: an absent ceiling projects `undefined` (the SDK
  * `useDomainMaturity()` hook treats absent as the most restrictive), and an
  * unrecognized domain projects `null` rather than leaking a raw value.
+ *
+ * ── `effectiveBrowsingLevel` ──────────────────────────────────────────────
+ *
+ * `maxBrowsingLevel` is a property of the DOMAIN: every viewer on `civitai.red`
+ * gets the same maximally-wide ceiling, including one whose own NSFW setting is
+ * off. `effectiveBrowsingLevel` is that ceiling intersected with the VIEWER's
+ * own browsing level, computed at mint by `resolveEffectiveBrowsingLevel`
+ * (`src/pages/api/v1/block-tokens/index.ts`) on top of the platform's existing
+ * `getServerBrowsingLevel` source of truth.
+ *
+ * 🔴 THE VIEWER'S RAW LEVEL IS DELIBERATELY NOT PROJECTED, AND MUST NOT BE.
+ * On `blue` the App-Blocks domain ceiling is SFW while a viewer's saved level
+ * may carry R/X/XXX — so the raw viewer level is WIDER than the domain permits
+ * and would read to a publisher as permission it does not have. It is also the
+ * higher-resolution form of `viewerNsfwEnabled`, which this very module was
+ * written to STOP sending to untrusted iframes (see the file header). Only the
+ * intersection goes on the wire.
+ *
+ * 🔴 THE CLAMP IS RE-APPLIED HERE RATHER THAN TRUSTED FROM THE SERVER, and the
+ * two clamps are not redundant in the way they look. The server's runs against
+ * the ceiling it computed in the same request; this one runs against the
+ * ceiling actually being PROJECTED on this message, after the sanitisation
+ * above has had its say. They can disagree — a `maxBrowsingLevel` that fails
+ * the finite check is dropped to `undefined` HERE, at which point there is no
+ * ceiling left to bound anything, and a value the server considered clamped
+ * would ride out unbounded. Hence the two rules below.
+ *
+ * FAIL-CLOSED, in the same shape as its sibling field, plus one rule of its own:
+ *   - absent / non-finite / negative → `undefined`; the SDK then falls back to
+ *     `maxBrowsingLevel`, i.e. exactly the pre-field behaviour. A host or server
+ *     that predates this field cannot regress, and an upgrading block can only
+ *     ever see the SAME or a NARROWER permission — never a wider one.
+ *   - 🔴 NEVER projected without a projected `maxBrowsingLevel`. With no ceiling
+ *     to intersect against there is nothing bounding the value, so it is
+ *     dropped rather than forwarded on trust. Negative is rejected for the
+ *     reason `effectiveBrowsingCeiling` documents: `-1 & ceiling === ceiling`,
+ *     so masking junk would resolve it to the WIDEST possible viewer.
  */
 export function projectBlockInitMaturity(input: {
   domain?: string | null;
   maxBrowsingLevel?: number | null;
-}): Pick<BlockInitPayload, 'domain' | 'maxBrowsingLevel'> {
+  effectiveBrowsingLevel?: number | null;
+}): Pick<BlockInitPayload, 'domain' | 'maxBrowsingLevel' | 'effectiveBrowsingLevel'> {
   const domain =
     input.domain === 'green' || input.domain === 'blue' || input.domain === 'red'
       ? input.domain
@@ -118,7 +157,15 @@ export function projectBlockInitMaturity(input: {
     typeof input.maxBrowsingLevel === 'number' && Number.isFinite(input.maxBrowsingLevel)
       ? input.maxBrowsingLevel
       : undefined;
-  return { domain, maxBrowsingLevel };
+  const rawEffective = input.effectiveBrowsingLevel;
+  const effectiveBrowsingLevel =
+    maxBrowsingLevel !== undefined &&
+    typeof rawEffective === 'number' &&
+    Number.isFinite(rawEffective) &&
+    rawEffective >= 0
+      ? Flags.intersection(maxBrowsingLevel, rawEffective)
+      : undefined;
+  return { domain, maxBrowsingLevel, effectiveBrowsingLevel };
 }
 
 /**

--- a/src/components/AppBlocks/types.ts
+++ b/src/components/AppBlocks/types.ts
@@ -405,9 +405,20 @@ export interface BlockInitPayload {
    * - `maxBrowsingLevel`: the bitwise browsing-level ceiling for this domain
    *   (green/blue → SFW, red → all). Consumed by the SDK `useDomainMaturity()`
    *   hook (separate follow-up PR in the SDK repo).
+   * - `effectiveBrowsingLevel`: that domain ceiling intersected with the
+   *   VIEWER's own browsing level. `maxBrowsingLevel` is identical for every
+   *   viewer on a domain, so it cannot answer "may I show THIS person mature
+   *   content"; this field can. ALWAYS a subset of `maxBrowsingLevel` — a block
+   *   can never widen its own ceiling by reading it. Absent when the mint did
+   *   not supply one, in which case consumers fall back to `maxBrowsingLevel`
+   *   (the pre-field behaviour). The viewer's RAW level is deliberately never
+   *   sent: on `blue` it is WIDER than the domain permits, and it is the
+   *   high-resolution form of the `viewerNsfwEnabled` over-share that
+   *   `projectBlockInit.ts` exists to drop.
    */
   domain?: 'green' | 'blue' | 'red' | null;
   maxBrowsingLevel?: number;
+  effectiveBrowsingLevel?: number;
 }
 
 export interface BlockManifest {

--- a/src/components/AppBlocks/useBlockToken.ts
+++ b/src/components/AppBlocks/useBlockToken.ts
@@ -22,6 +22,12 @@ interface UseBlockTokenResult {
   /** Advisory: the bitwise browsing-level ceiling for the domain (SFW on
    *  green/blue, all on red). undefined on legacy responses → fail closed. */
   maxBrowsingLevel: number | undefined;
+  /** Advisory: {@link maxBrowsingLevel} intersected with the VIEWER's own
+   *  browsing level — what THIS person may be shown here, as opposed to what
+   *  the domain permits anyone. Always a subset of `maxBrowsingLevel`.
+   *  undefined on legacy responses → consumers fall back to the domain
+   *  ceiling, i.e. the pre-field behaviour. */
+  effectiveBrowsingLevel: number | undefined;
   /**
    * A bounded automatic re-mint is scheduled after a refresh failure — i.e. the
    * hook has NOT settled. Consumers must not take a destructive action (collapse
@@ -50,6 +56,7 @@ interface TokenResponse {
   /** Advisory maturity signal. Omitted by pre-feature responses → fail closed. */
   domain?: 'green' | 'blue' | 'red' | null;
   maxBrowsingLevel?: number;
+  effectiveBrowsingLevel?: number;
 }
 
 const REFRESH_LEAD_MS = 2 * 60 * 1000; // refresh 2 minutes before expiry
@@ -84,6 +91,9 @@ export function useBlockToken(install: BlockInstall, context: SlotContext): UseB
   const [missingScopes, setMissingScopes] = useState<string[]>([]);
   const [domain, setDomain] = useState<'green' | 'blue' | 'red' | null>(null);
   const [maxBrowsingLevel, setMaxBrowsingLevel] = useState<number | undefined>(undefined);
+  const [effectiveBrowsingLevel, setEffectiveBrowsingLevel] = useState<number | undefined>(
+    undefined
+  );
   // A bounded automatic re-mint is scheduled. State (not a ref) because it is
   // part of the returned contract — it drives whether a consumer may take a
   // destructive action — so it has to re-render.
@@ -230,6 +240,16 @@ export function useBlockToken(install: BlockInstall, context: SlotContext): UseB
       setMaxBrowsingLevel(
         typeof data.maxBrowsingLevel === 'number' && Number.isFinite(data.maxBrowsingLevel)
           ? data.maxBrowsingLevel
+          : undefined
+      );
+      // Carried RAW here (shape-check only, no clamp): the intersection against
+      // the projected ceiling is `projectBlockInitMaturity`'s job, and doing it
+      // in exactly one place is what lets that function's tests be the whole
+      // statement of the never-widen rule.
+      setEffectiveBrowsingLevel(
+        typeof data.effectiveBrowsingLevel === 'number' &&
+          Number.isFinite(data.effectiveBrowsingLevel)
+          ? data.effectiveBrowsingLevel
           : undefined
       );
       setPending(false);
@@ -430,6 +450,7 @@ export function useBlockToken(install: BlockInstall, context: SlotContext): UseB
     missingScopes,
     domain,
     maxBrowsingLevel,
+    effectiveBrowsingLevel,
     retrying,
     // The mint failed, nothing usable is left, and no automatic attempt is
     // coming. This — NOT a bare `error` — is what a consumer may act

--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -30,7 +30,9 @@ import {
 import {
   allBrowsingLevelsFlag,
   domainBrowsingCeiling,
+  effectiveBrowsingCeiling,
 } from '~/shared/constants/browsingLevel.constants';
+import { getServerBrowsingLevel } from '~/server/utils/browsing-level';
 import {
   isKnownBlockScope,
   validateBlockScopesAgainstOauthClient,
@@ -50,6 +52,46 @@ import {
 } from '~/server/services/blocks/dev-scoped-mint.service';
 import type { SessionUser } from '~/types/session';
 import type { Logger } from '@civitai/next-axiom';
+
+/**
+ * The EFFECTIVE browsing-level ceiling this mint advertises to the host for
+ * `BLOCK_INIT` — the intersection of the domain ceiling already computed for
+ * the token claim and the VIEWER's own NSFW browsing level.
+ *
+ * 🔴 WHY THIS EXISTS AT ALL: `maxBrowsingLevel` is a property of the DOMAIN, so
+ * two viewers on `civitai.red` — one who never enabled NSFW, one at XXX — are
+ * handed the identical, maximally-wide ceiling. A block that renders mature
+ * affordances off `maxBrowsingLevel` therefore shows them to a viewer whose own
+ * setting says PG. This value is the one a block should render against.
+ *
+ * 🔴 WHY IT IS AN INTERSECTION AND NOT THE VIEWER'S RAW LEVEL: on `blue` the
+ * App-Blocks domain ceiling is SFW (see `domainBrowsingCeiling`) while the
+ * viewer's saved level may carry R/X/XXX, so the raw viewer level is WIDER than
+ * the domain permits. Shipping it would hand untrusted publisher code a number
+ * that reads as permission and is not one. Only the intersection is safe to
+ * project, and it is what a block actually needs.
+ *
+ * `getServerBrowsingLevel` is the platform's single source of truth for "the
+ * viewer's own level" (the same helper `wildcard-pack.service.ts` gates on);
+ * this does not re-derive it. It already fails closed to PG for an anonymous
+ * viewer and for a viewer with NSFW off, and `effectiveBrowsingCeiling` fails
+ * closed again on both operands — so every absent/anonymous/malformed path
+ * lands on a subset of the domain ceiling, never a superset.
+ *
+ * `canViewNsfw` is read from the SAME `getFeatureFlags({ user, req })` call
+ * shape the route already uses for `appBlocks`, so the domain half of the
+ * viewer-level derivation cannot drift from the rest of the request.
+ */
+function resolveEffectiveBrowsingLevel(args: {
+  req: NextApiRequest;
+  sessionUser: SessionUser | undefined;
+  maxBrowsingLevel: number;
+}): number {
+  const { req, sessionUser, maxBrowsingLevel } = args;
+  const canViewNsfw = getFeatureFlags({ user: sessionUser, req }).canViewNsfw;
+  const viewerBrowsingLevel = getServerBrowsingLevel({ canViewNsfw, user: sessionUser });
+  return effectiveBrowsingCeiling(maxBrowsingLevel, viewerBrowsingLevel);
+}
 
 /**
  * POST /api/v1/block-tokens
@@ -471,6 +513,14 @@ async function tryDevTunnelScopedMint(args: {
     // Forced-SFW: the dev mint never reads the request host.
     domain: null,
     maxBrowsingLevel: FORCED_SFW_CEILING,
+    // Still narrowed by the author's OWN browsing level: forced-SFW caps the
+    // domain half, it says nothing about the viewer half. An author with NSFW
+    // off dogfoods at PG here, exactly as they would on the public run page.
+    effectiveBrowsingLevel: resolveEffectiveBrowsingLevel({
+      req,
+      sessionUser,
+      maxBrowsingLevel: FORCED_SFW_CEILING,
+    }),
   });
   return 'handled';
 }
@@ -638,6 +688,12 @@ async function tryDevTunnelOwnedNonApprovedMint(args: {
     missingScopes: [],
     domain: null,
     maxBrowsingLevel: FORCED_SFW_CEILING,
+    // See the ephemeral branch above: forced-SFW is the DOMAIN half only.
+    effectiveBrowsingLevel: resolveEffectiveBrowsingLevel({
+      req,
+      sessionUser,
+      maxBrowsingLevel: FORCED_SFW_CEILING,
+    }),
   });
   return 'handled';
 }
@@ -1212,5 +1268,15 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     // self-filter their catalog reads / blur. See projectBlockInit.ts.
     domain: domainColor ?? null,
     maxBrowsingLevel,
+    // The PER-VIEWER narrowing of the line above. `maxBrowsingLevel` is a
+    // property of the domain and is identical for every viewer on it; this is
+    // that ceiling intersected with the viewer's own NSFW browsing level, and
+    // it is what a block should render mature affordances against. Always a
+    // subset of `maxBrowsingLevel` — see `resolveEffectiveBrowsingLevel`.
+    effectiveBrowsingLevel: resolveEffectiveBrowsingLevel({
+      req,
+      sessionUser: session?.user,
+      maxBrowsingLevel,
+    }),
   });
 });

--- a/src/pages/apps/dev/[blockId].tsx
+++ b/src/pages/apps/dev/[blockId].tsx
@@ -204,6 +204,7 @@ export default function DevTunnelPage(props: DevTunnelProps) {
     missingScopes,
     domain,
     maxBrowsingLevel,
+    effectiveBrowsingLevel,
     error,
     // `terminal` = the mint failed, nothing usable is left, AND the hook's
     // bounded automatic re-mints are spent. A bare `error` is NOT enough to tear
@@ -276,6 +277,7 @@ export default function DevTunnelPage(props: DevTunnelProps) {
             needsConsent={needsConsent}
             domain={domain}
             maxBrowsingLevel={maxBrowsingLevel}
+            effectiveBrowsingLevel={effectiveBrowsingLevel}
             tokenError={error != null}
             tokenTerminal={terminal}
             viewer={viewer}

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -327,6 +327,7 @@ function AppPage(props: PageProps) {
     missingScopes,
     domain,
     maxBrowsingLevel,
+    effectiveBrowsingLevel,
     error,
     // `terminal` = the mint failed, nothing usable is left, AND the hook's
     // bounded automatic re-mints are spent. A bare `error` is NOT enough to tear
@@ -458,6 +459,7 @@ function AppPage(props: PageProps) {
           needsConsent={needsConsent}
           domain={domain}
           maxBrowsingLevel={maxBrowsingLevel}
+          effectiveBrowsingLevel={effectiveBrowsingLevel}
           tokenError={error != null}
           tokenTerminal={terminal}
           viewer={viewer}

--- a/src/shared/constants/__tests__/browsingLevel-maturity.test.ts
+++ b/src/shared/constants/__tests__/browsingLevel-maturity.test.ts
@@ -5,6 +5,7 @@ import {
   contentRatingFromNsfwLevel,
   deriveContentRatingFromAssets,
   domainBrowsingCeiling,
+  effectiveBrowsingCeiling,
   nsfwBrowsingLevelsFlag,
   nsfwLevelFromContentRating,
   OFFSITE_CONTENT_RATING_LADDER,
@@ -12,6 +13,7 @@ import {
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 import { OFFSITE_CONTENT_RATINGS } from '~/server/schema/blocks/offsite-listing.schema';
+import { getServerBrowsingLevel } from '~/server/utils/browsing-level';
 import { NsfwLevel } from '~/server/common/enums';
 import { Flags } from '~/shared/utils/flags';
 
@@ -155,11 +157,154 @@ describe('off-site content-rating derive', () => {
 
   it('deriveContentRatingFromAssets is fail-safe for empty / null / undefined levels → g', () => {
     expect(deriveContentRatingFromAssets([])).toBe('g');
-    expect(deriveContentRatingFromAssets([{ nsfwLevel: null }, { nsfwLevel: undefined }])).toBe('g');
+    expect(deriveContentRatingFromAssets([{ nsfwLevel: null }, { nsfwLevel: undefined }])).toBe(
+      'g'
+    );
     expect(deriveContentRatingFromAssets([{}])).toBe('g');
   });
 
   it('deriveContentRatingFromAssets fails CLOSED to the top rating for an XXX asset', () => {
     expect(deriveContentRatingFromAssets([{ nsfwLevel: NsfwLevel.XXX }])).toBe('x');
+  });
+});
+
+/**
+ * `effectiveBrowsingCeiling` — the DOMAIN ceiling ∩ the VIEWER's own level.
+ *
+ * This is the value projected into `BLOCK_INIT` as `effectiveBrowsingLevel`.
+ * `domainBrowsingCeiling` above answers "what may be shown on this domain";
+ * this answers "what may be shown to THIS person, here", which is the question
+ * a block actually needs and the one `maxBrowsingLevel` alone cannot answer.
+ *
+ * 🔴 The two inputs disagree in BOTH directions in production — blue makes the
+ * viewer the wider one, red makes the domain the wider one — so every fixture
+ * below is a disagreeing pair. An agreeing pair cannot tell an intersection
+ * apart from either operand.
+ */
+describe('effectiveBrowsingCeiling', () => {
+  it('🔴 blue: the VIEWER is wider and loses — SFW(3) ∩ PG|PG13|R|X(15) → 3', () => {
+    // The concrete footgun. `domainBrowsingCeiling('blue')` is SFW for App
+    // Blocks while the site treats blue as mature, so a blue-domain viewer's
+    // saved level routinely carries R/X. The domain must win.
+    expect(effectiveBrowsingCeiling(domainBrowsingCeiling('blue'), 15)).toBe(sfwBrowsingLevelsFlag);
+    expect(
+      Flags.intersects(
+        effectiveBrowsingCeiling(domainBrowsingCeiling('blue'), 15),
+        nsfwBrowsingLevelsFlag
+      )
+    ).toBe(false);
+  });
+
+  it('🔴 red: the DOMAIN is wider and loses — all(31) ∩ PG(1) → 1', () => {
+    expect(effectiveBrowsingCeiling(domainBrowsingCeiling('red'), NsfwLevel.PG)).toBe(NsfwLevel.PG);
+  });
+
+  it('returns NEITHER operand when both carry bits the other lacks: 11 ∩ 22 → 2', () => {
+    // 11 = PG|PG13|X, 22 = PG13|R|XXX. An implementation returning either side,
+    // a min, or an OR (31) all give a different answer.
+    expect(effectiveBrowsingCeiling(11, 22)).toBe(2);
+  });
+
+  it('is always a subset of the domain ceiling over the whole 5-bit lattice', () => {
+    for (let ceiling = 0; ceiling < 32; ceiling++) {
+      for (let viewer = 0; viewer < 32; viewer++) {
+        expect(effectiveBrowsingCeiling(ceiling, viewer) & ~ceiling).toBe(0);
+      }
+    }
+  });
+
+  it('fails closed on an absent/malformed DOMAIN ceiling → SFW ∩ viewer', () => {
+    // Same fallback `domainBrowsingCeiling` uses for an unknown domain. The
+    // viewer here is all-levels, so a fallback of "all" would read 31.
+    expect(effectiveBrowsingCeiling(undefined, allBrowsingLevelsFlag)).toBe(sfwBrowsingLevelsFlag);
+    expect(effectiveBrowsingCeiling(null, allBrowsingLevelsFlag)).toBe(sfwBrowsingLevelsFlag);
+    expect(effectiveBrowsingCeiling(NaN, allBrowsingLevelsFlag)).toBe(sfwBrowsingLevelsFlag);
+  });
+
+  it('🔴 fails closed on an absent/malformed/negative VIEWER level → PG, not the ceiling', () => {
+    // PG (`publicBrowsingLevelsFlag`), matching what `getServerBrowsingLevel`
+    // returns for an anonymous viewer: "we could not establish who is looking"
+    // and "nobody is looking" must land on the same narrowest answer.
+    const red = domainBrowsingCeiling('red');
+    expect(effectiveBrowsingCeiling(red, undefined)).toBe(publicBrowsingLevelsFlag);
+    expect(effectiveBrowsingCeiling(red, null)).toBe(publicBrowsingLevelsFlag);
+    expect(effectiveBrowsingCeiling(red, NaN)).toBe(publicBrowsingLevelsFlag);
+    // 🔴 −1 has every bit set, so masking it would return the FULL ceiling —
+    // junk resolving to the widest possible viewer.
+    expect(effectiveBrowsingCeiling(red, -1)).toBe(publicBrowsingLevelsFlag);
+    expect(effectiveBrowsingCeiling(red, -1)).not.toBe(red);
+  });
+
+  it('an empty viewer level (0) yields 0 — a real answer, not a fallback', () => {
+    expect(effectiveBrowsingCeiling(allBrowsingLevelsFlag, 0)).toBe(0);
+  });
+});
+
+/**
+ * The composition actually shipped by the token mint's
+ * `resolveEffectiveBrowsingLevel`: `getServerBrowsingLevel` (the platform's
+ * existing source of truth for the viewer's own level — the same helper
+ * `wildcard-pack.service.ts` gates downloads on) fed into
+ * `effectiveBrowsingCeiling` against the domain ceiling already computed for
+ * the token claim.
+ *
+ * Pinned here because the mint's own helper is a private route-local function:
+ * these are its two operands, and the anonymous / NSFW-off / no-level-set cases
+ * the projection must fail closed on are decided entirely by this pair.
+ */
+describe('mint composition: getServerBrowsingLevel → effectiveBrowsingCeiling', () => {
+  const compose = (
+    color: 'green' | 'blue' | 'red',
+    canViewNsfw: boolean,
+    user?: { showNsfw?: boolean | null; browsingLevel?: number | null } | null
+  ) =>
+    effectiveBrowsingCeiling(
+      domainBrowsingCeiling(color),
+      getServerBrowsingLevel({ canViewNsfw, user })
+    );
+
+  it('ANONYMOUS on red (the widest domain) collapses to PG', () => {
+    // The domain permits everything; the absence of a viewer is what narrows it.
+    expect(compose('red', true, null)).toBe(publicBrowsingLevelsFlag);
+    expect(compose('red', true, undefined)).toBe(publicBrowsingLevelsFlag);
+  });
+
+  it('a signed-in viewer with NSFW OFF on red collapses to PG', () => {
+    expect(compose('red', true, { showNsfw: false, browsingLevel: allBrowsingLevelsFlag })).toBe(
+      publicBrowsingLevelsFlag
+    );
+  });
+
+  it('a signed-in viewer with NSFW ON but NO saved level on red collapses to PG', () => {
+    expect(compose('red', true, { showNsfw: true, browsingLevel: null })).toBe(
+      publicBrowsingLevelsFlag
+    );
+    expect(compose('red', true, { showNsfw: true, browsingLevel: 0 })).toBe(
+      publicBrowsingLevelsFlag
+    );
+  });
+
+  it('🔴 a full-NSFW viewer on BLUE is still clamped to SFW — the viewer cannot widen the domain', () => {
+    // canViewNsfw is TRUE on blue site-wide, so `getServerBrowsingLevel` hands
+    // back the raw all-levels preference; only the domain ceiling stops it.
+    const viewer = getServerBrowsingLevel({
+      canViewNsfw: true,
+      user: { showNsfw: true, browsingLevel: allBrowsingLevelsFlag },
+    });
+    expect(viewer).toBe(allBrowsingLevelsFlag); // the raw level IS wider than blue allows
+    expect(compose('blue', true, { showNsfw: true, browsingLevel: allBrowsingLevelsFlag })).toBe(
+      sfwBrowsingLevelsFlag
+    );
+  });
+
+  it('a full-NSFW viewer on RED keeps the mature levels (the feature is not a blanket clamp)', () => {
+    expect(compose('red', true, { showNsfw: true, browsingLevel: allBrowsingLevelsFlag })).toBe(
+      allBrowsingLevelsFlag
+    );
+  });
+
+  it('a PG13-only viewer on red gets PG13 — the domain does not widen the viewer either', () => {
+    const level = Flags.addFlag(NsfwLevel.PG, NsfwLevel.PG13);
+    expect(compose('red', true, { showNsfw: true, browsingLevel: level })).toBe(level);
   });
 });

--- a/src/shared/constants/browsingLevel.constants.ts
+++ b/src/shared/constants/browsingLevel.constants.ts
@@ -271,6 +271,55 @@ export function allowMatureContentForCeiling(maxBrowsingLevel: number): boolean 
   return Flags.intersects(maxBrowsingLevel, nsfwBrowsingLevelsFlag) ? undefined : false;
 }
 
+/**
+ * The EFFECTIVE browsing-level ceiling for one viewer on one color domain: the
+ * bitwise intersection of what the DOMAIN permits and what the VIEWER's own
+ * NSFW setting permits.
+ *
+ * 🔴 THE TWO INPUTS ROUTINELY DISAGREE, AND EITHER ONE CAN BE THE WIDER.
+ *   - On `blue`, `domainBrowsingCeiling` returns SFW (an App-Blocks-scoped
+ *     product decision — see its docstring) while `getServerBrowsingLevel`
+ *     returns the viewer's saved preference, which may carry R/X/XXX. The
+ *     VIEWER is wider; the domain must win.
+ *   - On `red`, the domain ceiling is every level while a viewer who never
+ *     enabled NSFW sits at PG. The DOMAIN is wider; the viewer must win.
+ * Taking either input alone is wrong in one of those two directions, which is
+ * why this returns the intersection and not a "max" or a preference order.
+ *
+ * FAIL CLOSED on both axes, and note they fail closed to DIFFERENT values:
+ *   - An absent / non-finite DOMAIN ceiling collapses to `sfwBrowsingLevelsFlag`
+ *     — the same most-restrictive-non-empty fallback `domainBrowsingCeiling`
+ *     uses for an unknown domain.
+ *   - An absent / non-finite / negative VIEWER level collapses to
+ *     `publicBrowsingLevelsFlag` (PG), matching what `getServerBrowsingLevel`
+ *     returns for an anonymous viewer. "We could not establish who is looking"
+ *     and "nobody is looking" must resolve to the same, narrowest answer.
+ * A negative viewer level is rejected rather than masked because a two's
+ * complement value has every high bit set: `-1 & ceiling === ceiling` would
+ * silently resolve to the FULL domain ceiling, i.e. junk input would read as
+ * the widest possible viewer, which is the one outcome this function exists to
+ * make impossible.
+ *
+ * The result is always a subset of the domain ceiling, so a consumer handed
+ * this value can never act on more than the domain allows.
+ */
+export function effectiveBrowsingCeiling(
+  domainCeiling: number | null | undefined,
+  viewerBrowsingLevel: number | null | undefined
+): number {
+  const ceiling =
+    typeof domainCeiling === 'number' && Number.isFinite(domainCeiling)
+      ? domainCeiling
+      : sfwBrowsingLevelsFlag;
+  const viewer =
+    typeof viewerBrowsingLevel === 'number' &&
+    Number.isFinite(viewerBrowsingLevel) &&
+    viewerBrowsingLevel >= 0
+      ? viewerBrowsingLevel
+      : publicBrowsingLevelsFlag;
+  return Flags.intersection(ceiling, viewer);
+}
+
 // helpers
 export function onlySelectableLevels(level: number) {
   if (Flags.hasFlag(level, NsfwLevel.Blocked)) level = Flags.removeFlag(level, NsfwLevel.Blocked);

--- a/src/tests/api/v1/block-tokens/index.test.ts
+++ b/src/tests/api/v1/block-tokens/index.test.ts
@@ -682,6 +682,156 @@ describe('POST /api/v1/block-tokens', () => {
   // ===========================================================================
   // NSFW-APP-RED-ONLY — host-driven maturity ceiling + mature-app refusal.
   // ===========================================================================
+  /**
+   * 🔴 `effectiveBrowsingLevel` — the per-VIEWER narrowing of `maxBrowsingLevel`.
+   *
+   * `maxBrowsingLevel` is a property of the DOMAIN: every viewer on
+   * `civitai.red` is handed the identical, maximally-wide ceiling, so a block
+   * rendering mature affordances off it shows them to a viewer whose own
+   * setting says PG. This field is the domain ceiling intersected with the
+   * viewer's own level (`getServerBrowsingLevel` — the platform's existing
+   * source of truth, reused rather than re-derived).
+   *
+   * 🔴 EVERY CASE BELOW MAKES THE DOMAIN AND THE VIEWER DISAGREE. The two
+   * disagree in BOTH directions in production (red ⇒ the domain is wider; blue
+   * ⇒ the viewer is wider), and a fixture where they agree cannot tell an
+   * intersection apart from either operand.
+   *
+   * The mocked `getFeatureFlags` must return `canViewNsfw` here — the route
+   * reads it to decide whether the viewer's saved level is honoured at all —
+   * so each case sets it explicitly rather than inheriting the suite default.
+   */
+  describe('effectiveBrowsingLevel (per-viewer ceiling in the mint response)', () => {
+    async function mintAs(opts: {
+      host: string;
+      canViewNsfw: boolean;
+      user: Record<string, unknown> | null;
+    }) {
+      const flagMod = await import('~/server/services/feature-flags.service');
+      (flagMod.getFeatureFlags as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        appBlocks: true,
+        canViewNsfw: opts.canViewNsfw,
+      });
+      mockSession.value = (opts.user ? { user: opts.user } : null) as never;
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(
+        makeReq({
+          origin: `https://${opts.host}`,
+          headers: { host: opts.host },
+          body: validBody(),
+        }),
+        res
+      );
+      return res;
+    }
+
+    const modBase = { id: 42, bannedAt: null, isModerator: true };
+
+    it('🔴 red domain + a viewer with NSFW OFF → PG, NOT the domain ceiling', async () => {
+      // The direction the feature exists for: the domain permits everything and
+      // the viewer permits PG. An implementation that echoed `maxBrowsingLevel`
+      // would return all-levels here.
+      const { allBrowsingLevelsFlag, publicBrowsingLevelsFlag } = await import(
+        '~/shared/constants/browsingLevel.constants'
+      );
+      const res = await mintAs({
+        host: 'civitai.red',
+        canViewNsfw: true,
+        user: { ...modBase, showNsfw: false, browsingLevel: allBrowsingLevelsFlag },
+      });
+      expect(res._status).toBe(200);
+      const body = res._body as { maxBrowsingLevel: number; effectiveBrowsingLevel: number };
+      expect(body.maxBrowsingLevel).toBe(allBrowsingLevelsFlag);
+      expect(body.effectiveBrowsingLevel).toBe(publicBrowsingLevelsFlag);
+      expect(body.effectiveBrowsingLevel).not.toBe(body.maxBrowsingLevel);
+    });
+
+    it('red domain + a full-NSFW viewer → the full ceiling (not a blanket clamp)', async () => {
+      const { allBrowsingLevelsFlag } = await import('~/shared/constants/browsingLevel.constants');
+      const res = await mintAs({
+        host: 'civitai.red',
+        canViewNsfw: true,
+        user: { ...modBase, showNsfw: true, browsingLevel: allBrowsingLevelsFlag },
+      });
+      expect((res._body as { effectiveBrowsingLevel: number }).effectiveBrowsingLevel).toBe(
+        allBrowsingLevelsFlag
+      );
+    });
+
+    it('red domain + a PG13-capped viewer → PG13, strictly between the two extremes', async () => {
+      // A third distinct value, so the assertion cannot be satisfied by either
+      // "always the domain ceiling" or "always PG".
+      const { NsfwLevel } = await import('~/server/common/enums');
+      const { Flags } = await import('~/shared/utils/flags');
+      const level = Flags.addFlag(NsfwLevel.PG, NsfwLevel.PG13);
+      const res = await mintAs({
+        host: 'civitai.red',
+        canViewNsfw: true,
+        user: { ...modBase, showNsfw: true, browsingLevel: level },
+      });
+      expect((res._body as { effectiveBrowsingLevel: number }).effectiveBrowsingLevel).toBe(level);
+    });
+
+    it('🔴 a full-NSFW viewer on civitai.com CANNOT widen past the SFW domain ceiling', async () => {
+      // The widening case. `canViewNsfw` is true site-wide on blue, so the raw
+      // viewer level here carries R/X/XXX while the App-Blocks domain ceiling is
+      // SFW. Projecting the viewer's raw level would hand a publisher the mature
+      // bits on a domain whose whole point is that they are not allowed.
+      const { allBrowsingLevelsFlag, sfwBrowsingLevelsFlag, nsfwBrowsingLevelsFlag } = await import(
+        '~/shared/constants/browsingLevel.constants'
+      );
+      const { Flags } = await import('~/shared/utils/flags');
+      const res = await mintAs({
+        host: 'civitai.com',
+        canViewNsfw: true,
+        user: { ...modBase, showNsfw: true, browsingLevel: allBrowsingLevelsFlag },
+      });
+      expect(res._status).toBe(200);
+      const body = res._body as { maxBrowsingLevel: number; effectiveBrowsingLevel: number };
+      expect(body.maxBrowsingLevel).toBe(sfwBrowsingLevelsFlag);
+      expect(body.effectiveBrowsingLevel).toBe(sfwBrowsingLevelsFlag);
+      expect(body.effectiveBrowsingLevel).not.toBe(allBrowsingLevelsFlag);
+      // The specific harm: no mature bit survives.
+      expect(Flags.intersects(body.effectiveBrowsingLevel, nsfwBrowsingLevelsFlag)).toBe(false);
+    });
+
+    it('a signed-in viewer with NO saved level on red → PG (fail-closed, not the ceiling)', async () => {
+      const { allBrowsingLevelsFlag, publicBrowsingLevelsFlag } = await import(
+        '~/shared/constants/browsingLevel.constants'
+      );
+      const res = await mintAs({
+        host: 'civitai.red',
+        canViewNsfw: true,
+        user: { ...modBase, showNsfw: true, browsingLevel: null },
+      });
+      const body = res._body as { maxBrowsingLevel: number; effectiveBrowsingLevel: number };
+      expect(body.maxBrowsingLevel).toBe(allBrowsingLevelsFlag);
+      expect(body.effectiveBrowsingLevel).toBe(publicBrowsingLevelsFlag);
+    });
+
+    it('the response ALWAYS carries a level that is a subset of maxBrowsingLevel', async () => {
+      // Structural, over every case this suite can produce: whatever the pair,
+      // `effective & ~max` is empty. A block can never widen its own ceiling.
+      const cases = [
+        { host: 'civitai.red', canViewNsfw: true, browsingLevel: 31, showNsfw: true },
+        { host: 'civitai.red', canViewNsfw: true, browsingLevel: 1, showNsfw: true },
+        { host: 'civitai.com', canViewNsfw: true, browsingLevel: 31, showNsfw: true },
+        { host: 'civitai.com', canViewNsfw: false, browsingLevel: 31, showNsfw: true },
+      ];
+      for (const c of cases) {
+        const res = await mintAs({
+          host: c.host,
+          canViewNsfw: c.canViewNsfw,
+          user: { ...modBase, showNsfw: c.showNsfw, browsingLevel: c.browsingLevel },
+        });
+        const body = res._body as { maxBrowsingLevel: number; effectiveBrowsingLevel: number };
+        expect(typeof body.effectiveBrowsingLevel).toBe('number');
+        expect(body.effectiveBrowsingLevel & ~body.maxBrowsingLevel).toBe(0);
+      }
+    });
+  });
+
   describe('NSFW-app-red-only maturity', () => {
     it('red-capable host (civitai.red) mints the FULL mature ceiling', async () => {
       mockSession.value = { user: { id: 42, bannedAt: null, isModerator: true } } as never;


### PR DESCRIPTION
## The gap

`BLOCK_INIT` carries `maxBrowsingLevel`, computed from `domainBrowsingCeiling(color)`.
That is a property of the **domain** — so every viewer on `civitai.red` receives the
identical, maximally-wide ceiling, **including one whose own NSFW setting is off**. A block
gating mature affordances on it shows them to someone who explicitly asked not to see
them. The viewer's own browsing level — the one they set with the native NSFW control in
the site header — was projected nowhere in `BLOCK_INIT`.

The platform already computes the viewer's level server-side (`getServerBrowsingLevel`,
which `wildcard-pack.service.ts` gates downloads on), just never sent it to blocks.

## What this adds

`effectiveBrowsingLevel` — the domain ceiling **intersected** with the viewer's own level.

| | answers |
|---|---|
| `maxBrowsingLevel` | what this **domain** permits anybody |
| `effectiveBrowsingLevel` | what **this viewer** may be shown here |

Path: mint response → `useBlockToken` → `IframeHost` / `PageBlockHost` props →
`projectBlockInitMaturity` → `BLOCK_INIT`. All three mint response paths carry it,
including the two forced-SFW dev-tunnel branches (forced-SFW caps the *domain* half only;
an author with NSFW off still dogfoods at PG).

## Raw vs effective — the design decision

**The viewer's raw level is deliberately not projected.** Two reasons:

1. 🔴 **On `blue` the raw viewer level is WIDER than the domain permits.**
   `domainBrowsingCeiling('blue')` is SFW for App Blocks (a deliberate product decision,
   documented on that function), while `canViewNsfw` is `true` on blue site-wide — so
   `getServerBrowsingLevel` returns a saved preference that routinely carries R/X/XXX.
   A raw number on the wire is not permission for anything, but it is *shaped* exactly
   like permission, and some block will eventually read it as such.
2. It is the higher-resolution form of `viewerNsfwEnabled` — the field
   `projectBlockInit.ts` was written specifically to **stop** sending to third-party
   iframes (its file header lists it first among the over-shares it drops). Shipping the
   raw level would quietly reverse that decision.

Only the intersection is both safe and useful, so only the intersection ships. The name is
`effectiveBrowsingLevel` rather than `viewerBrowsingLevel` precisely so it cannot be
misread as the raw preference.

## Clamped twice, and the two are not redundant

- The **mint** clamps against the ceiling it computed in the same request.
- `projectBlockInitMaturity` clamps again against the ceiling actually being **projected on
  that message**, after sanitisation has had its say.

They can disagree: a non-finite `maxBrowsingLevel` is dropped to `undefined` in the
projection, at which point **nothing bounds the value** and a server-clamped number would
ride out unbounded. Hence the rule that `effectiveBrowsingLevel` is never projected
without a projected `maxBrowsingLevel`.

## Fail-closed everywhere

| case | result |
|---|---|
| anonymous viewer | PG |
| signed in, NSFW off | PG |
| signed in, NSFW on, no saved level | PG |
| field absent (older mint) | omitted → consumers fall back to `maxBrowsingLevel` |
| `NaN` / `Infinity` / string / `null` | omitted |
| **negative** | omitted — *not* masked |

🔴 The negative case is the counter-intuitive one and is called out in the code: two's
complement sets every high bit, so `-1 & ceiling === ceiling`. Masking junk would resolve
it to the **full domain ceiling** — the widest possible viewer, the exact inversion of what
the field means.

## Test coverage

29 new cases across `browsingLevel-maturity.test.ts` (13), `projectBlockInit.test.ts` (10)
and the `/api/v1/block-tokens` endpoint suite (6). Those three files now run 107/107 green.

🔴 **Every fixture makes the domain and the viewer disagree — in both directions.** They
genuinely disagree both ways in production (blue ⇒ the viewer is wider, red ⇒ the domain
is wider), and a fixture where they agree cannot distinguish the intersection from either
input: all three produce the same number. Several fixtures (`11 ∩ 22 → 2`) are chosen so
the answer equals *neither* operand, killing "return the first argument", "return the
second", `min`, and `|` in one assertion. Plus an exhaustive subset check over the whole
5-bit level lattice.

The headline case — a full-NSFW viewer on `civitai.com` — is asserted at both the pure
projection and the live mint handler: the mature bits never survive.

## Mutation results

Seven mutants, all killed, each by an assertion naming its own guard:

| # | mutation | killed by |
|---|---|---|
| H1 | `effectiveBrowsingCeiling` returns the viewer level (no intersection) | 6 tests, incl. "a viewer WIDER than the domain cannot widen it" |
| H2 | absent-viewer fallback `PG` → the ceiling | line 224 — the `undefined` assertion |
| H3 | drop `viewerBrowsingLevel >= 0` | line 229 — the `-1` assertion *(distinct line from H2)* |
| H8 | domain-ceiling fallback SFW → all-levels | "fails closed on an absent/malformed DOMAIN ceiling" |
| H4 | projection returns the raw effective level (no clamp) | 3 tests, incl. the blue widening case |
| H5 | drop the "no ceiling ⇒ no field" rule | "omits the field when there is NO projected ceiling" |
| H6 | drop `rawEffective >= 0` | "rejects a NEGATIVE effective level instead of masking it" |
| H7 | mint returns `maxBrowsingLevel` (ignores the viewer) | 3 endpoint tests |

Method: `cp -a` pristine → single mutation (anchor asserted to occur exactly once) → run
→ restore → `cmp` byte-identity. Unmutated positive control: 107/107 green.

## Gates

| gate | result |
|---|---|
| `pnpm typecheck` | **0 type errors** (65s) |
| `eslint` on the 10 changed files | **0 errors**, 5 warnings (all on pre-existing lines) |
| `prettier --check` on the changed files | clean |
| full `vitest --project 'unit*'` | **1674 files / 38730 tests passed, 0 failed** (3 files / 33 tests skipped) |

An earlier local run of the full suite showed
`src/server/__tests__/eventloop-watchdog.capture.test.ts` failing. It is **not this
branch**: a clean detached worktree at `origin/main` with no changes reproduced the
identical failure in isolation. It passed on the final run, so it is a pre-existing flake
(there is already a `zach/3773-watchdog-poll-not-sleep` branch for it). Recorded here
rather than quietly dropped, because the green run alone would not have distinguished
"fixed" from "flaked".

## Sequencing

This is the platform half and **must land first**. The SDK half is
civitai/civitai-app-starters#299 (types, validator, `useDomainMaturity`, mock host); until
this merges the field is simply absent there and every consumer falls back to
`maxBrowsingLevel`.

All CI green: unit shards 1-4, App unit tests + typecheck, Package unit tests, Geometry
tests, ESLint + Prettier (changed files), Schema drift gate, event-engine-common pin,
Windows dev-env, and `tekton / typecheck`.

Merging to `main` here is not a deploy — this repo ships from `release`.
