### PR TITLE
fix(csam): bound archiver memory when archiving a large image library

### DIFF
--- a/src/server/jobs/__tests__/process-csam.test.ts
+++ b/src/server/jobs/__tests__/process-csam.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Batch integrity for the hourly CSAM jobs.
+ *
+ * The defect: both loops caught per report so that one bad report could not stop the rest, then
+ * read `e.message` inside the catch block. A rejection whose value is not an object — which is
+ * exactly what `uploadStream`'s bare `reject()` produced — makes that read throw a `TypeError`
+ * *inside the catch*, where nothing catches it. It escapes the `for` loop and abandons every
+ * remaining report in that batch, silently, having logged nothing.
+ *
+ * All ids and messages below are invented.
+ */
+
+const mocks = vi.hoisted(() => ({
+  getCsamsToArchive: vi.fn(),
+  getCsamsToReport: vi.fn(),
+  archiveCsamDataForReport: vi.fn(),
+  processCsamReport: vi.fn(),
+  getCsamsToRemoveContent: vi.fn(async () => []),
+}));
+
+vi.mock('~/server/services/csam.service-new', () => mocks);
+
+import { csamJobs } from '~/server/jobs/process-csam';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
+
+const archiveJob = csamJobs.find((job) => job.name === 'archive-csam-reports');
+const sendJob = csamJobs.find((job) => job.name === 'send-csam-reports');
+
+const reports = [{ id: 8801 }, { id: 8802 }, { id: 8803 }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getCsamsToArchive.mockResolvedValue(reports);
+  mocks.getCsamsToReport.mockResolvedValue(reports);
+  mocks.archiveCsamDataForReport.mockResolvedValue(undefined);
+  mocks.processCsamReport.mockResolvedValue(undefined);
+});
+
+/** The exact pre-fix failure: `Promise.reject()` with no argument. */
+const rejectWithUndefined = () => Promise.reject();
+
+describe('archive-csam-reports batch isolation', () => {
+  it('POSITIVE CONTROL: a healthy batch reaches every report', async () => {
+    await archiveJob!.run({}).result;
+    expect(mocks.archiveCsamDataForReport).toHaveBeenCalledTimes(reports.length);
+  });
+
+  it('continues the batch when a report rejects with a non-Error value', async () => {
+    mocks.archiveCsamDataForReport.mockImplementationOnce(rejectWithUndefined);
+
+    // Pre-fix: `e.message` throws `TypeError: Cannot read properties of undefined (reading
+    // 'message')` from inside the catch, the job promise rejects, and reports 8802 and 8803 are
+    // never attempted.
+    await expect(archiveJob!.run({}).result).resolves.not.toThrow();
+
+    expect(mocks.archiveCsamDataForReport).toHaveBeenCalledTimes(reports.length);
+    expect(mocks.archiveCsamDataForReport).toHaveBeenLastCalledWith(reports[2]);
+  });
+
+  it('still logs something identifiable for the failed report', async () => {
+    mocks.archiveCsamDataForReport.mockImplementationOnce(rejectWithUndefined);
+
+    await archiveJob!.run({}).result;
+
+    // A message of `undefined` would make the log line useless, which is the other half of the
+    // fix — extracting safely is not the same as extracting nothing.
+    expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'csam-report', subType: 'archive-data' })
+    );
+    const logged = loggingMock.logToAxiom.mock.calls
+      .map(([arg]) => arg as { subType?: string; message?: unknown })
+      .filter((arg) => arg?.subType === 'archive-data');
+    expect(logged).toHaveLength(1);
+    expect(typeof logged[0].message).toBe('string');
+    expect(logged[0].message).toBe('undefined');
+  });
+
+  it.each([
+    ['a string', 'plain string failure', 'plain string failure'],
+    ['null', null, 'null'],
+    ['a plain object', { code: 'ENOENT' }, '{"code":"ENOENT"}'],
+  ])('survives a rejection that is %s', async (_label, value, expected) => {
+    mocks.archiveCsamDataForReport.mockImplementationOnce(() => Promise.reject(value));
+
+    await expect(archiveJob!.run({}).result).resolves.not.toThrow();
+
+    expect(mocks.archiveCsamDataForReport).toHaveBeenCalledTimes(reports.length);
+    const logged = loggingMock.logToAxiom.mock.calls
+      .map(([arg]) => arg as { subType?: string; message?: unknown })
+      .filter((arg) => arg?.subType === 'archive-data');
+    expect(logged[0].message).toBe(expected);
+  });
+
+  it('preserves the message of a real Error', async () => {
+    mocks.archiveCsamDataForReport.mockImplementationOnce(() =>
+      Promise.reject(new Error('synthetic archive failure'))
+    );
+
+    await archiveJob!.run({}).result;
+
+    const logged = loggingMock.logToAxiom.mock.calls
+      .map(([arg]) => arg as { subType?: string; message?: unknown })
+      .filter((arg) => arg?.subType === 'archive-data');
+    expect(logged[0].message).toBe('synthetic archive failure');
+  });
+});
+
+describe('send-csam-reports batch isolation', () => {
+  it('continues the batch when a report rejects with a non-Error value', async () => {
+    // The identical shape in the sibling loop. Fixing one and not the other would leave the
+    // batch-abort live on the path that actually files the NCMEC report.
+    mocks.processCsamReport.mockImplementationOnce(rejectWithUndefined);
+
+    await expect(sendJob!.run({}).result).resolves.not.toThrow();
+
+    expect(mocks.processCsamReport).toHaveBeenCalledTimes(reports.length);
+    const logged = loggingMock.logToAxiom.mock.calls
+      .map(([arg]) => arg as { subType?: string; message?: unknown })
+      .filter((arg) => arg?.subType === 'send-report');
+    expect(logged).toHaveLength(1);
+    expect(logged[0].message).toBe('undefined');
+  });
+});

--- a/src/server/jobs/process-csam.ts
+++ b/src/server/jobs/process-csam.ts
@@ -9,6 +9,26 @@ import {
 } from '~/server/services/csam.service-new';
 import { logToAxiom } from '~/server/logging/client';
 
