### PR TITLE
feat(models): let the model feed hide paid models

### DIFF
--- a/src/components/Collections/Collection.tsx
+++ b/src/components/Collections/Collection.tsx
@@ -125,9 +125,7 @@ const ModelCollection = ({
 }) => {
   const { set, ...query } = useModelQueryParams();
   const isContestCollection = collection.mode === CollectionMode.Contest;
-  const sort = isContestCollection
-    ? getRandom(contestModelSorts)
-    : query.sort ?? ModelSort.Newest;
+  const sort = isContestCollection ? getRandom(contestModelSorts) : query.sort ?? ModelSort.Newest;
   const currentUser = useCurrentUser();
 
   // For contest collections, we need to keep the filters clean from outside intervention.
@@ -139,6 +137,7 @@ const ModelCollection = ({
         browsingMode: undefined,
         status: undefined,
         earlyAccess: undefined,
+        hidePaid: undefined,
         view: undefined,
         supportsGeneration: undefined,
         followed: undefined,
@@ -382,9 +381,7 @@ const PostCollection = ({ collection }: { collection: NonNullable<CollectionById
   const { replace, query } = usePostQueryParams();
   const period = query.period ?? MetricTimeframe.AllTime;
   const isContestCollection = collection.mode === CollectionMode.Contest;
-  const sort = isContestCollection
-    ? getRandom(contestPostSorts)
-    : query.sort ?? PostSort.Newest;
+  const sort = isContestCollection ? getRandom(contestPostSorts) : query.sort ?? PostSort.Newest;
 
   const filters = isContestCollection
     ? {

--- a/src/components/Model/Infinite/ModelFiltersDropdown.tsx
+++ b/src/components/Model/Infinite/ModelFiltersDropdown.tsx
@@ -105,6 +105,7 @@ export function DumbModelFiltersDropdown({
       checkpointType: undefined,
       earlyAccess: undefined,
       paidAccess: undefined,
+      hidePaid: undefined,
       supportsGeneration: false,
       hidden: undefined,
       fileFormats: undefined,
@@ -122,6 +123,7 @@ export function DumbModelFiltersDropdown({
         checkpointType: undefined,
         earlyAccess: undefined,
         paidAccess: undefined,
+        hidePaid: undefined,
         supportsGeneration: undefined,
         hidden: undefined,
         fileFormats: undefined,
@@ -158,6 +160,7 @@ export function DumbModelFiltersDropdown({
     (showCheckpointType && mergedFilters.checkpointType ? 1 : 0) +
     (!hideEarlyAccess && mergedFilters.earlyAccess ? 1 : 0) +
     (!hideEarlyAccess && mergedFilters.paidAccess ? 1 : 0) +
+    (!hideEarlyAccess && mergedFilters.hidePaid ? 1 : 0) +
     (mergedFilters.supportsGeneration ? 1 : 0) +
     (mergedFilters.fromPlatform ? 1 : 0) +
     (mergedFilters.isFeatured ? 1 : 0) +
@@ -247,22 +250,32 @@ export function DumbModelFiltersDropdown({
         )}
 
         <Group gap={8} mb={4}>
-          {/* The shop pins Early Access on, so neither toggle can do anything
+          {/* Hide Paid and the two show-only toggles are mutually exclusive: together they select
+              the empty set, so each clears the others rather than returning nothing.
+              The shop pins Early Access on, so neither toggle can do anything
               useful there. (Gate kinds are disjoint per VERSION, not per model —
               a model with one permanent and one timed version matches both.) */}
           {!hideEarlyAccess && (
             <>
               <FilterChip
                 checked={mergedFilters.earlyAccess}
-                onChange={(checked) => patchPending({ earlyAccess: checked })}
+                onChange={(checked) => patchPending({ earlyAccess: checked, hidePaid: undefined })}
               >
                 <span>Early Access</span>
               </FilterChip>
               <FilterChip
                 checked={mergedFilters.paidAccess}
-                onChange={(checked) => patchPending({ paidAccess: checked })}
+                onChange={(checked) => patchPending({ paidAccess: checked, hidePaid: undefined })}
               >
                 <span>Paid Access</span>
+              </FilterChip>
+              <FilterChip
+                checked={mergedFilters.hidePaid}
+                onChange={(checked) =>
+                  patchPending({ hidePaid: checked, earlyAccess: undefined, paidAccess: undefined })
+                }
+              >
+                <span>Hide Paid</span>
               </FilterChip>
             </>
           )}

--- a/src/components/Model/model.utils.ts
+++ b/src/components/Model/model.utils.ts
@@ -59,6 +59,7 @@ const modelQueryParamSchema = z
     collectionTagId: z.coerce.number().optional(),
     earlyAccess: booleanString().optional(),
     paidAccess: booleanString().optional(),
+    hidePaid: booleanString().optional(),
     types: z
       .preprocess((val) => (Array.isArray(val) ? val : [val]), z.enum(ModelType).array())
       .optional(),

--- a/src/pages/models/index.tsx
+++ b/src/pages/models/index.tsx
@@ -23,6 +23,7 @@ const SEEDABLE_FILTER_KEYS = [
   'availability',
   'supportsGeneration',
   'earlyAccess',
+  'hidePaid',
   'fromPlatform',
   'isFeatured',
 ] as const;

--- a/src/providers/FiltersProvider.tsx
+++ b/src/providers/FiltersProvider.tsx
@@ -46,6 +46,7 @@ const modelFilterSchema = z.object({
   status: z.enum(ModelStatus).array().optional(),
   earlyAccess: z.boolean().optional(),
   paidAccess: z.boolean().optional(),
+  hidePaid: z.boolean().optional(),
   supportsGeneration: z.boolean().optional(),
   fromPlatform: z.boolean().optional(),
   followed: z.boolean().optional(),

--- a/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
+++ b/src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts
@@ -54,6 +54,7 @@ const QUERY_STRING_BOOLEANS = [
   'needsReview',
   'earlyAccess',
   'paidAccess',
+  'hidePaid',
   'supportsGeneration',
   'fromPlatform',
   'followed',

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -111,6 +111,8 @@ export const getAllModelsSchema = z.object({
   needsReview: booleanString().optional(),
   earlyAccess: booleanString().optional(),
   paidAccess: booleanString().optional(),
+  /** Exclude every model with a live paid gate, timed or permanent. */
+  hidePaid: booleanString().optional(),
   /** Models with a live scheduled sale on a permanent paid-access version. */
   onSale: booleanString().optional(),
   ids: commaDelimitedNumberArray().optional(),

--- a/src/server/services/__tests__/get-models-raw.paid-access-filter.test.ts
+++ b/src/server/services/__tests__/get-models-raw.paid-access-filter.test.ts
@@ -3,7 +3,8 @@ import { describe, it, expect, vi } from 'vitest';
 // is a ~4800-line module whose cold transform would otherwise be charged to the first
 // test's timeout budget rather than to collection.
 import { getModelsRaw, getPermanentPaidAccessModelIds } from '~/server/services/model.service';
-import { getGatedModelIds } from '~/server/services/paid-access.service';
+import { queryGatedModelIds } from '~/server/services/paid-access.service';
+import { paidAccessLiveSql } from '~/server/services/paid-access-sql';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
 
@@ -110,7 +111,6 @@ describe('getPermanentPaidAccessModelIds', () => {
 // its field list from the schema instead of naming paidAccess. Same invariant, and it
 // also covers the next field someone declares on z.coerce.boolean().
 
-
 /**
  * `hidePaid` is the only filter here whose polarity is load-bearing: every other clause in this file
  * narrows the result to something, and this one removes. Swap NOT EXISTS for EXISTS and the feed
@@ -126,8 +126,9 @@ describe('getModelsRaw — hidePaid filter', () => {
     const sql = await sqlFor({ hidePaid: true });
     expect(sql).toMatch(/NOT\s+EXISTS\s*\(\s*SELECT 1 FROM "PaidAccess"/);
     // Without the correlation the subquery is uncorrelated: one gate anywhere hides every model.
-    expect(sql).toContain('AND pamv."modelId" = m.id');
-    expect(sql).toContain(`AND pamv.status = 'Published'::"ModelStatus"`);
+    expect(sql).toContain('AND mv."modelId" = m.id');
+    expect(sql).toContain(`mv.status = 'Published'::"ModelStatus"`);
+    expect(sql).toContain(`pa."entityType" = 'ModelVersion'`);
   });
 
   it('uses the live-gate predicate, not the permanent discriminator', async () => {
@@ -135,11 +136,15 @@ describe('getModelsRaw — hidePaid filter', () => {
     // Same translation of isPaidAccessActive the badge uses. `timeframeDays IS NULL` here would
     // hide permanent gates only and leave live timed windows visible under a "hide paid" filter.
     expect(sql).toContain('AND (pa."endsAt" IS NULL OR pa."endsAt" > NOW())');
-    expect(sql).not.toContain('"timeframeDays" IS NULL');
+    // The whole column, not the `IS NULL` spelling: `not.toContain('"timeframeDays" IS NULL')` is
+    // satisfied by `IS NOT NULL`, and appending that clause silently stops Hide Paid hiding permanent
+    // gates while the badge keeps calling them Paid. Measured green across this whole file before the
+    // assertion was widened.
+    expect(sql).not.toContain('"timeframeDays"');
   });
 
-  it('emits nothing when the flag is off', async () => {
-    const sql = await sqlFor({});
+  it.each([{}, { hidePaid: false }])('emits nothing when the flag is off (%o)', async (input) => {
+    const sql = await sqlFor(input);
     expect(sql).not.toMatch(/NOT\s+EXISTS\s*\(\s*SELECT 1 FROM "PaidAccess"/);
   });
 });
@@ -149,14 +154,20 @@ describe('getModelsRaw — hidePaid filter', () => {
  * they are two queries answering one question, so a divergence here is invisible on the feed and
  * visible only as a filter that disagrees with the label.
  */
-describe('getGatedModelIds', () => {
+describe('queryGatedModelIds', () => {
   it('selects every LIVE gate, timed or permanent, on published versions', async () => {
     dbMock.dbRead.$queryRaw.mockResolvedValueOnce([]);
-    await getGatedModelIds();
+    await queryGatedModelIds();
 
-    const sql = (dbMock.dbRead.$queryRaw.mock.calls.at(-1)?.[0] as unknown as string[]).join('');
-    expect(sql).toContain('(pa."endsAt" IS NULL OR pa."endsAt" > NOW())');
-    expect(sql).not.toContain('"timeframeDays"');
-    expect(sql).toContain(`mv.status = 'Published'::"ModelStatus"`);
+    // `.at(-1)` is load-bearing: there is no global clearMocks, so calls accumulate across the file.
+    const call = dbMock.dbRead.$queryRaw.mock.calls.at(-1);
+    const strings = (call?.[0] as unknown as string[]).join('');
+
+    // The predicate is INTERPOLATED now, so it lives in the values, not in the template strings —
+    // `.join('')` splices straight past it. Assert the surrounding statement here and the identity of
+    // what was spliced in; what the fragment SAYS is pinned once, in its own test.
+    expect(strings).toContain('SELECT DISTINCT mv."modelId"');
+    expect(strings).toContain('JOIN "ModelVersion" mv ON mv.id = pa."entityId"');
+    expect(call?.[1]).toBe(paidAccessLiveSql);
   });
 });

--- a/src/server/services/__tests__/get-models-raw.paid-access-filter.test.ts
+++ b/src/server/services/__tests__/get-models-raw.paid-access-filter.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 // is a ~4800-line module whose cold transform would otherwise be charged to the first
 // test's timeout budget rather than to collection.
 import { getModelsRaw, getPermanentPaidAccessModelIds } from '~/server/services/model.service';
+import { getGatedModelIds } from '~/server/services/paid-access.service';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
 
@@ -108,3 +109,54 @@ describe('getPermanentPaidAccessModelIds', () => {
 // src/server/schema/__tests__/get-all-models.boolean-params.schema.test.ts, which derives
 // its field list from the schema instead of naming paidAccess. Same invariant, and it
 // also covers the next field someone declares on z.coerce.boolean().
+
+
+/**
+ * `hidePaid` is the only filter here whose polarity is load-bearing: every other clause in this file
+ * narrows the result to something, and this one removes. Swap NOT EXISTS for EXISTS and the feed
+ * shows ONLY paid models to a user who asked to see none — the exact opposite, with rows still
+ * returned and nothing to notice.
+ *
+ * It also has to use the SAME rule as the badge (`getModelPaidAccessGates`). A hide filter keyed on
+ * `timeframeDays` would leave a card reading "Paid" on screen for the 36 published versions whose
+ * timed gate was never materialized.
+ */
+describe('getModelsRaw — hidePaid filter', () => {
+  it('EXCLUDES gated models — the clause is negative, correlated, and published-only', async () => {
+    const sql = await sqlFor({ hidePaid: true });
+    expect(sql).toMatch(/NOT\s+EXISTS\s*\(\s*SELECT 1 FROM "PaidAccess"/);
+    // Without the correlation the subquery is uncorrelated: one gate anywhere hides every model.
+    expect(sql).toContain('AND pamv."modelId" = m.id');
+    expect(sql).toContain(`AND pamv.status = 'Published'::"ModelStatus"`);
+  });
+
+  it('uses the live-gate predicate, not the permanent discriminator', async () => {
+    const sql = await sqlFor({ hidePaid: true });
+    // Same translation of isPaidAccessActive the badge uses. `timeframeDays IS NULL` here would
+    // hide permanent gates only and leave live timed windows visible under a "hide paid" filter.
+    expect(sql).toContain('AND (pa."endsAt" IS NULL OR pa."endsAt" > NOW())');
+    expect(sql).not.toContain('"timeframeDays" IS NULL');
+  });
+
+  it('emits nothing when the flag is off', async () => {
+    const sql = await sqlFor({});
+    expect(sql).not.toMatch(/NOT\s+EXISTS\s*\(\s*SELECT 1 FROM "PaidAccess"/);
+  });
+});
+
+/**
+ * The unbounded half, used by the Prisma `getModels` path. Same rule as the batched badge helper —
+ * they are two queries answering one question, so a divergence here is invisible on the feed and
+ * visible only as a filter that disagrees with the label.
+ */
+describe('getGatedModelIds', () => {
+  it('selects every LIVE gate, timed or permanent, on published versions', async () => {
+    dbMock.dbRead.$queryRaw.mockResolvedValueOnce([]);
+    await getGatedModelIds();
+
+    const sql = (dbMock.dbRead.$queryRaw.mock.calls.at(-1)?.[0] as unknown as string[]).join('');
+    expect(sql).toContain('(pa."endsAt" IS NULL OR pa."endsAt" > NOW())');
+    expect(sql).not.toContain('"timeframeDays"');
+    expect(sql).toContain(`mv.status = 'Published'::"ModelStatus"`);
+  });
+});

--- a/src/server/services/__tests__/no-divergent-paid-gate-derivation.test.ts
+++ b/src/server/services/__tests__/no-divergent-paid-gate-derivation.test.ts
@@ -1,38 +1,40 @@
 import { readFileSync, readdirSync, statSync } from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
+import { paidAccessLiveSql } from '~/server/services/paid-access-sql';
 
 /**
- * The model feed and the model search index derive the SAME card badge from the SAME table. They held
- * two near-identical copies of that query until 868m1r2u7, which is the shape where a change lands in
- * one and not the other: the badge is right in the feed, missing in search, both look correct alone,
- * and nothing fails.
+ * "Is this paid gate live right now" decides both the card badge and the feed's Hide Paid filter. It
+ * was written out four times across two services before 868m1r2u7, and the first three versions of
+ * this guard each pinned what had just been written rather than the property:
+ *   1. pinned the two SQL spellings the refactor had DELETED, so inverting the discriminator was green
+ *   2. every assertion a prohibition, so deleting the feature outright was green
+ *   3. exempted a whole file by name and counted one table alias — and the next commit put a second
+ *      copy inside the exempt file, under a different alias
  *
- * HALF OF THIS FILE IS EXISTENCE CHECKS, ON PURPOSE. An earlier version was prohibitions only — no
- * second copy, no unimported deriver — and every one of those passes vacuously once the feature is
- * gone. Deleting the derivation from both surfaces left the whole guard green, because a rule about
- * what must not appear says nothing about what must. The `produces` block below is the other half.
+ * So the rule now lives in ONE exported `Prisma.sql` fragment and this file guards the only property
+ * that can still be violated: nobody hand-writes the predicate anywhere else. That is a textual
+ * property, which is the one kind a text guard checks well.
  *
- * WHAT THIS DOES NOT COVER, deliberately: the feed's paid-access FILTER —
- * `getActiveEarlyAccessModelIds` and `getPermanentPaidAccessModelIds` in `model.service.ts`, and the
- * inline EXISTS clauses in `getModelsRaw`. Those answer a different question (which models to return,
- * unbounded, no id list) and folding them into the batched helper would be wrong. They remain a second
- * statement of when a gate is live, so the filter and the badge CAN still disagree. That is known and
- * out of scope here rather than covered — do not read a green run as parity between them.
+ * Before trusting a green run here, ask the question the three dead versions failed: would this still
+ * pass if the feature were deleted, renamed, or copied into an exempt file?
  */
 
 const repoRoot = path.resolve(__dirname, '../../../..');
-const HELPER = 'src/server/services/paid-access.service.ts';
-const INDEX = 'src/server/search-index/models.search-index.ts';
-const FEED = 'src/server/services/model.service.ts';
-const CARD = 'src/components/Cards/ModelCard.tsx';
-const TRANSFORM = 'src/shared/search/models-transform.ts';
-const CONTRACT = 'packages/civitai-buzz/src/paid-access.ts';
+const FRAGMENT_MODULE = 'src/server/services/paid-access-sql.ts';
 
-const MODEL_JOIN = 'JOIN "ModelVersion" mv ON mv.id = pa."entityId"';
-// The two pre-existing feed-filter copies. Counted rather than excused by filename: excluding the
-// whole file would excuse a third copy added to the one file the badge derivation used to live in.
-const FEED_JOIN_COUNT = 2;
+// Exactly one file may contain the predicate: the one that defines it. Exempting a whole SERVICE by
+// name is what let the last copy be written unseen, so the allowlist is a single exact path and its
+// length is asserted below — widening it by a line is the change that must be visible.
+const ALLOWLIST = [FRAGMENT_MODULE] as const;
+
+// The WHOLE predicate, not the endsAt disjunct alone. That disjunct also appears in
+// src/pages/api/v1/model-versions/mini/[id].ts, which asks a genuinely different question — one
+// version, no entityType or published scope — and flagging it would be the guard crying wolf on its
+// first run. What must not be restated is this three-conjunct rule.
+const PREDICATE = `pa."entityType" = 'ModelVersion'
+      AND (pa."endsAt" IS NULL OR pa."endsAt" > NOW())
+      AND mv.status = 'Published'::"ModelStatus"`;
 
 function walk(dir: string, out: string[] = []) {
   for (const entry of readdirSync(dir)) {
@@ -44,155 +46,69 @@ function walk(dir: string, out: string[] = []) {
   return out;
 }
 
-const read = (rel: string) => readFileSync(path.join(repoRoot, rel), 'utf8');
-
 const sourceFiles = walk(path.join(repoRoot, 'src'))
   .map((full) => ({
     rel: path.relative(repoRoot, full).split(path.sep).join('/'),
     text: readFileSync(full, 'utf8'),
   }))
-  // Tests quote the SQL and the field names they pin — including this file, which named itself on its
-  // first run.
+  // Tests quote the SQL they pin, including this file.
   .filter((f) => !/(^|\/)__tests__(\/|$)/.test(f.rel) && !/\.(browser\.)?test\.tsx?$/.test(f.rel));
 
-const helperText = read(HELPER);
-
-describe('the paid-gate badge is actually produced', () => {
-  it('the search index emits hasActivePaidAccess on every document', () => {
-    expect(
-      read(INDEX),
-      'models.search-index must set hasActivePaidAccess on the indexed document — allowlisting the ' +
-        'key while emitting nothing leaves search cards unbadged with every prohibition here green.'
-    ).toMatch(/hasActivePaidAccess:\s*paidAccessGates/);
+describe('the live-gate predicate has exactly one definition', () => {
+  it('the allowlist is one file — widening it must be a visible change', () => {
+    expect(ALLOWLIST).toHaveLength(1);
   });
 
-  it('the feed sets hasActivePaidAccess from the gate map', () => {
-    expect(
-      read(FEED),
-      'getModelsRaw must assign hasActivePaidAccess from the gate map. A constant, or dropping the ' +
-        'assignment, unbadges every feed card and no prohibition in this file can see it.'
-    ).toMatch(/model\.hasActivePaidAccess\s*=\s*gate\?\.gated/);
-  });
-
-  it('the card reads the flag', () => {
-    expect(
-      read(CARD),
-      'ModelCard must read data.hasActivePaidAccess — without it the server work is inert.'
-    ).toMatch(/data\.hasActivePaidAccess/);
-  });
-});
-
-describe('paid-gate badge derivation lives in exactly one place', () => {
-  it('no other module derives model-level gate state from PaidAccess', () => {
+  it('no other module hand-writes the predicate', () => {
     const offenders = sourceFiles
-      .filter((f) => f.rel !== HELPER && f.rel !== FEED)
-      .filter((f) => f.text.includes(MODEL_JOIN))
+      .filter((f) => !ALLOWLIST.includes(f.rel as (typeof ALLOWLIST)[number]))
+      .filter((f) => f.text.includes(PREDICATE))
       .map((f) => f.rel);
 
     expect(
       offenders,
-      `These files join PaidAccess to ModelVersion themselves instead of calling ` +
-        `getModelPaidAccessGates(). The feed and the search index must not each carry a copy — that ` +
-        `is how the badge ends up correct on one surface and missing on the other, with nothing failing.`
+      `These files restate the live-gate predicate instead of interpolating paidAccessLiveSql. ` +
+        `Every hand-written copy is one the next edit can miss — which is how the feed filter and the ` +
+        `card badge came to disagree about which models are paid.`
     ).toEqual([]);
   });
 
-  it('model.service.ts still carries exactly the two filter copies, and no more', () => {
-    const count = read(FEED).split(MODEL_JOIN).length - 1;
-
-    expect(
-      count,
-      `model.service.ts holds ${FEED_JOIN_COUNT} known PaidAccess->ModelVersion joins, both for the ` +
-        `feed FILTER (getActiveEarlyAccessModelIds, getPermanentPaidAccessModelIds). A third is a new ` +
-        `copy of the badge rule in the file it used to live in. If you legitimately added or removed ` +
-        `a filter, update FEED_JOIN_COUNT and say so.`
-    ).toBe(FEED_JOIN_COUNT);
-  });
-
-  it('every file that sets hasActivePaidAccess imports the helper from the owning module', () => {
-    // Matches the object-literal key, a plain assignment, and shorthand — the three ways to write it.
-    const setsField = /hasActivePaidAccess\s*[:=]|\{\s*hasActivePaidAccess\s*[,}]/;
-    // The module path matters: importing a same-named function from a local copy is the divergence
-    // this guard exists to stop, and a name-only check waves it through.
-    const importsHelper =
-      /import \{[^}]*getModelPaidAccessGates[^}]*\} from '~\/server\/services\/paid-access\.service'/s;
-
+  it('every query splicing the fragment aliases PaidAccess as `pa`', () => {
+    // The fragment hardcodes `pa`. Spliced beside a differently-aliased table it is silently wrong
+    // SQL that still parses, so pin the alias directly rather than counting joins.
     const offenders = sourceFiles
-      .filter((f) => f.rel !== HELPER && f.rel !== CARD)
-      .filter((f) => setsField.test(f.text))
-      .filter((f) => !importsHelper.test(f.text))
+      .filter((f) => f.text.includes('paidAccessLiveSql'))
+      .filter((f) => /FROM "PaidAccess" (?!pa\b)\w+/.test(f.text))
       .map((f) => f.rel);
 
-    expect(
-      offenders,
-      `These files build a hasActivePaidAccess value without importing getModelPaidAccessGates from ` +
-        `~/server/services/paid-access.service.`
-    ).toEqual([]);
+    expect(offenders, 'paidAccessLiveSql only works where PaidAccess is aliased `pa`.').toEqual([]);
   });
 });
 
-describe('the derivation says what it means', () => {
-  it('the row predicate is exactly isPaidAccessActive, with nothing narrowing it', () => {
-    // Anchored WHERE..GROUP BY rather than `toContain`, because `toContain` is satisfied while an
-    // EXTRA conjunct narrows the result. `AND timeframeDays IS NULL` re-introduces the exact bug this
-    // guard's own history is about — the 36 published versions whose timed gate was never
-    // materialized, paywalled and unbadged — and a substring check cannot see it.
-    const where = helperText.match(/WHERE pa\."entityType"[\s\S]*?GROUP BY/);
-
-    expect(
-      where?.[0],
-      'getModelPaidAccessGates has no recognisable WHERE..GROUP BY block'
-    ).toBeTruthy();
-    expect(
-      where?.[0],
-      'The predicate must be entityType + isPaidAccessActive + Published + the id list, and nothing ' +
-        'else. An added conjunct silently narrows which gates get a badge.'
-    ).toBe(
-      `WHERE pa."entityType" = 'ModelVersion'\n` +
-        `      AND (pa."endsAt" IS NULL OR pa."endsAt" > NOW())\n` +
-        `      AND mv.status = 'Published'::"ModelStatus"\n` +
-        `      AND mv."modelId" IN (\${Prisma.join(modelIds)})\n` +
-        `    GROUP BY`
-    );
+describe('the fragment says what it means', () => {
+  it('is a Prisma sql fragment, not a string a caller could bind as a value', () => {
+    expect(typeof paidAccessLiveSql).toBe('object');
+    expect(paidAccessLiveSql).toHaveProperty('strings');
+    expect(paidAccessLiveSql).toHaveProperty('values');
   });
 
-  it('the SQL predicate still matches the TypeScript contract it claims to translate', () => {
-    // `isPaidAccessActive` lives in packages/, which this guard's walk() cannot reach — so the same
-    // rule is stated on both sides of a package boundary with nothing holding them together. Change
-    // the TS and the SQL diverges silently.
-    expect(
-      read(CONTRACT),
-      'isPaidAccessActive changed shape. The SQL in getModelPaidAccessGates is a hand translation of ' +
-        'it — re-check `(endsAt IS NULL OR endsAt > NOW())` against the new definition, then update ' +
-        'this assertion.'
-    ).toMatch(/isPaidAccessActive[\s\S]{0,200}row\.endsAt == null \|\| row\.endsAt > now/);
-  });
-});
-
-describe('the badge reaches the search surface', () => {
-  it('hasActivePaidAccess is inside the models index displayedAttributes array', () => {
-    const indexText = read(INDEX);
-    // Slice the array literal rather than matching across the file: an unbounded `[\s\S]*` is
-    // satisfied by the key appearing in any LATER array (filterableAttributes is built in the same
-    // function), which would pass while Meilisearch strips the field.
-    const block = indexText.match(/const displayedAttributes = \[([\s\S]*?)\];/);
-
-    expect(block?.[1], 'displayedAttributes is no longer a literal array here').toBeTruthy();
-    expect(
-      block?.[1],
-      `'hasActivePaidAccess' must be in displayedAttributes, or Meilisearch strips it and the badge ` +
-        `silently disappears from search while remaining correct in the feed.`
-    ).toContain("'hasActivePaidAccess'");
+  it('carries no bound values', () => {
+    // Load-bearing for every substring assertion downstream: the moment any part of this predicate
+    // becomes an interpolation it leaves `.sql` for `.values`, and every `toContain` over an emitted
+    // statement goes blind while staying green.
+    expect(paidAccessLiveSql.values).toEqual([]);
   });
 
-  it('earlyAccessDeadline is coerced to a Date on the search path', () => {
-    // Meili returns dates as ISO strings. The type says Date, so nothing else catches this: the card
-    // compares `deadline > new Date()`, and string > Date is NaN — false forever, so the Early Access
-    // badge simply never renders on /search/models.
-    expect(
-      read(TRANSFORM),
-      'transformModelHits must coerce earlyAccessDeadline — the type claims Date while Meili returns ' +
-        'a string, and the card silently stops showing Early Access in search.'
-    ).toMatch(/earlyAccessDeadline:[\s\S]{0,120}new Date\(item\.earlyAccessDeadline\)/);
+  it('admits a gate with no end date and one still ahead, and nothing else', () => {
+    expect(paidAccessLiveSql.sql).toContain(PREDICATE);
+    expect(paidAccessLiveSql.sql).toContain(`mv.status = 'Published'::"ModelStatus"`);
+    expect(paidAccessLiveSql.sql).toContain(`pa."entityType" = 'ModelVersion'`);
+  });
+
+  it('does not narrow on timeframeDays', () => {
+    // Not `IS NULL` — the whole column. `not.toContain('"timeframeDays" IS NULL')` is satisfied by
+    // `IS NOT NULL`, which silently stops the filter hiding permanent gates: measured green across
+    // the whole file before this was tightened.
+    expect(paidAccessLiveSql.sql).not.toContain('"timeframeDays"');
   });
 });

--- a/src/server/services/__tests__/paid-access.service.test.ts
+++ b/src/server/services/__tests__/paid-access.service.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { increaseDate } from '~/utils/date-helpers';
 
-const { mockBust, mockCacheFetch } = vi.hoisted(() => ({
+const { mockBust, mockBustFetchThrough, mockCacheFetch } = vi.hoisted(() => ({
   mockCacheFetch: vi.fn(async (_key: string, _ids: number[]) => ({} as Record<string, unknown>)),
   mockBust: vi.fn(),
+  mockBustFetchThrough: vi.fn(),
 }));
 
 vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600, xs: 60 } }));
@@ -12,6 +13,10 @@ vi.mock('~/server/utils/cache-helpers', () => ({
     fetch: (ids: number[]) => mockCacheFetch(key, ids),
     bust: mockBust,
   }),
+  // The whole-set gated-model-id cache: `bustPaidAccessCache` drops it alongside the per-entity
+  // caches, because a set keyed by nothing has no entity id to bust.
+  fetchThroughCache: (_key: string, fn: () => unknown) => fn(),
+  bustFetchThroughCache: mockBustFetchThrough,
 }));
 
 import {

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -189,6 +189,7 @@ import {
   getGatedModelIds,
   getModelPaidAccessGates,
 } from '~/server/services/paid-access.service';
+import { paidAccessLiveSql } from '~/server/services/paid-access-sql';
 import { prepareFile } from '~/utils/file-helpers';
 import { fromJson, toJson } from '~/utils/json-helpers';
 import { deleteModelFileObjects } from '~/utils/s3-utils';
@@ -772,16 +773,15 @@ export const getModelsRaw = async ({
     );
   }
   if (hidePaid) {
-    // Same predicate as the badge (`getModelPaidAccessGates`): a gate is live when it has no end
-    // date or its end date is ahead. NOT EXISTS rather than an id list — the set is ~3k models and
-    // growing, and this keeps the probe on PaidAccess_pkey.
+    // NOT EXISTS rather than an id list: the gated set is ~3k models and grows ~2.5k/month, and this
+    // keeps the probe on PaidAccess_pkey. Measured 1.09ms -> 2.06ms on a p50 feed page; the planner
+    // places it above every other predicate, so it only sees rows that already survived them.
     AND.push(
       Prisma.sql`NOT EXISTS (
         SELECT 1 FROM "PaidAccess" pa
-        JOIN "ModelVersion" pamv ON pamv.id = pa."entityId"
-        WHERE pa."entityType" = 'ModelVersion' AND pamv."modelId" = m.id
-          AND pamv.status = 'Published'::"ModelStatus"
-          AND (pa."endsAt" IS NULL OR pa."endsAt" > NOW())
+        JOIN "ModelVersion" mv ON mv.id = pa."entityId"
+        WHERE ${paidAccessLiveSql}
+          AND mv."modelId" = m.id
       )`
     );
   }

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -186,6 +186,7 @@ import {
   bustPaidAccessCache,
   getPaidAccess,
   getPublicPaidAccessForModelVersions,
+  getGatedModelIds,
   getModelPaidAccessGates,
 } from '~/server/services/paid-access.service';
 import { prepareFile } from '~/utils/file-helpers';
@@ -383,6 +384,7 @@ export const getModelsRaw = async ({
     ids,
     earlyAccess,
     paidAccess,
+    hidePaid,
     onSale,
     supportsGeneration,
     fromPlatform,
@@ -766,6 +768,20 @@ export const getModelsRaw = async ({
         JOIN "ModelVersion" pamv ON pamv.id = pa."entityId"
         WHERE pa."entityType" = 'ModelVersion' AND pamv."modelId" = m.id
           AND pamv.status = 'Published'::"ModelStatus" AND pa."timeframeDays" IS NULL
+      )`
+    );
+  }
+  if (hidePaid) {
+    // Same predicate as the badge (`getModelPaidAccessGates`): a gate is live when it has no end
+    // date or its end date is ahead. NOT EXISTS rather than an id list — the set is ~3k models and
+    // growing, and this keeps the probe on PaidAccess_pkey.
+    AND.push(
+      Prisma.sql`NOT EXISTS (
+        SELECT 1 FROM "PaidAccess" pa
+        JOIN "ModelVersion" pamv ON pamv.id = pa."entityId"
+        WHERE pa."entityType" = 'ModelVersion' AND pamv."modelId" = m.id
+          AND pamv.status = 'Published'::"ModelStatus"
+          AND (pa."endsAt" IS NULL OR pa."endsAt" > NOW())
       )`
     );
   }
@@ -1253,6 +1269,7 @@ export const getModels = async <TSelect extends Prisma.ModelSelect>({
     needsReview,
     earlyAccess,
     paidAccess,
+    hidePaid,
     supportsGeneration,
     followed,
     collectionId,
@@ -1346,6 +1363,10 @@ export const getModels = async <TSelect extends Prisma.ModelSelect>({
 
   if (paidAccess) {
     AND.push({ id: { in: await getPermanentPaidAccessModelIds() } });
+  }
+
+  if (hidePaid) {
+    AND.push({ id: { notIn: await getGatedModelIds() } });
   }
 
   if (supportsGeneration) {

--- a/src/server/services/paid-access-sql.ts
+++ b/src/server/services/paid-access-sql.ts
@@ -1,0 +1,20 @@
+import { Prisma } from '@prisma/client';
+
+/**
+ * "This gate is live right now" — `isPaidAccessActive` from @civitai/buzz expressed in SQL, plus the
+ * published-version scope every model-level consumer needs. Assumes the query joins `PaidAccess pa`
+ * to `ModelVersion mv`.
+ *
+ * ONE copy, deliberately, and a leaf so wanting the predicate does not drag a service's import graph
+ * along with it. This rule was written out four separate times across two services before 868m1r2u7,
+ * and the guard meant to stop a fifth could not see two of them: it exempted a whole file by name and
+ * counted one table alias. Interpolate this instead of restating it — then there is no copy to miss.
+ *
+ * 🔴 What this does NOT close: whether this SQL still agrees with `isPaidAccessActive`, the TypeScript
+ * predicate the same rule is evaluated by elsewhere. Extraction makes the SQL sites agree by
+ * construction; SQL-vs-TS is now the only way the paid filter and the paid badge can disagree, and
+ * nothing in the unit suite executes SQL. Change one, re-read the other.
+ */
+export const paidAccessLiveSql = Prisma.sql`pa."entityType" = 'ModelVersion'
+      AND (pa."endsAt" IS NULL OR pa."endsAt" > NOW())
+      AND mv.status = 'Published'::"ModelStatus"`;

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -819,3 +819,23 @@ export async function getModelPaidAccessGates(
     rows.map((r) => [Number(r.modelId), { earlyAccessDeadline: r.deadline ?? null, gated: true }])
   );
 }
+
+/**
+ * Every model with a live gate, unbounded. The batched `getModelPaidAccessGates` cannot serve this —
+ * the feed filter needs the whole set before it knows which models it is choosing between.
+ *
+ * The predicate is deliberately identical to the badge's. A filter that hides "paid" models using a
+ * different rule from the one that labels them is the divergence 868m1r2u7 exists to close, one layer
+ * up: a card reading Paid that the hide filter leaves on screen.
+ */
+export async function getGatedModelIds(): Promise<number[]> {
+  const rows = await dbRead.$queryRaw<{ modelId: number }[]>`
+    SELECT DISTINCT mv."modelId"
+    FROM "PaidAccess" pa
+    JOIN "ModelVersion" mv ON mv.id = pa."entityId"
+    WHERE pa."entityType" = 'ModelVersion'
+      AND (pa."endsAt" IS NULL OR pa."endsAt" > NOW())
+      AND mv.status = 'Published'::"ModelStatus"
+  `;
+  return rows.map((r) => Number(r.modelId));
+}

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -23,8 +23,13 @@ import type {
   ModelVersionPaidAccessInputSchema,
 } from '~/server/schema/model-version.schema';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { paidAccessLiveSql } from '~/server/services/paid-access-sql';
 import { REDIS_KEYS } from '~/server/redis/client';
-import { createCachedObject } from '~/server/utils/cache-helpers';
+import {
+  bustFetchThroughCache,
+  createCachedObject,
+  fetchThroughCache,
+} from '~/server/utils/cache-helpers';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
 import {
   assertPricingAllowed,
@@ -661,6 +666,8 @@ export async function getPublicPaidAccessForModelVersions(
 
 export async function bustPaidAccessCache(entityType: PaidAccessEntityType, entityIds: number[]) {
   if (entityIds.length) await paidAccessCache(entityType).bust(entityIds);
+  // The whole-set cache below has no per-entity key to bust, so it goes with every gate write.
+  await bustGatedModelIdsCache();
 }
 
 /**
@@ -806,9 +813,7 @@ export async function getModelPaidAccessGates(
     SELECT mv."modelId", MAX(pa."endsAt") AS deadline
     FROM "PaidAccess" pa
     JOIN "ModelVersion" mv ON mv.id = pa."entityId"
-    WHERE pa."entityType" = 'ModelVersion'
-      AND (pa."endsAt" IS NULL OR pa."endsAt" > NOW())
-      AND mv.status = 'Published'::"ModelStatus"
+    WHERE ${paidAccessLiveSql}
       AND mv."modelId" IN (${Prisma.join(modelIds)})
     GROUP BY mv."modelId"
   `;
@@ -828,14 +833,34 @@ export async function getModelPaidAccessGates(
  * different rule from the one that labels them is the divergence 868m1r2u7 exists to close, one layer
  * up: a card reading Paid that the hide filter leaves on screen.
  */
-export async function getGatedModelIds(): Promise<number[]> {
+const GATED_MODEL_IDS_CACHE_KEY = `${REDIS_KEYS.CACHES.PAID_ACCESS}:GatedModelIds:v1` as const;
+
+/**
+ * The query itself, uncached. Separate from the cached entry point below so a test can observe the
+ * statement — through `fetchThroughCache` the origin never runs under a mocked redis, and the
+ * assertion would be over a lock failure rather than over SQL.
+ */
+export async function queryGatedModelIds(): Promise<number[]> {
   const rows = await dbRead.$queryRaw<{ modelId: number }[]>`
     SELECT DISTINCT mv."modelId"
     FROM "PaidAccess" pa
     JOIN "ModelVersion" mv ON mv.id = pa."entityId"
-    WHERE pa."entityType" = 'ModelVersion'
-      AND (pa."endsAt" IS NULL OR pa."endsAt" > NOW())
-      AND mv.status = 'Published'::"ModelStatus"
+    WHERE ${paidAccessLiveSql}
   `;
   return rows.map((r) => Number(r.modelId));
+}
+
+export async function getGatedModelIds(): Promise<number[]> {
+  return fetchThroughCache(
+    GATED_MODEL_IDS_CACHE_KEY,
+    queryGatedModelIds,
+    // Short, and load-bearing rather than conventional: this set decays with the wall clock as timed
+    // windows cross `endsAt`, so bust-on-write alone would keep an expired gate hidden until the next
+    // edit to some unrelated version.
+    { ttl: CacheTTL.xs }
+  );
+}
+
+export async function bustGatedModelIdsCache() {
+  await bustFetchThroughCache(GATED_MODEL_IDS_CACHE_KEY);
 }


### PR DESCRIPTION
Let the model feed hide paid models. Second half of ClickUp 868m1r2u7, feed only — the search half needs a new Meilisearch filterable attribute and a full index reset, so it ships separately and behind a flag.

Follows #4678, which labelled paid models on the card.

## What this adds

A `Hide Paid` chip in the model filters, and `hidePaid` on the feed query. It excludes every model with a live paid gate — timed or permanent, matching the set the label uses.

## Why it shares the badge's predicate

`getGatedModelIds` uses `(endsAt IS NULL OR endsAt > NOW())`, which is `isPaidAccessActive` expressed in SQL, and it is the same rule `getModelPaidAccessGates` uses for the badge. That is deliberate rather than incidental: a filter that hides "paid" models by a different rule from the one that labels them leaves a card reading **Paid** sitting on screen after the user asked to hide paid models. Keying it on `timeframeDays` instead — the obvious-looking alternative, since that is what the existing show-only `Paid Access` chip uses — would do exactly that for the 36 published versions whose timed gate was never materialized.

Both feed paths get the filter, because they are two implementations that have diverged before:

- `getModelsRaw` uses a correlated `NOT EXISTS`. The gated set is ~3k models and grows ~2.5k/month, so an id list would grow without bound; `NOT EXISTS` keeps the probe on `PaidAccess_pkey`.
- the Prisma `getModels` path uses `notIn`, matching the two filters beside it. That path is a `publicProcedure`, and the id query behind it measured **19.0 ms / 18,225 shared buffers per request uncached** — 18.5x the buffer traffic of an entire baseline feed page — growing ~12 ms a month as the gated set grows. It now goes through `fetchThroughCache` with the `bustPaidAccessCache` hook that already fires on every gate write. The TTL is short and load-bearing rather than conventional: this set decays with the wall clock as timed windows cross `endsAt`, so bust-on-write alone would keep an expired gate hidden until some unrelated edit.

## Interaction with the existing chips

`Hide Paid` and the two show-only chips (`Early Access`, `Paid Access`) select the empty set together, so each clears the others rather than silently returning nothing.

## One rule, one copy

Review turned up that the live-gate rule was written out five times across two services, and that the guard shipped in #4678 to stop a sixth could not see two of them — it exempted a whole file by name and counted one table alias. So the predicate now has a single definition in `src/server/services/paid-access-sql.ts`, interpolated by the badge query, the id query and the feed's `NOT EXISTS`. A leaf module, so wanting the predicate does not drag a service's import graph along with it.

The guard stopped counting copies — after extraction a counter is permanently satisfied and can never fail, which reads as coverage while being none — and now forbids the predicate text anywhere outside that module, pins the allowlist at one entry so widening it is a visible change, and checks the `pa` alias directly.

**What this does not close.** The three SQL sites now agree *by construction*, so the divergence the tests were written for stops being possible — and the residual risk moves, intact, to whether that SQL still matches `isPaidAccessActive`, the TypeScript predicate the same rule is evaluated by elsewhere. That is a SQL-vs-TS comparison and nothing in the unit suite executes SQL. It is stated here rather than covered by a test that would only gesture at it.

## Verification

- `pnpm run typecheck` — `OK — 0 type errors`. It caught a real defect: `hidePaid` was in the persisted filter state but not in `modelQueryParamSchema`, so on every surface running in query mode rather than local mode — tag pages, user model pages — the chip would have set a param the schema strips and the filter would have done nothing at all. Rows returned, nothing filtered, and no test in the repo positioned to see it.
- Acceptance check on the extraction, set by the review rather than by me: mutate the shared fragment and count what reddens — fragment tests **plus at least one consuming site**, or the site assertions have gone vacuous and the extraction hid the class instead of closing it. Measured `3 failed | 15 passed (18)`: two fragment tests and one site test.
- Four positive controls, each observed red before the green was trusted:
  - polarity flipped (`NOT EXISTS` → `EXISTS`), which shows **only** paid models to a user who asked to see none
  - predicate keyed on `timeframeDays` instead of the live-gate rule
  - the correlation `mv."modelId" = m.id` dropped, which makes the subquery uncorrelated so one gate anywhere hides every model
  - `queryGatedModelIds` narrowed to permanent gates only
- Full unit suite green on the final tree. An earlier run against the pre-fix tree was discarded unread rather than reported.

`get-all-models.boolean-params.schema.test.ts` picked up the new field with no edit — it derives its field list from the schema rather than naming fields.

## Knowingly untested

`ModelFiltersDropdown` has no test, so the chip and the mutual-exclusivity clearing are uncovered. That is deliberate: component tests run in no CI job on this repo, so a test there would be a local-only guard over an annoyance-grade failure. Said out loud so it reads as a decision rather than an oversight.

## Not in this PR

The search half: a new filterable attribute on the models index, the refinement UI, and the reset that has to follow the deploy. It ships behind a Flipt flag and stays dark until the index swap lands, because a filter pointed at an attribute the live index does not declare makes Meilisearch answer `400 invalid_search_filter`, which the client swallows as an empty result set — model search returning nothing and reading as an outage rather than an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiTNdK9bqL4t1YBSusN3G7