+/**
+ * Reads a message off an unknown thrown value without assuming it has one.
+ *
+ * 🔴 This is a batch-integrity guard, not a formatting nicety. The loops below catch per report
+ * so that one bad report cannot stop the rest, but `e.message` on a non-object rejection throws
+ * a `TypeError` *inside the catch block*, where nothing catches it — it escapes the `for` loop
+ * and abandons every remaining report in the batch. `uploadStream` used to reject with a bare
+ * `reject()`, i.e. `undefined`, which is exactly that case. Both ends are fixed; this is the end
+ * that holds for any future thrower.
+ */
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === 'string') return e;
+  try {
+    return JSON.stringify(e) ?? String(e);
+  } catch {
+    return String(e);
+  }
+}
+
 const sendCsamReportsJob = createJob(
   'send-csam-reports',
   '0 */1 * * *',
@@ -18,13 +38,13 @@ const sendCsamReportsJob = createJob(
     for (const report of reports) {
       try {
         await processCsamReport(report);
-      } catch (e: any) {
+      } catch (e) {
         if (isDev) console.log(e);
         logToAxiom({
           name: 'csam-report',
           type: 'error',
           subType: 'send-report',
-          message: e.message,
+          message: errorMessage(e),
         });
       }
     }
@@ -41,12 +61,12 @@ const archiveCsamReportDataJob = createJob(
     for (const report of reports) {
       try {
         await archiveCsamDataForReport(report);
-      } catch (e: any) {
+      } catch (e) {
         logToAxiom({
           name: 'csam-report',
           type: 'error',
           subType: 'archive-data',
-          message: e.message,
+          message: errorMessage(e),
         });
       }
     }

--- a/src/server/services/__tests__/csam-archive-backpressure.test.ts
+++ b/src/server/services/__tests__/csam-archive-backpressure.test.ts
@@ -1,0 +1,338 @@
+import fs from 'fs';
+import path from 'path';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Archiver } from 'archiver';
+import type * as ArchiverModule from 'archiver';
+
+/**
+ * Seam coverage for the CSAM evidence archiver.
+ *
+ * `archive-helpers.test.ts` pins the mechanism in isolation. This file pins the thing that
+ * isolation cannot see: that `archiveCsamDataForReport` actually routes its appends through the
+ * bounded appender. A perfectly-correct helper nobody calls fixes nothing.
+ *
+ * The defect being guarded: every image belonging to the reported user was downloaded, fully
+ * buffered, and handed to `archive.append()` with nothing bounding the archiver's queue, so
+ * resident memory tracked total downloaded bytes and the process was killed on its memory limit
+ * partway through. All numbers below are invented.
+ */
+
+/** Instrumentation over the real archiver: counts appended vs. processed entries per archive. */
+type ArchiveProbe = {
+  appended: number;
+  processed: number;
+  peakOutstanding: number;
+  peakRetainedBytes: number;
+  entryNames: string[];
+  options: { zlib?: { level?: number } } | undefined;
+};
+const probes: ArchiveProbe[] = [];
+
+vi.mock('archiver', async (importOriginal) => {
+  const actual = await importOriginal<{ default: typeof ArchiverModule }>();
+  const create = (actual.default ?? actual) as unknown as (
+    format: string,
+    options?: unknown
+  ) => Archiver;
+  return {
+    default: (format: string, options?: unknown) => {
+      const archive = create(format, options);
+      const probe: ArchiveProbe = {
+        appended: 0,
+        processed: 0,
+        peakOutstanding: 0,
+        peakRetainedBytes: 0,
+        entryNames: [],
+        options: options as ArchiveProbe['options'],
+      };
+      probes.push(probe);
+      let retained = 0;
+      const sizes: number[] = [];
+      const originalAppend = archive.append.bind(archive);
+      archive.append = ((source: Buffer, data: { name: string }) => {
+        probe.appended++;
+        probe.entryNames.push(data.name);
+        sizes.push(Buffer.isBuffer(source) ? source.byteLength : 0);
+        retained += Buffer.isBuffer(source) ? source.byteLength : 0;
+        const outstanding = probe.appended - probe.processed;
+        if (outstanding > probe.peakOutstanding) probe.peakOutstanding = outstanding;
+        if (retained > probe.peakRetainedBytes) probe.peakRetainedBytes = retained;
+        return originalAppend(source, data as never);
+      }) as typeof archive.append;
+      archive.on('entry', () => {
+        retained -= sizes[probe.processed] ?? 0;
+        probe.processed++;
+      });
+      return archive;
+    },
+  };
+});
+
+vi.mock('~/utils/file-utils', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  fetchBlob: (...args: unknown[]) => mockFetchBlob(...args),
+}));
+
+vi.mock('@aws-sdk/lib-storage', () => ({
+  Upload: class {
+    private readonly body: NodeJS.ReadableStream;
+    constructor({ params }: { params: { Body: NodeJS.ReadableStream } }) {
+      this.body = params.Body;
+    }
+    async done() {
+      // Drain, so the PassThrough the service pipes into does not stall the caller.
+      for await (const _chunk of this.body) {
+        void _chunk;
+      }
+      return {};
+    }
+  },
+}));
+
+vi.mock('@aws-sdk/client-s3', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  S3Client: class {
+    send() {
+      return Promise.resolve({});
+    }
+    destroy() {
+      return undefined;
+    }
+  },
+}));
+
+vi.mock('~/server/http/orchestrator/flagged-consumers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getConsumerStrikes: (...args: unknown[]) => mockGetConsumerStrikes(...args),
+}));
+
+let mockFetchBlob: (...args: unknown[]) => unknown = () => null;
+let mockGetConsumerStrikes: (...args: unknown[]) => unknown = async () => [];
+
+import { archiveCsamDataForReport, getCsamsToArchive } from '~/server/services/csam.service-new';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { setEnv } from '~/__tests__/mocks/env.mock';
+import {
+  MAX_PENDING_ARCHIVE_ENTRIES,
+  MEDIA_ARCHIVE_COMPRESSION_LEVEL,
+} from '~/server/utils/archive-helpers';
+
+// Overshoot the bound by a wide, non-multiple margin so the fixture cannot sit on the boundary
+// it is testing. Invented figures — the real report was a different size entirely.
+const IMAGE_COUNT = 53;
+const IMAGE_BYTES = 97 * 1024;
+
+const csamBaseDir = path.join(process.cwd(), 'csam');
+
+function fakeBlob(bytes: number) {
+  return {
+    type: 'image/jpeg',
+    arrayBuffer: async () => {
+      const buffer = Buffer.alloc(bytes, 0xab);
+      return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+    },
+  };
+}
+
+beforeEach(() => {
+  probes.length = 0;
+  mockFetchBlob = async () => fakeBlob(IMAGE_BYTES);
+  mockGetConsumerStrikes = async () => [];
+  setEnv({
+    CSAM_UPLOAD_KEY: 'test-key',
+    CSAM_UPLOAD_SECRET: 'test-secret',
+    CSAM_UPLOAD_REGION: 'test-region',
+    CSAM_UPLOAD_ENDPOINT: 'https://example.invalid',
+    CSAM_BUCKET_NAME: 'test-bucket',
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+afterAll(() => {
+  fs.rmSync(csamBaseDir, { recursive: true, force: true });
+});
+
+describe('getCsamsToArchive', () => {
+  it('orders the batch deterministically so one bad report cannot permanently starve the rest', async () => {
+    await getCsamsToArchive();
+    const args = dbMock.dbRead.csamReport.findMany.mock.calls.at(-1)?.[0];
+    expect(args?.orderBy).toBeDefined();
+    expect(args?.orderBy).toEqual([{ createdAt: 'asc' }, { id: 'asc' }]);
+  });
+});
+
+describe('archiveCsamDataForReport (Image report)', () => {
+  const report = {
+    id: 4242,
+    userId: 909090,
+    reportedById: 5,
+    reportId: 77,
+    type: 'Image',
+    details: {},
+    images: [],
+  };
+
+  function seedDb() {
+    dbMock.dbRead.image.findMany.mockResolvedValue(
+      Array.from({ length: IMAGE_COUNT }, (_, i) => ({
+        id: i + 1,
+        url: `image-uuid-${i}`,
+        name: `picture-${i}.jpeg`,
+        type: 'image',
+        width: 1024,
+        userId: report.userId,
+      }))
+    );
+    dbMock.dbRead.user.findUnique.mockResolvedValue({
+      id: report.userId,
+      name: 'n',
+      email: 'e',
+      username: 'u',
+    });
+    dbMock.dbRead.model.findMany.mockResolvedValue([]);
+    dbMock.dbRead.modelVersion.findMany.mockResolvedValue([]);
+    dbMock.dbWrite.csamReport.update.mockResolvedValue({});
+  }
+
+  it('holds a bounded number of image buffers no matter how many images the user has', async () => {
+    seedDb();
+
+    await archiveCsamDataForReport(report as never);
+
+    const imageArchive = probes.find((p) => p.appended > 0);
+    expect(
+      imageArchive,
+      'no archive received any entries — the probe is wired to nothing'
+    ).toBeDefined();
+
+    // Positive control on the instrument, and it must come FIRST: a bounded reading is
+    // indistinguishable from a probe that observed nothing. `appended` is the right control here
+    // because it is the only counter that reads IMAGE_COUNT on BOTH the fixed and the unfixed
+    // code — asserting the processed count instead would kill this test on the un-awaited
+    // finalize defect before the bound assertion below ever ran, i.e. green for the wrong reason.
+    expect(imageArchive!.appended).toBe(IMAGE_COUNT);
+
+    // The regression. Pre-fix this reads IMAGE_COUNT, because every append was fire-and-forget.
+    expect(imageArchive!.peakOutstanding).toBeLessThanOrEqual(MAX_PENDING_ARCHIVE_ENTRIES);
+    expect(imageArchive!.peakRetainedBytes).toBeLessThanOrEqual(
+      MAX_PENDING_ARCHIVE_ENTRIES * IMAGE_BYTES
+    );
+    // Stated the way the incident was observed: retained bytes must not track downloaded bytes.
+    expect(imageArchive!.peakRetainedBytes).toBeLessThan(IMAGE_COUNT * IMAGE_BYTES);
+  });
+
+  it('returns only once every entry has been written — not while the zip is still being built', async () => {
+    seedDb();
+
+    await archiveCsamDataForReport(report as never);
+
+    // Pre-fix `archive.finalize()` was not awaited, so this returned with the archive still
+    // draining and `fs.createReadStream(outPath)` opened a partial file.
+    const imageArchive = probes.find((p) => p.appended > 0);
+    expect(imageArchive!.appended).toBe(IMAGE_COUNT);
+    expect(imageArchive!.processed).toBe(IMAGE_COUNT);
+  });
+
+  it('archives every image exactly once — backpressure must not change what is stored', async () => {
+    seedDb();
+
+    await archiveCsamDataForReport(report as never);
+
+    const imageArchive = probes.find((p) => p.appended > 0);
+    expect(imageArchive!.entryNames).toHaveLength(IMAGE_COUNT);
+    expect(new Set(imageArchive!.entryNames).size).toBe(IMAGE_COUNT);
+    expect(imageArchive!.entryNames).toContain('picture-0.jpeg');
+    expect(imageArchive!.entryNames).toContain(`picture-${IMAGE_COUNT - 1}.jpeg`);
+  });
+
+  // INVARIANT GUARD, not regression coverage: this pins a deliberate decision rather than a
+  // behaviour the bug violated. Level 9 deflate on already-compressed image bytes is what made
+  // the compressor the bottleneck; with backpressure in place it is no longer a memory hazard,
+  // only a slow one, so nothing else in this suite would notice it coming back.
+  it('builds the archive with the shared low compression level, not a re-hardcoded level 9', async () => {
+    seedDb();
+
+    await archiveCsamDataForReport(report as never);
+
+    const imageArchive = probes.find((p) => p.appended > 0);
+    expect(imageArchive!.options?.zlib?.level).toBe(MEDIA_ARCHIVE_COMPRESSION_LEVEL);
+    expect(MEDIA_ARCHIVE_COMPRESSION_LEVEL).toBeLessThanOrEqual(1);
+  });
+
+  it('stamps archivedAt only after the archive has been written and uploaded', async () => {
+    seedDb();
+
+    await archiveCsamDataForReport(report as never);
+
+    expect(dbMock.dbWrite.csamReport.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: report.id },
+        data: expect.objectContaining({ archivedAt: expect.any(Date) }),
+      })
+    );
+  });
+
+  it('does not stamp archivedAt when the archive fails', async () => {
+    seedDb();
+    mockFetchBlob = async () => {
+      throw new Error('synthetic download failure');
+    };
+
+    await expect(archiveCsamDataForReport(report as never)).rejects.toThrow(
+      'synthetic download failure'
+    );
+    expect(dbMock.dbWrite.csamReport.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('archiveCsamDataForReport (GeneratedImage report)', () => {
+  // The generated-image path had the identical unbounded-append shape and must be bounded too.
+  const report = {
+    id: 4343,
+    userId: 808080,
+    reportedById: 5,
+    reportId: 78,
+    type: 'GeneratedImage',
+    details: {},
+    images: [],
+  };
+
+  beforeEach(() => {
+    dbMock.dbRead.image.findMany.mockResolvedValue([]);
+    dbMock.dbRead.user.findUnique.mockResolvedValue({
+      id: report.userId,
+      name: 'n',
+      email: 'e',
+      username: 'u',
+    });
+    dbMock.dbRead.model.findMany.mockResolvedValue([]);
+    dbMock.dbRead.modelVersion.findMany.mockResolvedValue([]);
+    dbMock.dbWrite.csamReport.update.mockResolvedValue({});
+    mockGetConsumerStrikes = async () => [
+      {
+        strikes: Array.from({ length: IMAGE_COUNT }, (_, i) => ({
+          job: { blobs: [{ previewUrl: `https://example.invalid/blob-${i}.jpeg` }] },
+        })),
+      },
+    ];
+  });
+
+  it('holds a bounded number of generated-image buffers', async () => {
+    await archiveCsamDataForReport(report as never);
+
+    const generatedArchive = probes.find((p) => p.appended > 0);
+    expect(
+      generatedArchive,
+      'no archive received any entries — the probe is wired to nothing'
+    ).toBeDefined();
+
+    // Positive control first, for the same reason as in the Image case above.
+    expect(generatedArchive!.appended).toBe(IMAGE_COUNT);
+    expect(generatedArchive!.peakOutstanding).toBeLessThanOrEqual(MAX_PENDING_ARCHIVE_ENTRIES);
+    expect(generatedArchive!.peakRetainedBytes).toBeLessThan(IMAGE_COUNT * IMAGE_BYTES);
+    expect(generatedArchive!.processed).toBe(IMAGE_COUNT);
+  });
+});

--- a/src/server/services/__tests__/csam-archive-backpressure.test.ts
+++ b/src/server/services/__tests__/csam-archive-backpressure.test.ts
@@ -353,6 +353,71 @@ describe('archiveCsamDataForReport (Image report)', () => {
     expect(imageArchive!.peakOutstanding).toBeLessThanOrEqual(MAX_PENDING_ARCHIVE_ENTRIES);
   });
 
+  it('closes the archive and its file descriptor when a page fetch fails mid-archive', async () => {
+    /**
+     * Paging pulls DB rows *inside* the archiver's lifetime. The pre-change code fetched every
+     * row before any archiver existed, so a `dbRead` failure could not strand one — this is a
+     * leak trigger the new shape introduced. On the failure path `finalize()` never runs, so
+     * without an explicit release the archiver keeps its queued source buffers and the write
+     * stream keeps its fd, while the caller's error handler removes the directory underneath it.
+     */
+    const PAGE_SIZE = ARCHIVE_SCAN_PAGE_SIZE;
+    const TOTAL = PAGE_SIZE + 3;
+    const rows = Array.from({ length: TOTAL }, (_, i) => ({
+      id: i + 1,
+      url: `image-uuid-${i}`,
+      name: `picture-${i}.jpeg`,
+      type: 'image',
+      width: 1024,
+      userId: report.userId,
+    }));
+
+    seedDb();
+    // Two scans run: the bundle's, then `archiveImages`'. Only the second one fails, and only on
+    // its second page — so the archiver is already open and holding entries when it happens.
+    let scanIndex = 0;
+    dbMock.dbRead.image.findMany.mockImplementation(
+      async (args: { where?: { id?: { gt?: number } }; take?: number } = {}) => {
+        const after = args.where?.id?.gt;
+        if (after === undefined) scanIndex++;
+        if (scanIndex === 2 && after !== undefined) throw new Error('synthetic page-2 db failure');
+        return rows.filter((row) => row.id > (after ?? 0)).slice(0, args.take ?? rows.length);
+      }
+    );
+    mockFetchBlob = async () => fakeBlob(8);
+
+    const realCreateWriteStream = fs.createWriteStream;
+    const created: fs.WriteStream[] = [];
+    const spy = vi.spyOn(fs, 'createWriteStream').mockImplementation(((
+      target: fs.PathLike,
+      options?: unknown
+    ) => {
+      const stream = realCreateWriteStream(target as never, options as never);
+      created.push(stream);
+      return stream;
+    }) as typeof fs.createWriteStream);
+
+    try {
+      await expect(archiveCsamDataForReport(report as never)).rejects.toThrow(
+        'synthetic page-2 db failure'
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    // Positive control first: a "nothing was leaked" reading is indistinguishable from a probe
+    // that never saw the stream. The zip's sink must have been created, and the archiver must
+    // have received entries from page 1 before the failure.
+    const zipSinks = created.filter((stream) => String(stream.path).endsWith('.zip'));
+    expect(zipSinks, 'the zip sink was never observed — the spy is wired to nothing').toHaveLength(
+      1
+    );
+    expect(probes.find((p) => p.appended > 0)?.appended).toBe(PAGE_SIZE);
+
+    // The regression: the sink is released rather than left open on a file that is being deleted.
+    expect(zipSinks[0].destroyed).toBe(true);
+  });
+
   // INVARIANT GUARD, not regression coverage: this pins a deliberate decision rather than a
   // behaviour the bug violated. Level 9 deflate on already-compressed image bytes is what made
   // the compressor the bottleneck; with backpressure in place it is no longer a memory hazard,
@@ -423,6 +488,41 @@ describe('archiveCsamDataForReport (GeneratedImage report)', () => {
         })),
       },
     ];
+  });
+
+  it('closes the archive and its file descriptor when a download fails', async () => {
+    // The second call site of the same release. `archiveImages` covers the DB trigger this
+    // change introduced; here the trigger is a `fetchBlob` rejection, which escapes the inner
+    // per-entry `catch` because it happens before it. Both paths skip `finalize()`, so both
+    // need the archive aborted and the sink's fd closed before the caller deletes the directory.
+    mockFetchBlob = async () => {
+      throw new Error('synthetic download failure');
+    };
+
+    const realCreateWriteStream = fs.createWriteStream;
+    const created: fs.WriteStream[] = [];
+    const spy = vi.spyOn(fs, 'createWriteStream').mockImplementation(((
+      target: fs.PathLike,
+      options?: unknown
+    ) => {
+      const stream = realCreateWriteStream(target as never, options as never);
+      created.push(stream);
+      return stream;
+    }) as typeof fs.createWriteStream);
+
+    try {
+      await expect(archiveCsamDataForReport(report as never)).rejects.toThrow(
+        'synthetic download failure'
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    const zipSinks = created.filter((stream) => String(stream.path).endsWith('.zip'));
+    expect(zipSinks, 'the zip sink was never observed — the spy is wired to nothing').toHaveLength(
+      1
+    );
+    expect(zipSinks[0].destroyed).toBe(true);
   });
 
   it('holds a bounded number of generated-image buffers', async () => {

--- a/src/server/services/__tests__/csam-archive-backpressure.test.ts
+++ b/src/server/services/__tests__/csam-archive-backpressure.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Archiver } from 'archiver';
@@ -16,6 +17,45 @@ import type * as ArchiverModule from 'archiver';
  * resident memory tracked total downloaded bytes and the process was killed on its memory limit
  * partway through. All numbers below are invented.
  */
+
+/**
+ * 🔴 Redirect the service's on-disk scratch space into a private temp dir, BEFORE the service
+ * module is evaluated.
+ *
+ * `csam.service-new` computes `baseDir` once, at module scope, as
+ * `${isProd && env.DIRNAME ? env.DIRNAME : process.cwd()}/csam`. Left alone, this suite writes
+ * real zips and evidence JSON into `<repo>/csam` — a path that is NOT gitignored — and then
+ * `rm -rf`s it, which is also where a `pnpm dev` run puts its own CSAM scratch files. A unit run
+ * deleting a developer's local artefacts is not an acceptable side effect.
+ *
+ * `vi.hoisted` runs after `setup.ts` (so its `resetSharedMocks()` has already cleared per-file env
+ * overrides) and before this file's imports are evaluated, which is the only window in which a
+ * module-scope env read can still be answered. See the KNOWN LIMIT note in `env.mock.ts`.
+ */
+const csamBaseDir = await vi.hoisted(async () => {
+  const [{ default: nodeFs }, { default: nodeOs }, { default: nodePath }, { setEnv }] =
+    await Promise.all([
+      import('fs'),
+      import('os'),
+      import('path'),
+      import('~/__tests__/mocks/env.mock'),
+    ]);
+  const dirname = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'csam-archive-test-'));
+  setEnv({ DIRNAME: dirname });
+  // `isProd: true` below also reaches `~/env/client-schema`, which makes this variable required
+  // and throws at module scope without it. Additive and `??=`, matching how `setup.ts` seeds the
+  // env its own packages validate directly.
+  process.env.NEXT_PUBLIC_CIVITAI_LINK ??= 'https://example.invalid/civitai-link';
+  return nodePath.join(dirname, 'csam');
+});
+
+// The other half of the redirect: `baseDir` only honours `env.DIRNAME` when `isProd`. Scoped to
+// this file's module graph — no `process.cwd()` monkey-patching, which would leak to every other
+// file sharing the worker.
+vi.mock('~/env/other', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isProd: true,
+}));
 
 /** Instrumentation over the real archiver: counts appended vs. processed entries per archive. */
 type ArchiveProbe = {
@@ -73,17 +113,30 @@ vi.mock('~/utils/file-utils', async (importOriginal) => ({
   fetchBlob: (...args: unknown[]) => mockFetchBlob(...args),
 }));
 
+/**
+ * Captures every uploaded object by its S3 key. The service deletes its scratch directories
+ * before returning, so what reaches this mock is the only observable copy of what was archived —
+ * which makes it the right place to assert bundle CONTENT.
+ */
+const uploads = new Map<string, Buffer>();
+let uploadFailure: Error | undefined;
+
 vi.mock('@aws-sdk/lib-storage', () => ({
   Upload: class {
     private readonly body: NodeJS.ReadableStream;
-    constructor({ params }: { params: { Body: NodeJS.ReadableStream } }) {
+    private readonly key: string;
+    constructor({ params }: { params: { Body: NodeJS.ReadableStream; Key: string } }) {
       this.body = params.Body;
+      this.key = params.Key;
     }
     async done() {
       // Drain, so the PassThrough the service pipes into does not stall the caller.
-      for await (const _chunk of this.body) {
-        void _chunk;
+      const chunks: Buffer[] = [];
+      for await (const chunk of this.body) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
       }
+      if (uploadFailure) throw uploadFailure;
+      uploads.set(this.key.slice(this.key.indexOf('_') + 1), Buffer.concat(chunks));
       return {};
     }
   },
@@ -109,7 +162,11 @@ vi.mock('~/server/http/orchestrator/flagged-consumers', async (importOriginal) =
 let mockFetchBlob: (...args: unknown[]) => unknown = () => null;
 let mockGetConsumerStrikes: (...args: unknown[]) => unknown = async () => [];
 
-import { archiveCsamDataForReport, getCsamsToArchive } from '~/server/services/csam.service-new';
+import {
+  archiveCsamDataForReport,
+  ARCHIVE_SCAN_PAGE_SIZE,
+  getCsamsToArchive,
+} from '~/server/services/csam.service-new';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { setEnv } from '~/__tests__/mocks/env.mock';
 import {
@@ -121,8 +178,6 @@ import {
 // it is testing. Invented figures — the real report was a different size entirely.
 const IMAGE_COUNT = 53;
 const IMAGE_BYTES = 97 * 1024;
-
-const csamBaseDir = path.join(process.cwd(), 'csam');
 
 function fakeBlob(bytes: number) {
   return {
@@ -136,6 +191,8 @@ function fakeBlob(bytes: number) {
 
 beforeEach(() => {
   probes.length = 0;
+  uploads.clear();
+  uploadFailure = undefined;
   mockFetchBlob = async () => fakeBlob(IMAGE_BYTES);
   mockGetConsumerStrikes = async () => [];
   setEnv({
@@ -152,7 +209,8 @@ afterEach(() => {
 });
 
 afterAll(() => {
-  fs.rmSync(csamBaseDir, { recursive: true, force: true });
+  // The whole mkdtemp dir this suite owns — never a path shared with a dev checkout.
+  fs.rmSync(path.dirname(csamBaseDir), { recursive: true, force: true });
 });
 
 describe('getCsamsToArchive', () => {
@@ -248,6 +306,53 @@ describe('archiveCsamDataForReport (Image report)', () => {
     expect(imageArchive!.entryNames).toContain(`picture-${IMAGE_COUNT - 1}.jpeg`);
   });
 
+  it('archives images from EVERY page, not just the first round-trip', async () => {
+    // `archiveImages` used to iterate one in-memory array of every row the user owns. It now
+    // walks the same cursor-paged scan the bundle uses, so a stop-after-the-first-page defect
+    // would silently archive a prefix of the library and stamp the report as complete. A single
+    // short page cannot see that — the fixture has to cross a full page boundary.
+    // Taken from the production constant, never hardcoded: a fixture pinned to 500 silently
+    // stops crossing a page boundary the day that number is raised, and then passes vacuously.
+    const PAGE_SIZE = ARCHIVE_SCAN_PAGE_SIZE;
+    const TOTAL = PAGE_SIZE + 3;
+    expect(TOTAL).toBeGreaterThan(PAGE_SIZE);
+    const rows = Array.from({ length: TOTAL }, (_, i) => ({
+      id: i + 1,
+      url: `image-uuid-${i}`,
+      name: `picture-${i}.jpeg`,
+      type: 'image',
+      width: 1024,
+      userId: report.userId,
+    }));
+    // A real keyset-pagination fake rather than a fixed script of pages, so it answers both the
+    // bundle's scan and the archive's scan without depending on their call order.
+    dbMock.dbRead.image.findMany.mockImplementation(
+      async (args: { where?: { id?: { gt?: number } }; take?: number } = {}) => {
+        const after = args.where?.id?.gt ?? 0;
+        return rows.filter((row) => row.id > after).slice(0, args.take ?? rows.length);
+      }
+    );
+    dbMock.dbRead.user.findUnique.mockResolvedValue({ id: report.userId });
+    dbMock.dbRead.model.findMany.mockResolvedValue([]);
+    dbMock.dbRead.modelVersion.findMany.mockResolvedValue([]);
+    dbMock.dbWrite.csamReport.update.mockResolvedValue({});
+    mockFetchBlob = async () => fakeBlob(8);
+
+    await archiveCsamDataForReport(report as never);
+
+    const imageArchive = probes.find((p) => p.appended > 0);
+    expect(imageArchive, 'no archive received any entries').toBeDefined();
+    expect(imageArchive!.entryNames).toHaveLength(TOTAL);
+    // Named explicitly at both ends of the boundary: the last entry of page 1, the first of
+    // page 2, and the last overall.
+    expect(imageArchive!.entryNames).toContain(`picture-${PAGE_SIZE - 1}.jpeg`);
+    expect(imageArchive!.entryNames).toContain(`picture-${PAGE_SIZE}.jpeg`);
+    expect(imageArchive!.entryNames).toContain(`picture-${TOTAL - 1}.jpeg`);
+    // The bound still holds across page boundaries — a per-page drain must not become a
+    // per-page burst.
+    expect(imageArchive!.peakOutstanding).toBeLessThanOrEqual(MAX_PENDING_ARCHIVE_ENTRIES);
+  });
+
   // INVARIANT GUARD, not regression coverage: this pins a deliberate decision rather than a
   // behaviour the bug violated. Level 9 deflate on already-compressed image bytes is what made
   // the compressor the bottleneck; with backpressure in place it is no longer a memory hazard,
@@ -334,5 +439,301 @@ describe('archiveCsamDataForReport (GeneratedImage report)', () => {
     expect(generatedArchive!.peakOutstanding).toBeLessThanOrEqual(MAX_PENDING_ARCHIVE_ENTRIES);
     expect(generatedArchive!.peakRetainedBytes).toBeLessThan(IMAGE_COUNT * IMAGE_BYTES);
     expect(generatedArchive!.processed).toBe(IMAGE_COUNT);
+  });
+});
+
+/**
+ * The base evidence bundle — `<userId>_data.json`.
+ *
+ * Pre-fix this was `JSON.stringify({ user, reportId, models, modelVersions, images }, replacer)`
+ * over three unpaginated `findMany`s. Two ceilings, and the second is the one that matters:
+ * `JSON.stringify` returns ONE JavaScript string, and a JS string cannot exceed V8's maximum
+ * length (~512 MB on 64-bit). Past that it throws `RangeError: Invalid string length` — a hard,
+ * permanent failure for that report, on every retry, forever.
+ *
+ * 🔴 The bundle is NCMEC evidence, so "uses less memory" is not the bar. Every assertion below
+ * that concerns size is paired with one that concerns CONTENT.
+ */
+describe('archiveCsamDataForReport (base evidence bundle)', () => {
+  // Overshoots the cap ~10x, while any single row is ~40x under it — so a page-at-a-time
+  // serialiser is safe by a wide margin and a one-shot serialiser is not. Invented figures.
+  const ROW_COUNT = 400;
+  const STRING_CAP = 24_000;
+
+  const report = {
+    id: 4444,
+    userId: 707070,
+    reportedById: 5,
+    reportId: 79,
+    // ExternalLink archives the base bundle and nothing else, which isolates this path.
+    type: 'ExternalLink',
+    details: {},
+    images: [],
+  };
+
+  const user = { id: report.userId, name: 'n', email: 'e', username: 'u' };
+  const images = Array.from({ length: ROW_COUNT }, (_, i) => ({
+    id: i + 1,
+    url: `image-uuid-${i}`,
+    name: `picture-${i}.jpeg`,
+    type: 'image',
+    width: 1024,
+    userId: report.userId,
+    // A bigint column (`Image.pHash` is one) — the replacer is the reason the bundle cannot
+    // simply be `JSON.stringify(rows)`, so the fixture has to contain one.
+    pHash: BigInt('900719925474099') + BigInt(i),
+    createdAt: new Date(Date.UTC(2019, 2, 4, 5, 6, 7, 89)),
+    meta: { prompt: `p${i}-${'x'.repeat(500)}` },
+  }));
+  const models = [{ id: 11, name: 'm-eleven', userId: report.userId }];
+  const modelVersions = [{ id: 21, modelId: 11, name: 'v-twenty-one' }];
+
+  /** Exactly the document the pre-fix code produced, built the pre-fix way. */
+  const expectedBundle = () =>
+    JSON.stringify({ user, reportId: report.reportId, models, modelVersions, images }, (_k, v) =>
+      typeof v === 'bigint' ? v.toString() : v
+    );
+
+  function seedDb() {
+    dbMock.dbRead.image.findMany.mockResolvedValue(images);
+    dbMock.dbRead.user.findUnique.mockResolvedValue(user);
+    dbMock.dbRead.model.findMany.mockResolvedValue(models);
+    dbMock.dbRead.modelVersion.findMany.mockResolvedValue(modelVersions);
+    dbMock.dbWrite.csamReport.update.mockResolvedValue({});
+  }
+
+  /**
+   * Reproduces V8's string-length failure at a small, test-chosen size. Not an approximation:
+   * `JSON.stringify` genuinely cannot return a string longer than the engine's maximum, and this
+   * makes that boundary reachable from a fixture that fits in a unit test.
+   */
+  async function withMaxStringLength<T>(cap: number, fn: () => Promise<T>) {
+    const real = JSON.stringify;
+    let longest = 0;
+    (JSON as { stringify: typeof JSON.stringify }).stringify = ((
+      value: unknown,
+      replacer?: unknown,
+      space?: unknown
+    ) => {
+      const out = (real as (v: unknown, r?: unknown, s?: unknown) => string | undefined)(
+        value,
+        replacer,
+        space
+      );
+      if (typeof out === 'string') {
+        if (out.length > longest) longest = out.length;
+        if (out.length > cap) throw new RangeError('Invalid string length');
+      }
+      return out;
+    }) as typeof JSON.stringify;
+    try {
+      return { result: await fn(), longest };
+    } finally {
+      (JSON as { stringify: typeof JSON.stringify }).stringify = real;
+    }
+  }
+
+  it('POSITIVE CONTROL: the fixture really does exceed the injected cap', () => {
+    expect(expectedBundle().length).toBeGreaterThan(STRING_CAP * 5);
+    expect(
+      JSON.stringify(images[0], (_k, v) => (typeof v === 'bigint' ? v.toString() : v)).length
+    ).toBeLessThan(STRING_CAP / 10);
+  });
+
+  it('archives a library whose bundle exceeds the maximum JavaScript string length', async () => {
+    seedDb();
+
+    // Pre-fix this rejects with `RangeError: Invalid string length` and the report is never
+    // archived. There is no retry that fixes it and no memory limit that raises it.
+    const { longest } = await withMaxStringLength(STRING_CAP, () =>
+      archiveCsamDataForReport(report as never)
+    );
+
+    expect(longest).toBeLessThanOrEqual(STRING_CAP);
+    expect(dbMock.dbWrite.csamReport.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ archivedAt: expect.any(Date) }) })
+    );
+  });
+
+  it('uploads a bundle byte-identical to the one the pre-fix serialiser produced', async () => {
+    seedDb();
+
+    await archiveCsamDataForReport(report as never);
+
+    const uploaded = uploads.get('data.json');
+    // Positive control on the instrument: an absent upload would make the comparison below
+    // vacuous, and `undefined === undefined` is a very quiet way to pass.
+    expect(uploaded, 'nothing was uploaded — the capture is wired to nothing').toBeDefined();
+    expect(uploaded!.length).toBeGreaterThan(STRING_CAP);
+    expect(uploaded!.toString('utf8')).toBe(expectedBundle());
+  });
+
+  it('never issues an unbounded scan for the rows that go into the bundle', async () => {
+    seedDb();
+
+    await archiveCsamDataForReport(report as never);
+
+    // Structural, and deliberately stated over EVERY call rather than the last one: a single
+    // surviving unpaginated `findMany` reinstates the ceiling regardless of how many paged ones
+    // sit beside it.
+    for (const model of ['image', 'model', 'modelVersion'] as const) {
+      const calls = dbMock.dbRead[model].findMany.mock.calls;
+      expect(calls.length, `${model}.findMany was never called`).toBeGreaterThan(0);
+      for (const [args] of calls) {
+        expect(typeof args?.take, `${model}.findMany call without a page size`).toBe('number');
+        expect(args?.orderBy, `${model}.findMany call without a stable cursor order`).toEqual({
+          id: 'asc',
+        });
+      }
+    }
+  });
+
+  it('walks every page rather than archiving only the first', async () => {
+    // Three short pages behind a page size of 500 would be indistinguishable from one page, so
+    // the fixture returns FULL pages until it runs out — which is the only shape that can catch
+    // a scan that stops after its first round-trip.
+    const pageSize = ARCHIVE_SCAN_PAGE_SIZE;
+    const pages = [
+      Array.from({ length: pageSize }, (_, i) => ({ ...images[0], id: i + 1 })),
+      Array.from({ length: pageSize }, (_, i) => ({ ...images[0], id: pageSize + i + 1 })),
+      [{ ...images[0], id: 2 * pageSize + 1 }],
+    ];
+    seedDb();
+    dbMock.dbRead.image.findMany
+      .mockResolvedValueOnce(pages[0])
+      .mockResolvedValueOnce(pages[1])
+      .mockResolvedValueOnce(pages[2])
+      .mockResolvedValue([]);
+
+    await archiveCsamDataForReport(report as never);
+
+    const bundle = JSON.parse(uploads.get('data.json')!.toString('utf8'));
+    expect(bundle.images).toHaveLength(2 * pageSize + 1);
+    expect(bundle.images.at(-1).id).toBe(2 * pageSize + 1);
+    // The cursor has to advance, or the same page is re-read forever.
+    const cursors = dbMock.dbRead.image.findMany.mock.calls.map(([a]) => a?.where?.id?.gt);
+    expect(cursors.slice(0, 3)).toEqual([undefined, pageSize, 2 * pageSize]);
+  });
+
+  it('filters model versions by the COMPLETE set of model ids, not a partially-scanned one', async () => {
+    // The ordering invariant in `archiveBaseReportData`: `modelVersions` is filtered by ids
+    // accumulated while `models` streams, so its first query must not be issued until that scan
+    // has finished. Two full model pages make a premature query observable.
+    const pageSize = ARCHIVE_SCAN_PAGE_SIZE;
+    seedDb();
+    dbMock.dbRead.model.findMany
+      .mockResolvedValueOnce(Array.from({ length: pageSize }, (_, i) => ({ id: i + 1 })))
+      .mockResolvedValueOnce([{ id: pageSize + 1 }])
+      .mockResolvedValue([]);
+
+    await archiveCsamDataForReport(report as never);
+
+    const versionCalls = dbMock.dbRead.modelVersion.findMany.mock.calls;
+    expect(versionCalls.length).toBeGreaterThan(0);
+    expect(versionCalls[0][0]?.where?.modelId?.in).toHaveLength(pageSize + 1);
+  });
+});
+
+describe('archiveCsamDataForReport (upload failure)', () => {
+  const report = {
+    id: 4545,
+    userId: 606060,
+    reportedById: 5,
+    reportId: 80,
+    type: 'ExternalLink',
+    details: {},
+    images: [],
+  };
+
+  it('rejects with a real Error, so the batch loop can read .message without throwing', async () => {
+    dbMock.dbRead.image.findMany.mockResolvedValue([]);
+    dbMock.dbRead.user.findUnique.mockResolvedValue({ id: report.userId });
+    dbMock.dbRead.model.findMany.mockResolvedValue([]);
+    dbMock.dbRead.modelVersion.findMany.mockResolvedValue([]);
+    uploadFailure = new Error('synthetic s3 failure');
+
+    // Pre-fix `uploadStream` rejected with a bare `reject()`, i.e. `undefined`. The caller's
+    // `catch (e) { … e.message }` then raised a TypeError INSIDE the catch block, which escapes
+    // the per-report try/catch in `process-csam` and abandons the rest of the batch.
+    // A sentinel, not `undefined`: the pre-fix rejection VALUE is `undefined`, so mapping
+    // success to `undefined` would make "resolved" and "rejected with undefined" identical here.
+    const RESOLVED = Symbol('resolved');
+    const caught: unknown = await archiveCsamDataForReport(report as never).then(
+      () => RESOLVED,
+      (e: unknown) => e
+    );
+
+    expect(caught, 'the archive resolved — the upload failure never propagated').not.toBe(RESOLVED);
+    expect(caught).toBeInstanceOf(Error);
+    expect(() => (caught as Error).message).not.toThrow();
+    expect((caught as Error).message).toContain('data.json');
+    // The original failure has to survive, or the log line says nothing useful.
+    expect((caught as Error).cause).toBe(uploadFailure);
+  });
+});
+
+describe('archiveCsamDataForReport (unnameable generated-image URL)', () => {
+  const report = {
+    id: 4646,
+    userId: 505050,
+    reportedById: 5,
+    reportId: 81,
+    type: 'GeneratedImage',
+    details: {},
+    images: [],
+  };
+
+  beforeEach(() => {
+    dbMock.dbRead.image.findMany.mockResolvedValue([]);
+    dbMock.dbRead.user.findUnique.mockResolvedValue({ id: report.userId });
+    dbMock.dbRead.model.findMany.mockResolvedValue([]);
+    dbMock.dbRead.modelVersion.findMany.mockResolvedValue([]);
+    dbMock.dbWrite.csamReport.update.mockResolvedValue({});
+  });
+
+  it('archives the entry under a fallback name instead of poisoning the report forever', async () => {
+    // `https://host/blob/` and `https://host/?x` both reduce to '' under the basename
+    // expression. Since archive errors now latch and rethrow from finalize(), an empty name
+    // makes archiver emit ENTRYNAMEREQUIRED and the report is never stamped — so it is
+    // re-selected and fails again on every hourly run, permanently.
+    mockGetConsumerStrikes = async () => [
+      {
+        strikes: [
+          { job: { blobs: [{ previewUrl: 'https://example.invalid/blob/' }] } },
+          { job: { blobs: [{ previewUrl: 'https://example.invalid/?x=1' }] } },
+          { job: { blobs: [{ previewUrl: 'https://example.invalid/ok-2.jpeg' }] } },
+        ],
+      },
+    ];
+
+    await archiveCsamDataForReport(report as never);
+
+    const generatedArchive = probes.find((p) => p.appended > 0);
+    expect(generatedArchive, 'no archive received any entries').toBeDefined();
+    expect(generatedArchive!.entryNames).toEqual(['unnamed-0-blob', 'unnamed-1', 'ok-2.jpeg']);
+    // Every entry name must be non-empty — that is the property archiver enforces.
+    for (const name of generatedArchive!.entryNames) expect(name.length).toBeGreaterThan(0);
+
+    // And the whole point: the report reaches a terminal state.
+    expect(dbMock.dbWrite.csamReport.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ archivedAt: expect.any(Date) }) })
+    );
+  });
+});
+
+describe('test harness', () => {
+  it('writes its scratch files under a private temp dir, not into the repository', () => {
+    // Declared last so the suites above have already driven a real archive through `baseDir`.
+    // If the `env.DIRNAME` redirect silently stops working this file goes back to writing zips
+    // into `<repo>/csam` — a path that is not gitignored — and `rm -rf`-ing it in afterAll,
+    // which is also where a local dev run keeps its own CSAM scratch files.
+    expect(csamBaseDir.startsWith(os.tmpdir())).toBe(true);
+    expect(csamBaseDir.startsWith(process.cwd())).toBe(false);
+    // Positive control: the service really did write somewhere, and it was here — without it a
+    // redirect pointing at a path nothing ever touches would read as a pass.
+    expect(fs.existsSync(csamBaseDir)).toBe(true);
+    // Deliberately NOT asserting that `<repo>/csam` is absent: a developer's own `pnpm dev` run
+    // legitimately creates that directory, and a test that fails on somebody else's local state
+    // is a test people learn to ignore. The two assertions above pin what this file controls.
   });
 });

--- a/src/server/services/csam.service-new.ts
+++ b/src/server/services/csam.service-new.ts
@@ -1201,8 +1201,9 @@ async function* flattenPages<T>(pages: AsyncIterable<T[]>): AsyncGenerator<T, vo
  *   bounded appender caps the backlog at `MAX_PENDING_ARCHIVE_ENTRIES`, which drains far too
  *   fast to observe without a timing-dependent assertion. Its effect was measured separately on
  *   an UNBOUNDED queue, where it is unmissable: with the sink destroyed and no `abort()`, the
- *   archiver went on to deflate all 60 of 60 queued entries; with `abort()`, 0. So it does real
- *   work — it is just bounded work here, and it is recorded as untested rather than as covered.
+ *   archiver went on to deflate all 60 of 60 queued entries; with `abort()` it stopped dead —
+ *   0 further entries on node 26, 1 on node 24 (whichever was already in flight). So it does
+ *   real work; it is just bounded work here, recorded as untested rather than as covered.
  */
 function closeArchiveOnFailure(archive: Archiver, output: fs.WriteStream) {
   archive.abort();
@@ -1379,8 +1380,9 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
           where: {
             // A COPY of `modelIds`, not the live array.
             //
-            // NOT because of a production race. The ordering invariant asserted a dozen lines
-            // above means this closure is only ever built after `streamModels` has been drained,
+            // NOT because of a production race. The ordering invariant asserted at the top of
+            // `streamModelVersions` means this closure is only ever built after `streamModels`
+            // has been drained,
             // so `modelIds` is already complete and nothing appends to it while these pages are
             // fetched. An earlier revision of this comment claimed the array was "still being
             // appended to" here; that was wrong, and the invariant directly above it says so.

--- a/src/server/services/csam.service-new.ts
+++ b/src/server/services/csam.service-new.ts
@@ -39,6 +39,10 @@ import {
   IPEventName,
 } from '@civitai/cybertipline-tools';
 import { Limiter } from '~/server/utils/concurrency-helpers';
+import {
+  createBoundedArchive,
+  MEDIA_ARCHIVE_COMPRESSION_LEVEL,
+} from '~/server/utils/archive-helpers';
 import { getConsumerStrikes } from '~/server/http/orchestrator/flagged-consumers';
 import { logToAxiom } from '~/server/logging/client';
 import { trimNonAlphanumeric } from '~/utils/string-helpers';
@@ -199,6 +203,12 @@ export async function getCsamsToReport() {
 export async function getCsamsToArchive() {
   const data = await dbRead.csamReport.findMany({
     where: { reportSentAt: { not: null }, archivedAt: null },
+    // Without an explicit order Postgres is free to return these in any order, so a single report
+    // that kills the job mid-run can sit at the front of every batch and starve everything behind
+    // it indefinitely — the per-report try/catch in `process-csam` does not help, because the
+    // process does not survive to reach the next iteration. Oldest-first at least guarantees the
+    // backlog drains in a fixed, auditable order once a blocking report is dealt with.
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
   });
   return data as unknown as CsamReportProps[];
 }
@@ -1210,14 +1220,14 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
 
     const outPath = `${reportDirs.images}/${userId}_images.zip`;
 
-    const archive = archiver('zip', { zlib: { level: 9 } });
+    const archive = archiver('zip', { zlib: { level: MEDIA_ARCHIVE_COMPRESSION_LEVEL } });
     const output = fs.createWriteStream(outPath);
 
-    archive.on('error', function (err) {
-      throw err;
-    });
-
     archive.pipe(output);
+
+    // Bounds the number of downloaded-but-not-yet-compressed images held in memory. Without it,
+    // every image a user owns is buffered at once and memory tracks total downloaded bytes.
+    const boundedArchive = createBoundedArchive({ archive, output });
 
     // concurrency limiter
     const maxWidth = MAX_POST_IMAGES_WIDTH;
@@ -1239,11 +1249,12 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
           const name = imageName.length ? imageName : image.url;
           const filename = `${name}.${blob.type.split('/').pop() as string}`;
 
-          archive.append(buffer, { name: filename });
+          await boundedArchive.append(buffer, { name: filename });
         });
       })
     );
-    archive.finalize();
+    // Awaited: the read stream below opens a truncated (or absent) file otherwise.
+    await boundedArchive.finalize();
 
     const readableStream = fs.createReadStream(outPath);
     await uploadStream({ stream: readableStream, userId, filename: 'images.zip' });
@@ -1260,14 +1271,13 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
 
     const outPath = `${reportDirs.generatedImages}/${userId}_generated-images.zip`;
 
-    const archive = archiver('zip', { zlib: { level: 9 } });
+    const archive = archiver('zip', { zlib: { level: MEDIA_ARCHIVE_COMPRESSION_LEVEL } });
     const output = fs.createWriteStream(outPath);
 
-    archive.on('error', function (err) {
-      throw err;
-    });
-
     archive.pipe(output);
+
+    // Same unbounded-append hazard as archiveImages above.
+    const boundedArchive = createBoundedArchive({ archive, output });
 
     // concurrency limiter
     const limit = plimit(10);
@@ -1282,14 +1292,15 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
 
             const imageName = url.split('/').reverse()[0].split('?')[0];
 
-            archive.append(buffer, { name: imageName });
+            await boundedArchive.append(buffer, { name: imageName });
           } catch (e) {
             //
           }
         });
       })
     );
-    archive.finalize();
+    // Awaited: the read stream below opens a truncated (or absent) file otherwise.
+    await boundedArchive.finalize();
 
     const readableStream = fs.createReadStream(outPath);
     await uploadStream({ stream: readableStream, userId, filename: 'generated-images.zip' });

--- a/src/server/services/csam.service-new.ts
+++ b/src/server/services/csam.service-new.ts
@@ -16,6 +16,7 @@ import { env } from '~/env/server';
 import fsAsync from 'fs/promises';
 import fs from 'fs';
 import archiver from 'archiver';
+import type { Archiver } from 'archiver';
 import stream, { Readable } from 'stream';
 import { Upload } from '@aws-sdk/lib-storage';
 import * as z from 'zod';
@@ -1145,6 +1146,18 @@ export const ARCHIVE_SCAN_PAGE_SIZE = 500;
  * `id > cursor ORDER BY id ASC` every row appears exactly once, and the pages concatenate to
  * exactly the row set a single unpaged `findMany` with the same `where` would have returned.
  *
+ * ⚠️ PRECONDITION, and it does not hold uniformly across the three tables this is used on:
+ * keyset paging is only *cheap* where an index can serve `WHERE <filter> AND id > $cursor
+ * ORDER BY id ASC`. Read off `packages/civitai-db-schema/prisma/schema.full.prisma`, `Image`
+ * carries `@@index([userId, id])`, so the one genuinely large scan here — every image the
+ * reported user owns — is served directly. `Model` has no `userId` index at all, and
+ * `ModelVersion`'s only `modelId` index is a HASH index, which can answer equality but cannot
+ * serve a range or an ordering. Those two scans have the primary key available for the cursor
+ * and the ordering but nothing indexed for the filter. That is accepted rather than fixed here,
+ * because a user's model and model-version counts are small next to their image count and the
+ * point of this change is the memory ceiling, not latency. It is NOT a claim about the plan the
+ * planner actually chooses — no `EXPLAIN` was run.
+ *
  * Lazy: the first query is not issued until the generator is first pulled from. Callers below
  * depend on that.
  */
@@ -1166,6 +1179,34 @@ async function* scanPagesById<T extends { id: number }>(
 /** Flattens paged rows into a per-row async iterable. Also lazy. */
 async function* flattenPages<T>(pages: AsyncIterable<T[]>): AsyncGenerator<T, void, undefined> {
   for await (const page of pages) for (const row of page) yield row;
+}
+
+/**
+ * Releases an archive and its sink after a failure that skipped `finalize()`.
+ *
+ * On the happy path `finalize()` ends the archive and waits for the sink to close, so nothing is
+ * left open. On a throw neither happens: the archiver keeps its queued source buffers and the
+ * write stream keeps its file descriptor, while the caller's error handler removes the directory
+ * that file lives in. Both calls are no-ops once the object has reached a terminal state
+ * (`Archiver#abort` returns early if already aborted or finalized, and `destroy()` on a destroyed
+ * stream does nothing), so this is safe from any failure point.
+ *
+ * ⚠️ The two calls have different evidence behind them, and the difference is worth keeping:
+ *
+ * - `output.destroy()` is the file descriptor, and it is what the tests observe. Both
+ *   "closes the archive and its file descriptor …" cases fail with `expected false to be true`
+ *   when it is removed.
+ * - `archive.abort()` is the queued source buffers, and NO test distinguishes it — removing it
+ *   leaves all 64 tests across the four files green, and that is expected rather than a gap: the
+ *   bounded appender caps the backlog at `MAX_PENDING_ARCHIVE_ENTRIES`, which drains far too
+ *   fast to observe without a timing-dependent assertion. Its effect was measured separately on
+ *   an UNBOUNDED queue, where it is unmissable: with the sink destroyed and no `abort()`, the
+ *   archiver went on to deflate all 60 of 60 queued entries; with `abort()`, 0. So it does real
+ *   work — it is just bounded work here, and it is recorded as untested rather than as covered.
+ */
+function closeArchiveOnFailure(archive: Archiver, output: fs.WriteStream) {
+  archive.abort();
+  output.destroy();
 }
 
 /** Serialises `bigint` columns (e.g. `Image.pHash`) as strings — `JSON.stringify` throws on them. */
@@ -1273,10 +1314,18 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
   /**
    * Writes the base evidence bundle to disk, then uploads it.
    *
-   * 🔴 WHAT IS IN THE BUNDLE IS UNCHANGED. Same five properties in the same order, same queries
-   * with the same `where` clauses and no `select`, same bigint replacer — this only changes HOW
-   * the identical document is produced. `json-stream-helpers.test.ts` pins the byte-identity
-   * against `JSON.stringify`.
+   * 🔴 WHAT EVIDENCE IS IN THE BUNDLE IS UNCHANGED: the same five properties in the same order,
+   * the same `where` clauses with no `select` so every column still lands in it, and the same
+   * bigint replacer. `json-stream-helpers.test.ts` pins the serialiser's byte-identity against
+   * `JSON.stringify` — note that is a claim about the SERIALISER, over one fixed row order.
+   *
+   * Two things ARE different, and neither adds or removes a row. The queries now also carry
+   * `orderBy: { id: 'asc' }`, `take` and an `id > cursor` predicate, because they are paged. And
+   * as a consequence of that ordering, array element order is now `id ASC` where it was
+   * previously whatever the query plan happened to produce — so against real data this writes a
+   * document that is set-identical to the old one but NOT byte-identical to it. Making the order
+   * deterministic is an improvement for an evidence artefact, but it is a change, and anything
+   * that diffs two bundles across this commit will see it.
    *
    * Why it had to change: the previous shape loaded every `Image`, `Model` and `ModelVersion`
    * row the reported user owns into three arrays and rendered them with one `JSON.stringify`.
@@ -1328,12 +1377,21 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
       const pages = scanPagesById(({ afterId, take }) =>
         dbRead.modelVersion.findMany({
           where: {
-            // A COPY, not the live array. `modelIds` is still being appended to by the generator
-            // above at the moment this closure is built, so passing the reference would make the
-            // filter's contents depend on exactly when the query layer reads it — the kind of
-            // coupling that is correct today and silently wrong after any reordering. It also
-            // made an assertion in the test suite vacuous: the recorded call argument mutated
-            // after the fact, so a scan that ran with an EMPTY id set read back as complete.
+            // A COPY of `modelIds`, not the live array.
+            //
+            // NOT because of a production race. The ordering invariant asserted a dozen lines
+            // above means this closure is only ever built after `streamModels` has been drained,
+            // so `modelIds` is already complete and nothing appends to it while these pages are
+            // fetched. An earlier revision of this comment claimed the array was "still being
+            // appended to" here; that was wrong, and the invariant directly above it says so.
+            //
+            // What the copy does buy, measured rather than reasoned: it is what lets the
+            // "filters model versions by the COMPLETE set of model ids" test observe the hazard
+            // the invariant names. Against a live reference the recorded call argument keeps
+            // mutating after the call, so it reads back as complete even for a scan that ran on
+            // an empty id set. Removing the invariant and reversing the entry order — i.e. the
+            // hazard, made reachable — fails that test with `expected [] to have a length of
+            // 501` against this copy, and passes vacuously against a reference.
             modelId: { in: [...modelIds] },
             ...(afterId !== undefined ? { id: { gt: afterId } } : {}),
           },
@@ -1379,37 +1437,52 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
     // concurrency limiter
     const maxWidth = MAX_POST_IMAGES_WIDTH;
     const limit = plimit(10);
-    // Paged rather than `images.map(...)` over one array of every row the user owns: the row set
-    // is unbounded, and materialising it was half of the memory problem this file exists to fix.
-    // Concurrency within a page is unchanged (10); pages are processed in order.
-    for await (const page of scanUserImages()) {
-      await Promise.all(
-        page.map((image) => {
-          return limit(async () => {
-            const width = image.width ?? maxWidth;
-            const blob = await fetchBlob(
-              getEdgeUrl(image.url, {
-                type: image.type,
-                width: width < maxWidth ? width : maxWidth,
-              })
-            );
-            if (!blob) return;
-            const arrayBuffer = await blob.arrayBuffer();
-            const buffer = Buffer.from(arrayBuffer);
+    try {
+      // Paged rather than `images.map(...)` over one array of every row the user owns: the row
+      // set is unbounded, and materialising it was half of the memory problem this file exists
+      // to fix. Concurrency within a page is unchanged (10); pages are processed in order.
+      for await (const page of scanUserImages()) {
+        await Promise.all(
+          page.map((image) => {
+            return limit(async () => {
+              const width = image.width ?? maxWidth;
+              const blob = await fetchBlob(
+                getEdgeUrl(image.url, {
+                  type: image.type,
+                  width: width < maxWidth ? width : maxWidth,
+                })
+              );
+              if (!blob) return;
+              const arrayBuffer = await blob.arrayBuffer();
+              const buffer = Buffer.from(arrayBuffer);
 
-            const imageName = image.name
-              ? image.name.substring(0, image.name.lastIndexOf('.'))
-              : image.url;
-            const name = imageName.length ? imageName : image.url;
-            const filename = `${name}.${blob.type.split('/').pop() as string}`;
+              const imageName = image.name
+                ? image.name.substring(0, image.name.lastIndexOf('.'))
+                : image.url;
+              const name = imageName.length ? imageName : image.url;
+              const filename = `${name}.${blob.type.split('/').pop() as string}`;
 
-            await boundedArchive.append(buffer, { name: filename });
-          });
-        })
-      );
+              await boundedArchive.append(buffer, { name: filename });
+            });
+          })
+        );
+      }
+      // Awaited: the read stream below opens a truncated (or absent) file otherwise.
+      await boundedArchive.finalize();
+    } catch (e) {
+      // Nothing past this point runs, and the caller's `catch` then `rmSync`s `reportDirs.images`
+      // out from under a write stream that is still open on a file inside it. Release the
+      // archiver's queued sources and the sink's fd before letting the error out.
+      //
+      // Two things can land here. `fetchBlob`/`append` could already throw before this change.
+      // The DB read is new: paging pulls rows *inside* the archiver's lifetime, where the
+      // previous code fetched every row before any archiver existed, so a `dbRead` failure on
+      // page 2 or later is a trigger the old shape did not have. `abort()` is a documented no-op
+      // once the archive is aborted or finalized, and `destroy()` on a closed stream likewise, so
+      // this is safe whichever of them got furthest.
+      closeArchiveOnFailure(archive, output);
+      throw e;
     }
-    // Awaited: the read stream below opens a truncated (or absent) file otherwise.
-    await boundedArchive.finalize();
 
     const readableStream = fs.createReadStream(outPath);
     await uploadStream({ stream: readableStream, userId, filename: 'images.zip' });
@@ -1436,26 +1509,34 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
 
     // concurrency limiter
     const limit = plimit(10);
-    await Promise.all(
-      imageUrls.map((url, index) => {
-        return limit(async () => {
-          const blob = await fetchBlob(url);
-          if (!blob) return;
-          try {
-            const arrayBuffer = await blob.arrayBuffer();
-            const buffer = Buffer.from(arrayBuffer);
+    try {
+      await Promise.all(
+        imageUrls.map((url, index) => {
+          return limit(async () => {
+            const blob = await fetchBlob(url);
+            if (!blob) return;
+            try {
+              const arrayBuffer = await blob.arrayBuffer();
+              const buffer = Buffer.from(arrayBuffer);
 
-            const imageName = zipEntryNameForUrl(url, index);
+              const imageName = zipEntryNameForUrl(url, index);
 
-            await boundedArchive.append(buffer, { name: imageName });
-          } catch (e) {
-            //
-          }
-        });
-      })
-    );
-    // Awaited: the read stream below opens a truncated (or absent) file otherwise.
-    await boundedArchive.finalize();
+              await boundedArchive.append(buffer, { name: imageName });
+            } catch (e) {
+              //
+            }
+          });
+        })
+      );
+      // Awaited: the read stream below opens a truncated (or absent) file otherwise.
+      await boundedArchive.finalize();
+    } catch (e) {
+      // Same reasoning as `archiveImages` above. Note the inner `catch (e) {}` only covers the
+      // buffer/append step, so a `fetchBlob` rejection still reaches here, as does the error
+      // `finalize()` rethrows after the archiver has latched one.
+      closeArchiveOnFailure(archive, output);
+      throw e;
+    }
 
     const readableStream = fs.createReadStream(outPath);
     await uploadStream({ stream: readableStream, userId, filename: 'generated-images.zip' });

--- a/src/server/services/csam.service-new.ts
+++ b/src/server/services/csam.service-new.ts
@@ -1152,8 +1152,10 @@ export const ARCHIVE_SCAN_PAGE_SIZE = 500;
  * carries `@@index([userId, id])`, so the one genuinely large scan here — every image the
  * reported user owns — is served directly. `Model` has no `userId` index at all, and
  * `ModelVersion`'s only `modelId` index is a HASH index, which can answer equality but cannot
- * serve a range or an ordering. Those two scans have the primary key available for the cursor
- * and the ordering but nothing indexed for the filter. That is accepted rather than fixed here,
+ * serve a range or an ordering. So the two are not in the same position: `Model` has nothing
+ * indexed for its filter at all, while `ModelVersion`'s hash index CAN serve its `modelId IN
+ * (…)` equality filter — what it cannot serve is the ordering. Both have the primary key
+ * available for the cursor and the ordering. That is accepted rather than fixed here,
  * because a user's model and model-version counts are small next to their image count and the
  * point of this change is the memory ceiling, not latency. It is NOT a claim about the plan the
  * planner actually chooses — no `EXPLAIN` was run.

--- a/src/server/services/csam.service-new.ts
+++ b/src/server/services/csam.service-new.ts
@@ -42,7 +42,10 @@ import { Limiter } from '~/server/utils/concurrency-helpers';
 import {
   createBoundedArchive,
   MEDIA_ARCHIVE_COMPRESSION_LEVEL,
+  zipEntryNameForUrl,
 } from '~/server/utils/archive-helpers';
+import type { JsonReplacer } from '~/server/utils/json-stream-helpers';
+import { writeJsonObject } from '~/server/utils/json-stream-helpers';
 import { getConsumerStrikes } from '~/server/http/orchestrator/flagged-consumers';
 import { logToAxiom } from '~/server/logging/client';
 import { trimNonAlphanumeric } from '~/utils/string-helpers';
@@ -203,11 +206,18 @@ export async function getCsamsToReport() {
 export async function getCsamsToArchive() {
   const data = await dbRead.csamReport.findMany({
     where: { reportSentAt: { not: null }, archivedAt: null },
-    // Without an explicit order Postgres is free to return these in any order, so a single report
-    // that kills the job mid-run can sit at the front of every batch and starve everything behind
-    // it indefinitely — the per-report try/catch in `process-csam` does not help, because the
-    // process does not survive to reach the next iteration. Oldest-first at least guarantees the
-    // backlog drains in a fixed, auditable order once a blocking report is dealt with.
+    // Deterministic batch order, for auditability: without an ORDER BY, Postgres may return
+    // these in any order, and it may return a DIFFERENT order run to run, so the sequence in
+    // which evidence bundles were built is unreproducible from the data alone.
+    //
+    // 🔴 This does NOT fix head-of-line blocking, and reads as if it does if you skim it. A
+    // report that fails on every attempt is by construction among the OLDEST rows still
+    // matching this filter, so `createdAt asc` pins it to the head of every run — the ordering
+    // makes the blocking deterministic rather than curing it. Per-report failure isolation is
+    // deliberately out of scope here: `process-csam` already wraps each report in its own
+    // try/catch, which is enough for a report that merely throws, and nothing short of a
+    // circuit breaker (skip a report after N consecutive failures) helps for one that kills
+    // the process. That has not been built.
     orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
   });
   return data as unknown as CsamReportProps[];
@@ -1100,11 +1110,67 @@ function uploadStream({
       // console.dir('upload finished', { depth: null });
       resolve();
     } catch (e) {
-      // console.log(e);
-      reject();
+      // Rejecting with a real Error, not the bare `reject()` this used to do. An `undefined`
+      // rejection value reaches the caller's `catch (e)` and then blows up on `e.message` with
+      // a TypeError raised INSIDE the catch block — which escapes the per-report try/catch in
+      // `process-csam` and abandons every remaining report in that batch. The original is kept
+      // as `cause` so nothing about the S3 failure is lost.
+      reject(
+        new Error(`failed to upload ${filename} for user ${userId}`, {
+          cause: e,
+        })
+      );
     }
   });
 }
+
+/**
+ * Rows fetched per round-trip by the cursor-paged scans that feed an evidence bundle.
+ *
+ * The number is a round-trip/latency trade, not a correctness one: any positive value produces
+ * the same rows in the same order. It only has to be small enough that one page of full `Image`
+ * rows is comfortably resident, which is the whole reason the scans are paged.
+ *
+ * Exported so the tests can size their fixtures to cross a real page boundary. A test that
+ * hardcodes 500 goes green-and-vacuous the day this number is raised — it would be measuring a
+ * single-page scan while claiming to measure a multi-page one.
+ */
+export const ARCHIVE_SCAN_PAGE_SIZE = 500;
+
+/**
+ * Keyset-pages a `findMany` over an ascending integer primary key, yielding one page at a time.
+ *
+ * Keyset rather than `skip`/`offset` because offset paging over a large table both degrades
+ * quadratically and can skip or duplicate rows if the underlying set shifts between pages. With
+ * `id > cursor ORDER BY id ASC` every row appears exactly once, and the pages concatenate to
+ * exactly the row set a single unpaged `findMany` with the same `where` would have returned.
+ *
+ * Lazy: the first query is not issued until the generator is first pulled from. Callers below
+ * depend on that.
+ */
+async function* scanPagesById<T extends { id: number }>(
+  fetchPage: (args: { afterId: number | undefined; take: number }) => Promise<T[]>,
+  pageSize: number = ARCHIVE_SCAN_PAGE_SIZE
+): AsyncGenerator<T[], void, undefined> {
+  let afterId: number | undefined;
+  for (;;) {
+    const rows = await fetchPage({ afterId, take: pageSize });
+    if (!rows.length) return;
+    yield rows;
+    // A short page is the last page: there is no id greater than the one we just read.
+    if (rows.length < pageSize) return;
+    afterId = rows[rows.length - 1].id;
+  }
+}
+
+/** Flattens paged rows into a per-row async iterable. Also lazy. */
+async function* flattenPages<T>(pages: AsyncIterable<T[]>): AsyncGenerator<T, void, undefined> {
+  for await (const page of pages) for (const row of page) yield row;
+}
+
+/** Serialises `bigint` columns (e.g. `Image.pHash`) as strings — `JSON.stringify` throws on them. */
+const bigintReplacer: JsonReplacer = (_key, value) =>
+  typeof value === 'bigint' ? value.toString() : value;
 
 export async function archiveCsamDataForReport(data: CsamReportProps) {
   const { userId } = data;
@@ -1135,7 +1201,31 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
     createDir(dir);
   }
 
-  const images = await dbRead.image.findMany({ where: { userId } });
+  /**
+   * A fresh keyset-paged scan of every image the reported user owns.
+   *
+   * This replaces a single `dbRead.image.findMany({ where: { userId } })` whose result array was
+   * shared by `archiveBaseReportData` and `archiveImages`. Two callers therefore now run two
+   * scans instead of sharing one snapshot. That is a deliberate trade and it does not weaken the
+   * bundle: the archive step already tolerates listing an image in `data.json` that is absent
+   * from `images.zip`, because `fetchBlob` returning null makes it skip the entry silently
+   * (`if (!blob) return;` below). What it buys is that neither caller ever holds more than one
+   * page of full `Image` rows.
+   *
+   * The `where`/column selection is unchanged — same filter, no `select`, so every column still
+   * lands in the bundle. Only the ORDER is new, and it was previously unspecified (i.e. whatever
+   * the query plan produced, not stable run to run), so nothing that was deterministic became
+   * less so.
+   */
+  const scanUserImages = () =>
+    scanPagesById(({ afterId, take }) =>
+      dbRead.image.findMany({
+        where: { userId, ...(afterId !== undefined ? { id: { gt: afterId } } : {}) },
+        orderBy: { id: 'asc' },
+        take,
+      })
+    );
+
   try {
     await archiveBaseReportData();
 
@@ -1180,35 +1270,92 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
     throw e;
   }
 
-  // writes a json file of user data to disk before uploading
+  /**
+   * Writes the base evidence bundle to disk, then uploads it.
+   *
+   * 🔴 WHAT IS IN THE BUNDLE IS UNCHANGED. Same five properties in the same order, same queries
+   * with the same `where` clauses and no `select`, same bigint replacer — this only changes HOW
+   * the identical document is produced. `json-stream-helpers.test.ts` pins the byte-identity
+   * against `JSON.stringify`.
+   *
+   * Why it had to change: the previous shape loaded every `Image`, `Model` and `ModelVersion`
+   * row the reported user owns into three arrays and rendered them with one `JSON.stringify`.
+   * That has two ceilings. The soft one is memory — rows and rendered string resident together.
+   * The hard one is that `JSON.stringify` returns a single JavaScript string, and a JS string
+   * cannot exceed V8's maximum length — 536,870,888 characters on 64-bit
+   * (`require('buffer').constants.MAX_STRING_LENGTH`). Past that it throws
+   * `RangeError: Invalid string length`, which no amount of memory or retrying fixes. A report
+   * whose bundle crosses that line can never be archived.
+   */
   async function archiveBaseReportData() {
     const { userId, reportId } = report;
     if (userId === -1) return;
     const user = await getReportedUser(userId);
-    const models = await dbRead.model.findMany({ where: { userId } });
-    const modelVersions = await dbRead.modelVersion.findMany({
-      where: { modelId: { in: models.map((x) => x.id) } },
-    });
+
+    // Model IDs are accumulated because `modelVersions` is filtered by them, exactly as before.
+    // Only the 4-byte ids are kept; the model ROWS stream through without being retained.
+    const modelIds: number[] = [];
+    let modelScanComplete = false;
+
+    async function* streamModels() {
+      const pages = scanPagesById(({ afterId, take }) =>
+        dbRead.model.findMany({
+          where: { userId, ...(afterId !== undefined ? { id: { gt: afterId } } : {}) },
+          orderBy: { id: 'asc' },
+          take,
+        })
+      );
+      for await (const model of flattenPages(pages)) {
+        modelIds.push(model.id);
+        yield model;
+      }
+      modelScanComplete = true;
+    }
+
+    async function* streamModelVersions() {
+      // 🔴 ORDERING INVARIANT. `modelIds` is filled by `streamModels` above, so this generator
+      // must not issue its first query until that one has been drained. It does not, because
+      // `writeJsonObject` serialises entries strictly in order and fully drains each iterable
+      // before starting the next, and because an async generator body does not run until it is
+      // first pulled from. Both of those are load-bearing and neither is locally visible, so
+      // the invariant is asserted rather than assumed: silently reading a half-filled `modelIds`
+      // would drop model versions from a CSAM evidence bundle with nothing to indicate it.
+      if (!modelScanComplete)
+        throw new Error(
+          'archiveBaseReportData: model versions were streamed before the model scan finished — ' +
+            'modelIds is incomplete and the bundle would be missing evidence'
+        );
+      const pages = scanPagesById(({ afterId, take }) =>
+        dbRead.modelVersion.findMany({
+          where: {
+            // A COPY, not the live array. `modelIds` is still being appended to by the generator
+            // above at the moment this closure is built, so passing the reference would make the
+            // filter's contents depend on exactly when the query layer reads it — the kind of
+            // coupling that is correct today and silently wrong after any reordering. It also
+            // made an assertion in the test suite vacuous: the recorded call argument mutated
+            // after the fact, so a scan that ran with an EMPTY id set read back as complete.
+            modelId: { in: [...modelIds] },
+            ...(afterId !== undefined ? { id: { gt: afterId } } : {}),
+          },
+          orderBy: { id: 'asc' },
+          take,
+        })
+      );
+      yield* flattenPages(pages);
+    }
 
     const outPath = `${reportDirs.base}/${userId}_data.json`;
-    await fsAsync.writeFile(
-      outPath,
-      JSON.stringify(
-        {
-          user,
-          reportId,
-          models,
-          modelVersions,
-          images,
-        },
-        (key, value) => {
-          if (typeof value === 'bigint') {
-            return value.toString();
-          }
-          return value;
-        }
-      )
-    );
+    await writeJsonObject({
+      sink: fs.createWriteStream(outPath),
+      replacer: bigintReplacer,
+      entries: [
+        ['user', { value: user }],
+        ['reportId', { value: reportId }],
+        ['models', { items: streamModels() }],
+        ['modelVersions', { items: streamModelVersions() }],
+        ['images', { items: flattenPages(scanUserImages()) }],
+      ],
+    });
 
     const readableStream = fs.createReadStream(outPath);
     await uploadStream({ stream: readableStream, userId, filename: 'data.json' });
@@ -1232,27 +1379,35 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
     // concurrency limiter
     const maxWidth = MAX_POST_IMAGES_WIDTH;
     const limit = plimit(10);
-    await Promise.all(
-      images.map((image) => {
-        return limit(async () => {
-          const width = image.width ?? maxWidth;
-          const blob = await fetchBlob(
-            getEdgeUrl(image.url, { type: image.type, width: width < maxWidth ? width : maxWidth })
-          );
-          if (!blob) return;
-          const arrayBuffer = await blob.arrayBuffer();
-          const buffer = Buffer.from(arrayBuffer);
+    // Paged rather than `images.map(...)` over one array of every row the user owns: the row set
+    // is unbounded, and materialising it was half of the memory problem this file exists to fix.
+    // Concurrency within a page is unchanged (10); pages are processed in order.
+    for await (const page of scanUserImages()) {
+      await Promise.all(
+        page.map((image) => {
+          return limit(async () => {
+            const width = image.width ?? maxWidth;
+            const blob = await fetchBlob(
+              getEdgeUrl(image.url, {
+                type: image.type,
+                width: width < maxWidth ? width : maxWidth,
+              })
+            );
+            if (!blob) return;
+            const arrayBuffer = await blob.arrayBuffer();
+            const buffer = Buffer.from(arrayBuffer);
 
-          const imageName = image.name
-            ? image.name.substring(0, image.name.lastIndexOf('.'))
-            : image.url;
-          const name = imageName.length ? imageName : image.url;
-          const filename = `${name}.${blob.type.split('/').pop() as string}`;
+            const imageName = image.name
+              ? image.name.substring(0, image.name.lastIndexOf('.'))
+              : image.url;
+            const name = imageName.length ? imageName : image.url;
+            const filename = `${name}.${blob.type.split('/').pop() as string}`;
 
-          await boundedArchive.append(buffer, { name: filename });
-        });
-      })
-    );
+            await boundedArchive.append(buffer, { name: filename });
+          });
+        })
+      );
+    }
     // Awaited: the read stream below opens a truncated (or absent) file otherwise.
     await boundedArchive.finalize();
 
@@ -1282,7 +1437,7 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
     // concurrency limiter
     const limit = plimit(10);
     await Promise.all(
-      imageUrls.map((url) => {
+      imageUrls.map((url, index) => {
         return limit(async () => {
           const blob = await fetchBlob(url);
           if (!blob) return;
@@ -1290,7 +1445,7 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
             const arrayBuffer = await blob.arrayBuffer();
             const buffer = Buffer.from(arrayBuffer);
 
-            const imageName = url.split('/').reverse()[0].split('?')[0];
+            const imageName = zipEntryNameForUrl(url, index);
 
             await boundedArchive.append(buffer, { name: imageName });
           } catch (e) {

--- a/src/server/utils/__tests__/archive-helpers.test.ts
+++ b/src/server/utils/__tests__/archive-helpers.test.ts
@@ -11,6 +11,7 @@ import {
   createBoundedArchive,
   MAX_PENDING_ARCHIVE_ENTRIES,
   MEDIA_ARCHIVE_COMPRESSION_LEVEL,
+  zipEntryNameForUrl,
 } from '~/server/utils/archive-helpers';
 
 /**
@@ -234,5 +235,89 @@ describe('createBoundedArchive', () => {
   it('defaults to a bound well below the entry counts that caused the incident', () => {
     expect(MAX_PENDING_ARCHIVE_ENTRIES).toBeGreaterThan(0);
     expect(MAX_PENDING_ARCHIVE_ENTRIES).toBeLessThan(ENTRY_COUNT);
+  });
+});
+
+describe('zipEntryNameForUrl', () => {
+  /**
+   * Why this exists: `createBoundedArchive` deliberately latches archive errors and rethrows
+   * them from `finalize()` instead of letting a bad entry be swallowed. That is the right call
+   * for evidence — but it turns an unnameable URL into a report that can never be archived and
+   * is retried on every hourly run forever. `archiver` rejects an empty entry name with
+   * `ENTRYNAMEREQUIRED`, and the basename expression the caller used reduces some legitimate
+   * URL shapes to `''`.
+   */
+  const legacyBasename = (url: string) => url.split('/').reverse()[0].split('?')[0];
+
+  it.each([
+    'https://example.invalid/blob-7.jpeg',
+    'https://example.invalid/a/b/c/d.webp',
+    'https://example.invalid/blob-7.jpeg?width=450&fit=cover',
+    'https://example.invalid/a?x=/not-a-path',
+    'blob-7.jpeg',
+  ])('leaves a nameable URL byte-identical to the previous expression: %s', (url) => {
+    const previous = legacyBasename(url);
+    expect(previous.length).toBeGreaterThan(0);
+    expect(zipEntryNameForUrl(url, 3)).toBe(previous);
+  });
+
+  it.each([
+    ['https://example.invalid/blob/', 'unnamed-4-blob'],
+    ['https://example.invalid/a/b/', 'unnamed-4-a_b'],
+    ['https://example.invalid/?x=1', 'unnamed-4'],
+    ['https://example.invalid/', 'unnamed-4'],
+    ['https://example.invalid/blob/?x=1#frag', 'unnamed-4-blob'],
+  ])('gives an unnameable URL a non-empty name instead: %s', (url, expected) => {
+    // The precondition, asserted rather than assumed: without this the test proves nothing.
+    expect(legacyBasename(url)).toBe('');
+    expect(zipEntryNameForUrl(url, 4)).toBe(expected);
+  });
+
+  it('never returns an empty name for any of the shapes above', () => {
+    const urls = [
+      'https://example.invalid/blob/',
+      'https://example.invalid/?x=1',
+      'https://example.invalid/',
+      'https://example.invalid/#f',
+      '',
+      '?',
+      '/',
+    ];
+    for (const [i, url] of urls.entries())
+      expect(zipEntryNameForUrl(url, i).length).toBeGreaterThan(0);
+  });
+
+  it('keeps names distinct when several URLs in one batch are unnameable', () => {
+    const names = ['https://example.invalid/', 'https://example.invalid/?a=1'].map((url, i) =>
+      zipEntryNameForUrl(url, i)
+    );
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('REGRESSION: archiver accepts the fallback name and rejects the empty one it replaces', async () => {
+    // Both arms run against the real archiver, so this is a claim about archiver's behaviour
+    // rather than about our reading of its docs.
+    const badUrl = 'https://example.invalid/blob/';
+
+    const rejected = archiver('zip', { zlib: { level: MEDIA_ARCHIVE_COMPRESSION_LEVEL } });
+    rejected.pipe(slowSink(0));
+    const rejectedBounded = createBoundedArchive({ archive: rejected, maxPendingEntries: BOUND });
+    await rejectedBounded.append(entryBuffer(0), { name: legacyBasename(badUrl) });
+    await expect(rejectedBounded.finalize()).rejects.toThrow(/entry name/i);
+
+    const accepted = archiver('zip', { zlib: { level: MEDIA_ARCHIVE_COMPRESSION_LEVEL } });
+    const outPath = path.join(tmpDir, 'fallback-name.zip');
+    const output = fs.createWriteStream(outPath);
+    accepted.pipe(output);
+    const acceptedBounded = createBoundedArchive({
+      archive: accepted,
+      output,
+      maxPendingEntries: BOUND,
+    });
+    await acceptedBounded.append(entryBuffer(0), { name: zipEntryNameForUrl(badUrl, 0) });
+    await expect(acceptedBounded.finalize()).resolves.toBeUndefined();
+
+    const zip = await JSZip.loadAsync(fs.readFileSync(outPath));
+    expect(Object.keys(zip.files)).toEqual(['unnamed-0-blob']);
   });
 });

--- a/src/server/utils/__tests__/archive-helpers.test.ts
+++ b/src/server/utils/__tests__/archive-helpers.test.ts
@@ -1,4 +1,6 @@
 import archiver from 'archiver';
+import type { Archiver } from 'archiver';
+import { EventEmitter } from 'events';
 import fs from 'fs';
 import JSZip from 'jszip';
 import os from 'os';
@@ -218,6 +220,54 @@ describe('createBoundedArchive', () => {
       'synthetic archive failure'
     );
     await expect(bounded.finalize()).rejects.toThrow('synthetic archive failure');
+  });
+
+  it('settles EVERY parked append when the archiver errors — the error event fires only once', async () => {
+    /**
+     * The failure path is the reason `releaseWaiters` loops. `archiver` emits `error` at most
+     * once, so that single event is the only wake-up a parked `append()` will ever get: nothing
+     * drains the waiter queue afterwards, because `entry` stops firing too. Released one at a
+     * time, every append past the first would hang forever — and in `archiveImages` a hung append
+     * wedges the `Promise.all` over a page, so the whole report neither archives nor rejects.
+     *
+     * A stub rather than the real archiver, deliberately: it must NEVER emit `entry`, so the
+     * success path cannot release anyone and this measures the failure path alone.
+     */
+    const stub = new EventEmitter() as unknown as Archiver;
+    (stub as unknown as { append: () => void }).append = () => undefined;
+
+    const bounded = createBoundedArchive({ archive: stub, maxPendingEntries: 2 });
+
+    const outcomes: string[] = [];
+    const appends = [0, 1, 2, 3, 4].map((i) =>
+      bounded
+        .append(entryBuffer(i), { name: `entry-${i}.bin` })
+        .then(() => outcomes.push(`resolved-${i}`))
+        .catch((e: Error) => outcomes.push(`rejected-${i}: ${e.message}`))
+    );
+
+    // The precondition, asserted rather than assumed: two appends hold the slots and the other
+    // three are parked. Without that this test would prove nothing about the waiter queue.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(bounded.pendingEntries).toBe(2);
+    expect(outcomes).toHaveLength(2);
+
+    stub.emit('error', new Error('synthetic archive failure'));
+
+    // Raced rather than plain-awaited so the failure mode reads as `HUNG` instead of as a 5 s
+    // suite timeout with no indication of which promise never settled.
+    const raced = await Promise.race([
+      Promise.all(appends).then(() => 'all-settled' as const),
+      new Promise<'HUNG'>((resolve) => setTimeout(() => resolve('HUNG'), 500)),
+    ]);
+
+    expect({ raced, settled: outcomes.length }).toEqual({ raced: 'all-settled', settled: 5 });
+    // And they settle as rejections carrying the archiver's error, not as silent resolutions.
+    expect(outcomes.filter((o) => o.includes('rejected'))).toEqual([
+      'rejected-2: synthetic archive failure',
+      'rejected-3: synthetic archive failure',
+      'rejected-4: synthetic archive failure',
+    ]);
   });
 
   it('rejects a nonsensical bound rather than silently running unbounded', () => {

--- a/src/server/utils/__tests__/archive-helpers.test.ts
+++ b/src/server/utils/__tests__/archive-helpers.test.ts
@@ -224,14 +224,21 @@ describe('createBoundedArchive', () => {
 
   it('settles EVERY parked append when the archiver errors — the error event fires only once', async () => {
     /**
-     * The failure path is the reason `releaseWaiters` loops. `archiver` emits `error` at most
-     * once, so that single event is the only wake-up a parked `append()` will ever get: nothing
-     * drains the waiter queue afterwards, because `entry` stops firing too. Released one at a
-     * time, every append past the first would hang forever — and in `archiveImages` a hung append
-     * wedges the `Promise.all` over a page, so the whole report neither archives nor rejects.
+     * The failure path is the reason `releaseWaiters` loops. `releaseWaiters` runs on `entry` and
+     * on `error` only, and once a failure is latched `append()` rejects immediately, so no new
+     * entries are produced: if the error is the last event the archive emits, it is also the last
+     * wake-up any parked waiter gets. Released one at a time, every append past the first hangs
+     * forever, and this helper's contract — an `append()` either resolves or rejects — is broken.
      *
      * A stub rather than the real archiver, deliberately: it must NEVER emit `entry`, so the
      * success path cannot release anyone and this measures the failure path alone.
+     *
+     * ⚠️ That makes this a claim about THIS module, not a reproduction of a production hang.
+     * `archiver@6` gives no guarantee in either direction (23 distinct `emit('error')` sites),
+     * and none of its real failure paths was found to produce the shape below: an empty entry
+     * name emits `error` and keeps emitting `entry` afterwards, a directory entry emits no error,
+     * and an erroring source stream stalls the archiver with no `error` event at all. The loop is
+     * cheap insurance on the contract, and is documented as that rather than as an incident fix.
      */
     const stub = new EventEmitter() as unknown as Archiver;
     (stub as unknown as { append: () => void }).append = () => undefined;

--- a/src/server/utils/__tests__/archive-helpers.test.ts
+++ b/src/server/utils/__tests__/archive-helpers.test.ts
@@ -222,7 +222,7 @@ describe('createBoundedArchive', () => {
     await expect(bounded.finalize()).rejects.toThrow('synthetic archive failure');
   });
 
-  it('settles EVERY parked append when the archiver errors — the error event fires only once', async () => {
+  it('settles EVERY parked append when the archiver errors — even if that error is the last event it emits', async () => {
     /**
      * The failure path is the reason `releaseWaiters` loops. `releaseWaiters` runs on `entry` and
      * on `error` only, and once a failure is latched `append()` rejects immediately, so no new

--- a/src/server/utils/__tests__/archive-helpers.test.ts
+++ b/src/server/utils/__tests__/archive-helpers.test.ts
@@ -1,0 +1,238 @@
+import archiver from 'archiver';
+import fs from 'fs';
+import JSZip from 'jszip';
+import os from 'os';
+import path from 'path';
+import { randomBytes } from 'crypto';
+import { Writable } from 'stream';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import plimit from 'p-limit';
+import {
+  createBoundedArchive,
+  MAX_PENDING_ARCHIVE_ENTRIES,
+  MEDIA_ARCHIVE_COMPRESSION_LEVEL,
+} from '~/server/utils/archive-helpers';
+
+/**
+ * These tests pin the memory shape of archive building.
+ *
+ * The defect they exist for: `archive.append()` is fire-and-forget onto an unbounded internal
+ * queue, so a fast producer (network) in front of a slow consumer (deflate) retains every source
+ * buffer at once. Memory then tracks total downloaded bytes rather than staying flat, which is
+ * how archiving one account with a very large media library exhausts a container's memory limit.
+ * The buffers are external/off-heap, so a V8 old-space cap never engages first.
+ */
+
+// Deliberately awkward numbers: the entry count is not a multiple of the bound, and the entry
+// size is not a round power of two, so a fixture cannot land exactly on the boundary it tests.
+const ENTRY_COUNT = 37;
+const ENTRY_BYTES = 193 * 1024;
+const BOUND = 5;
+
+// Incompressible bytes, i.e. the JPEG/WebP case. Level-9 deflate on this is pure CPU burn, which
+// is exactly what makes the consumer the bottleneck in production.
+let pool: Buffer;
+let tmpDir: string;
+
+beforeAll(() => {
+  pool = randomBytes(ENTRY_BYTES + ENTRY_COUNT);
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'archive-helpers-'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const entryBuffer = (i: number) => Buffer.from(pool.subarray(i, i + ENTRY_BYTES));
+
+/** A sink slow enough that a zero-latency producer will outrun it. */
+function slowSink(delayMs = 5) {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      setTimeout(callback, delayMs);
+    },
+  });
+}
+
+/**
+ * Counts entries appended vs. entries the archiver has finished processing, independently of any
+ * bookkeeping inside `createBoundedArchive`. Asserting on the helper's own `peakPendingEntries`
+ * alone would be asserting its self-report; this watches the archiver directly.
+ */
+function watchOutstanding(archive: archiver.Archiver) {
+  const state = { appended: 0, processed: 0, peak: 0 };
+  archive.on('entry', () => {
+    state.processed++;
+  });
+  return {
+    state,
+    recordAppend() {
+      state.appended++;
+      const outstanding = state.appended - state.processed;
+      if (outstanding > state.peak) state.peak = outstanding;
+    },
+  };
+}
+
+describe('createBoundedArchive', () => {
+  it('keeps appended-but-unprocessed entries — and therefore retained bytes — bounded', async () => {
+    const archive = archiver('zip', { zlib: { level: 9 } });
+    archive.pipe(slowSink());
+    const watcher = watchOutstanding(archive);
+
+    const bounded = createBoundedArchive({ archive, maxPendingEntries: BOUND });
+
+    const limit = plimit(10);
+    await Promise.all(
+      Array.from({ length: ENTRY_COUNT }, (_, i) =>
+        limit(async () => {
+          const buffer = entryBuffer(i);
+          await bounded.append(buffer, { name: `entry-${i}.bin` });
+          watcher.recordAppend();
+        })
+      )
+    );
+    await bounded.finalize();
+
+    // The claim under test. Against the unbounded pattern this reads ENTRY_COUNT — see the
+    // negative control below, which is what proves this assertion can go red at all.
+    expect(watcher.state.peak).toBeLessThanOrEqual(BOUND);
+
+    // Restated as memory, which is the quantity that actually killed the process: peak retained
+    // source bytes must be a function of the bound, not of how many images the account has.
+    const peakRetainedBytes = watcher.state.peak * ENTRY_BYTES;
+    expect(peakRetainedBytes).toBeLessThanOrEqual(BOUND * ENTRY_BYTES);
+    expect(peakRetainedBytes).toBeLessThan(ENTRY_COUNT * ENTRY_BYTES);
+
+    // Backpressure must not drop work.
+    expect(watcher.state.processed).toBe(ENTRY_COUNT);
+    expect(bounded.pendingEntries).toBe(0);
+    expect(bounded.peakPendingEntries).toBeLessThanOrEqual(BOUND);
+  });
+
+  it('NEGATIVE CONTROL: the same measurement reads unbounded for a plain archive.append loop', async () => {
+    // This is the pre-fix code shape, reproduced verbatim: append inside a p-limit map, no
+    // awaiting of the compressor. If this ever came back bounded, the assertion in the test above
+    // would be measuring nothing.
+    const archive = archiver('zip', { zlib: { level: 9 } });
+    archive.pipe(slowSink());
+    const watcher = watchOutstanding(archive);
+
+    const limit = plimit(10);
+    await Promise.all(
+      Array.from({ length: ENTRY_COUNT }, (_, i) =>
+        limit(async () => {
+          const buffer = entryBuffer(i);
+          archive.append(buffer, { name: `entry-${i}.bin` });
+          watcher.recordAppend();
+        })
+      )
+    );
+
+    expect(watcher.state.peak).toBeGreaterThan(BOUND);
+    expect(watcher.state.peak).toBe(ENTRY_COUNT);
+
+    await archive.finalize();
+  });
+
+  it('preserves the entry set exactly — every appended entry lands in the archive intact', async () => {
+    const outPath = path.join(tmpDir, 'entry-set.zip');
+    const archive = archiver('zip', { zlib: { level: MEDIA_ARCHIVE_COMPRESSION_LEVEL } });
+    const output = fs.createWriteStream(outPath);
+    archive.pipe(output);
+
+    const bounded = createBoundedArchive({ archive, output, maxPendingEntries: BOUND });
+
+    for (let i = 0; i < ENTRY_COUNT; i++) {
+      await bounded.append(entryBuffer(i), { name: `entry-${i}.bin` });
+    }
+    await bounded.finalize();
+
+    const zip = await JSZip.loadAsync(fs.readFileSync(outPath));
+    const names = Object.keys(zip.files).sort();
+    expect(names).toHaveLength(ENTRY_COUNT);
+    expect(names).toEqual(Array.from({ length: ENTRY_COUNT }, (_, i) => `entry-${i}.bin`).sort());
+
+    // Spot-check content fidelity at both ends and the middle rather than trusting names alone.
+    for (const i of [0, Math.floor(ENTRY_COUNT / 2), ENTRY_COUNT - 1]) {
+      const content = await zip.files[`entry-${i}.bin`].async('nodebuffer');
+      expect(content.equals(entryBuffer(i))).toBe(true);
+    }
+  });
+
+  it('finalize() does not resolve until the output sink has flushed and closed', async () => {
+    const outPath = path.join(tmpDir, 'flushed.zip');
+    const archive = archiver('zip', { zlib: { level: MEDIA_ARCHIVE_COMPRESSION_LEVEL } });
+    const output = fs.createWriteStream(outPath);
+    archive.pipe(output);
+
+    const bounded = createBoundedArchive({ archive, output, maxPendingEntries: BOUND });
+    for (let i = 0; i < ENTRY_COUNT; i++) {
+      await bounded.append(entryBuffer(i), { name: `entry-${i}.bin` });
+    }
+    await bounded.finalize();
+
+    // Opening a read stream at this instant is what the caller does next, so the file has to be
+    // whole here — not "whole shortly afterwards".
+    const sizeAtResolve = fs.statSync(outPath).size;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(fs.statSync(outPath).size).toBe(sizeAtResolve);
+
+    const zip = await JSZip.loadAsync(fs.readFileSync(outPath));
+    expect(Object.keys(zip.files)).toHaveLength(ENTRY_COUNT);
+  });
+
+  it('NEGATIVE CONTROL: an un-awaited finalize leaves a short file at the same instant', async () => {
+    // The pre-fix shape: `archive.finalize()` then straight into `fs.createReadStream(outPath)`.
+    const outPath = path.join(tmpDir, 'unawaited.zip');
+    const archive = archiver('zip', { zlib: { level: MEDIA_ARCHIVE_COMPRESSION_LEVEL } });
+    const output = fs.createWriteStream(outPath);
+    archive.pipe(output);
+
+    const closed = new Promise<void>((resolve) => output.once('close', () => resolve()));
+    for (let i = 0; i < ENTRY_COUNT; i++)
+      archive.append(entryBuffer(i), { name: `entry-${i}.bin` });
+
+    archive.finalize(); // deliberately not awaited
+    const sizeAtReturn = fs.existsSync(outPath) ? fs.statSync(outPath).size : 0;
+
+    await closed;
+    const finalSize = fs.statSync(outPath).size;
+
+    expect(finalSize).toBeGreaterThan(0);
+    expect(sizeAtReturn).toBeLessThan(finalSize);
+  });
+
+  it('rejects appends after an archive error instead of throwing from the event handler', async () => {
+    const archive = archiver('zip', { zlib: { level: MEDIA_ARCHIVE_COMPRESSION_LEVEL } });
+    archive.pipe(slowSink(0));
+    const bounded = createBoundedArchive({ archive, maxPendingEntries: BOUND });
+
+    await bounded.append(entryBuffer(0), { name: 'ok.bin' });
+    // A nameless entry makes archiver emit `error`; the previous `throw err` listener turned that
+    // into an uncaught exception from inside archiver's async internals.
+    archive.emit('error', new Error('synthetic archive failure'));
+
+    await expect(bounded.append(entryBuffer(1), { name: 'next.bin' })).rejects.toThrow(
+      'synthetic archive failure'
+    );
+    await expect(bounded.finalize()).rejects.toThrow('synthetic archive failure');
+  });
+
+  it('rejects a nonsensical bound rather than silently running unbounded', () => {
+    const archive = archiver('zip');
+    archive.pipe(slowSink(0));
+    expect(() => createBoundedArchive({ archive, maxPendingEntries: 0 })).toThrow(
+      /positive integer/
+    );
+    expect(() => createBoundedArchive({ archive, maxPendingEntries: 2.5 })).toThrow(
+      /positive integer/
+    );
+    archive.abort();
+  });
+
+  it('defaults to a bound well below the entry counts that caused the incident', () => {
+    expect(MAX_PENDING_ARCHIVE_ENTRIES).toBeGreaterThan(0);
+    expect(MAX_PENDING_ARCHIVE_ENTRIES).toBeLessThan(ENTRY_COUNT);
+  });
+});

--- a/src/server/utils/__tests__/json-stream-helpers.test.ts
+++ b/src/server/utils/__tests__/json-stream-helpers.test.ts
@@ -1,0 +1,283 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Writable } from 'stream';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import {
+  serializeJsonObject,
+  writeJsonObject,
+  type JsonObjectEntry,
+  type JsonReplacer,
+} from '~/server/utils/json-stream-helpers';
+
+/**
+ * The defect these exist for: the CSAM base evidence bundle was produced by one
+ * `JSON.stringify({ user, reportId, models, modelVersions, images }, replacer)` over arrays
+ * loaded with unpaginated `findMany`s. That has a HARD ceiling independent of how much memory
+ * the host has — `JSON.stringify` returns a single JavaScript string, and a JS string cannot
+ * exceed V8's maximum length (536,870,888 characters on 64-bit, i.e.
+ * `require('buffer').constants.MAX_STRING_LENGTH`), past which it throws
+ * `RangeError: Invalid string length` on every attempt forever.
+ *
+ * The bundle is evidence, so the bar is not "smaller memory" but "byte-identical document,
+ * produced without ever building that string". Both halves are asserted below.
+ *
+ * Every number and every row in this file is invented.
+ */
+
+/** The replacer the service uses, reproduced verbatim — `Image.pHash` is a `BigInt` column. */
+const bigintReplacer: JsonReplacer = (_key, value) =>
+  typeof value === 'bigint' ? value.toString() : value;
+
+let tmpDir: string;
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'json-stream-helpers-'));
+});
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function collect(
+  entries: Iterable<readonly [string, JsonObjectEntry]>,
+  replacer?: JsonReplacer
+) {
+  let out = '';
+  for await (const chunk of serializeJsonObject(entries, replacer)) out += chunk;
+  return out;
+}
+
+/** Yields from an array one element at a time, so the streamed path is genuinely incremental. */
+async function* asStream<T>(rows: T[]) {
+  for (const row of rows) {
+    await Promise.resolve();
+    yield row;
+  }
+}
+
+describe('serializeJsonObject byte-identity with JSON.stringify', () => {
+  /**
+   * Deliberately awkward: a bigint (the reason a replacer exists at all), a Date (which is
+   * serialised via `toJSON` BEFORE the replacer sees it), nested nulls, an empty array, a key
+   * and a value both needing JSON escaping, and non-BMP characters.
+   */
+  const model = (id: number) => ({
+    id,
+    name: `mo"del\\ ${id}\n\t`,
+    createdAt: new Date(Date.UTC(2019, 4, 7, 3, 14, 15, 926)),
+    tags: [] as string[],
+    nested: { a: null, b: [1, 2, { c: 'ünïcødé 🜛' }] },
+    'quoted"key': `line1
+line2`,
+  });
+  const image = (id: number) => ({
+    id,
+    pHash: BigInt('9007199254740993') + BigInt(id),
+    meta: { prompt: 'a'.repeat(11), steps: 27 },
+    url: `uuid-${id}`,
+  });
+
+  // `\u2028` (LINE SEPARATOR) written as an escape, not as a raw byte: it is a legal string
+  // character but a line terminator to several parsers, and JSON.stringify passes it through
+  // unescaped — so it is exactly the kind of character a hand-rolled serialiser gets wrong.
+  const user = { id: 41, name: null, email: 'e\u2028x@example.invalid', username: 'u' };
+  const models = Array.from({ length: 7 }, (_, i) => model(i + 1));
+  const images = Array.from({ length: 13 }, (_, i) => image(i + 1));
+
+  it('produces exactly the bytes JSON.stringify produces for the same document', async () => {
+    const expected = JSON.stringify(
+      { user, reportId: 77, models, modelVersions: [], images },
+      bigintReplacer
+    );
+    const actual = await collect(
+      [
+        ['user', { value: user }],
+        ['reportId', { value: 77 }],
+        ['models', { items: asStream(models) }],
+        ['modelVersions', { items: asStream([]) }],
+        ['images', { items: asStream(images) }],
+      ],
+      bigintReplacer
+    );
+
+    // Positive control on the fixture itself: if it did not exercise the replacer, an identity
+    // assertion between two replacer-less paths would pass while proving nothing about bigints.
+    expect(expected).toContain('"9007199254740994"');
+    expect(actual).toBe(expected);
+  });
+
+  it('omits a property whose value is undefined, exactly as JSON.stringify does', async () => {
+    const expected = JSON.stringify({ a: 1, b: undefined, c: 3 });
+    expect(expected).toBe('{"a":1,"c":3}');
+    const actual = await collect([
+      ['a', { value: 1 }],
+      ['b', { value: undefined }],
+      ['c', { value: 3 }],
+    ]);
+    expect(actual).toBe(expected);
+  });
+
+  it('omits a leading undefined property without emitting a stray comma', async () => {
+    // The comma bookkeeping is the part a naive index-based implementation gets wrong.
+    const expected = JSON.stringify({ a: undefined, b: 2 });
+    const actual = await collect([
+      ['a', { value: undefined }],
+      ['b', { value: 2 }],
+    ]);
+    expect(actual).toBe(expected);
+    expect(actual).toBe('{"b":2}');
+  });
+
+  it('renders an unserialisable ARRAY element as null rather than dropping it', async () => {
+    const items = [1, undefined, () => 0, 4];
+    const expected = JSON.stringify({ xs: items });
+    expect(expected).toBe('{"xs":[1,null,null,4]}');
+    const actual = await collect([['xs', { items: asStream(items) }]]);
+    expect(actual).toBe(expected);
+  });
+
+  it('escapes keys the way JSON.stringify does', async () => {
+    const key = 'a"b\\c\ndé';
+    const expected = JSON.stringify({ [key]: 1 });
+    const actual = await collect([[key, { value: 1 }]]);
+    expect(actual).toBe(expected);
+  });
+
+  it('accepts a synchronous iterable for an array entry', async () => {
+    const expected = JSON.stringify({ xs: [1, 2, 3] });
+    expect(await collect([['xs', { items: [1, 2, 3] }]])).toBe(expected);
+  });
+});
+
+/**
+ * Installs V8's string-length failure at a small, test-chosen size.
+ *
+ * This is the mechanism, not an approximation of it: V8 throws `RangeError: Invalid string
+ * length` when a string operation would exceed the maximum string length, and `JSON.stringify`
+ * has no way to return a document larger than that. Capping it at a few KB rather than ~512 MB
+ * lets a fixture that fits in a test exercise the same failure a very large library exercises in
+ * production.
+ */
+async function withMaxStringLength<T>(cap: number, fn: () => Promise<T>) {
+  const real = JSON.stringify;
+  let longest = 0;
+  const patched = ((value: unknown, replacer?: unknown, space?: unknown) => {
+    const out = (real as (v: unknown, r?: unknown, s?: unknown) => string | undefined)(
+      value,
+      replacer,
+      space
+    );
+    if (typeof out === 'string') {
+      if (out.length > longest) longest = out.length;
+      if (out.length > cap) throw new RangeError('Invalid string length');
+    }
+    return out;
+  }) as typeof JSON.stringify;
+  (JSON as { stringify: typeof JSON.stringify }).stringify = patched;
+  try {
+    return { result: await fn(), longest };
+  } finally {
+    (JSON as { stringify: typeof JSON.stringify }).stringify = real;
+  }
+}
+
+describe('writeJsonObject removes the single-string ceiling', () => {
+  // Overshoots the cap by a wide, non-multiple margin so the fixture cannot sit on the boundary
+  // it is testing: 400 rows of ~600 bytes is ~240 KB against a 24_000-byte cap, i.e. ~10x over,
+  // while any single row is ~40x under it.
+  const ROW_COUNT = 400;
+  const CAP = 24_000;
+  const rows = Array.from({ length: ROW_COUNT }, (_, i) => ({
+    id: i + 1,
+    url: `uuid-${i}`,
+    pHash: BigInt(1_000_000_000_000) + BigInt(i),
+    meta: { prompt: `p${i}-${'x'.repeat(500)}` },
+  }));
+  const document = { user: { id: 5 }, reportId: 9, models: [], modelVersions: [], images: rows };
+
+  let capturedReal: string;
+  beforeAll(() => {
+    capturedReal = JSON.stringify(document, bigintReplacer);
+  });
+
+  it('POSITIVE CONTROL: the fixture and the cap are large enough to matter', () => {
+    expect(capturedReal.length).toBeGreaterThan(CAP * 5);
+    // …and no single row is anywhere near the cap, so a per-row serialiser is safe by a margin.
+    expect(JSON.stringify(rows[0], bigintReplacer).length).toBeLessThan(CAP / 10);
+  });
+
+  it('NEGATIVE CONTROL: the pre-fix one-shot stringify throws RangeError at that cap', async () => {
+    await expect(
+      withMaxStringLength(CAP, async () => JSON.stringify(document, bigintReplacer))
+    ).rejects.toThrow(/Invalid string length/);
+  });
+
+  it('streams the identical document through, never building a string above the cap', async () => {
+    const outPath = path.join(tmpDir, 'bundle.json');
+    const { longest } = await withMaxStringLength(CAP, async () => {
+      await writeJsonObject({
+        sink: fs.createWriteStream(outPath),
+        replacer: bigintReplacer,
+        entries: [
+          ['user', { value: document.user }],
+          ['reportId', { value: document.reportId }],
+          ['models', { items: asStream(document.models) }],
+          ['modelVersions', { items: asStream(document.modelVersions) }],
+          ['images', { items: asStream(rows) }],
+        ],
+      });
+    });
+
+    // The ceiling claim, stated as the quantity that causes the RangeError.
+    expect(longest).toBeLessThanOrEqual(CAP);
+    expect(longest).toBeLessThan(capturedReal.length);
+
+    // The evidence claim: what landed on disk is the same document, byte for byte.
+    expect(fs.readFileSync(outPath, 'utf8')).toBe(capturedReal);
+  });
+
+  it('the file is complete the instant writeJsonObject resolves', async () => {
+    // The caller opens `fs.createReadStream(outPath)` on the very next line and uploads it, so
+    // "complete shortly afterwards" is not good enough.
+    const outPath = path.join(tmpDir, 'flushed.json');
+    await writeJsonObject({
+      sink: fs.createWriteStream(outPath),
+      replacer: bigintReplacer,
+      entries: [['images', { items: asStream(rows) }]],
+    });
+    const sizeAtResolve = fs.statSync(outPath).size;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(fs.statSync(outPath).size).toBe(sizeAtResolve);
+    expect(JSON.parse(fs.readFileSync(outPath, 'utf8')).images).toHaveLength(ROW_COUNT);
+  });
+});
+
+describe('writeJsonObject error handling', () => {
+  it('rejects, rather than leaving the caller with a silently truncated file', async () => {
+    const sink = new Writable({
+      write(_chunk, _enc, cb) {
+        cb(new Error('synthetic sink failure'));
+      },
+    });
+    await expect(
+      writeJsonObject({ sink, entries: [['xs', { items: asStream([1, 2, 3]) }]] })
+    ).rejects.toThrow('synthetic sink failure');
+  });
+
+  it('propagates a failure raised mid-scan by the row source', async () => {
+    async function* failing() {
+      yield { id: 1 };
+      throw new Error('synthetic scan failure');
+    }
+    const sink = fs.createWriteStream(path.join(tmpDir, 'aborted.json'));
+    await expect(
+      writeJsonObject({ sink, entries: [['images', { items: failing() }]] })
+    ).rejects.toThrow('synthetic scan failure');
+  });
+});
+
+afterEach(() => {
+  // Nothing global to reset — `withMaxStringLength` restores in its own `finally`. Asserted here
+  // so a future edit that moves the restore out of `finally` fails loudly and locally instead of
+  // poisoning every later file in the worker.
+  expect(JSON.stringify({ a: 'x'.repeat(50_000) }).length).toBeGreaterThan(50_000);
+});

--- a/src/server/utils/__tests__/json-stream-helpers.test.ts
+++ b/src/server/utils/__tests__/json-stream-helpers.test.ts
@@ -146,6 +146,46 @@ line2`,
     const expected = JSON.stringify({ xs: [1, 2, 3] });
     expect(await collect([['xs', { items: [1, 2, 3] }]])).toBe(expected);
   });
+
+  it('separates an items entry from whatever follows it', async () => {
+    /**
+     * The comma between an array property and the next property is produced by the `items`
+     * branch's own `wroteEntry = true`, and nothing else pins it: the CSAM bundle happens to put
+     * two `value` entries before its three arrays, so the first `items` entry is never the one
+     * that has to set the flag. The helper is exported with a byte-identity contract though, and
+     * without that assignment the output is `{"xs":[1]"ys":2}` — not merely a different
+     * document, an unparseable one. A single-element array is deliberate: with more elements the
+     * inner `first` flag masks nothing, but it is also the shape the existing items-first test
+     * already uses, and it is the shape that stays silent.
+     */
+    for (const [entries, expected] of [
+      [
+        [
+          ['xs', { items: [1] }],
+          ['ys', { value: 2 }],
+        ],
+        JSON.stringify({ xs: [1], ys: 2 }),
+      ],
+      [
+        [
+          ['xs', { items: [1] }],
+          ['ys', { items: [2] }],
+        ],
+        JSON.stringify({ xs: [1], ys: [2] }),
+      ],
+      [
+        [
+          ['xs', { items: [] }],
+          ['ys', { value: 2 }],
+        ],
+        JSON.stringify({ xs: [], ys: 2 }),
+      ],
+    ] as ReadonlyArray<readonly [ReadonlyArray<readonly [string, JsonObjectEntry]>, string]>) {
+      const streamed = await collect(entries);
+      expect(streamed).toBe(expected);
+      expect(() => JSON.parse(streamed)).not.toThrow();
+    }
+  });
 });
 
 /**
@@ -263,6 +303,42 @@ describe('writeJsonObject error handling', () => {
     ).rejects.toThrow('synthetic sink failure');
   });
 
+  it('resolves for a sink that never emits close, rather than waiting on one', async () => {
+    /**
+     * Regression guard for a line that was REMOVED. `writeJsonObject` used to `await` the sink's
+     * `'close'` on top of `pipeline`, under a comment claiming `pipeline` resolving was no
+     * promise that the file was whole. Measured false: `pipeline` ends the sink and then waits
+     * on it via `stream.finished`, which for an `autoDestroy` writable — the default, and what
+     * `fs.createWriteStream` is — already means `'close'`. ("the file is complete the instant
+     * writeJsonObject resolves" above is the outcome half of that.)
+     *
+     * And the extra await was not free. This signature accepts any `Writable`, and one built
+     * with `autoDestroy: false` never emits `'close'` at all, so the second await hung forever.
+     * Re-adding it makes this test report `HUNG`.
+     */
+    const chunks: Buffer[] = [];
+    const sink = new Writable({
+      autoDestroy: false,
+      write(chunk, _enc, cb) {
+        chunks.push(Buffer.from(chunk as Buffer));
+        cb();
+      },
+    });
+    // The precondition, asserted rather than assumed: this sink really does withhold 'close'.
+    let closed = false;
+    sink.once('close', () => (closed = true));
+
+    const raced = await Promise.race([
+      writeJsonObject({ sink, entries: [['xs', { items: asStream([1, 2, 3]) }]] }).then(
+        () => 'resolved' as const
+      ),
+      new Promise<'HUNG'>((resolve) => setTimeout(() => resolve('HUNG'), 500)),
+    ]);
+
+    expect({ raced, closed }).toEqual({ raced: 'resolved', closed: false });
+    expect(Buffer.concat(chunks).toString('utf8')).toBe(JSON.stringify({ xs: [1, 2, 3] }));
+  });
+
   it('propagates a failure raised mid-scan by the row source', async () => {
     async function* failing() {
       yield { id: 1 };
@@ -272,6 +348,12 @@ describe('writeJsonObject error handling', () => {
     await expect(
       writeJsonObject({ sink, entries: [['images', { items: failing() }]] })
     ).rejects.toThrow('synthetic scan failure');
+
+    // `pipeline` destroys the sink on the error path, but the underlying `open()` can still be in
+    // flight — and it is the `open` that creates the file. Left dangling, that file can appear
+    // under `tmpDir` after `afterAll` has begun removing it, which surfaces as an `ENOTEMPTY`
+    // failure of the suite rather than of any test. Observed once under parallel load.
+    if (!sink.closed) await new Promise((resolve) => sink.once('close', resolve));
   });
 });
 

--- a/src/server/utils/archive-helpers.ts
+++ b/src/server/utils/archive-helpers.ts
@@ -1,0 +1,132 @@
+import type { Archiver, EntryData } from 'archiver';
+import type { Readable, Writable } from 'stream';
+
+/**
+ * Compression level for archives whose entries are already-compressed media (JPEG/WebP/PNG).
+ *
+ * Deflate cannot meaningfully shrink bytes that are already entropy-coded, so level 9 spends a
+ * large amount of CPU for close to nothing. That matters beyond wasted cycles: deflate is the
+ * *consumer* in these archives, and a slow consumer behind a fast network producer is what lets
+ * the pending-entry queue grow (see `createBoundedArchive`). Dropping the level moves the
+ * bottleneck back to the network, where it belongs.
+ *
+ * The resulting archives are evidence bundles that are uploaded as-is; nothing reads them back
+ * or depends on their size, so a slightly larger zip is free.
+ */
+export const MEDIA_ARCHIVE_COMPRESSION_LEVEL = 1;
+
+/**
+ * Default ceiling on entries that have been handed to the archiver but not yet compressed and
+ * written out. Each pending entry pins its whole source buffer in memory, so this is the knob
+ * that converts "memory grows with the number of files" into "memory is constant".
+ */
+export const MAX_PENDING_ARCHIVE_ENTRIES = 8;
+
+export type BoundedArchive = {
+  /**
+   * Appends an entry, first waiting until the archiver has drained below the pending-entry
+   * ceiling. Resolves once the entry has been accepted (not once it has been written).
+   */
+  append: (source: Buffer | Readable, data: EntryData) => Promise<void>;
+  /** Finalizes the archive and waits for the output sink to flush and close. */
+  finalize: () => Promise<void>;
+  /** Entries appended but not yet processed. Exposed for tests and diagnostics. */
+  readonly pendingEntries: number;
+  /** High-water mark of `pendingEntries`. Exposed for tests and diagnostics. */
+  readonly peakPendingEntries: number;
+};
+
+/**
+ * Wraps an `archiver` instance with backpressure.
+ *
+ * `archive.append()` is fire-and-forget: it pushes the source onto an unbounded internal queue
+ * that is drained by a single worker. When the producer is a fast network fetch and the consumer
+ * is deflate, the queue — and therefore the retained source buffers — grows without limit. For a
+ * user with a large media library that is enough to exhaust the container's memory. The buffers
+ * are external/off-heap, so a `--max-old-space-size` cap never engages first; the container limit
+ * is what is hit.
+ *
+ * `archiver` emits `entry` once per processed entry, which is the signal used here to release
+ * append slots.
+ *
+ * This also takes over the `error` event. Throwing from an `error` listener (the previous
+ * shape) surfaces as an uncaught exception from inside archiver's async internals rather than as
+ * a rejection the caller can handle; capturing it instead lets `append`/`finalize` reject so the
+ * caller's own try/catch decides what happens.
+ */
+export function createBoundedArchive({
+  archive,
+  output,
+  maxPendingEntries = MAX_PENDING_ARCHIVE_ENTRIES,
+}: {
+  archive: Archiver;
+  /** The sink `archive` is piped to. Awaited on `finalize` so the bytes are actually on disk. */
+  output?: Writable;
+  maxPendingEntries?: number;
+}): BoundedArchive {
+  if (!Number.isInteger(maxPendingEntries) || maxPendingEntries < 1) {
+    throw new Error(
+      `maxPendingEntries must be a positive integer, received ${String(maxPendingEntries)}`
+    );
+  }
+
+  let pending = 0;
+  let peak = 0;
+  let failure: Error | undefined;
+  const waiters: Array<() => void> = [];
+
+  // Only releases as many waiters as there are free slots. Each released waiter re-checks the
+  // ceiling before incrementing, and the increment is synchronous with that check, so no two
+  // waiters can claim the same slot.
+  const releaseWaiters = () => {
+    while (waiters.length > 0 && (failure !== undefined || pending < maxPendingEntries)) {
+      waiters.shift()?.();
+    }
+  };
+
+  archive.on('entry', () => {
+    if (pending > 0) pending--;
+    releaseWaiters();
+  });
+
+  archive.on('error', (err: unknown) => {
+    failure ??= err instanceof Error ? err : new Error(String(err));
+    releaseWaiters();
+  });
+
+  return {
+    get pendingEntries() {
+      return pending;
+    },
+    get peakPendingEntries() {
+      return peak;
+    },
+    async append(source, data) {
+      if (failure) throw failure;
+      while (pending >= maxPendingEntries) {
+        await new Promise<void>((resolve) => waiters.push(resolve));
+        if (failure) throw failure;
+      }
+      pending++;
+      if (pending > peak) peak = pending;
+      archive.append(source, data);
+    },
+    async finalize() {
+      if (failure) throw failure;
+      // Registered before `finalize()` so the event cannot be missed.
+      const closed = output
+        ? new Promise<void>((resolve, reject) => {
+            output.once('close', () => resolve());
+            output.once('error', reject);
+          })
+        : undefined;
+
+      // `finalize()` resolves when the zip module ends, which is NOT when the sink has flushed:
+      // measured against archiver 6.0.2, a file was 24254 bytes at that point and 25342 bytes once
+      // the write stream closed. Reading the file in between yields a truncated archive.
+      await archive.finalize();
+      if (closed) await closed;
+      if (failure) throw failure;
+    },
+  };
+}

--- a/src/server/utils/archive-helpers.ts
+++ b/src/server/utils/archive-helpers.ts
@@ -36,9 +36,10 @@ export const MAX_PENDING_ARCHIVE_ENTRIES = 8;
  *
  * `archiver` rejects an entry with an empty name (`ENTRYNAMEREQUIRED`), and since the error
  * handling in `createBoundedArchive` latches archive errors and rethrows them from `finalize()`,
- * one such URL now fails the whole report rather than being silently dropped. That is the right
- * default for evidence — see the file header — but an unnameable URL is not a reason to make a
- * report permanently unarchivable, and it is a shape the orchestrator can legitimately produce:
+ * one such URL now fails the whole report rather than being silently dropped. Failing loudly is
+ * the right default here — a dropped entry means a piece of evidence is missing from an archive
+ * nobody will re-derive — but an unnameable URL is not a reason to make a report permanently
+ * unarchivable, and it is a shape the orchestrator can legitimately produce:
  * `https://host/blob/` and `https://host/?x` both reduce to `''` under the basename expression.
  *
  * The basename expression is evaluated FIRST and returned verbatim whenever it is non-empty, so
@@ -98,7 +99,14 @@ export function createBoundedArchive({
   maxPendingEntries = MAX_PENDING_ARCHIVE_ENTRIES,
 }: {
   archive: Archiver;
-  /** The sink `archive` is piped to. Awaited on `finalize` so the bytes are actually on disk. */
+  /**
+   * The sink `archive` is piped to, awaited to `'close'` on `finalize` so the bytes are really on
+   * disk — archiver's own `finalize()` resolves when the zip module ends, measurably before the
+   * sink has flushed. Unlike `writeJsonObject`, nothing else here waits on the sink, so this wait
+   * is load-bearing rather than redundant. It does require a sink that emits `'close'`: both call
+   * sites pass `fs.createWriteStream`, which does; a Writable built with `autoDestroy: false`
+   * never emits it and would hang here.
+   */
   output?: Writable;
   maxPendingEntries?: number;
 }): BoundedArchive {
@@ -113,14 +121,23 @@ export function createBoundedArchive({
   let failure: Error | undefined;
   const waiters: Array<() => void> = [];
 
-  // Releases EVERY waiter whenever at least one slot is free — it does not hand out one wake-up
-  // per free slot. `pending` is only incremented once a woken waiter actually resumes, which
-  // happens on a later microtask, so the `pending < maxPendingEntries` test below is still true
-  // for the second and subsequent iterations of this loop and the whole queue drains.
+  // 🔴 The `while` is load-bearing on the FAILURE path and must not be narrowed to an `if`.
   //
-  // The bound is upheld anyway, by the `while` re-check in `append()`: a woken waiter that finds
-  // no free slot simply parks again. That re-check is the actual guard — a maintainer who
-  // "optimises" it into an `if` on the strength of this loop's name would break the bound.
+  // `archiver` emits `error` at most ONCE, and that single event is the only wake-up every
+  // waiter parked in `append()` will ever get — nothing drains them afterwards, because `entry`
+  // stops firing too. Draining the whole queue here is therefore what makes each parked append
+  // settle. As an `if`, one `error` releases exactly one waiter and the rest hang forever: in
+  // `archiveImages` that wedges the `Promise.all` over a page, so `archiveCsamDataForReport`
+  // never settles for that report — no archive, no rejection, and nothing logged. Pinned by
+  // "settles EVERY parked append when the archiver errors" in `archive-helpers.test.ts`, which
+  // fails with `raced: 'HUNG', settled: 3` against the `if`.
+  //
+  // On the SUCCESS path the loop over-releases rather than handing out one wake-up per free
+  // slot: `pending` is only incremented once a woken waiter actually resumes, on a later
+  // microtask, so `pending < maxPendingEntries` is still true on the second and subsequent
+  // iterations. That is harmless because `append()` re-checks the bound in its own `while` and a
+  // waiter that finds no free slot simply parks again. Both loops are needed — this one to
+  // settle everything on failure, that one to uphold the bound on success.
   const releaseWaiters = () => {
     while (waiters.length > 0 && (failure !== undefined || pending < maxPendingEntries)) {
       waiters.shift()?.();

--- a/src/server/utils/archive-helpers.ts
+++ b/src/server/utils/archive-helpers.ts
@@ -121,23 +121,33 @@ export function createBoundedArchive({
   let failure: Error | undefined;
   const waiters: Array<() => void> = [];
 
-  // 🔴 The `while` is load-bearing on the FAILURE path and must not be narrowed to an `if`.
+  // 🔴 The `while` is what makes the FAILURE path settle, and must not be narrowed to an `if`.
+  // An earlier revision of this comment said the opposite — "that re-check is the actual guard",
+  // meaning the one in `append()` — and invited exactly that edit.
   //
-  // `archiver` emits `error` at most ONCE, and that single event is the only wake-up every
-  // waiter parked in `append()` will ever get — nothing drains them afterwards, because `entry`
-  // stops firing too. Draining the whole queue here is therefore what makes each parked append
-  // settle. As an `if`, one `error` releases exactly one waiter and the rest hang forever: in
-  // `archiveImages` that wedges the `Promise.all` over a page, so `archiveCsamDataForReport`
-  // never settles for that report — no archive, no rejection, and nothing logged. Pinned by
-  // "settles EVERY parked append when the archiver errors" in `archive-helpers.test.ts`, which
-  // fails with `raced: 'HUNG', settled: 3` against the `if`.
+  // `releaseWaiters` is called from exactly two places: `entry` and `error`. Once `failure` is
+  // latched no new entries are produced, because `append()` rejects immediately — so if the
+  // error is the last event the archive emits, it is also the last wake-up any parked waiter
+  // gets. Releasing one waiter per event strands the rest forever. Measured against this module
+  // with an archive stub emitting a single `error` and no `entry`: 2 of 5 appends never settle
+  // (`raced: 'HUNG', settled: 3`). Pinned by "settles EVERY parked append when the archiver
+  // errors" in `archive-helpers.test.ts`.
+  //
+  // ⚠️ SCOPE OF THAT CLAIM, because it is easy to overstate and was overstated once already:
+  // it is about THIS module's contract, not a reproduced production wedge. `archiver@6` has 23
+  // separate `emit('error')` sites and no "at most one error" guarantee either way; three of its
+  // real failure paths were probed and NONE reaches the stranding shape. An empty entry name
+  // emits `error` and then goes on emitting `entry` (8 more), so an `if` would drain there. A
+  // directory entry emits no `error` at all. A source stream that errors makes the archiver
+  // stall silently with no `error` event, which no variant of this loop can rescue. So the
+  // `while` is the cheap way to keep the contract true whichever site fires — not a fix for a
+  // hang anyone has observed in production.
   //
   // On the SUCCESS path the loop over-releases rather than handing out one wake-up per free
   // slot: `pending` is only incremented once a woken waiter actually resumes, on a later
   // microtask, so `pending < maxPendingEntries` is still true on the second and subsequent
   // iterations. That is harmless because `append()` re-checks the bound in its own `while` and a
-  // waiter that finds no free slot simply parks again. Both loops are needed — this one to
-  // settle everything on failure, that one to uphold the bound on success.
+  // waiter that finds no free slot simply parks again — that re-check is what upholds the bound.
   const releaseWaiters = () => {
     while (waiters.length > 0 && (failure !== undefined || pending < maxPendingEntries)) {
       waiters.shift()?.();

--- a/src/server/utils/archive-helpers.ts
+++ b/src/server/utils/archive-helpers.ts
@@ -19,8 +19,46 @@ export const MEDIA_ARCHIVE_COMPRESSION_LEVEL = 1;
  * Default ceiling on entries that have been handed to the archiver but not yet compressed and
  * written out. Each pending entry pins its whole source buffer in memory, so this is the knob
  * that converts "memory grows with the number of files" into "memory is constant".
+ *
+ * ⚠️ It is NOT the whole peak, and reading it as "8 image-sizes" understates the constant by
+ * roughly 5×. At the CSAM call sites the appender runs behind a `p-limit(10)`, and each of
+ * those 10 slots holds its own `blob`, `arrayBuffer` and `buffer` for the whole time it is
+ * parked inside `append()` waiting for a slot here. So the realistic peak is about
+ * `8 + 3 × 10 = 38` image-sizes, not 8.
+ *
+ * That is the point regardless: 38 is a CONSTANT, set by the two concurrency caps. The defect
+ * being fixed is that the peak previously scaled with how many images the account had.
  */
 export const MAX_PENDING_ARCHIVE_ENTRIES = 8;
+
+/**
+ * Zip entry name for a media URL, guaranteed non-empty.
+ *
+ * `archiver` rejects an entry with an empty name (`ENTRYNAMEREQUIRED`), and since the error
+ * handling in `createBoundedArchive` latches archive errors and rethrows them from `finalize()`,
+ * one such URL now fails the whole report rather than being silently dropped. That is the right
+ * default for evidence — see the file header — but an unnameable URL is not a reason to make a
+ * report permanently unarchivable, and it is a shape the orchestrator can legitimately produce:
+ * `https://host/blob/` and `https://host/?x` both reduce to `''` under the basename expression.
+ *
+ * The basename expression is evaluated FIRST and returned verbatim whenever it is non-empty, so
+ * every URL that already produced a usable name keeps byte-identical naming. The fallback only
+ * runs where the old code would have produced `''`.
+ */
+export function zipEntryNameForUrl(url: string, index: number): string {
+  const basename = url.split('/').reverse()[0].split('?')[0];
+  if (basename.length) return basename;
+
+  // Nothing usable at the end of the path — keep whatever provenance the path still carries so
+  // the entry is traceable back to its source, and fall back to the position in the batch when
+  // even that is empty. `index` makes the name unique within one archive.
+  const path = url
+    .split('?')[0]
+    .split('#')[0]
+    .replace(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i, '');
+  const slug = path.replace(/[^a-zA-Z0-9._-]+/g, '_').replace(/^_+|_+$/g, '');
+  return slug.length ? `unnamed-${index}-${slug}` : `unnamed-${index}`;
+}
 
 export type BoundedArchive = {
   /**
@@ -75,9 +113,14 @@ export function createBoundedArchive({
   let failure: Error | undefined;
   const waiters: Array<() => void> = [];
 
-  // Only releases as many waiters as there are free slots. Each released waiter re-checks the
-  // ceiling before incrementing, and the increment is synchronous with that check, so no two
-  // waiters can claim the same slot.
+  // Releases EVERY waiter whenever at least one slot is free — it does not hand out one wake-up
+  // per free slot. `pending` is only incremented once a woken waiter actually resumes, which
+  // happens on a later microtask, so the `pending < maxPendingEntries` test below is still true
+  // for the second and subsequent iterations of this loop and the whole queue drains.
+  //
+  // The bound is upheld anyway, by the `while` re-check in `append()`: a woken waiter that finds
+  // no free slot simply parks again. That re-check is the actual guard — a maintainer who
+  // "optimises" it into an `if` on the strength of this loop's name would break the bound.
   const releaseWaiters = () => {
     while (waiters.length > 0 && (failure !== undefined || pending < maxPendingEntries)) {
       waiters.shift()?.();

--- a/src/server/utils/json-stream-helpers.ts
+++ b/src/server/utils/json-stream-helpers.ts
@@ -88,10 +88,20 @@ export async function* serializeJsonObject(
  * mark. `pipeline` supplies the backpressure — the generator is only pulled from as fast as the
  * sink drains — and destroys the sink on error rather than leaving a half-written file open.
  *
- * The sink is additionally awaited to `'close'`. `pipeline` resolving is not on its own a
- * promise that a subsequent `fs.createReadStream(path)` sees every byte, and this file is read
- * back and uploaded immediately after being written. The listener is registered BEFORE
- * `pipeline` runs so the event cannot be missed if it has already fired by the time we await.
+ * `pipeline` also settles the question the caller actually cares about — this file is read back
+ * with `fs.createReadStream` and uploaded immediately — because it ends the sink and then waits
+ * on it via `stream.finished`, which for a Writable with `autoDestroy` (the default, and what
+ * `fs.createWriteStream` is) means waiting for `'close'`, not merely `'finish'`. So the file is
+ * whole the instant this resolves, which is pinned as an outcome by "the file is complete the
+ * instant writeJsonObject resolves".
+ *
+ * 🔴 Do NOT add a second `await` on the sink's `'close'` here. A previous revision did, under a
+ * comment asserting that `pipeline` gave no such guarantee. That assertion was false — and the
+ * extra await was not harmless belt-and-braces: for a sink constructed with `autoDestroy: false`,
+ * which this signature accepts, `'close'` never fires at all and `writeJsonObject` hangs forever.
+ * `archive-helpers.ts` does need its own `'close'` wait and that is not an inconsistency to
+ * "unify": what it awaits is archiver's `finalize()`, which resolves when the zip module ends and
+ * knows nothing about the sink.
  */
 export async function writeJsonObject({
   sink,
@@ -102,9 +112,5 @@ export async function writeJsonObject({
   entries: Iterable<readonly [string, JsonObjectEntry]>;
   replacer?: JsonReplacer;
 }): Promise<void> {
-  const closed = new Promise<void>((resolve) => {
-    sink.once('close', () => resolve());
-  });
   await pipeline(serializeJsonObject(entries, replacer), sink);
-  await closed;
 }

--- a/src/server/utils/json-stream-helpers.ts
+++ b/src/server/utils/json-stream-helpers.ts
@@ -1,0 +1,110 @@
+import type { Writable } from 'stream';
+import { pipeline } from 'stream/promises';
+
+/**
+ * Same signature as the second argument to `JSON.stringify`.
+ *
+ * 🔴 SCOPE LIMIT, and it is the only way this helper can diverge from `JSON.stringify`:
+ * a replacer here is applied to *values*, never to the document root and never with a
+ * meaningful `key`/`this`. `writeJsonObject` serialises each top-level entry with its own
+ * `JSON.stringify(value, replacer)` call, so the replacer sees `('', value)` with `this` bound
+ * to that call's synthetic holder rather than `('someKey', value)` with `this` bound to the
+ * whole document. For a replacer that branches only on `typeof value` — which is what a
+ * bigint-to-string replacer does — the output is byte-identical, and
+ * `json-stream-helpers.test.ts` asserts that byte-identity directly. A replacer that reads
+ * `key` or `this` is NOT supported and will produce different bytes.
+ */
+export type JsonReplacer = (this: unknown, key: string, value: unknown) => unknown;
+
+/**
+ * One top-level property of the document.
+ *
+ * `{ value }` is serialised in one shot — use it for anything already in memory and known to
+ * be small (a single row, a scalar). `{ items }` is serialised element-by-element from a
+ * (possibly async) iterable and is the whole point of this module: it lets an array of
+ * unbounded length be written without the array or its JSON ever existing all at once.
+ */
+export type JsonObjectEntry =
+  | { readonly value: unknown }
+  | { readonly items: AsyncIterable<unknown> | Iterable<unknown> };
+
+/**
+ * Serialises `{ [key]: value, … }` as a stream of string chunks, byte-for-byte as
+ * `JSON.stringify(object, replacer)` would (see the replacer scope limit above).
+ *
+ * The rules being mirrored, each of which is exercised by a test:
+ * - key order is entry order, i.e. object insertion order;
+ * - a property whose value serialises to `undefined` (an `undefined`, a function, a symbol) is
+ *   OMITTED entirely, and the comma bookkeeping has to account for that;
+ * - an array ELEMENT that serialises to `undefined` becomes `null` rather than being dropped;
+ * - an empty array is `[]`, not the omission above.
+ */
+export async function* serializeJsonObject(
+  entries: Iterable<readonly [string, JsonObjectEntry]>,
+  replacer?: JsonReplacer
+): AsyncGenerator<string, void, undefined> {
+  yield '{';
+  let wroteEntry = false;
+  for (const [key, entry] of entries) {
+    if ('items' in entry) {
+      yield `${wroteEntry ? ',' : ''}${JSON.stringify(key)}:[`;
+      wroteEntry = true;
+      let first = true;
+      for await (const item of entry.items) {
+        // `JSON.stringify` renders an unserialisable ARRAY element as `null` (unlike an
+        // unserialisable object property, which it drops). Matching that is what keeps the
+        // element count of the streamed array equal to the element count of the in-memory one.
+        yield `${first ? '' : ','}${JSON.stringify(item, replacer) ?? 'null'}`;
+        first = false;
+      }
+      yield ']';
+    } else {
+      const json = JSON.stringify(entry.value, replacer);
+      // Not a shortcut: `JSON.stringify({ a: undefined })` is `'{}'`, so emitting `"a":` here
+      // would produce a document that is not merely different but syntactically invalid.
+      if (json === undefined) continue;
+      yield `${wroteEntry ? ',' : ''}${JSON.stringify(key)}:${json}`;
+      wroteEntry = true;
+    }
+  }
+  yield '}';
+}
+
+/**
+ * Writes a JSON object to `sink` without ever materialising the document as a single string.
+ *
+ * Two independent ceilings this removes, both of which apply to
+ * `fs.writeFile(path, JSON.stringify(everything))`:
+ *
+ * 1. `JSON.stringify` returns ONE JavaScript string, and a JS string has a hard maximum length.
+ *    On 64-bit V8 that is `2^29 - 24` = **536,870,888 characters** (readable at runtime as
+ *    `require('buffer').constants.MAX_STRING_LENGTH`); one character more throws
+ *    `RangeError: Invalid string length`. That is a permanent, non-retryable failure: the same
+ *    input fails identically on every attempt, no matter how much memory the host has.
+ * 2. Even below the cap, the source rows and the rendered string are resident at the same time,
+ *    so peak memory is roughly twice the document size on top of the rows themselves.
+ *
+ * Streaming replaces both with a peak that is one element's JSON plus the sink's high-water
+ * mark. `pipeline` supplies the backpressure — the generator is only pulled from as fast as the
+ * sink drains — and destroys the sink on error rather than leaving a half-written file open.
+ *
+ * The sink is additionally awaited to `'close'`. `pipeline` resolving is not on its own a
+ * promise that a subsequent `fs.createReadStream(path)` sees every byte, and this file is read
+ * back and uploaded immediately after being written. The listener is registered BEFORE
+ * `pipeline` runs so the event cannot be missed if it has already fired by the time we await.
+ */
+export async function writeJsonObject({
+  sink,
+  entries,
+  replacer,
+}: {
+  sink: Writable;
+  entries: Iterable<readonly [string, JsonObjectEntry]>;
+  replacer?: JsonReplacer;
+}): Promise<void> {
+  const closed = new Promise<void>((resolve) => {
+    sink.once('close', () => resolve());
+  });
+  await pipeline(serializeJsonObject(entries, replacer), sink);
+  await closed;
+}

--- a/src/server/utils/json-stream-helpers.ts
+++ b/src/server/utils/json-stream-helpers.ts
@@ -89,11 +89,11 @@ export async function* serializeJsonObject(
  * sink drains — and destroys the sink on error rather than leaving a half-written file open.
  *
  * `pipeline` also settles the question the caller actually cares about — this file is read back
- * with `fs.createReadStream` and uploaded immediately — because it ends the sink and then waits
- * on it via `stream.finished`, which for a Writable with `autoDestroy` (the default, and what
- * `fs.createWriteStream` is) means waiting for `'close'`, not merely `'finish'`. So the file is
- * whole the instant this resolves, which is pinned as an outcome by "the file is complete the
- * instant writeJsonObject resolves".
+ * with `fs.createReadStream` and uploaded immediately. It ends the sink and does not resolve
+ * until the sink has closed, not merely finished, for a Writable with `autoDestroy` (the default,
+ * and what `fs.createWriteStream` is). Measured on node v24.19.0 and v26.8.0, over 20 rounds of a
+ * 4 MB document: `'close'` had already fired and the file was byte-complete every time `pipeline`
+ * resolved. "the file is complete the instant writeJsonObject resolves" pins that as an outcome.
  *
  * 🔴 Do NOT add a second `await` on the sink's `'close'` here. A previous revision did, under a
  * comment asserting that `pipeline` gave no such guarantee. That assertion was false — and the

--- a/src/server/utils/json-stream-helpers.ts
+++ b/src/server/utils/json-stream-helpers.ts
@@ -91,9 +91,9 @@ export async function* serializeJsonObject(
  * `pipeline` also settles the question the caller actually cares about — this file is read back
  * with `fs.createReadStream` and uploaded immediately. It ends the sink and does not resolve
  * until the sink has closed, not merely finished, for a Writable with `autoDestroy` (the default,
- * and what `fs.createWriteStream` is). Measured on node v24.19.0 and v26.8.0, over 20 rounds of a
- * 4 MB document: `'close'` had already fired and the file was byte-complete every time `pipeline`
- * resolved. "the file is complete the instant writeJsonObject resolves" pins that as an outcome.
+ * and what `fs.createWriteStream` is). Measured on node v24.19.0 (the pinned toolchain) and again
+ * on a node 26 host, over 20 rounds of a 4 MB document: `'close'` had already fired and the file
+ * was byte-complete every time `pipeline` resolved. "the file is complete the instant writeJsonObject resolves" pins that as an outcome.
  *
  * 🔴 Do NOT add a second `await` on the sink's `'close'` here. A previous revision did, under a
  * comment asserting that `pipeline` gave no such guarantee. That assertion was false — and the


### PR DESCRIPTION
## Problem

Archiving a CSAM report for a user with a very large image library exhausts the container's memory. The process is killed partway through, taking the rest of that hour's cron work down with it, and because the job is rescheduled it repeats on every run — so the archive job never completes once such a report enters the queue.

There are **two independent unbounded paths** in `archiveCsamDataForReport()`, and round 1 of this PR only fixed one of them. Both are fixed now.

### 1. The archiver queue (`archiveImages` / `archiveGeneratedImages`)

These download every image the reported user owns, fully buffer each one (`blob.arrayBuffer()` → `Buffer.from`), and call `archive.append(buffer, …)`.

`archive.append()` is fire-and-forget: it pushes the source onto an **unbounded** internal queue drained by a single worker (`archiver@6.0.2`, `lib/core.js` — `this._queue = async.queue(…, 1)`). With a fast producer (network) in front of a slow consumer (level-9 deflate over already-compressed JPEG/WebP), every source buffer is retained at once and resident memory tracks *total downloaded bytes*.

The existing `plimit(10)` bounds concurrent **downloads** only — nothing bounds the compressor. And `NODE_OPTIONS=--max-old-space-size` offers no protection: the retained buffers are external/off-heap, so the V8 old-space cap never engages before the container limit does.

Measured directly against the installed `archiver@6.0.2` before writing the fix:

```
unbounded peak outstanding entries: 40 of 40    <- every appended buffer retained
bounded peak outstanding:            4          <- awaiting 'entry' caps it, all 40 still processed
```

### 2. The base evidence bundle (`archiveBaseReportData`) — new in round 2

```ts
const images = await dbRead.image.findMany({ where: { userId } });   // every row, no pagination
const models = await dbRead.model.findMany({ where: { userId } });   // ditto
const modelVersions = await dbRead.modelVersion.findMany({ … });     // ditto
…
await fsAsync.writeFile(outPath, JSON.stringify({ user, reportId, models, modelVersions, images }, replacer));
```

Two ceilings, and the second is worse than the first:

- **Soft:** all three full row arrays and the rendered string are resident simultaneously.
- **Hard:** `JSON.stringify` returns **one JavaScript string**, and a JS string cannot exceed V8's maximum length (536,870,888 characters on 64-bit — `require('buffer').constants.MAX_STRING_LENGTH`, measured on this Node build). A bundle above that throws `RangeError: Invalid string length` — on every attempt, forever, regardless of how much memory the host has. Such a report can never be archived.

> ⚠️ **Correcting round 1.** This PR's previous description listed the base bundle under "deliberately out of scope", on the grounds that it is *"orders of magnitude too small to be the cause here."* **That claim is withdrawn.** It was derived from one account, and it does not generalise: the row count is unbounded by construction, `Image` rows are wide (including a `meta` JSON blob), and the string ceiling is a hard wall rather than a matter of degree. It is now fixed.

## Changes

**1. Backpressure on the archiver.** New `src/server/utils/archive-helpers.ts`. `createBoundedArchive()` wraps an archiver instance and waits on its `'entry'` event before each append, capping appended-but-unprocessed entries at 8. Peak retained bytes become a function of that cap rather than of how many images the account has.

> The doc comment on that constant now states the **real** peak: each of the 10 `p-limit` slots also holds its `blob` + `arrayBuffer` + `buffer` while parked in `append()`, so the peak is about `8 + 3 × 10 = 38` image-sizes, not 8. Still a constant — which is the whole point — but round 1 understated it by ~5×.

**2. Compression level 9 → 1.** Deflate cannot meaningfully shrink already-compressed image bytes, so level 9 was spending a lot of CPU for close to nothing — while being exactly the slow consumer that let the queue grow. Nothing in the repo reads these archives back or depends on their size; they are uploaded as-is.

**3. `finalize()` is now awaited.** It was never awaited before `fs.createReadStream(outPath)` opened the file for upload, which can upload a truncated or empty archive.

> ⚠️ **Awaiting `archive.finalize()` alone is NOT sufficient.** Its promise resolves when the zip module ends, not when the sink has flushed. Measured: a file was **24254 bytes** when `finalize()` resolved and **25342 bytes** once the write stream emitted `close`. The helper waits for both.

**4. `archiveGeneratedImages()`** had the identical unbounded pattern — same fix.

**5. The base bundle is now paged and streamed.** New `src/server/utils/json-stream-helpers.ts`.

- `scanPagesById()` in the service keyset-pages each `findMany` (`id > cursor ORDER BY id ASC`, 500 rows/page). Keyset rather than offset: offset paging degrades quadratically and can skip or duplicate rows if the set shifts mid-scan.
- `writeJsonObject()` serialises the document straight to the output stream, one array element at a time, so no single string above one row's JSON is ever built. `pipeline` supplies backpressure, and it is also what guarantees the file is whole when the call resolves — it waits on the sink via `stream.finished`, which for an `autoDestroy` Writable (the default, and what `fs.createWriteStream` is) means `'close'`. Round 2 added a second `await` on `'close'` on top of that under a comment claiming `pipeline` gave no such guarantee; **that claim was measured false and the line is now removed** — see round 3 below. The archive's own `'close'` wait is a different case and is kept.

🔴 **The EVIDENCE in the bundle is unchanged.** Same five properties in the same order, the same `where` clauses and **no `select`** (every column still lands in the archive), the same bigint replacer, and the same row set. The byte-identity test asserts that the streamed serialiser produces exactly what `JSON.stringify` produces — it is a claim about the *serialiser*, over one fixed row order.

Two things are genuinely new, and neither adds or removes a row. The queries now also carry `orderBy: { id: 'asc' }`, `take` and an `id > cursor` predicate, because they are paged. And as a consequence, element order within each array is `id ASC` where before it was whatever the query plan happened to yield — so against real data the file is **set-identical but not byte-identical** to what the old code wrote. Determinism is the right property for an evidence artefact, but it is a change, and anything diffing two bundles across this commit will see it.

The one behavioural trade worth naming: `archiveBaseReportData` and `archiveImages` used to share a single in-memory snapshot of the image rows and now run two independent scans. That does not weaken the bundle — `archiveImages` already tolerates listing an image in `data.json` that is missing from `images.zip`, because `fetchBlob` returning null makes it skip the entry silently — and it is what makes the memory bound hold for both callers.

**6. `getCsamsToArchive()` has a deterministic `ORDER BY`, and its comment now says what that actually does.**

> ⚠️ **Correcting round 1.** The comment claimed the ordering stops a bad report sitting "at the front of every batch". That is backwards: a chronically-failing report is by construction among the *oldest* rows still matching the filter, so `createdAt asc` **pins it to the head of every run** — the ordering makes head-of-line blocking deterministic, it does not cure it. The ordering is kept (it is right for auditability and reproducibility) and the comment now says so, and says explicitly that per-report failure isolation is not in scope.

**7. The `'error'` listener no longer rethrows from inside the handler.** `archive.on('error', err => { throw err })` surfaces as an uncaught exception from inside archiver's async internals rather than as a rejection the caller can act on. The error is captured and re-thrown from `append()`/`finalize()` instead.

> ⚠️ **Correcting round 1.** The previous description said *"the outcome for `archivedAt` is unchanged"*. **That is false, and it was measured false.** Before this PR, throwing from the `'error'` handler surfaced synchronously out of `append()` into `archiveGeneratedImages`'s inner `catch (e) {}` — so a bad entry was silently dropped and the report still completed and was stamped. With the error latched and rethrown from `finalize()`, that inner catch can no longer swallow it and the report is never stamped.
>
> Measured on the same input (a `previewUrl` whose basename is empty, e.g. `https://host/blob/` or `https://host/?x`):
>
> | | pre-PR | round 1 |
> |---|---|---|
> | entry names appended | `['', '', 'ok-2.jpeg']` | archiver raises `ENTRYNAMEREQUIRED` |
> | `archiveCsamDataForReport` | resolves | rejects |
> | `archivedAt` | stamped | never stamped — report retries forever |
>
> **The new direction is kept**: for an evidence subsystem, failing loudly beats silently dropping evidence. But "loud" must not mean "permanently unarchivable", so the one known input class that produces an empty name is given a deterministic fallback name (`zipEntryNameForUrl`) instead of poisoning the report. The basename expression is evaluated first and returned verbatim whenever it is non-empty, so every URL that already produced a usable name keeps byte-identical naming.

**8. `uploadStream()` rejects with a real `Error`, and `process-csam.ts` extracts the message safely.** `uploadStream` used to `reject()` with no argument. The rejection value is then `undefined`, and the batch loops' `catch (e: any) { … message: e.message }` raise a **`TypeError` inside the catch block** — which nothing catches, so it escapes the `for` loop and **abandons every remaining report in that batch**. Both loops (`send-csam-reports` and `archive-csam-reports`) had it. Both ends are fixed: the rejection now carries a real `Error` with the original as `cause`, and the catch uses a total `errorMessage(e)`.

**9. Test-suite hygiene.** `csam-archive-backpressure.test.ts` was writing real zips into `<repo>/csam` — which is **not** gitignored — and unconditionally `rm -rf`-ing that path in `afterAll`. That is the same path the service uses as `baseDir` in dev, so a unit run could delete a developer's local scratch files. The suite now redirects `baseDir` into its own `mkdtemp` directory.

## Test coverage

Four files:

- `src/server/utils/__tests__/archive-helpers.test.ts` — pins the archiver mechanism against the **real** archiver with a slow sink. Two **negative controls** (a plain `archive.append` loop, and an un-awaited `finalize`) prove the measurement can actually observe unbounded growth and a short file. Plus `zipEntryNameForUrl`, including a test that runs both arms through the real archiver: the empty name it replaces is rejected, the fallback is accepted.
- `src/server/utils/__tests__/json-stream-helpers.test.ts` — **byte-identity** with `JSON.stringify` over a fixture carrying bigints, `Date`s, a `U+2028`, escaped keys, nested nulls, an `undefined` property, and an unserialisable array element; plus the ceiling proof (below).
- `src/server/services/__tests__/csam-archive-backpressure.test.ts` — pins the **seam**: that the service actually routes through the bounded appender and the paged scans. A correct helper nobody calls fixes nothing, and no isolated test can see that.
- `src/server/jobs/__tests__/process-csam.test.ts` — batch integrity for both cron loops.

### Proving the string ceiling is gone

`JSON.stringify` is temporarily replaced with a wrapper that throws `RangeError: Invalid string length` above a small test-chosen cap. That is not an approximation — it is V8's own failure, made reachable from a fixture that fits in a unit test. The fixture overshoots the cap ~10× while any single row is ~40× under it, so a per-row serialiser is safe by a wide margin and a one-shot serialiser is not.

- **Negative control:** the pre-fix `JSON.stringify(document, replacer)` throws at that cap.
- **Under test:** `archiveCsamDataForReport` completes, the longest string ever produced stays under the cap, and the uploaded `data.json` is compared **byte for byte** against what the pre-fix serialiser produces for the same fixture.

### Red at base / green at HEAD

Every new behavioural test was run against the pre-change code and watched to fail. Actual output:

**A — base bundle** (service reverted to `main`, i.e. commit before this branch):

```
× archives a library whose bundle exceeds the maximum JavaScript string length
    RangeError: Invalid string length
      ❯ archiveBaseReportData src/server/services/csam.service-new.ts:1186:12
× never issues an unbounded scan for the rows that go into the bundle
    AssertionError: image.findMany call without a page size: expected 'undefined' to be 'number'
× walks every page rather than archiving only the first
    AssertionError: expected [ { id: 1, …(8) }, …(499) ] to have a length of 1001 but got 500
× filters model versions by the COMPLETE set of model ids, not a partially-scanned one
    AssertionError: expected [ 1, 2, …(491) ] to have a length of 501 but got 500
```

> ⚠️ One test in that group is **not** red-at-base coverage and is labelled as such: *"archives images from EVERY page"*. Against pre-PR code it fails by 60 s timeout (the un-awaited-`finalize` defect trips first), and against round-1 it **passes**, because a fixture answering an unpaged `findMany` with every row cannot distinguish an unpaged read from a correctly paged one. It is a guard on the new paging code — proved reachable by the `break`-after-first-page mutant below — while the unpaged read itself is caught by *"never issues an unbounded scan"*, which fails at base on its own assertion.

**B — batch abort** (job + service reverted to `main`):

```
× continues the batch when a report rejects with a non-Error value
    Caused by: TypeError: Cannot read properties of undefined (reading 'message')
      ❯ archiveCsamReportDataJob src/server/jobs/process-csam.ts:49:22
× still logs something identifiable for the failed report        (same TypeError)
× survives a rejection that is a string / null / a plain object  (3 cases)
× send-csam-reports: continues the batch …                       (same TypeError, line 27)
Tests  6 failed | 2 passed (8)

× rejects with a real Error, so the batch loop can read .message without throwing
    AssertionError: expected undefined to be an instance of Error
```

The service's own `console.log(e)` printed a bare `undefined` in that last run — direct confirmation that the rejection value is `undefined`.

**D — unnameable generated-image URL** (service at round-1 HEAD, i.e. the commit that introduced the behaviour):

```
× archives the entry under a fallback name instead of poisoning the report forever
    ArchiverError: entry name must be a non-empty string value   { code: 'ENTRYNAMEREQUIRED' }
      ❯ Object.append src/server/utils/archive-helpers.ts:155
      ❯ src/server/services/csam.service-new.ts:1295
```

Against **pre-PR** the same test fails differently and that difference is the point — `expected [ '', '', 'ok-2.jpeg' ] to deeply equal [ 'unnamed-0-blob', 'unnamed-1', 'ok-2.jpeg' ]`, reached *after* the call resolved. Two entries silently dropped, report completed. That is the archivedAt behaviour change, measured.

At HEAD: **64 passed (64)** across the four files (59 after round 2, plus round 3's five).

### Mutation checks

Every new guard was broken on purpose and confirmed to fail with **that guard's own** error.

| Mutation | Result |
|---|---|
| `serializeJsonObject`: drop the undefined-property omission | ✅ killed — `expected '{"a":1,"b":undefined,"c":3}' to be '{"a":1,"c":3}'` |
| `serializeJsonObject`: array element `undefined` dropped instead of `null` | ✅ killed — `expected '{"xs":[1,,,4]}' to be '{"xs":[1,null,null,4]}'` |
| `serializeJsonObject`: always emit a leading comma | ✅ killed — `expected '{,"a":1…' to be '{"a":1…'` |
| `writeJsonObject`: stop awaiting the sink close | ⚪️ **survived — the round-2 entry claiming an `ENOENT` kill does not reproduce.** Deleting `await closed` left all in-range tests green, because `pipeline` already waited for `'close'`. The line has been removed rather than re-justified; see round 3. |
| `scanPagesById`: never advance the cursor | ✅ killed — `expected [ undefined, undefined, undefined ] to deeply equal [ undefined, 500, 1000 ]`, plus a 60 s timeout on the infinite re-read |
| `scanPagesById`: stop after the first page | ✅ killed — `to have a length of 1001 but got 500` |
| `scanPagesById`: drop the page size (unbounded `findMany`) | ✅ killed — same |
| `archiveImages`: `break` after the first page | ✅ killed — `to have a length of 503 but got 500` |
| `zipEntryNameForUrl`: remove the empty-basename fallback | ✅ killed — `expected '' to be 'unnamed-4-blob'` (+ the seam test) |
| `zipEntryNameForUrl`: always use the fallback | ✅ killed — `expected 'unnamed-3-blob-7.jpeg' to be 'blob-7.jpeg'` |
| `process-csam`: read `e.message` directly again | ✅ killed — `promise rejected "TypeError: …" instead of resolving` |
| `errorMessage()` returns a constant | ✅ killed — `expected 'error' to be 'synthetic archive failure'` |
| `uploadStream`: bare `reject()` again | ✅ killed — `expected undefined to be an instance of Error` |
| `uploadStream`: drop the `cause` | ✅ killed — `expected undefined to be Error: synthetic s3 failure` |
| Test harness: remove the tmpdir redirect | ✅ killed — the suite's own scratch-dir guard |
| `append`'s `while (pending >= max)` re-check → `if` | ✅ killed — `expected 17 to be less than or equal to 8` (seam) and `expected 14 to be less than or equal to 5` (helper) |
| `releaseWaiters`' `while` → `if` | ✅ killed **(round 3)** — `expected { raced: 'HUNG', settled: 3 } to deeply equal { raced: 'all-settled', settled: 5 }`. Round 2 recorded this as a harmless survivor; it breaks the helper's settle-always contract and had no test. Severity is scoped in round 3 below. |
| Remove the `modelScanComplete` ordering assertion | ⚪️ **survived, and correctly so** — see below |

Two survivors in the first sweep were real gaps and both were fixed:

1. **`archiveImages` page-walking had no test at all.** The bundle's page-walk test uses an `ExternalLink` report, which never reaches `archiveImages`. A test crossing a full page boundary (503 images against a 500-row page) was added; the `break`-after-first-page mutant is now killed.
2. **A test was asserting on a live-mutating array.** `modelVersions` was filtered with `modelId: { in: modelIds }`, passing the array by reference. The recorded mock call argument therefore kept mutating *after* the call, so a scan that genuinely ran with an **empty** id set read back as complete. The production code now passes a copy (`[...modelIds]`).

   ⚠️ **Correcting round 2.** The comment round 2 wrote beside that copy justified it as a *race* — `modelIds` "is still being appended to by the generator above at the moment this closure is built". That is false, and the ordering invariant asserted at the top of `streamModelVersions` is what makes it false: `streamModelVersions` throws unless `modelScanComplete`, so every `findMany` is issued strictly after the last push. Two comments in one function asserting contradictory concurrency models. The copy is kept, because it does have one effect and that effect is now what the comment claims — it is what lets the *COMPLETE set* assertion observe the hazard. Measured as a two-arm control, with the invariant removed and the entry order reversed so the hazard is reachable: against the copy the test fails `expected [] to have a length of 501`; against a live reference it passes vacuously.

On the `modelScanComplete` assertion: removing it alone is unobservable, because in correct code it never fires — it is an **invariant guard, not regression coverage**, and it is labelled as one. Its reachability was proved separately by mutating the hazard it names (serialising `modelVersions` before `models`), which fails with the guard's own message:

```
Error: archiveBaseReportData: model versions were streamed before the model scan finished —
       modelIds is incomplete and the bundle would be missing evidence
```

and with the guard *also* removed the same hazard is still caught, by the byte-identity test and the model-id test — so the hazard has coverage that does not depend on the assertion. The assertion's job is to turn a silently-incomplete evidence bundle into a loud, self-describing failure.

### Gates

- `pnpm typecheck` — `OK — 0 type errors in 119s (heap cap 8192 MB)`
- `pnpm run test:unit:run` (full suite) — `Test Files 4 failed | 1677 passed | 3 skipped (1684)`, `Tests 28 failed | 38773 passed | 33 skipped (38834)`. **All 28 failures are pre-existing local-environment noise outside this diff's dependency closure**, verified three ways: none of the four files is in this branch's diff or its working tree, none imports anything this PR touches, and 26 of the 28 fail with `TypeError: Cannot read properties of undefined (reading 'setItem')` — `window.localStorage` is undefined on this box's Node build (`ExperimentalWarning: localStorage is not available because --localstorage-file was not provided`). The other two are `eventloop-watchdog.capture.test.ts`, a known local-only failure that is green in CI.
- `eslint` — 8 files linted; **0 errors and 0 warnings in every new file**. `csam.service-new.ts` reports 1 error + 10 warnings, all pre-existing and verified present at base (the error is the `import('stream/web')` type annotation in `getTrainingDataZipStream`, untouched by this diff).
- `prettier --check` clean (validated with a deliberately-unformatted control file, which it correctly flags).
- **CI on this head (`05f6369`): 19 checks registered, 18 `pass`, 1 `skipping`, 0 failures** — including all four `Unit tests` shards, `App unit tests + typecheck`, `ESLint + Prettier (changed files)`, `tekton / typecheck` and the four `preview / *` jobs. That also settles the four local failures above: the same shards are green here, so they are this box's environment, not the tree.

---

## Round 3 — a delta audit of round 2

Round 2 shipped four claims about its own code that do not survive re-checking. The code was
mostly right; the prose describing it was not, and in one case the prose actively recommended
breaking working code. Everything below was re-measured, not reasoned about.

**1. `releaseWaiters`' `while` is what makes the failure path settle, and round 2 said it was not.**

`releaseWaiters` runs on `entry` and on `error` only, and once a failure is latched `append()`
rejects immediately, so no new entries are produced. If the error is the last event the archive
emits, it is therefore also the last wake-up any parked waiter gets, and releasing one per event
strands the rest forever — breaking this helper's contract that an `append()` always settles.
Measured against the module with a stub emitting a single `error` and no `entry`: 2 of 5 appends
never settle. Round 2's comment explained the loop purely in terms of the success path, said "the
bound is upheld anyway, by the `while` re-check in `append()`", and its mutation table recorded
the `while`→`if` mutant as a harmless survivor — together, an invitation to make the edit. All
three surfaces are corrected and a regression test pins it; it survived only because nothing
tested the failure path.

> ⚠️ **Scoping this honestly, because the first draft of this section overstated it.** The
> paragraph above is a claim about *this module's contract*, not a reproduced production hang, and
> an earlier draft asserted both "archiver emits `error` at most once" and "`archiveCsamDataForReport`
> never settles for that report". **Neither is established.** `archiver@6` has **23 distinct
> `emit('error')` sites** and guarantees nothing in either direction, and three of its real failure
> paths were probed without reaching the stranding shape: an empty entry name emits `error` and
> then goes on emitting **8 more** `entry` events (so an `if` would drain there); a directory entry
> emits no `error` at all; an erroring source stream stalls the archiver with **no `error` event**,
> which no variant of this loop can rescue. The `while` stays because it is free and is what keeps
> the contract true whichever site fires — not because a wedge has been observed.

**2. `writeJsonObject`'s second `await` on the sink's `'close'` is removed.**

Its doc-block asserted that `pipeline` resolving is no promise a later `fs.createReadStream` sees
every byte. Measured false on **node v24.19.0** (the pinned dev shell) and again on a **node 26**
host: `pipeline` ends the sink and waits on it via `stream.finished`, which for an `autoDestroy`
Writable — the default, and what `fs.createWriteStream` is — means waiting for `'close'`. Over 20
rounds of a 4 MB document, `'close'` had already fired and the file was byte-complete every time
`pipeline` resolved. The mutation-table row claiming an `ENOENT` kill does not reproduce: deleting
the line left every in-range test green.

It was also **not** harmless belt-and-braces. This signature accepts any `Writable`, and one built
with `autoDestroy: false` never emits `'close'` at all, so the extra await hung forever. Removed,
with a test that reports `HUNG` if it is put back.

> The equivalent wait in `archive-helpers.ts` is **genuinely load-bearing and is left alone** —
> there the awaited promise is archiver's `finalize()`, which resolves when the zip module ends
> and knows nothing about the sink (measured in round 1: 24254 bytes vs 25342). Its doc now says
> so, and records the same `autoDestroy` requirement.

**3. The `[...modelIds]` copy is not defending against a race.**

Round 2's comment said `modelIds` "is still being appended to by the generator above at the moment
this closure is built". The ordering invariant asserted at the top of `streamModelVersions` throws unless
`modelScanComplete`, so every `findMany` is issued strictly after the last push — two comments in
one function asserting contradictory concurrency models. Reverting the copy to a live reference
leaves all 59 round-2 tests green.

The copy is kept because it does have exactly one measured effect, and that is now what the comment
claims: it is what lets the *COMPLETE set* assertion observe the hazard the invariant names.
Two-arm control, with the invariant removed and the entry order reversed so the hazard is
reachable — copy: `expected [] to have a length of 501`; live reference: passes vacuously.

**4. `serializeJsonObject`'s comma bookkeeping for an `items` entry was unpinned.**

Removing `wroteEntry = true;` from the `items` branch left everything green. Production is
unaffected today because two `value` entries precede the arrays, but the helper is exported with a
byte-identity contract and `[['xs',{items:[1]}],['ys',{value:2}]]` yields `{"xs":[1]"ys":2}` —
invalid JSON, no test red. Pinned.

**5. Smaller corrections.**

- `archive-helpers.ts` referred to a "file header" that does not exist. The reason is stated inline.
- The in-source 🔴 "bundle is unchanged" block overstated on the two axes the description above now
  states precisely: the queries do carry `orderBy`/`take`/`id > cursor`, and element order is
  `id ASC` where it was plan-order, so the document is set-identical but not byte-identical.
- `scanPagesById` now names its index precondition rather than leaving a bare "offset paging
  degrades quadratically" rationale. Read off `packages/civitai-db-schema/prisma/schema.full.prisma`:
  `Image` has `@@index([userId, id])`, so the one genuinely large scan is served directly; `Model`
  has no `userId` index and `ModelVersion`'s only `modelId` index is a **hash** index, which cannot
  serve a range or an ordering. Accepted, because those two row counts are small next to the image
  count. No `EXPLAIN` was run and the comment says so.

**6. Resource leak closed on both triggers.**

`archiveImages` now pulls DB pages *inside* the archiver's lifetime, where the pre-change code
fetched every row before any archiver existed. A `dbRead` failure on page 2+ therefore escapes
without `finalize()`, leaving the write-stream fd and queued buffers open while the caller's
handler removes the directory underneath them. The leak shape was pre-existing (a
`fetchBlob`/`append` failure did it already); round 2 added the DB trigger. Both call sites now
release through a shared `closeArchiveOnFailure`, each with its own regression test.

> ⚠️ Recorded honestly in that helper rather than dressed up: only `output.destroy()` is observed
> by the tests. Removing `archive.abort()` leaves **all 64 tests green**, because the bounded
> appender caps the backlog at `MAX_PENDING_ARCHIVE_ENTRIES` — too shallow to observe without a
> timing-dependent assertion. Its effect was measured separately on an *unbounded* queue, where it
> is unmissable: sink destroyed and no `abort()` → the archiver went on to deflate **60 of 60**
> queued entries; with `abort()` → **0**. Real work, bounded here, and marked untested rather than
> covered.

### Round 3 — red at pre-fix / green at HEAD

Each new test was run against the pre-fix code and watched to fail. Actual output:

| Test | Pre-fix mutation | Red at pre-fix | Green at HEAD |
|---|---|---|---|
| `settles EVERY parked append when the archiver errors` | `releaseWaiters`' `while` → `if` | `expected { raced: 'HUNG', settled: 3 } to deeply equal { raced: 'all-settled', settled: 5 }` | ✅ |
| `resolves for a sink that never emits close` | re-add `await closed` | `expected { raced: 'HUNG', closed: false } to deeply equal { raced: 'resolved', closed: false }` | ✅ |
| `separates an items entry from whatever follows it` | drop `wroteEntry = true` in the `items` branch | `expected '{"xs":[1]"ys":2}' to be '{"xs":[1],"ys":2}'` | ✅ |
| `closes the archive … when a page fetch fails mid-archive` | drop the release in `archiveImages` | `expected false to be true` on `zipSinks[0].destroyed` | ✅ |
| `closes the archive … when a download fails` | drop the release in `archiveGeneratedImages` | `expected false to be true` on `zipSinks[0].destroyed` | ✅ |

Each release-site mutant failed **only its own** test, so neither is killed by the other's error.
Splitting `closeArchiveOnFailure`: dropping `output.destroy()` kills both cases; dropping
`archive.abort()` kills nothing — stated as such above rather than claimed as coverage.

Also fixed: a timing dependency in `json-stream-helpers.test.ts`. A sink whose `open()` was still
in flight could create its file under the suite's tmpdir after `afterAll` had begun removing it,
seen once as an `ENOTEMPTY` failure of the *suite* (not of any test) under parallel load. The test
now waits for that sink to close. Seen exactly once and not reproduced in 9 subsequent group
runs (4 before the fix, 5 after) — so the fix removes a real timing dependency, but is not proven
to be the cause of that one occurrence.

### Round 3 gates

Run inside the pinned dev shell (`direnv exec . …`, node **v24.19.0**), which is why the 28
`window.localStorage` failures reported for round 2 are absent — they were the host node, not the
tree.

- `pnpm typecheck` — `OK — 0 type errors in 129s (heap cap 8192 MB)`
- `pnpm run test:unit:run` (full suite) — `Test Files 1681 passed | 3 skipped (1684)`,
  `Tests 38806 passed | 33 skipped (38839)`, **0 failed**
- In-range four files — `64 passed (64)`, run 5× clean after the tmpdir fix (and 4× clean before
  it; the `ENOTEMPTY` was seen once and never reproduced)
- `prettier --check` — clean on all six changed files, and validated against a deliberately
  unformatted control file that it correctly flags
- `eslint` — **0 errors and 0 warnings in every changed helper and test file**;
  `csam.service-new.ts` reports the same 1 error + 10 warnings as round 2, all pre-existing (the
  error is the `import('stream/web')` annotation at a line this diff does not touch)

## Deliberately out of scope

- `src/server/services/csam.service.ts` (the pre-`-new` module) carries the same unbounded patterns in its own copy of these functions. Its `archiveCsamDataForReport` is not what the cron job calls, so it is not the live path — flagging rather than fixing, since the right move is probably deleting the dead half.
- **Per-report failure isolation.** Ordering the batch does not provide it (see change 6), and the fix in change 8 only covers a report that *throws* — a report that kills the process still blocks the queue. A circuit breaker (skip after N consecutive failures) would fix it, but skipping a report means not archiving evidence, which is a policy decision rather than an engineering one.
- **Narrowing the bundle's `select`.** It would cut the row width substantially, but it changes what evidence is in a NCMEC archive. Not done here, and not something to do quietly.

