### PR TITLE
fix(images): observe whether a created Image row's media actually exists, and stop the upload hook lying about a refused PUT

### DIFF
--- a/src/hooks/__tests__/useCFImageUpload.test.ts
+++ b/src/hooks/__tests__/useCFImageUpload.test.ts
@@ -188,11 +188,12 @@ describe('useCFImageUpload — the tracked file must not lie about a refused PUT
      * 🔴 THE REMAINING HALF OF THE DEFECT, PINNED RATHER THAN FIXED. `uploadToCF` still
      * RESOLVES on a refused PUT, handing the caller a media key with nothing behind it —
      * which is how an `Image` row gets written for media that never landed. Making it
-     * reject is the follow-up, and it is not a one-line change: 11 of 24 call sites do not
-     * catch, and `ImageUpload`'s uncaught `Promise.all` would propagate local `blob:` URLs
-     * into `onChange` as image values. Asserting the current behaviour makes that follow-up
-     * a deliberate edit to this expectation instead of a silent drift, and the observe-only
-     * probe in `createImage` covers the exposure server-side meanwhile.
+     * reject is the follow-up, and it is not a one-line change: 14 of the 32 direct call
+     * sites do not catch, and `ImageUpload`'s uncaught `Promise.all` would propagate local
+     * `blob:` URLs into `onChange` as image values. Asserting the current behaviour makes
+     * that follow-up a deliberate edit to this expectation instead of a silent drift, and
+     * the observe-only probe in `createImage` covers the `createImage` funnel server-side
+     * meanwhile — not every `Image` row; see that call site for the paths it misses.
      */
     expect(settled.error).toBeUndefined();
     expect(settled.value).toEqual({

--- a/src/hooks/__tests__/useCFImageUpload.test.ts
+++ b/src/hooks/__tests__/useCFImageUpload.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+import type { act as actType } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+
+// React 18.3 exposes `act` on the `react` export, but our @types/react predates that typing.
+const act = (React as unknown as { act: typeof actType }).act;
+// Without this React warns on every `act(...)` and does not flush its queue the same way.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+vi.mock('~/utils/notifications', () => ({ showErrorNotification: vi.fn() }));
+vi.mock('~/utils/media-preprocessors', () => ({
+  preprocessFile: vi.fn(async () => ({
+    type: 'image',
+    objectUrl: 'blob:fake-object-url',
+    meta: {},
+    metadata: { width: 64, height: 48, hash: 'LKO2' },
+  })),
+  auditImageMeta: vi.fn(async () => ({ blockedFor: undefined })),
+}));
+
+import { useCFImageUpload } from '~/hooks/useCFImageUpload';
+
+/** The key the (stubbed) sign endpoint hands back. Distinct from every other literal here. */
+const UPLOAD_ID = 'd47b16f0-9a25-4e88-8c31-71fe0a3b62d4';
+
+type Listeners = Record<string, Array<() => void>>;
+
+/**
+ * A hand-rolled XHR that lets a test decide which terminal event sequence the browser
+ * delivers. The sequences are the ones the spec mandates and they are the whole point of
+ * the code under test: `error` and `abort` are EACH FOLLOWED BY `loadend`, while a
+ * completed-but-refused request delivers `loadend` alone.
+ */
+class FakeXHR {
+  static last: FakeXHR;
+  readyState = 0;
+  status = 0;
+  upload = { addEventListener: (t: string, f: () => void) => this.add(this.uploadListeners, t, f) };
+  private listeners: Listeners = {};
+  private uploadListeners: Listeners = {};
+
+  constructor() {
+    FakeXHR.last = this;
+  }
+  private add(bag: Listeners, type: string, fn: () => void) {
+    (bag[type] ??= []).push(fn);
+  }
+  addEventListener(type: string, fn: () => void) {
+    this.add(this.listeners, type, fn);
+  }
+  open() {
+    /* no-op */
+  }
+  send() {
+    /* no-op — the test drives the terminal events itself */
+  }
+  abort() {
+    /* no-op */
+  }
+  private fire(type: string) {
+    for (const fn of this.listeners[type] ?? []) fn();
+  }
+  /** A request that completed with this status, i.e. `load` -> `loadend`, no `error`. */
+  completeWith(status: number) {
+    this.readyState = 4;
+    this.status = status;
+    this.fire('loadend');
+  }
+  /** A transport-level failure: `error` then `loadend`. */
+  networkError() {
+    this.readyState = 4;
+    this.status = 0;
+    this.fire('error');
+    this.fire('loadend');
+  }
+  /** A user cancel: `abort` then `loadend`. */
+  cancel() {
+    this.readyState = 0;
+    this.status = 0;
+    this.fire('abort');
+    this.fire('loadend');
+  }
+}
+
+type Harness = {
+  upload: (file: File) => Promise<unknown>;
+  statuses: () => string[];
+  unmount: () => void;
+};
+
+async function mountHook(): Promise<Harness> {
+  let api: ReturnType<typeof useCFImageUpload> | undefined;
+  function Probe() {
+    api = useCFImageUpload();
+    return null;
+  }
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(Probe));
+  });
+  return {
+    upload: (file) => api!.uploadToCF(file),
+    statuses: () => api!.files.map((f) => f.status),
+    unmount: () => act(() => root.unmount()),
+  };
+}
+
+/** Start an upload, let it reach the point where the XHR has been sent, and hand back both. */
+async function startUpload(h: Harness) {
+  const settled: { value?: unknown; error?: unknown } = {};
+  let promise!: Promise<unknown>;
+  await act(async () => {
+    promise = h.upload(new File(['x'], 'a.png', { type: 'image/png' }));
+    promise.then(
+      (value) => (settled.value = value),
+      (error) => (settled.error = error)
+    );
+    // Let the sign fetch + preprocess microtasks drain so the XHR exists.
+    await new Promise((r) => setTimeout(r, 0));
+  });
+  return { promise, settled, xhr: FakeXHR.last };
+}
+
+describe('useCFImageUpload — the tracked file must not lie about a refused PUT', () => {
+  beforeEach(() => {
+    vi.stubGlobal('XMLHttpRequest', FakeXHR);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ json: async () => ({ id: UPLOAD_ID, uploadURL: 'https://store/put' }) }))
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('marks the file successful on a 200', async () => {
+    const h = await mountHook();
+    const { settled, xhr } = await startUpload(h);
+
+    await act(async () => {
+      xhr.completeWith(200);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(h.statuses()).toEqual(['success']);
+    expect(settled.value).toEqual({
+      url: 'https://store/put',
+      id: UPLOAD_ID,
+      objectUrl: 'blob:fake-object-url',
+      type: 'image',
+    });
+    h.unmount();
+  });
+
+  it.each([201, 204])('marks the file successful on a %i', async (status) => {
+    // 🔴 A 2xx is a successful PUT by any reading. Reporting one as an error would put a
+    // failure badge on an upload that worked.
+    const h = await mountHook();
+    const { xhr } = await startUpload(h);
+
+    await act(async () => {
+      xhr.completeWith(status);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(h.statuses()).toEqual(['success']);
+    h.unmount();
+  });
+
+  it.each([400, 403, 500, 503])('marks the file errored on a refused %i', async (status) => {
+    // 🔴 THE DEFECT THIS FIXES. A refused PUT never fires `error` — it completes and lands
+    // on `loadend`. Before this change the branch updated nothing, so the tracked file
+    // asserted `uploading` forever: `ImageUpload` never showed its error badge and
+    // `ChallengeSubmitModal`'s submit gate (`some(f => f.status === 'uploading')`) could
+    // never clear.
+    const h = await mountHook();
+    const { settled, xhr } = await startUpload(h);
+
+    await act(async () => {
+      xhr.completeWith(status);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(h.statuses()).toEqual(['error']);
+    /**
+     * 🔴 THE REMAINING HALF OF THE DEFECT, PINNED RATHER THAN FIXED. `uploadToCF` still
+     * RESOLVES on a refused PUT, handing the caller a media key with nothing behind it —
+     * which is how an `Image` row gets written for media that never landed. Making it
+     * reject is the follow-up, and it is not a one-line change: 11 of 24 call sites do not
+     * catch, and `ImageUpload`'s uncaught `Promise.all` would propagate local `blob:` URLs
+     * into `onChange` as image values. Asserting the current behaviour makes that follow-up
+     * a deliberate edit to this expectation instead of a silent drift, and the observe-only
+     * probe in `createImage` covers the exposure server-side meanwhile.
+     */
+    expect(settled.error).toBeUndefined();
+    expect(settled.value).toEqual({
+      url: 'https://store/put',
+      id: UPLOAD_ID,
+      objectUrl: 'blob:fake-object-url',
+      type: 'image',
+    });
+    h.unmount();
+  });
+
+  it('marks the file errored and rejects on a network failure', async () => {
+    const h = await mountHook();
+    const { settled, xhr } = await startUpload(h);
+
+    await act(async () => {
+      xhr.networkError();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(h.statuses()).toEqual(['error']);
+    expect((settled.error as Error).message).toBe('Upload failed (status 0)');
+    h.unmount();
+  });
+
+  it('keeps a canceled upload reported as aborted, not errored', async () => {
+    // 🔴 `abort` is FOLLOWED by `loadend`. Without the terminal guard the `loadend` handler
+    // re-decides the status and overwrites the user's cancel with a failure — this test
+    // fails without it.
+    const h = await mountHook();
+    const { settled, xhr } = await startUpload(h);
+
+    await act(async () => {
+      xhr.cancel();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(h.statuses()).toEqual(['aborted']);
+    expect((settled.error as Error).message).toBe('Upload canceled');
+    h.unmount();
+  });
+});

--- a/src/hooks/__tests__/useCFImageUpload.test.ts
+++ b/src/hooks/__tests__/useCFImageUpload.test.ts
@@ -76,9 +76,27 @@ class FakeXHR {
     this.fire('error');
     this.fire('loadend');
   }
-  /** A user cancel: `abort` then `loadend`. */
+  /**
+   * A user cancel: `abort` then `loadend`.
+   *
+   * 🔴 `readyState` is 4 — the same value `src/utils/__tests__/upload-settlement.test.ts`
+   * uses, and for the same reason: `abort()` runs the request-error steps, which set the
+   * state to DONE and fire both events, and only afterwards is the state reset to UNSENT.
+   * This stub said 0, i.e. two stubs of the same browser event disagreed about it, and one
+   * of them had to be wrong.
+   *
+   * ⚠ THE SCOPE OF THAT FIX, MEASURED RATHER THAN ASSUMED. A round-2 audit predicted the
+   * old `0` made the cancel case pass for the wrong reason — `success` computing false via
+   * the `readyState === 4` clause instead of via `status === 0`. That prediction does not
+   * hold here: deleting the `aborted` guard from `attachUploadSettlement` turns this case
+   * red under BOTH values, identically (`expected [ 'error' ] to deeply equal [ 'aborted' ]`,
+   * 1 failed | 8 passed), because with the guard gone `success` is false either way and
+   * `onError` overwrites the cancel regardless of which clause produced the false. So this
+   * is a FIDELITY fix — the stub now models the browser and agrees with its sibling — and
+   * not a discrimination fix. The case was already discriminating.
+   */
   cancel() {
-    this.readyState = 0;
+    this.readyState = 4;
     this.status = 0;
     this.fire('abort');
     this.fire('loadend');
@@ -188,9 +206,19 @@ describe('useCFImageUpload — the tracked file must not lie about a refused PUT
      * 🔴 THE REMAINING HALF OF THE DEFECT, PINNED RATHER THAN FIXED. `uploadToCF` still
      * RESOLVES on a refused PUT, handing the caller a media key with nothing behind it —
      * which is how an `Image` row gets written for media that never landed. Making it
-     * reject is the follow-up, and it is not a one-line change: 14 of the 32 direct call
-     * sites do not catch, and `ImageUpload`'s uncaught `Promise.all` would propagate local
-     * `blob:` URLs into `onChange` as image values. Asserting the current behaviour makes
+     * reject is the follow-up, and it is not a one-line change: most direct call sites do
+     * not catch, and `ImageUpload`'s uncaught `Promise.all` would propagate local `blob:`
+     * URLs into `onChange` as image values.
+     *
+     * ⚠ There was a precise count here ("14 of the 32 direct call sites"). It is gone
+     * deliberately, and NOT because the qualitative claim weakened — the `Promise.all`
+     * consequence above is verified at `src/components/ImageUpload/ImageUpload.tsx`. The
+     * count is gone because it was derived four times and moved every time (24 → ~38 → 42
+     * → 32/14), a round-2 audit independently got a different numerator, and nothing in
+     * this repo asserts on any of those numbers, so the figure could only ever rot. Do not
+     * reinstate one without a test that fails when it drifts.
+     *
+     * Asserting the current behaviour makes
      * that follow-up a deliberate edit to this expectation instead of a silent drift, and
      * the observe-only probe in `createImage` covers the `createImage` funnel server-side
      * meanwhile — not every `Image` row; see that call site for the paths it misses.

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:3267':
+  'server/services/image.service.ts:3268':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:3311':
+  'server/services/image.service.ts:3312':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4080':
+  'server/services/image.service.ts:4081':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4890':
+  'server/services/image.service.ts:4891':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -219,7 +219,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:3311')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:3312')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/services/__tests__/create-image-media-verify.test.ts
+++ b/src/server/services/__tests__/create-image-media-verify.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CreatedImageMediaVerdict } from '~/server/utils/created-image-media-probe';
+
+const { probeMock } = vi.hoisted(() => ({
+  probeMock: vi.fn<() => Promise<CreatedImageMediaVerdict>>(),
+}));
+
+vi.mock('~/server/utils/created-image-media-probe', () => ({
+  probeCreatedImageMedia: probeMock,
+}));
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
+import { createImage } from '~/server/services/image.service';
+
+/**
+ * Distinct from every constant asserted below, so a mutant that logs a hardcoded key or the
+ * wrong field cannot pass by coincidence.
+ */
+const KEY = '3f6c2b91-0d84-4a15-9e70-c2b8a4d15e33';
+const USER_ID = 8113;
+const POST_ID = 55207;
+const CREATED_ID = 90210;
+
+function givenVerdict(verdict: CreatedImageMediaVerdict) {
+  probeMock.mockResolvedValue(verdict);
+}
+
+async function create(over: Record<string, unknown> = {}) {
+  return createImage({
+    url: KEY,
+    type: 'image',
+    userId: USER_ID,
+    postId: POST_ID,
+    skipIngestion: true,
+    ...over,
+  } as never);
+}
+
+/** The single `create-image-media-verify` line emitted by the call under test. */
+function verifyLine() {
+  const calls = loggingMock.logToAxiom.mock.calls.filter(
+    (c: unknown[]) => (c[0] as { name?: string })?.name === 'create-image-media-verify'
+  );
+  expect(calls).toHaveLength(1);
+  return calls[0][0] as Record<string, unknown>;
+}
+
+describe('createImage — media existence probe (observe-only)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock.dbWrite.image.create.mockResolvedValue({ id: CREATED_ID } as never);
+  });
+
+  it('probes the row url before writing the row', async () => {
+    givenVerdict('present');
+
+    await create();
+
+    expect(probeMock).toHaveBeenCalledTimes(1);
+    expect(probeMock).toHaveBeenCalledWith(KEY);
+    // 🔴 The probe exists to answer BEFORE the row is committed — this is the whole reason
+    // the check sits inside `createImage` rather than at a router. If it ran after, an
+    // enforcing successor could not stop the write it is meant to stop.
+    expect(probeMock.mock.invocationCallOrder[0]).toBeLessThan(
+      dbMock.dbWrite.image.create.mock.invocationCallOrder[0]
+    );
+  });
+
+  it.each<CreatedImageMediaVerdict>(['present', 'absent', 'unknown', 'not-applicable'])(
+    'emits exactly one line carrying the %s verdict',
+    async (verdict) => {
+      givenVerdict(verdict);
+
+      await create();
+
+      // 🔴 One line on EVERY call, whatever the verdict — the `absent` count is only a rate
+      // if the same log carries its own denominator, and `present` is the positive control
+      // that separates "no defects" from "the probe never reached the store".
+      expect(verifyLine()).toMatchObject({ verdict, userId: USER_ID, postId: POST_ID });
+    }
+  );
+
+  it('carries the media key for a probed verdict', async () => {
+    givenVerdict('absent');
+
+    await create();
+
+    // The only field that makes an `absent` verdict actionable: settling defect-vs-false-
+    // verdict means HEADing this exact key by hand.
+    expect(verifyLine().url).toBe(KEY);
+  });
+
+  it('omits the url for a not-applicable verdict', async () => {
+    givenVerdict('not-applicable');
+
+    await create({ url: 'some-file-the-caller-invented.png' });
+
+    // 🔴 `not-applicable` is BY DEFINITION the arbitrary caller-supplied strings the
+    // predicate rejected. Those are unbounded text nobody will ever look up, so they must
+    // not be shipped to the log sink.
+    expect(verifyLine().url).toBeNull();
+  });
+
+  it('still creates the row when the media is absent', async () => {
+    givenVerdict('absent');
+
+    // 🔴 OBSERVE-ONLY. An `absent` verdict must not reject: this ships to measure the rate,
+    // and rejecting is a new user-facing failure mode that has to be sized first. If a
+    // later change makes this throw, this test is the one that has to be updated
+    // deliberately rather than the behaviour changing silently.
+    await expect(create()).resolves.toEqual({ id: CREATED_ID });
+    expect(dbMock.dbWrite.image.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('still creates the row when the store could not be consulted', async () => {
+    givenVerdict('unknown');
+
+    await expect(create()).resolves.toEqual({ id: CREATED_ID });
+    expect(dbMock.dbWrite.image.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs a null postId rather than dropping the field when there is no post', async () => {
+    givenVerdict('present');
+
+    await create({ postId: undefined });
+
+    const line = verifyLine();
+    expect(line.postId).toBeNull();
+    expect(line.userId).toBe(USER_ID);
+  });
+});

--- a/src/server/services/__tests__/create-image-media-verify.test.ts
+++ b/src/server/services/__tests__/create-image-media-verify.test.ts
@@ -76,7 +76,10 @@ describe('createImage — media existence probe (observe-only)', () => {
 
       // 🔴 One line on EVERY call, whatever the verdict — the `absent` count is only a rate
       // if the same log carries its own denominator, and `present` is the positive control
-      // that separates "no defects" from "the probe never reached the store".
+      // that separates "no defects" from "the probe never reached the store". `present` is
+      // NOT sufficient on its own: it proves the credential can read an object that exists,
+      // not that a MISSING key answers 404 rather than 403. That half was measured against
+      // the real bucket rather than reasoned about — see the call site in `image.service`.
       expect(verifyLine()).toMatchObject({ verdict, userId: USER_ID, postId: POST_ID });
     }
   );

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -6124,7 +6124,7 @@ export async function createImage({
    * each caller, because a predicate open-coded at N sites is wrong at N-1 of them. It
    * cannot live in the zod schema, because it needs IO.
    *
-   * 🔴 IT IS NOT EVERY `Image` ROW, AND THIS COMMENT USED TO CLAIM IT WAS. Five write
+   * 🔴 IT IS NOT EVERY `Image` ROW, AND THIS COMMENT USED TO CLAIM IT WAS. Six write
    * paths reach the `Image` table without passing through here, so their rows appear in
    * neither the numerator nor the denominator of anything this emits:
    *   1. `article.service.ts` `linkArticleContentImages` (`tx.image.createManyAndReturn`)
@@ -6132,6 +6132,21 @@ export async function createImage({
    *   3. `updateEntityImages`, below in this file (`dbClient.image.createMany`)
    *   4. `blocks/app-listing-assets.service.ts` (`dbWrite.image.create`)
    *   5. `pages/api/admin/temp/migrate-article-images.ts` (a one-off admin backfill)
+   *   6. `jobs/daily-challenge-processing.ts` `duplicateImage` — a raw
+   *      `INSERT INTO "Image" (…) SELECT … FROM "Image" i WHERE i.id = …` that re-owns an
+   *      existing row's columns (`url` first among them) to another user, for the
+   *      challenge cover.
+   *
+   * 🔴 THIS LIST SAID FIVE UNTIL A ROUND-2 AUDIT FOUND (6), so treat it as a claim that
+   * has already been wrong once. The population it asserts over is: every
+   * `.image.(create|createMany|createManyAndReturn|upsert)` call and every raw
+   * `INSERT INTO "Image"` under `src/`, excluding test files. Re-derive it, do not trust
+   * it — and note that (6) is the LOWER-risk shape of the two kinds here: its `url` is
+   * copied from a row that already exists rather than freshly minted from a client
+   * upload, so it can propagate an existing defective key but cannot create a new one.
+   * (1)–(5) all take their `url` from their INPUT rather than from an existing `Image`
+   * row, so those are where a brand-new orphan key can enter. That is a claim about the
+   * SHAPE of each write, not a ranking — nothing here has measured a per-path rate.
    *
    * 🔴 The article path is the highest-risk of those, because it is fed by the exact hook
    * defect this change describes: the TipTap editor nodes (`TipTap/EdgeMediaNode.tsx`,
@@ -6164,15 +6179,26 @@ export async function createImage({
    * (`images` capped at 10). Both loops are sequential, so they add up to 20 and up to 10
    * sequential probes respectively.
    *
-   * 🔴 Size the DEGRADED case, not the healthy one: as documented on
-   * `CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS`, the 2s budget bounds each network attempt but
-   * not wall-clock time, so per-call worst case is the budget plus one non-abort-aware SDK
-   * backoff. Against a degraded store the added cost of a full bulk import is therefore 20
-   * of those, not 20 × 2s. Both loops are already N sequential IO round-trips per item (a
-   * DB write plus an ingestion call), so this is a proportional addition to an existing
-   * sequential-IO path rather than a new failure class — but "proportional" is a claim
-   * about shape, not about the absolute number, and the absolute number is unbounded until
-   * `getB2ImageS3Client` sets a `maxAttempts`.
+   * 🔴 Size the DEGRADED case, not the healthy one — and it is now an ACTUAL NUMBER. An
+   * earlier version of this comment ended "the absolute number is unbounded until
+   * `getB2ImageS3Client` sets a `maxAttempts`", which was true and is the defect this
+   * paragraph used to describe: an abort signal bounds each network ATTEMPT, and the SDK's
+   * between-attempt sleep is not abort-aware, so a degraded store could add tens of seconds
+   * to a 20-item import and blow the request budget — telemetry becoming a new failure mode
+   * on a working path.
+   *
+   * That is closed, and NOT by changing `getB2ImageS3Client`: that factory is shared with
+   * the live upload-completion endpoints, which want their retries. The probe was given its
+   * own `maxAttempts: 1` client (`getImageUploadProbeBackend`), and
+   * `probeCreatedImageMedia` additionally races itself against
+   * `CREATED_IMAGE_MEDIA_PROBE_DEADLINE_MS` so the bound holds without trusting the SDK.
+   * Worst case is therefore 3s per call: 60s added to a 20-item `bulkCreatePanels` and 30s
+   * to a 10-item `addReferenceImages` — bounded, and only while the store is degraded.
+   *
+   * Both loops are already N sequential IO round-trips per item (a DB write plus an
+   * ingestion call), so this remains a proportional addition to an existing sequential-IO
+   * path. If those worst cases are judged too large, the lever is the deadline constant or
+   * making these two routers probe concurrently — not removing the bound.
    */
   const mediaVerdict = await probeCreatedImageMedia(image.url);
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -254,6 +254,7 @@ import {
   sanitizeProvenance,
   storedSourceImageIds,
 } from '~/server/services/orchestrator/remix-provenance';
+import { probeCreatedImageMedia } from '~/server/utils/created-image-media-probe';
 
 const {
   cacheHitRequestsTotal,
@@ -6114,6 +6115,64 @@ export async function createImage({
    */
   verifiedSourceImageIds?: number[] | null;
 }) {
+  /**
+   * 🔴 THE ROW MUST NOT OUTLIVE ITS MEDIA — so ask the store before writing it.
+   *
+   * Every `Image` row in the app goes through here: `addPostImage`, the post-with-images
+   * handler, model-version and collection paths, comics, cover images, thumbnails. The
+   * check belongs at this one funnel and nowhere else — four copies of a predicate is a
+   * predicate that is wrong at three of them — and it cannot live in the zod schema
+   * because it needs IO.
+   *
+   * 🔴 OBSERVE-ONLY, BY CONSTRUCTION AND NOT BY A FLAG. The verdict is logged and then
+   * dropped; nothing below branches on it. Rejecting here would be a new failure mode on
+   * a working user-facing path, and the only honest way to size that is to let the
+   * `absent` rate accumulate against a real denominator first. Enforcement is a separate
+   * change gated on the measurement this emits — which is also why there is no env var to
+   * flip: an unused enforcement branch is an untested one.
+   */
+  const mediaVerdict = await probeCreatedImageMedia(image.url);
+
+  /**
+   * Logged on EVERY call, whatever the verdict, so the `absent` rate has a denominator:
+   * one line per `createImage` call means the denominator is "image creations", which is
+   * the population the historical 10-in-a-sample figure was measured against. A log
+   * emitted only on the bad verdict counts a numerator against nothing.
+   *
+   * 🔴 THE POSITIVE CONTROL IS `present`, AND IT IS WHY THIS IS NOT A ONE-FIELD LOG. A
+   * probe that can never answer emits zero `absent` verdicts, and "zero absent" is exactly
+   * what a clean result looks like. `getImageUploadBackend()` throws without credentials
+   * and a rotated key answers 403 — both land on `unknown`, both look clean. Do not read
+   * the `absent` count until a NON-ZERO `present` count proves the probe reaches the store
+   * at all, and `unknown` is a small share of `present + absent + unknown`.
+   *
+   * `url` is logged only for a PROBED verdict, where `isProbeableMediaKey` has already
+   * accepted the value and it is therefore a 36-character uuid — not a filename and not
+   * PII. It is the field that makes an `absent` verdict actionable: settling "real defect
+   * or false verdict" means taking a key and HEADing the store by hand, and there is
+   * nothing else to look up (`postId` is null on most non-post paths, and `userId` alone
+   * selects thousands of rows). `not-applicable` is by definition the arbitrary
+   * caller-supplied strings that FAILED that predicate, so those are omitted rather than
+   * shipped to a log sink.
+   *
+   * There is deliberately no image id — the row does not exist yet, which is the whole
+   * reason the check sits here.
+   *
+   * 🔴 NOT AWAITED, AND CONTAINED. Telemetry must never be able to change this call's
+   * outcome, nor sit on a user-facing mutation's latency budget.
+   */
+  void logToAxiom({
+    type: 'info',
+    name: 'create-image-media-verify',
+    message: 'createImage media existence probe',
+    verdict: mediaVerdict,
+    url: mediaVerdict === 'not-applicable' ? null : image.url,
+    userId: image.userId,
+    postId: image.postId ?? null,
+  }).catch(() => {
+    // swallow — best-effort logging must never break the creation it is observing
+  });
+
   const meta = sanitizeProvenance(
     image.meta as Record<string, unknown> | null | undefined,
     verifiedSourceImageIds

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -6118,11 +6118,38 @@ export async function createImage({
   /**
    * 🔴 THE ROW MUST NOT OUTLIVE ITS MEDIA — so ask the store before writing it.
    *
-   * Every `Image` row in the app goes through here: `addPostImage`, the post-with-images
-   * handler, model-version and collection paths, comics, cover images, thumbnails. The
-   * check belongs at this one funnel and nowhere else — four copies of a predicate is a
-   * predicate that is wrong at three of them — and it cannot live in the zod schema
-   * because it needs IO.
+   * `createImage` is the widest single funnel for `Image` rows — `addPostImage`, the
+   * post-with-images handler, model-version and collection paths, comics, cover images,
+   * thumbnails all arrive here — and the check belongs at that one funnel rather than at
+   * each caller, because a predicate open-coded at N sites is wrong at N-1 of them. It
+   * cannot live in the zod schema, because it needs IO.
+   *
+   * 🔴 IT IS NOT EVERY `Image` ROW, AND THIS COMMENT USED TO CLAIM IT WAS. Five write
+   * paths reach the `Image` table without passing through here, so their rows appear in
+   * neither the numerator nor the denominator of anything this emits:
+   *   1. `article.service.ts` `linkArticleContentImages` (`tx.image.createManyAndReturn`)
+   *   2. `createEntityImages`, below in this file (`dbClient.image.createMany`)
+   *   3. `updateEntityImages`, below in this file (`dbClient.image.createMany`)
+   *   4. `blocks/app-listing-assets.service.ts` (`dbWrite.image.create`)
+   *   5. `pages/api/admin/temp/migrate-article-images.ts` (a one-off admin backfill)
+   *
+   * 🔴 The article path is the highest-risk of those, because it is fed by the exact hook
+   * defect this change describes: the TipTap editor nodes (`TipTap/EdgeMediaNode.tsx`,
+   * `libs/tiptap/extensions/CustomImage.tsx`) write the upload's key into article content
+   * on a promise that RESOLVES even when the PUT was refused, and that content is then
+   * materialised into rows by `linkArticleContentImages` — unprobed.
+   *
+   * 🔴 EXTENDING THE PROBE TO IT IS A SEPARATE CHANGE, and the reason is structural, not
+   * scheduling: `linkArticleContentImages` does its `createManyAndReturn` INSIDE a
+   * `dbWrite.$transaction` callback, and this repo has a lint rule
+   * (`local-rules/no-io-in-transaction`) whose whole purpose is to keep network IO out of
+   * that callback, because it burns the transaction's timeout budget. Adding a HEAD there
+   * means restructuring the transaction first.
+   *
+   * So the honest scope of what follows is: every `Image` row written through
+   * `createImage`. Both halves of this change are partial — the client half only reaches
+   * sessions that have loaded the new bundle, this half only reaches this funnel — and
+   * nothing here establishes which of the two leaves more rows uncovered.
    *
    * 🔴 OBSERVE-ONLY, BY CONSTRUCTION AND NOT BY A FLAG. The verdict is logged and then
    * dropped; nothing below branches on it. Rejecting here would be a new failure mode on
@@ -6130,6 +6157,22 @@ export async function createImage({
    * `absent` rate accumulate against a real denominator first. Enforcement is a separate
    * change gated on the measurement this emits — which is also why there is no env var to
    * flip: an unused enforcement branch is an untested one.
+   *
+   * 🔴 COST, AND THE LOOPS THAT MULTIPLY IT. One HEAD per call. Most callers are
+   * single-image, but TWO `comics.router.ts` procedures call this once per input item:
+   * `bulkCreatePanels` (`panels` capped at 20 by its zod schema) and `addReferenceImages`
+   * (`images` capped at 10). Both loops are sequential, so they add up to 20 and up to 10
+   * sequential probes respectively.
+   *
+   * 🔴 Size the DEGRADED case, not the healthy one: as documented on
+   * `CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS`, the 2s budget bounds each network attempt but
+   * not wall-clock time, so per-call worst case is the budget plus one non-abort-aware SDK
+   * backoff. Against a degraded store the added cost of a full bulk import is therefore 20
+   * of those, not 20 × 2s. Both loops are already N sequential IO round-trips per item (a
+   * DB write plus an ingestion call), so this is a proportional addition to an existing
+   * sequential-IO path rather than a new failure class — but "proportional" is a claim
+   * about shape, not about the absolute number, and the absolute number is unbounded until
+   * `getB2ImageS3Client` sets a `maxAttempts`.
    */
   const mediaVerdict = await probeCreatedImageMedia(image.url);
 
@@ -6146,6 +6189,26 @@ export async function createImage({
    * the `absent` count until a NON-ZERO `present` count proves the probe reaches the store
    * at all, and `unknown` is a small share of `present + absent + unknown`.
    *
+   * 🔴 BUT A NON-ZERO `present` IS NOT SUFFICIENT ON ITS OWN, AND AN EARLIER VERSION OF
+   * THIS COMMENT SAID IT WAS. `present` proves the credential can read an object that
+   * EXISTS; it does not prove that a key which does NOT exist comes back as a 404 rather
+   * than a 403. `isNotFoundError` in `~/utils/s3-utils` accepts only `NotFound`,
+   * `NoSuchKey` and a 404 status, so under a 403-on-missing credential every real defect
+   * would land on `unknown` and `absent` would sit at zero — while the `present` control
+   * above reads perfectly healthy.
+   *
+   * That specific hazard was MEASURED rather than reasoned about, on 2026-09-08, by
+   * issuing HeadObject against the production image bucket with the production upload
+   * credential: a key that does not exist answered `name=NotFound`,
+   * `$metadata.httpStatusCode=404` (and a key that does exist returned its
+   * `ContentLength`, as the positive control). So `absent` IS reachable and the counter is
+   * not structurally pinned at zero.
+   *
+   * 🔴 That measurement is contingent on the credential it was taken with. A key rotation,
+   * a permissions change, or a move to a different bucket can reintroduce the hazard
+   * silently — the symptom is `absent` going to zero while `present` stays healthy. If you
+   * see that shape, re-take the measurement before concluding the defect is gone.
+   *
    * `url` is logged only for a PROBED verdict, where `isProbeableMediaKey` has already
    * accepted the value and it is therefore a 36-character uuid — not a filename and not
    * PII. It is the field that makes an `absent` verdict actionable: settling "real defect
@@ -6160,6 +6223,20 @@ export async function createImage({
    *
    * 🔴 NOT AWAITED, AND CONTAINED. Telemetry must never be able to change this call's
    * outcome, nor sit on a user-facing mutation's latency budget.
+   *
+   * 🔴 THIS LINE IS TEMPORARY, AND HERE IS WHAT ENDS IT. It is unsampled — one line per
+   * `createImage` call — which is the only shape that gives the `absent` count a
+   * denominator, and also the reason it must not live here indefinitely.
+   *
+   * CLOSING CONDITION: a merged PR that reads the `present` / `absent` / `unknown` counts
+   * for `create-image-media-verify`, quotes those three numbers in its body, and then
+   * either (a) adds the enforcement branch this measurement exists to size, or (b) deletes
+   * this call outright because the rate does not justify one. Either way that PR removes
+   * or samples down this `logToAxiom`.
+   *
+   * MECHANICAL CHECK THAT IT IS CLOSED: the string `create-image-media-verify` no longer
+   * appears in this file. Until then, an unread counter is the failure mode — if you are
+   * reading this and no such PR exists, the counts are already in the log; read them.
    */
   void logToAxiom({
     type: 'info',

--- a/src/server/utils/__tests__/created-image-media-probe.default-deps.test.ts
+++ b/src/server/utils/__tests__/created-image-media-probe.default-deps.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * The SEAM between the probe and the bounded client.
+ *
+ * 🔴 EVERY OTHER TEST OF THIS MODULE INJECTS `deps`, so none of them can see which backend
+ * production resolves. That is the gap this file closes: switch the import in
+ * `created-image-media-probe.ts` back to `getImageUploadBackend` and the probe would run on
+ * the SHARED, retrying client again — an unbounded probe on a user-facing mutation — while
+ * `created-image-media-probe.test.ts` stayed entirely green, because it never exercises the
+ * default deps at all. The bound would be documented, tested in isolation, and not in
+ * effect.
+ *
+ * Two claims, and they are separate: that the probe asks for the PROBE backend, and that it
+ * does not ask for the shared one. The second is what fails if someone "helpfully" resolves
+ * both.
+ */
+
+const { getImageUploadProbeBackend, getImageUploadBackend, headObject } = vi.hoisted(() => ({
+  getImageUploadProbeBackend: vi.fn(async () => ({
+    s3: { marker: 'probe-client' } as never,
+    bucket: 'probe-backend-bucket',
+    backend: 'backblaze' as const,
+  })),
+  getImageUploadBackend: vi.fn(async () => ({
+    s3: { marker: 'shared-client' } as never,
+    bucket: 'shared-backend-bucket',
+    backend: 'backblaze' as const,
+  })),
+  headObject: vi.fn(async () => ({ status: 'present' as const, size: 128 })),
+}));
+
+vi.mock('~/utils/s3-utils', () => ({
+  getImageUploadProbeBackend,
+  getImageUploadBackend,
+  headObject,
+}));
+
+import { probeCreatedImageMedia } from '~/server/utils/created-image-media-probe';
+
+/** Distinct from every other literal here, so nothing can pass by coincidence. */
+const KEY = 'b7d4e0a2-31c5-4f68-9a03-5c8ef1276b4d';
+
+describe('probeCreatedImageMedia default deps', () => {
+  it('resolves the RETRY-FREE probe backend, and only that one', async () => {
+    await expect(probeCreatedImageMedia(KEY)).resolves.toBe('present');
+
+    expect(getImageUploadProbeBackend).toHaveBeenCalledTimes(1);
+    // 🔴 The half that catches a revert: the shared upload client keeps SDK-default
+    // retries on purpose, and a probe running on it is exactly the unbounded shape this
+    // change exists to remove.
+    expect(getImageUploadBackend).not.toHaveBeenCalled();
+  });
+
+  it('heads the probe backend’s bucket with the probe backend’s client', async () => {
+    await probeCreatedImageMedia(KEY);
+
+    const [bucket, key, s3] = headObject.mock.calls.at(-1) as unknown as [string, string, unknown];
+    expect(bucket).toBe('probe-backend-bucket');
+    expect(key).toBe(KEY);
+    expect(s3).toEqual({ marker: 'probe-client' });
+  });
+});

--- a/src/server/utils/__tests__/created-image-media-probe.test.ts
+++ b/src/server/utils/__tests__/created-image-media-probe.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ObjectHeadResult } from '~/utils/s3-utils';
 import {
+  CREATED_IMAGE_MEDIA_PROBE_DEADLINE_MS,
   CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS,
   isProbeableMediaKey,
   probeCreatedImageMedia,
@@ -164,5 +165,74 @@ describe('probeCreatedImageMedia', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+/**
+ * The WALL-CLOCK bound, which is a different claim from the per-attempt one above.
+ *
+ * 🔴 Why these exist at all: the per-attempt budget is a request to the SDK, and the SDK's
+ * between-attempt sleep is not abort-aware — so before this bound a degraded store could
+ * hold a `createImage` call for the budget plus a full backoff, and the two `comics.router`
+ * loops multiply that by up to 20. A configured retry count nobody watched take effect is a
+ * claim; these watch it.
+ */
+describe('probeCreatedImageMedia — the wall-clock bound', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('gives up with unknown when the store never answers', async () => {
+    vi.useFakeTimers();
+    // A head that NEVER settles — the shape an unbounded probe cannot survive. Without the
+    // deadline race this test hangs until vitest's own timeout kills it.
+    const d = deps(() => new Promise<ObjectHeadResult>(() => undefined));
+
+    const verdict = probeCreatedImageMedia(KEY, d);
+    await vi.advanceTimersByTimeAsync(CREATED_IMAGE_MEDIA_PROBE_DEADLINE_MS);
+
+    await expect(verdict).resolves.toBe('unknown');
+  });
+
+  it('gives up with unknown when resolving the backend never answers', async () => {
+    // 🔴 The head is not the only thing that can hang. `getBackend` builds a client and
+    // reads config; putting only the head inside the race would leave this uncovered.
+    vi.useFakeTimers();
+    const d = deps({ status: 'present', size: 1 });
+    d.getBackend = vi.fn(() => new Promise(() => undefined)) as never;
+
+    const verdict = probeCreatedImageMedia(KEY, d);
+    await vi.advanceTimersByTimeAsync(CREATED_IMAGE_MEDIA_PROBE_DEADLINE_MS);
+
+    await expect(verdict).resolves.toBe('unknown');
+  });
+
+  it('does NOT give up before the deadline — a slow-but-answering store still counts', async () => {
+    /**
+     * The negative control for the two cases above. A deadline that fires early would turn
+     * every slow-but-successful probe into `unknown`, which is exactly the reading that
+     * makes the `absent` rate unusable: `unknown` is the fail-open bucket, so a probe that
+     * quietly moved its own traffic there would report a healthy zero forever.
+     */
+    vi.useFakeTimers();
+    let release!: (r: ObjectHeadResult) => void;
+    const d = deps(() => new Promise<ObjectHeadResult>((r) => (release = r)));
+
+    const verdict = probeCreatedImageMedia(KEY, d);
+    await vi.advanceTimersByTimeAsync(CREATED_IMAGE_MEDIA_PROBE_DEADLINE_MS - 1);
+    release({ status: 'present', size: 7 });
+
+    await expect(verdict).resolves.toBe('present');
+  });
+
+  it('bounds one call at 3s, above the per-attempt budget and below any request timeout', () => {
+    // Literals, not a re-read of the constants: a mutant that moves the deadline has to
+    // fail here even if it moves the constant's declaration with it.
+    expect(CREATED_IMAGE_MEDIA_PROBE_DEADLINE_MS).toBe(3000);
+    // 🔴 The ORDER is the load-bearing part. Equal budgets would let the deadline win the
+    // race on the ordinary abort path, hiding a broken abort behind a passing test.
+    expect(CREATED_IMAGE_MEDIA_PROBE_DEADLINE_MS).toBeGreaterThan(
+      CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS
+    );
   });
 });

--- a/src/server/utils/__tests__/created-image-media-probe.test.ts
+++ b/src/server/utils/__tests__/created-image-media-probe.test.ts
@@ -69,17 +69,17 @@ describe('probeCreatedImageMedia', () => {
   });
 
   it('returns present when the store reports the object with bytes', async () => {
-    await expect(probeCreatedImageMedia(KEY, deps({ status: 'present', size: 4096 }))).resolves.toBe(
-      'present'
-    );
+    await expect(
+      probeCreatedImageMedia(KEY, deps({ status: 'present', size: 4096 }))
+    ).resolves.toBe('present');
   });
 
   it('returns present when the store reports no length at all', async () => {
     // 🔴 `size: null` is "the backend reported no length", NOT "size zero". Reading it as
     // zero would report every length-less backend response as a missing-media defect.
-    await expect(probeCreatedImageMedia(KEY, deps({ status: 'present', size: null }))).resolves.toBe(
-      'present'
-    );
+    await expect(
+      probeCreatedImageMedia(KEY, deps({ status: 'present', size: null }))
+    ).resolves.toBe('present');
   });
 
   it('returns absent when the store answers that the key is not there', async () => {

--- a/src/server/utils/__tests__/created-image-media-probe.test.ts
+++ b/src/server/utils/__tests__/created-image-media-probe.test.ts
@@ -137,4 +137,32 @@ describe('probeCreatedImageMedia', () => {
     // value that would outlive a user-facing request has to fail here.
     expect(CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS).toBe(2000);
   });
+
+  it('hands the store a signal carrying THAT budget, not merely some signal', async () => {
+    /**
+     * 🔴 THE CONSTANT AND THE DELIVERED BUDGET ARE TWO DIFFERENT CLAIMS, and the tests
+     * above pin only the first two-thirds of them: one asserts the constant is 2000,
+     * another asserts that `options.abortSignal instanceof AbortSignal`. Neither can see a
+     * probe that declares a 2s budget and then bounds the actual request with something
+     * else. Measured: mutating the call to `AbortSignal.timeout(600000)` left all 24 probe
+     * tests green — a 10-minute deadline on a user-facing mutation, invisible.
+     *
+     * So assert the number that reaches `AbortSignal.timeout`, and assert it against a
+     * LITERAL rather than re-reading the constant: a mutant that moves the constant AND the
+     * call site together still has to fail here, which re-reading the constant could not
+     * catch.
+     */
+    const spy = vi.spyOn(AbortSignal, 'timeout');
+    try {
+      await probeCreatedImageMedia(KEY, deps({ status: 'present', size: 1 }));
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][0]).toBe(2000);
+      // And the two claims agree — so raising the constant alone is caught by the test
+      // above, and raising only the delivered value is caught by the assertion above this.
+      expect(spy.mock.calls[0][0]).toBe(CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS);
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });

--- a/src/server/utils/__tests__/created-image-media-probe.test.ts
+++ b/src/server/utils/__tests__/created-image-media-probe.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ObjectHeadResult } from '~/utils/s3-utils';
+import {
+  CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS,
+  isProbeableMediaKey,
+  probeCreatedImageMedia,
+  type CreatedImageMediaProbeDeps,
+} from '~/server/utils/created-image-media-probe';
+
+/**
+ * A uuid that is NOT any constant this file asserts against, so a mutant that hardcodes a
+ * key cannot pass by coincidence.
+ */
+const KEY = '9c1f8a3e-4b2d-4c77-b0a1-6e5d2f7a91cc';
+
+/**
+ * Deps that answer with a fixed head result and record what they were asked.
+ *
+ * The bucket name is deliberately not the production one: `getImageUploadBackend` is the
+ * seam under test, so an assertion that the probe passes ITS bucket through has to be able
+ * to fail when the probe substitutes a literal.
+ */
+function deps(head: ObjectHeadResult | (() => Promise<ObjectHeadResult>)) {
+  const headObject = vi.fn(async () => (typeof head === 'function' ? head() : head));
+  const getBackend = vi.fn(async () => ({ s3: { marker: 's3' } as never, bucket: 'probe-bucket' }));
+  return {
+    getBackend,
+    headObject,
+  } as unknown as CreatedImageMediaProbeDeps & {
+    getBackend: ReturnType<typeof vi.fn>;
+    headObject: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('isProbeableMediaKey', () => {
+  it('accepts the bare uuid shape our upload endpoints mint', () => {
+    expect(isProbeableMediaKey(KEY)).toBe(true);
+    expect(isProbeableMediaKey('9C1F8A3E-4B2D-4C77-B0A1-6E5D2F7A91CC')).toBe(true);
+  });
+
+  it.each([
+    ['a filename', 'photo.jpg'],
+    ['a prefixed key', `uploads/${KEY}`],
+    ['a trailing extension', `${KEY}.png`],
+    ['an http url', `https://example.test/${KEY}`],
+    ['a blob url', 'blob:https://example.test/abc'],
+    ['a data url', 'data:image/png;base64,AAAA'],
+    ['a bare number', '12345'],
+    ['the empty string', ''],
+  ])('declines %s', (_label, url) => {
+    expect(isProbeableMediaKey(url)).toBe(false);
+  });
+
+  it.each([[null], [undefined], [42], [{}], [[KEY]]])('declines the non-string %s', (url) => {
+    expect(isProbeableMediaKey(url)).toBe(false);
+  });
+});
+
+describe('probeCreatedImageMedia', () => {
+  it('returns not-applicable and never touches the store for a non-key url', async () => {
+    const d = deps({ status: 'absent' });
+
+    await expect(probeCreatedImageMedia('photo.jpg', d)).resolves.toBe('not-applicable');
+
+    // 🔴 The point of the predicate: an arbitrary caller-supplied string must not produce a
+    // 404 that is then counted as a defect. If the probe asked anyway, this fails.
+    expect(d.getBackend).not.toHaveBeenCalled();
+    expect(d.headObject).not.toHaveBeenCalled();
+  });
+
+  it('returns present when the store reports the object with bytes', async () => {
+    await expect(probeCreatedImageMedia(KEY, deps({ status: 'present', size: 4096 }))).resolves.toBe(
+      'present'
+    );
+  });
+
+  it('returns present when the store reports no length at all', async () => {
+    // 🔴 `size: null` is "the backend reported no length", NOT "size zero". Reading it as
+    // zero would report every length-less backend response as a missing-media defect.
+    await expect(probeCreatedImageMedia(KEY, deps({ status: 'present', size: null }))).resolves.toBe(
+      'present'
+    );
+  });
+
+  it('returns absent when the store answers that the key is not there', async () => {
+    await expect(probeCreatedImageMedia(KEY, deps({ status: 'absent' }))).resolves.toBe('absent');
+  });
+
+  it('returns absent for a zero-length object', async () => {
+    // The shape the production sample actually showed: a signed key whose object landed
+    // with no bytes. Present-but-empty cannot render, so it is the same defect.
+    await expect(probeCreatedImageMedia(KEY, deps({ status: 'present', size: 0 }))).resolves.toBe(
+      'absent'
+    );
+  });
+
+  it('returns unknown when the store could not be consulted', async () => {
+    await expect(probeCreatedImageMedia(KEY, deps({ status: 'unknown' }))).resolves.toBe('unknown');
+  });
+
+  it('returns unknown, not absent, when the backend cannot be resolved', async () => {
+    // 🔴 An unconfigured or credential-less environment must fail OPEN. Collapsing this
+    // into `absent` would make every such deploy read as a fleet-wide defect spike.
+    const d = deps({ status: 'present', size: 1 });
+    d.getBackend = vi.fn(async () => {
+      throw new Error('no credentials');
+    }) as never;
+
+    await expect(probeCreatedImageMedia(KEY, d)).resolves.toBe('unknown');
+  });
+
+  it('returns unknown when the head itself throws', async () => {
+    const d = deps(async () => {
+      throw new Error('boom');
+    });
+
+    await expect(probeCreatedImageMedia(KEY, d)).resolves.toBe('unknown');
+  });
+
+  it('asks the resolved backend for the exact key, under an abort signal', async () => {
+    const d = deps({ status: 'present', size: 1 });
+
+    await probeCreatedImageMedia(KEY, d);
+
+    expect(d.headObject).toHaveBeenCalledTimes(1);
+    const [bucket, key, s3, options] = d.headObject.mock.calls[0];
+    expect(bucket).toBe('probe-bucket');
+    expect(key).toBe(KEY);
+    expect(s3).toEqual({ marker: 's3' });
+    // 🔴 An unbounded probe on a user-facing mutation hangs the request rather than
+    // failing open. Pin that a signal is passed at all.
+    expect(options?.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('bounds the probe with a budget under 5s', () => {
+    // A literal bound, not a re-read of the constant: a mutant that raises the budget to a
+    // value that would outlive a user-facing request has to fail here.
+    expect(CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS).toBe(2000);
+  });
+});

--- a/src/server/utils/created-image-media-probe.ts
+++ b/src/server/utils/created-image-media-probe.ts
@@ -1,0 +1,153 @@
+import type { S3Client } from '@aws-sdk/client-s3';
+import { getImageUploadBackend, headObject } from '~/utils/s3-utils';
+
+/**
+ * Does the media an `Image` row is about to point at actually exist in the store?
+ *
+ * `createImage` writes its row from client-supplied JSON. `url` — the media key — arrives
+ * over the wire and is never checked against storage, so a key whose object never landed
+ * produces a complete, healthy-looking row whose media 404s forever. There is no repair
+ * path: nothing later in the pipeline re-derives the bytes.
+ *
+ * The dominant producer is the browser upload hook (`src/hooks/useCFImageUpload.tsx`).
+ * XHR's `error` event is NETWORK-ONLY, so a PUT that reaches the store and is REFUSED
+ * (an expired presign, a malformed request, a briefly unavailable store) completes
+ * normally, lands on `loadend`, and the hook proceeds to hand the caller a key with
+ * nothing behind it. Measured over a ~24h production window, 7 of 10 sampled defective
+ * rows had a key an upload endpoint had signed 2.0–23.3s before the row was written, with
+ * zero bytes ever stored — a real upload attempt that failed silently down that path.
+ *
+ * 🔴 A CLIENT FIX CANNOT CLOSE THIS AND THIS ONE CAN. The hook only protects sessions that
+ * have loaded the new bundle, and it is one of several producers. Every `Image` row in the
+ * app goes through `createImage`, so a check here covers every producer the moment it
+ * deploys — including the ones nobody has enumerated.
+ *
+ * 🔴 OBSERVE-ONLY. This module answers a question; it does not act on the answer. The
+ * caller logs the verdict and continues. Rejecting an image creation is a NEW failure mode
+ * on a working user-facing path, and the only honest way to size it is to let the `absent`
+ * rate accumulate against a real denominator first. Enforcement is deliberately a separate
+ * change, gated on that measurement.
+ */
+
+/**
+ * The one rule for "may this `Image.url` be handed to our media store as an object key?".
+ *
+ * 🔴 A DELIBERATE UNDER-APPROXIMATION, and the direction is chosen from what each error
+ * costs. It is NOT true that every legitimate key here is a uuid: every key-MINTING site is
+ * a bare `crypto.randomUUID()` with no prefix and no extension, but several WRITE paths
+ * accept a caller-supplied string and never check its shape, so `foo/uuid`, `photo.jpg` or
+ * `12345` can all reach this column. Probing those would produce 404s that are
+ * indistinguishable from real misses and would inflate the `absent` rate this check exists
+ * to measure — so they are classified `not-applicable` and never asked about. A key we
+ * decline to probe costs a detection; a non-key we probe costs a wrong measurement.
+ *
+ * A url carrying a URI scheme (`http:`, `blob:`, `data:`) fails this for free — none of
+ * them is a uuid.
+ *
+ * 🔴 KNOWN DUPLICATE, RECORDED RATHER THAN HIDDEN. An identical predicate is being added as
+ * `@civitai/shared`'s `isProbeableMediaKey` by the publish-guard change (civitai#4490),
+ * which is open and unmerged. This repo forbids stacked PRs, so importing it here would
+ * base this change on that branch. The two must be consolidated onto the shared module by
+ * whichever lands second — a predicate open-coded at N sites is wrong at N-1 of them, and
+ * these two are the same question asked by two guards. That is a real follow-up, and its
+ * closing condition is mechanical: this file no longer declares `MEDIA_KEY_RE`.
+ */
+const MEDIA_KEY_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isProbeableMediaKey(url: unknown): url is string {
+  return typeof url === 'string' && MEDIA_KEY_RE.test(url);
+}
+
+/**
+ * What the probe concluded. 🔴 FOUR values, never a boolean.
+ *
+ * A boolean forces the fail-open case to be reported as one of the other two, and both
+ * readings are wrong: counting `unknown` as present asserts we confirmed an object we never
+ * saw, and counting it as absent inflates the defect rate with probes that could not reach
+ * the bucket at all. Both directions corrupt the measurement this exists to take.
+ *
+ * Mirrors the three-valued shape `headObject` already returns in `~/utils/s3-utils`.
+ */
+export type CreatedImageMediaVerdict =
+  /** The store answered that the key is there, with bytes. */
+  | 'present'
+  /** The store ANSWERED absent, or answered present with zero bytes. This is the defect. */
+  | 'absent'
+  /** The store could not be consulted — threw, timed out, or is unconfigured. Fail open. */
+  | 'unknown'
+  /** `url` is not a bare media key this store owns, so there is nothing to ask about. */
+  | 'not-applicable';
+
+/**
+ * Timeout budget for the probe.
+ *
+ * 🔴 A BOUND IS NOT OPTIONAL. `createImage` sits inline on a user-facing mutation and the
+ * uploads client is built with SDK-default retries and no request timeout, so an unbounded
+ * probe against a degraded store does not fail open — it HANGS the request holding it,
+ * which is strictly worse than the bug it observes.
+ *
+ * 2s, taken from `COVER_IMAGE_EXISTS_TIMEOUT_MS` in `~/server/services/cover-image.service`
+ * rather than picked afresh, so the two probes against this same store cannot drift apart.
+ * An abort surfaces as an `AbortError`, which is not a not-found shape, so it lands on
+ * `unknown` like any other unreachable-bucket outcome.
+ */
+export const CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS = 2000;
+
+/**
+ * Seam for tests. Both default to the real implementations, so production behaviour is
+ * whatever `getImageUploadBackend` / `headObject` do — the injection point exists so a test
+ * can drive every verdict without a bucket, not so the probe can differ in production.
+ */
+export type CreatedImageMediaProbeDeps = {
+  getBackend: () => Promise<{ s3: S3Client; bucket: string }>;
+  headObject: typeof headObject;
+};
+
+/**
+ * 🔴 THE BUCKET IS RESOLVED THROUGH `getImageUploadBackend()`, NOT OPEN-CODED.
+ *
+ * `Image.url` is the key the UPLOAD path minted, so the only store that can answer about it
+ * is the one that path writes to. Every key-minting site already goes through this resolver,
+ * so the probe asks about the bucket the key was actually minted into by construction rather
+ * than by two constants happening to agree today. `cover-image.service` resolves the same
+ * way; an open-coded client plus a bucket literal would silently keep asking the old store
+ * the moment uploads move, and answer 404 for every key.
+ */
+const defaultDeps: CreatedImageMediaProbeDeps = {
+  getBackend: async () => {
+    const { s3, bucket } = await getImageUploadBackend();
+    return { s3, bucket };
+  },
+  headObject,
+};
+
+/**
+ * 🔴 NEVER THROWS. This observes a working code path, so it must not be able to break that
+ * path by its own absence: resolving the backend is inside the try, and an unconfigured
+ * environment (local, CI, rotated credentials) lands on `unknown` rather than propagating.
+ */
+export async function probeCreatedImageMedia(
+  url: unknown,
+  deps: CreatedImageMediaProbeDeps = defaultDeps
+): Promise<CreatedImageMediaVerdict> {
+  if (!isProbeableMediaKey(url)) return 'not-applicable';
+
+  try {
+    const { s3, bucket } = await deps.getBackend();
+    const head = await deps.headObject(bucket, url, s3, {
+      abortSignal: AbortSignal.timeout(CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS),
+    });
+    if (head.status === 'absent') return 'absent';
+    if (head.status === 'unknown') return 'unknown';
+    /**
+     * A zero-length object is a stored object that cannot render — the same defect from the
+     * viewer's point of view, and the shape the production sample actually showed. `size:
+     * null` is "the backend reported no length", NOT "size zero", so it must not trip this;
+     * see `ObjectHeadResult`.
+     */
+    if (head.size === 0) return 'absent';
+    return 'present';
+  } catch {
+    return 'unknown';
+  }
+}

--- a/src/server/utils/created-image-media-probe.ts
+++ b/src/server/utils/created-image-media-probe.ts
@@ -17,10 +17,20 @@ import { getImageUploadBackend, headObject } from '~/utils/s3-utils';
  * rows had a key an upload endpoint had signed 2.0–23.3s before the row was written, with
  * zero bytes ever stored — a real upload attempt that failed silently down that path.
  *
- * 🔴 A CLIENT FIX CANNOT CLOSE THIS AND THIS ONE CAN. The hook only protects sessions that
- * have loaded the new bundle, and it is one of several producers. Every `Image` row in the
- * app goes through `createImage`, so a check here covers every producer the moment it
- * deploys — including the ones nobody has enumerated.
+ * 🔴 WHAT THIS COVERS, STATED EXACTLY: `Image` rows written through `createImage`. That is
+ * the widest single funnel — post images, model-version and collection paths, comics, cover
+ * images, thumbnails — and it reaches every session regardless of which bundle it loaded,
+ * which a client-side fix cannot. It is NOT every `Image` row: five write paths reach the
+ * table directly and are enumerated at the call site in `~/server/services/image.service`
+ * (`createImage`), the highest-risk being `linkArticleContentImages`, which materialises
+ * TipTap article content — fed by the same resolves-on-a-refused-PUT hook described above —
+ * inside a `dbWrite.$transaction`, where `local-rules/no-io-in-transaction` is what makes
+ * adding a HEAD a separate change rather than an extra argument.
+ *
+ * An earlier version of this comment claimed the funnel was total ("every `Image` row … so
+ * a check here covers every producer … including the ones nobody has enumerated"). It is
+ * not, and nothing here establishes whether this half or the client half leaves more rows
+ * uncovered — both are partial in different directions.
  *
  * 🔴 OBSERVE-ONLY. This module answers a question; it does not act on the answer. The
  * caller logs the verdict and continues. Rejecting an image creation is a NEW failure mode
@@ -90,6 +100,17 @@ export type CreatedImageMediaVerdict =
  * rather than picked afresh, so the two probes against this same store cannot drift apart.
  * An abort surfaces as an `AbortError`, which is not a not-found shape, so it lands on
  * `unknown` like any other unreachable-bucket outcome.
+ *
+ * 🔴 THIS BOUNDS EACH NETWORK ATTEMPT, NOT WALL-CLOCK TIME. `~/utils/s3-utils` records the
+ * mechanism on `checkFileExists` and `headObject`: the signal is shared by every retry
+ * attempt, but the SDK sleeps BETWEEN attempts on a plain, non-abort-aware timer, so a
+ * deadline landing mid-backoff lets that sleep run to completion and only the next attempt
+ * short-circuits. Worst case per call is therefore this budget plus one backoff, not 2s.
+ * `getB2ImageS3Client` (`~/utils/s3-utils`) sets neither `maxAttempts` nor a
+ * request-handler timeout, so the backoff length is whatever the SDK default schedule
+ * produces — s3-utils records one measurement against the installed SDK, a 300ms budget
+ * with a ~5s backoff in flight returning in ~4.7s. The consequence for the callers that
+ * loop is sized at the `createImage` call site.
  */
 export const CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS = 2000;
 

--- a/src/server/utils/created-image-media-probe.ts
+++ b/src/server/utils/created-image-media-probe.ts
@@ -1,5 +1,5 @@
 import type { S3Client } from '@aws-sdk/client-s3';
-import { getImageUploadBackend, headObject } from '~/utils/s3-utils';
+import { getImageUploadProbeBackend, headObject } from '~/utils/s3-utils';
 
 /**
  * Does the media an `Image` row is about to point at actually exist in the store?
@@ -20,7 +20,7 @@ import { getImageUploadBackend, headObject } from '~/utils/s3-utils';
  * 🔴 WHAT THIS COVERS, STATED EXACTLY: `Image` rows written through `createImage`. That is
  * the widest single funnel — post images, model-version and collection paths, comics, cover
  * images, thumbnails — and it reaches every session regardless of which bundle it loaded,
- * which a client-side fix cannot. It is NOT every `Image` row: five write paths reach the
+ * which a client-side fix cannot. It is NOT every `Image` row: six write paths reach the
  * table directly and are enumerated at the call site in `~/server/services/image.service`
  * (`createImage`), the highest-risk being `linkArticleContentImages`, which materialises
  * TipTap article content — fed by the same resolves-on-a-refused-PUT hook described above —
@@ -101,23 +101,49 @@ export type CreatedImageMediaVerdict =
  * An abort surfaces as an `AbortError`, which is not a not-found shape, so it lands on
  * `unknown` like any other unreachable-bucket outcome.
  *
- * 🔴 THIS BOUNDS EACH NETWORK ATTEMPT, NOT WALL-CLOCK TIME. `~/utils/s3-utils` records the
- * mechanism on `checkFileExists` and `headObject`: the signal is shared by every retry
- * attempt, but the SDK sleeps BETWEEN attempts on a plain, non-abort-aware timer, so a
+ * 🔴 ON ITS OWN THIS BOUNDS EACH NETWORK ATTEMPT, NOT WALL-CLOCK TIME. `~/utils/s3-utils`
+ * records the mechanism on `checkFileExists` and `headObject`: the signal is shared by every
+ * retry attempt, but the SDK sleeps BETWEEN attempts on a plain, non-abort-aware timer, so a
  * deadline landing mid-backoff lets that sleep run to completion and only the next attempt
- * short-circuits. Worst case per call is therefore this budget plus one backoff, not 2s.
- * `getB2ImageS3Client` (`~/utils/s3-utils`) sets neither `maxAttempts` nor a
- * request-handler timeout, so the backoff length is whatever the SDK default schedule
- * produces — s3-utils records one measurement against the installed SDK, a 300ms budget
- * with a ~5s backoff in flight returning in ~4.7s. The consequence for the callers that
- * loop is sized at the `createImage` call site.
+ * short-circuits — worst case would be this budget plus one backoff (s3-utils records one
+ * measurement against the installed SDK: a 300ms budget with a ~5s backoff in flight
+ * returning in ~4.7s).
+ *
+ * TWO THINGS CLOSE THAT, and they are independent on purpose:
+ *   1. the probe uses `getImageUploadProbeBackend()`, whose client is built with
+ *      `maxAttempts: 1` — with one attempt there are no between-attempt sleeps at all, so
+ *      the abort budget IS the call's budget;
+ *   2. {@link CREATED_IMAGE_MEDIA_PROBE_DEADLINE_MS} races the whole head call, so the
+ *      bound holds even if (1) stops being true — a config value nobody watched take
+ *      effect is a claim, and this one is checked by the caller rather than trusted.
  */
 export const CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS = 2000;
 
 /**
+ * Hard wall-clock ceiling on ONE `probeCreatedImageMedia` call, whatever the store does.
+ *
+ * 🔴 THE ONE BOUND THAT DOES NOT DEPEND ON THE SDK HONOURING ANYTHING. `AbortSignal` and
+ * `maxAttempts` are both requests to the SDK; this is a race the probe runs itself, so a
+ * head call that never settles — a wedged socket, a handler that swallows the abort, a
+ * future SDK that reinstates a retry — still returns `unknown` here. It exists because
+ * `createImage` sits inline on a user-facing mutation and two `comics.router.ts` procedures
+ * call it in bounded loops (20 and 10), so an unbounded per-call cost multiplies.
+ *
+ * Deliberately LARGER than the per-attempt budget, not equal to it: at 2000/2000 the race
+ * would routinely be won by this deadline rather than by the abort, which would hide a
+ * broken abort path behind a passing one. The 1s of headroom is the SDK's window to surface
+ * its own `AbortError` on the ordinary path.
+ */
+export const CREATED_IMAGE_MEDIA_PROBE_DEADLINE_MS = 3000;
+
+/**
  * Seam for tests. Both default to the real implementations, so production behaviour is
- * whatever `getImageUploadBackend` / `headObject` do — the injection point exists so a test
- * can drive every verdict without a bucket, not so the probe can differ in production.
+ * whatever `getImageUploadProbeBackend` / `headObject` do — the injection point exists so a
+ * test can drive every verdict without a bucket, not so the probe can differ in production.
+ *
+ * ⚠ Every test that passes `deps` therefore says NOTHING about which backend production
+ * resolves. That gap is covered separately, by
+ * `src/server/utils/__tests__/created-image-media-probe.default-deps.test.ts`.
  */
 export type CreatedImageMediaProbeDeps = {
   getBackend: () => Promise<{ s3: S3Client; bucket: string }>;
@@ -125,7 +151,7 @@ export type CreatedImageMediaProbeDeps = {
 };
 
 /**
- * 🔴 THE BUCKET IS RESOLVED THROUGH `getImageUploadBackend()`, NOT OPEN-CODED.
+ * 🔴 THE BUCKET IS RESOLVED THROUGH THE UPLOAD BACKEND RESOLVER, NOT OPEN-CODED.
  *
  * `Image.url` is the key the UPLOAD path minted, so the only store that can answer about it
  * is the one that path writes to. Every key-minting site already goes through this resolver,
@@ -133,10 +159,14 @@ export type CreatedImageMediaProbeDeps = {
  * than by two constants happening to agree today. `cover-image.service` resolves the same
  * way; an open-coded client plus a bucket literal would silently keep asking the old store
  * the moment uploads move, and answer 404 for every key.
+ *
+ * 🔴 `getImageUploadProbeBackend`, NOT `getImageUploadBackend`: same bucket expression, but
+ * a retry-free client. See `B2_IMAGE_PROBE_MAX_ATTEMPTS` in `~/utils/s3-utils` for why the
+ * shared upload client must NOT have its retries taken away to achieve this.
  */
 const defaultDeps: CreatedImageMediaProbeDeps = {
   getBackend: async () => {
-    const { s3, bucket } = await getImageUploadBackend();
+    const { s3, bucket } = await getImageUploadProbeBackend();
     return { s3, bucket };
   },
   headObject,
@@ -146,6 +176,12 @@ const defaultDeps: CreatedImageMediaProbeDeps = {
  * 🔴 NEVER THROWS. This observes a working code path, so it must not be able to break that
  * path by its own absence: resolving the backend is inside the try, and an unconfigured
  * environment (local, CI, rotated credentials) lands on `unknown` rather than propagating.
+ *
+ * 🔴 NEVER RUNS LONGER THAN {@link CREATED_IMAGE_MEDIA_PROBE_DEADLINE_MS}. Both the backend
+ * resolution and the head call are inside the race, because either can be the thing that
+ * hangs. Losing the race yields `unknown` — the same fail-open verdict as any other "could
+ * not consult the store" outcome, so a slow store degrades the MEASUREMENT and never the
+ * mutation.
  */
 export async function probeCreatedImageMedia(
   url: unknown,
@@ -153,22 +189,34 @@ export async function probeCreatedImageMedia(
 ): Promise<CreatedImageMediaVerdict> {
   if (!isProbeableMediaKey(url)) return 'not-applicable';
 
+  let deadline: ReturnType<typeof setTimeout> | undefined;
   try {
-    const { s3, bucket } = await deps.getBackend();
-    const head = await deps.headObject(bucket, url, s3, {
-      abortSignal: AbortSignal.timeout(CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS),
-    });
-    if (head.status === 'absent') return 'absent';
-    if (head.status === 'unknown') return 'unknown';
-    /**
-     * A zero-length object is a stored object that cannot render — the same defect from the
-     * viewer's point of view, and the shape the production sample actually showed. `size:
-     * null` is "the backend reported no length", NOT "size zero", so it must not trip this;
-     * see `ObjectHeadResult`.
-     */
-    if (head.size === 0) return 'absent';
-    return 'present';
+    return await Promise.race([
+      (async (): Promise<CreatedImageMediaVerdict> => {
+        const { s3, bucket } = await deps.getBackend();
+        const head = await deps.headObject(bucket, url, s3, {
+          abortSignal: AbortSignal.timeout(CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS),
+        });
+        if (head.status === 'absent') return 'absent';
+        if (head.status === 'unknown') return 'unknown';
+        /**
+         * A zero-length object is a stored object that cannot render — the same defect from
+         * the viewer's point of view, and the shape the production sample actually showed.
+         * `size: null` is "the backend reported no length", NOT "size zero", so it must not
+         * trip this; see `ObjectHeadResult`.
+         */
+        if (head.size === 0) return 'absent';
+        return 'present';
+      })(),
+      new Promise<CreatedImageMediaVerdict>((resolve) => {
+        deadline = setTimeout(() => resolve('unknown'), CREATED_IMAGE_MEDIA_PROBE_DEADLINE_MS);
+      }),
+    ]);
   } catch {
     return 'unknown';
+  } finally {
+    // Whoever won, stop holding the event loop open — an un-cleared timer would keep a
+    // serverless invocation (and a vitest run) alive for the full deadline on every call.
+    if (deadline) clearTimeout(deadline);
   }
 }

--- a/src/utils/__tests__/s3-utils.b2-image-probe-client.test.ts
+++ b/src/utils/__tests__/s3-utils.b2-image-probe-client.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * The read-only probe client's bound, and the proof that buying it cost the shared upload
+ * client nothing.
+ *
+ * 🔴 WHY THIS FILE EXISTS. `probeCreatedImageMedia` runs inline on `createImage`, a
+ * user-facing mutation, and two `comics.router.ts` procedures call it in bounded loops. Its
+ * `AbortSignal` bounds each network ATTEMPT, but the SDK's between-attempt sleep is not
+ * abort-aware — so with SDK-default retries a degraded store could hold each call for the
+ * budget plus a full backoff. The fix is a retry-free client for the probe ALONE.
+ *
+ * "Alone" is the load-bearing word and the reason for the negative control below: the
+ * obvious fix — putting `maxAttempts` on `getB2ImageS3Client` — would have reached the live
+ * upload-completion and abort endpoints, the announcement media check and the server-side
+ * upload path, all of which want their retries. A test that only asserted "the probe client
+ * has maxAttempts 1" would pass just as happily if the shared client had been changed too.
+ */
+
+// Concrete B2 image credentials so both factories can construct. Anything not overridden
+// falls through to the global env mock in `src/__tests__/setup.ts`.
+vi.mock('~/env/server', () => ({
+  env: new Proxy(
+    {
+      S3_IMAGE_B2_ENDPOINT: 'https://s3.us-west-004.backblazeb2.com',
+      S3_IMAGE_B2_ACCESS_KEY: 'image-b2-key',
+      S3_IMAGE_B2_SECRET_KEY: 'image-b2-secret',
+      S3_IMAGE_B2_BUCKET: 'civitai-media-uploads-test',
+      S3_IMAGE_B2_REGION: 'us-west-004',
+      S3_UPLOAD_ENDPOINT: 'https://abcd1234.r2.cloudflarestorage.com',
+      S3_UPLOAD_BUCKET: 'civitai-modelfiles',
+      S3_UPLOAD_KEY: 'test-key',
+      S3_UPLOAD_SECRET: 'test-secret',
+    } as Record<string, unknown>,
+    {
+      get(target, prop: string) {
+        if (prop in target) return target[prop];
+        return undefined;
+      },
+    }
+  ),
+}));
+
+import {
+  B2_IMAGE_PROBE_MAX_ATTEMPTS,
+  getB2ImageProbeS3Client,
+  getB2ImageS3Client,
+  getImageUploadBackend,
+  getImageUploadProbeBackend,
+} from '~/utils/s3-utils';
+
+/** `maxAttempts` is normalised to a provider by the SDK's config resolver. */
+async function attemptsOf(client: { config: { maxAttempts: unknown } }) {
+  const value = client.config.maxAttempts;
+  return typeof value === 'function' ? await (value as () => Promise<number>)() : value;
+}
+
+describe('the B2 image PROBE client is retry-free', () => {
+  it('attempts a request exactly once', async () => {
+    // The whole bound. One attempt means there is no between-attempt sleep for a
+    // non-abort-aware timer to sit in, so the abort budget IS the call's budget.
+    await expect(attemptsOf(getB2ImageProbeS3Client())).resolves.toBe(1);
+    expect(B2_IMAGE_PROBE_MAX_ATTEMPTS).toBe(1);
+  });
+
+  it('is memoised — one client, not one per probe', async () => {
+    // `createImage` is a hot path; constructing a client per call would trade a retry
+    // problem for an allocation one.
+    expect(getB2ImageProbeS3Client()).toBe(getB2ImageProbeS3Client());
+  });
+});
+
+describe('the SHARED B2 image client is untouched by that', () => {
+  it('still retries — this is the negative control for the assertion above', async () => {
+    /**
+     * 🔴 If this ever reads 1, someone bounded the probe by taking retries away from
+     * `src/pages/api/upload/complete.ts`, `src/pages/api/upload/abort.ts`,
+     * `src/server/jobs/announcement-media-check.ts` and the server-side upload/delete
+     * paths, where a transient 5xx losing a retry loses a user's bytes. It is also what
+     * makes the probe assertion non-vacuous: without it, "the probe client has 1 attempt"
+     * would pass in a world where EVERY client has 1 attempt.
+     */
+    const shared = await attemptsOf(getB2ImageS3Client());
+    expect(shared).toBeGreaterThan(1);
+  });
+
+  it('is a DIFFERENT client instance from the probe one', () => {
+    expect(getB2ImageProbeS3Client()).not.toBe(getB2ImageS3Client());
+  });
+});
+
+describe('the probe backend resolves the same store as the upload backend', () => {
+  it('hands back the probe client and the upload bucket', async () => {
+    /**
+     * 🔴 `Image.url` is the key the UPLOAD path minted, so the only store that can answer
+     * about it is the one that path writes to. A probe that bounded itself by open-coding
+     * its own bucket would answer 404 for every key the moment uploads moved — a
+     * fleet-wide false defect rate, arrived at while every test stayed green.
+     */
+    const upload = await getImageUploadBackend();
+    const probe = await getImageUploadProbeBackend();
+
+    expect(probe.bucket).toBe(upload.bucket);
+    expect(probe.backend).toBe(upload.backend);
+    expect(probe.s3).toBe(getB2ImageProbeS3Client());
+    expect(probe.s3).not.toBe(upload.s3);
+  });
+
+  it('points both clients at the same endpoint and region', async () => {
+    // The two clients must differ in `maxAttempts` and in NOTHING else — any other drift
+    // means the probe is asking a different store than the key was minted into.
+    const probe = getB2ImageProbeS3Client();
+    const shared = getB2ImageS3Client();
+
+    const endpointOf = async (c: { config: { endpoint?: unknown } }) => {
+      const e = c.config.endpoint;
+      return typeof e === 'function' ? await (e as () => Promise<unknown>)() : e;
+    };
+    const regionOf = async (c: { config: { region: unknown } }) => {
+      const r = c.config.region;
+      return typeof r === 'function' ? await (r as () => Promise<string>)() : r;
+    };
+
+    expect(await regionOf(probe)).toEqual(await regionOf(shared));
+    expect(await endpointOf(probe)).toEqual(await endpointOf(shared));
+  });
+});

--- a/src/utils/__tests__/upload-settlement.test.ts
+++ b/src/utils/__tests__/upload-settlement.test.ts
@@ -218,10 +218,28 @@ describe('attachUploadSettlement', () => {
   // the store and is REFUSED — an expired presign (403), a malformed request (400), a
   // store that is briefly unavailable (503) — completes normally and lands on
   // `loadend`. That branch reported nothing at all, so the tracked file went on
-  // asserting `uploading` forever: `ImageUpload` renders `status === 'error'` (a badge
-  // it never got to show) and `ChallengeSubmitModal` both renders it AND gates its
-  // submit on `status === 'uploading'`, so a refused PUT there wedges the submit
-  // button with a spinner that can never clear.
+  // asserting `uploading` forever.
+  //
+  // WHERE THAT IS USER-VISIBLE, MEASURED RATHER THAN ASSUMED: `ChallengeSubmitModal`
+  // reads the hook's `TrackedFile.status` directly — it renders `f.status === 'error'`
+  // (`ChallengeSubmitModal.tsx:593`) AND gates its submit on
+  // `some(f => f.status === 'uploading')` (`:407`) — so before this change a refused PUT
+  // there wedged the submit button with a spinner that could never clear. That half is
+  // verified end to end.
+  //
+  // 🔴 `ImageUpload` IS NOT SUCH A PLACE, AND AN EARLIER VERSION OF THIS COMMENT SAID IT
+  // WAS ("`ImageUpload` renders `status === 'error'`, a badge it never got to show").
+  // `ImageUpload.tsx` reads only `progress` off the hook's tracked file
+  // (`ImageUpload.tsx:214-215`); its `image.status === 'error'` at `:302` is
+  // `CustomFile.status`, the post-upload INGESTION status — a different type over a
+  // different value set (`'processing' | 'uploading' | 'complete' | 'blocked' | 'error'`,
+  // `src/types/global.d.ts:64`), which the hook never writes. So on the `ImageUpload`
+  // path a refused PUT is STILL SILENT to the user after this change: settlement resolves,
+  // `handleDrop` clears the entry's `file` and stores the presign id as its `url`
+  // (`ImageUpload.tsx:118-125`), the loading overlay therefore drops, and the entry
+  // renders as an ordinary uploaded image with no status at all. Do not read that silence
+  // as the fix being broken — it is the reach of the fix, and closing it means having
+  // `ImageUpload` consume the tracked file's status.
   // ---------------------------------------------------------------------------
 
   it.each([201, 204])('treats a %i as the successful PUT it is', async (status) => {

--- a/src/utils/__tests__/upload-settlement.test.ts
+++ b/src/utils/__tests__/upload-settlement.test.ts
@@ -54,8 +54,25 @@ class StubXhr implements SettlementXhr {
     this.fire('loadend');
   }
 
+  /**
+   * A user cancel: `abort` then `loadend`, same dispatch.
+   *
+   * 🔴 The `loadend` is not decoration. This stub used to fire `abort` alone, which is
+   * NOT what the browser does — per the XHR spec's request-error steps an `abort` at
+   * the XHR object is followed by `loadend` at the XHR object in the same dispatch,
+   * exactly as `error` is. While the non-2xx `loadend` branch called nothing, the
+   * difference was invisible; it stops being invisible the moment that branch reports
+   * an error, because an aborted request arrives at `loadend` with `status === 0`.
+   *
+   * `readyState` is 4 during these events: `abort()` runs the request-error steps
+   * (which set state to DONE and fire the events) and only afterwards resets state to
+   * UNSENT. `status` is 0 because the response is a network error.
+   */
   userAbort() {
+    this.readyState = 4;
+    this.status = 0;
     this.fire('abort');
+    this.fire('loadend');
   }
 }
 
@@ -194,5 +211,84 @@ describe('attachUploadSettlement', () => {
     await expect(settled).rejects.toThrow('Upload canceled');
     expect(cb.onAborted).toHaveBeenCalledTimes(1);
     expect(relay).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // The refused-PUT half. XHR's `error` event is NETWORK-only, so a PUT that reaches
+  // the store and is REFUSED — an expired presign (403), a malformed request (400), a
+  // store that is briefly unavailable (503) — completes normally and lands on
+  // `loadend`. That branch reported nothing at all, so the tracked file went on
+  // asserting `uploading` forever: `ImageUpload` renders `status === 'error'` (a badge
+  // it never got to show) and `ChallengeSubmitModal` both renders it AND gates its
+  // submit on `status === 'uploading'`, so a refused PUT there wedges the submit
+  // button with a spinner that can never clear.
+  // ---------------------------------------------------------------------------
+
+  it.each([201, 204])('treats a %i as the successful PUT it is', async (status) => {
+    // The store answers 200 to this PUT today, so `=== 200` was not WRONG in
+    // production — it was brittle. A 201 or 204 is a successful PUT by any reading,
+    // and badging one as a failure would put an error on an upload that worked.
+    const xhr = new StubXhr();
+    const cb = callbacks();
+    const relay = vi.fn();
+
+    const settled = attachUploadSettlement(xhr, relay, cb);
+    xhr.finishedWithStatus(status);
+
+    await expect(settled).resolves.toEqual({ kind: 'direct', success: true });
+    expect(cb.onSuccess).toHaveBeenCalledTimes(1);
+    expect(cb.onError).not.toHaveBeenCalled();
+    expect(relay).not.toHaveBeenCalled();
+  });
+
+  it.each([400, 403, 500, 503])('reports a refused %i to the caller', async (status) => {
+    const xhr = new StubXhr();
+    const cb = callbacks();
+    const relay = vi.fn();
+
+    const settled = attachUploadSettlement(xhr, relay, cb);
+    xhr.finishedWithStatus(status);
+
+    expect(cb.onError).toHaveBeenCalledTimes(1);
+    expect(cb.onSuccess).not.toHaveBeenCalled();
+    /**
+     * 🔴 THE REMAINING HALF OF THE DEFECT, PINNED RATHER THAN FIXED. Settlement still
+     * RESOLVES on a refused PUT, so the caller is still handed a media key with
+     * nothing behind it — which is how an `Image` row gets written for media that
+     * never landed. Making it reject is the follow-up, and it is not a one-line
+     * change: most `uploadToCF` call sites do not catch, so a rejection would surface
+     * uncaught in a number of them, including a bulk `Promise.all` in `ImageUpload`
+     * that would additionally propagate local `blob:` URLs into `onChange` as image
+     * values. Asserting the current behaviour makes that follow-up a deliberate edit
+     * to this expectation rather than a silent drift.
+     */
+    await expect(settled).resolves.toEqual({ kind: 'direct', success: false });
+  });
+
+  /**
+   * 🔴 REACHABLE ONLY BECAUSE OF THE CASE ABOVE, WHICH IS WHY THE GUARD IS NOT INERT.
+   * `abort` is followed by `loadend` in the same dispatch, and an aborted request
+   * arrives there with `status === 0`. While the non-2xx branch called nothing, that
+   * second dispatch was harmless; now that it reports an error, it would overwrite the
+   * user's `aborted` status with `error` — a cancel rendered as a failure.
+   *
+   * Watched to fail: with the `aborted` flag deleted from `attachUploadSettlement`
+   * this case fails with
+   *   AssertionError: expected "spy" to not be called at all, but actually been
+   *   called 1 times
+   * on the `onError` expectation, while every other case in this file stays green.
+   */
+  it('keeps a user cancel reported as aborted, not errored', async () => {
+    const xhr = new StubXhr();
+    const cb = callbacks();
+    const relay = vi.fn();
+
+    const settled = attachUploadSettlement(xhr, relay, cb);
+    xhr.userAbort();
+
+    await expect(settled).rejects.toThrow('Upload canceled');
+    expect(cb.onAborted).toHaveBeenCalledTimes(1);
+    expect(cb.onError).not.toHaveBeenCalled();
+    expect(cb.onSuccess).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -109,6 +109,73 @@ export async function getImageUploadBackend(): Promise<{
 }
 
 /**
+ * How many times the READ-ONLY probe client may attempt a request. ONE — i.e. no retries.
+ *
+ * 🔴 THIS IS THE ONLY THING THAT MAKES A PROBE'S WALL TIME BOUNDABLE. An `abortSignal`
+ * bounds each network ATTEMPT but not the call: the SDK sleeps BETWEEN attempts on a plain,
+ * non-abort-aware timer, so a deadline landing mid-backoff lets that sleep run to
+ * completion (documented on {@link checkFileExists}; measured there — a 300 ms budget with a
+ * ~5 s backoff in flight returned in ~4.7 s). With one attempt there is no between, so the
+ * abort budget IS the call's budget.
+ */
+export const B2_IMAGE_PROBE_MAX_ATTEMPTS = 1;
+
+let _b2ImageProbeS3Client: S3Client | null = null;
+/**
+ * A SEPARATE, retry-free B2 image client for read-only existence probes on user-facing
+ * paths.
+ *
+ * 🔴 WHY NOT JUST SET `maxAttempts` ON {@link getB2ImageS3Client}: that client is SHARED by
+ * the live upload-completion endpoints (`src/pages/api/upload/complete.ts`,
+ * `src/pages/api/upload/abort.ts`), the announcement media check
+ * (`src/server/jobs/announcement-media-check.ts`) and the server-side upload/delete paths.
+ * Those WANT the SDK's default retries — a transient 500 there loses a user's bytes. Taking
+ * retries away from all of them to bound a telemetry probe would be a production change far
+ * wider than the probe. So the probe gets its own client and the shared factory above is
+ * untouched.
+ *
+ * Same credentials, same region, same endpoint, same PUT-metrics wrapper — the ONLY
+ * difference is `maxAttempts`. Anything else drifting between the two would mean the probe
+ * is asking a different store than the one the key was minted into.
+ */
+export function getB2ImageProbeS3Client(): S3Client {
+  if (!env.S3_IMAGE_B2_ACCESS_KEY || !env.S3_IMAGE_B2_SECRET_KEY || !env.S3_IMAGE_B2_ENDPOINT) {
+    throw new Error('B2 image upload credentials not configured');
+  }
+  if (!_b2ImageProbeS3Client) {
+    _b2ImageProbeS3Client = instrumentB2Client(
+      new S3Client({
+        credentials: {
+          accessKeyId: env.S3_IMAGE_B2_ACCESS_KEY,
+          secretAccessKey: env.S3_IMAGE_B2_SECRET_KEY,
+        },
+        region: env.S3_IMAGE_B2_REGION ?? 'us-west-004',
+        endpoint: env.S3_IMAGE_B2_ENDPOINT,
+        forcePathStyle: true,
+        maxAttempts: B2_IMAGE_PROBE_MAX_ATTEMPTS,
+      })
+    );
+  }
+  return _b2ImageProbeS3Client;
+}
+
+/**
+ * The image-upload backend, with the retry-free probe client in place of the shared one.
+ *
+ * The BUCKET is taken from {@link getImageUploadBackend} rather than re-read from `env`, so
+ * a probe can never end up asking a different bucket than the one the upload path mints
+ * keys into — the two cannot drift because there is only one expression.
+ */
+export async function getImageUploadProbeBackend(): Promise<{
+  s3: S3Client;
+  bucket: string;
+  backend: ImageUploadBackend;
+}> {
+  const { bucket, backend } = await getImageUploadBackend();
+  return { s3: getB2ImageProbeS3Client(), bucket, backend };
+}
+
+/**
  * Server-side: upload ALREADY-FETCHED image bytes into the SAME store the
  * browser-direct client upload path uses (the B2 image bucket resolved by
  * `getImageUploadBackend`, registered in storage-resolver) and return the UUID

--- a/src/utils/upload-settlement.ts
+++ b/src/utils/upload-settlement.ts
@@ -52,11 +52,26 @@ export function attachUploadSettlement(
     // reads as protection and stops the next person looking for the real one.
     let relayPending = false;
 
+    // 🔴 REACHABLE, unlike the latch described above — do not delete it as another one.
+    // `abort()` dispatches `abort` and THEN `loadend`, so once `loadend` reports a
+    // non-2xx as an error (below), a user cancel would be overwritten with a failure.
+    // `keeps a user cancel reported as aborted, not errored` fails without this.
+    let aborted = false;
+
     xhr.addEventListener('loadend', () => {
       // A relay is in flight and owns settlement.
       if (relayPending) return;
-      const success = xhr.readyState === 4 && xhr.status === 200;
+      // A cancel already settled this; see the flag's comment.
+      if (aborted) return;
+      // 🔴 2xx, not `=== 200`. A store answering 201/204 stored the object; treating
+      // that as failure is the same defect in the other direction.
+      const success = xhr.readyState === 4 && xhr.status >= 200 && xhr.status < 300;
+      // 🔴 A non-2xx `loadend` means we REACHED the backend and it refused us. Before
+      // this branch existed no callback fired at all, so the tracked file kept its
+      // `uploading` status forever — a refused upload that renders as still in flight,
+      // and which permanently disabled any submit gated on that status.
       if (success) callbacks.onSuccess();
+      else callbacks.onError();
       resolve({ kind: 'direct', success });
     });
 
@@ -83,6 +98,7 @@ export function attachUploadSettlement(
     });
 
     xhr.addEventListener('abort', () => {
+      aborted = true;
       callbacks.onAborted();
       reject(new Error('Upload canceled'));
     });

--- a/src/utils/upload-settlement.ts
+++ b/src/utils/upload-settlement.ts
@@ -56,6 +56,16 @@ export function attachUploadSettlement(
     // `abort()` dispatches `abort` and THEN `loadend`, so once `loadend` reports a
     // non-2xx as an error (below), a user cancel would be overwritten with a failure.
     // `keeps a user cancel reported as aborted, not errored` fails without this.
+    //
+    // ⚠ ONE HONEST QUALIFICATION, so this guard is not over-trusted: as of this change
+    // NOTHING IN PRODUCTION TRIGGERS IT. `useCFImageUpload` exposes `abort` on each
+    // tracked file, but no consumer of that hook calls it — checked by enumerating every
+    // non-test file that calls `useCFImageUpload` and grepping each for `abort`; the only
+    // hit is `IterativeImageEditor`'s `handleAbort`, which cancels a GENERATION, not an
+    // upload. The `abort` path is pre-existing and unwired. Keep the guard: it is
+    // reachable by this module's own contract, it is what the cancel test exercises, and
+    // wiring a cancel button is a UI change away from making it live. But do not read its
+    // presence as evidence that cancel is a supported flow today.
     let aborted = false;
 
     xhr.addEventListener('loadend', () => {


### PR DESCRIPTION
> **Corrected after review (see the PR comment for the full list).** Three claims in the
> first version of this body were wrong or under-stated and have been fixed here and in the
> code: the server probe does **not** cover every `Image` row; a non-zero `present` count is
> **not** a sufficient positive control on its own (the missing half has now been measured);
> and the consumer count was **24**, derived from a literal grep that could not see aliased
> calls — it is re-derived below.

## The defect

An `Image` row is written from client-supplied JSON. The media key (`Image.url`) arrives over the wire and is never checked against storage, so a key whose object never landed produces a complete, healthy-looking row whose media 404s forever. There is no repair path — nothing later re-derives the bytes.

The dominant producer is `useCFImageUpload`. **XHR's `error` event is network-only**, so a PUT that reaches the store and is *refused* — an expired presign, a malformed request, a briefly unavailable store — completes normally and lands on `loadend`, where the hook resolves and hands the caller a key with nothing behind it. In a sampled production window, 7 of 10 defective rows had a key an upload endpoint had signed 2.0–23.3 s before the row was written, with zero bytes ever stored.

## The shape I chose, and why

**Server half — an observe-only existence check in `createImage`.** Nothing branches on the verdict: rejecting an image creation is a *new* user-facing failure mode, and the honest way to size it is to let the `absent` rate accumulate against a real denominator first. There is deliberately **no env flag** either — an enforcement branch nobody exercises is an untested one, so enforcement is a separate change gated on this measurement.

### 🔴 What that half actually covers — corrected

The first version of this body and both code comments said *"every `Image` row in the app goes through `createImage`"*, and used that to justify the whole approach. **That is false.** `createImage` is the widest single funnel — post images, model-version and collection paths, comics, cover images, thumbnails — and it reaches every session regardless of which bundle it loaded, which a client-side fix cannot. But five write paths reach the `Image` table without passing through it, so their rows are in neither the numerator nor the denominator of anything this emits:

| bypass | write |
|---|---|
| `article.service.ts` `linkArticleContentImages` | `tx.image.createManyAndReturn` |
| `image.service.ts` `createEntityImages` | `dbClient.image.createMany` |
| `image.service.ts` `updateEntityImages` | `dbClient.image.createMany` |
| `blocks/app-listing-assets.service.ts` | `dbWrite.image.create` |
| `pages/api/admin/temp/migrate-article-images.ts` | `tx.image.createManyAndReturn` (one-off admin backfill) |

**The article path is the highest-risk of those, because it is fed by the exact hook defect this PR describes.** `TipTap/EdgeMediaNode.tsx` and `libs/tiptap/extensions/CustomImage.tsx` write the upload's key into article content off a promise that resolves even when the PUT was refused; `linkArticleContentImages` then materialises that content into rows — unprobed.

**Extending the probe to it is a separate change, for a structural reason.** `linkArticleContentImages` does its `createManyAndReturn` *inside* a `dbWrite.$transaction` callback, and this repo has a lint rule (`local-rules/no-io-in-transaction`) whose whole purpose is to keep network IO out of that callback, because it burns the transaction's timeout budget. Adding a HEAD there means restructuring the transaction first — not adding an argument.

**I am not replacing the old justification with a better-sounding one.** Both halves of this change are partial — the client half only reaches sessions on the new bundle, this half only reaches this funnel — and **nothing here establishes which of the two leaves more rows uncovered.** The reason the server half ships first is that it is the one that does not depend on bundle rollout, not that it is complete.

**Client half — partial, and the partiality is the decision.** The `loadend` branch updated nothing on a refused PUT, so the tracked file asserted `uploading` forever. That is a second, independent bug: `ImageUpload` renders `status === 'error'` (a badge it never got to show) and `ChallengeSubmitModal` both renders it *and* gates its submit on `status === 'uploading'`, so a refused PUT there wedges the submit with a spinner that can never clear. This PR fixes that — a pure status-reporting fix with **no change to the promise contract**, so no consumer can break.

**The promise still resolves on a refused PUT, and that is deliberate.** Making it reject is the change that stops callers persisting a key with nothing behind it, and it is *not* a one-line change.

### Consumer audit — why the reject is not in this PR

🔴 **The "24 call sites" in the first version of this body was wrong.** It came from a literal `uploadToCF(` grep, which sees only the sites whose local binding is *named* `uploadToCF` and is blind to aliased destructures and to sites that hand the function on as a value. Re-derived:

**Method** (reproducible): enumerate every non-test file under `src/**` that mentions `uploadToCF`; for each, collect the local binding names introduced by the destructure, *including aliases* (`const { uploadToCF: uploadEnhanceToCF } = useCFImageUpload()` — there are **7** such alias sites); then per file match `<name>(` for invocations and bare `<name>` for value handoffs. Classify each invocation by walking the brace stack for an enclosing `try{}catch` (a `try{}finally` does **not** count — two comics sites are exactly that), plus a chained `.catch(` found by balanced-paren chain walking, plus `await`/`return`. Then hand-read the caller frame of every site the walk did *not* put in `caught`, because a lexical walk cannot see a rejection caught one frame up.

That last step mattered twice, and both were instrument defects rather than code findings: a first pass counted `try{}finally` as catching (2 false *caught*), and a `[^;]*` chain regex stopped at the first `;` inside a `.then` body and so could not see the trailing `.catch` on the two TipTap sites (2 false *floating*).

**42 call sites: 32 direct invocations + 10 handoffs.**

| direct invocation, by how a rejection would land | count |
|---|---|
| **Caught** (enclosing `try`/`catch`, chained `.catch`, or caught one frame up) | 18 |
| **Uncaught, awaited** — unhandled rejection, silent no-op or stuck UI | 10 |
| **Uncaught inside `Promise.all`** (`ImageUpload.tsx:118`) | 1 |
| **Floating** (fire-and-forget, no `.catch`) | 3 |

| handoff — the function passed as a value | count | rejection handling |
|---|---|---|
| `fetchAndUploadGeneratorImage(url, base, uploadFn)` | 5 | all 5 wrapped in `try`/`catch` by their callers |
| `openGeneratorImagePicker({ uploadFn })` | 5 | caught inside the helper (`Promise.allSettled` + `try`/`catch`) |

So **14 of the 32 direct sites do not catch**, and all 10 handoffs do. **The correction does not invert the scoping decision** — the sites the old grep missed are mostly *uncaught-awaited*, and the handoff surface it also missed is uniformly caught. The blocker is unchanged and is the batch case: `ImageUpload.tsx` awaits `uploadToCF` inside an uncaught `Promise.all`, so one rejection aborts the whole batch — including files that uploaded fine — and their entries keep their local `blob:` URLs, which the `useEffect` then hands to `onChange` **as the persisted image values**. That is data corruption, not a no-op, in the highest-traffic upload component.

So the reject needs its own PR with the consumer work attached. Given an earlier complete version of this arc was closed as too extensive for the root cause, splitting there rather than growing this one is the deliberate call.

## Files touched

| file | why |
|---|---|
| `src/server/utils/created-image-media-probe.ts` | **new** — the probe. Four-valued verdict (`present` / `absent` / `unknown` / `not-applicable`), never throws, bounded by a 2 s abort, bucket resolved through `getImageUploadBackend()` so it asks the store the key was actually minted into. |
| `src/server/utils/__tests__/created-image-media-probe.test.ts` | **new** — 25 cases over the predicate, all four verdicts, and the delivered timeout budget. |
| `src/server/services/image.service.ts` | the call site: probe, log, continue. Mostly rationale — including the bypass list, the measured 404 fact, the loop cost, and this log's removal condition. |
| `src/server/services/__tests__/create-image-media-verify.test.ts` | **new** — the seam: one line per call whatever the verdict, url present/omitted by verdict, probe ordered before the write, and the row still created on `absent`. |
| `src/hooks/useCFImageUpload.tsx` | mark the tracked file errored on a refused PUT; widen the success test to 2xx; guard `loadend` so it cannot overwrite `aborted` with `error`. |
| `src/hooks/__tests__/useCFImageUpload.test.ts` | **new** — drives a fake XHR through every terminal sequence the spec mandates. |
| `src/server/flipt/__tests__/flipt-eval-context.test.ts` | ledger line pins move by 1 for the single new import. Mechanical. |

## Reading the measurement

The log is `create-image-media-verify`, one line per `createImage` call.

🔴 **`present` is the positive control — do not read the `absent` count without it.** A probe that can never answer emits zero `absent` verdicts, and "zero absent" is exactly what a clean result looks like. Backend resolution throws without credentials; both that and an abort land on `unknown`, and both look clean. So: require a non-zero `present` count, check that `unknown` is a small share of `present + absent + unknown`, and only then read the `absent` rate against the total line count.

🔴 **But `present` alone is NOT sufficient, and the first version of this body said it was.** `present` proves the credential can read an object that *exists*; it does not prove that a key which does **not** exist comes back as a 404 rather than a 403. `isNotFoundError` in `src/utils/s3-utils.ts` accepts only `NotFound`, `NoSuchKey` and a 404 status — so under a 403-on-missing credential every real defect would route to `unknown`, `absent` would sit at zero, and the documented control above would still read healthy.

**That half was measured rather than reasoned about.** On 2026-09-08, HeadObject was issued against the production image bucket with the production upload credential:

- a key that does **not** exist → `name=NotFound`, `$metadata.httpStatusCode=404` (no `Code`);
- a key that **does** exist → success with a non-zero `ContentLength` (the positive control).

So `absent` is reachable and the counter is not structurally pinned at zero. 🔴 **That measurement is contingent on the credential it was taken with** — a key rotation, a permissions change, or a move to a different bucket can reintroduce the hazard silently. The symptom is `absent` going to zero while `present` stays healthy; if you see that shape, re-take the measurement before concluding the defect is gone.

Settle any individual `absent` by taking its logged key and HEADing the store by hand — which is what the `url` field is for. `url` is logged only for a probed verdict, where the predicate has already established it is a 36-character uuid. `not-applicable` is by definition the arbitrary caller-supplied strings that failed that predicate, so those are omitted rather than shipped to the log sink.

### 🔴 When this log comes out

It is unsampled — one line per `createImage` call — which is the only shape that gives `absent` a denominator, and also the reason it must not live here indefinitely.

**Closing condition:** a merged PR that reads the `present` / `absent` / `unknown` counts for `create-image-media-verify`, quotes those three numbers in its body, and then either (a) adds the enforcement branch this measurement exists to size, or (b) deletes this call outright because the rate does not justify one. Either way that PR removes or samples down the `logToAxiom`.

**Mechanical check that it is closed:** the string `create-image-media-verify` no longer appears in `src/server/services/image.service.ts`.

## Verification

Every guard was watched fail before it passed. 12 mutants, each killed by the specific test for that guard, with that test's own assertion:

| mutation | test that failed | message |
|---|---|---|
| restore the original `loadend` branch | 6 hook tests | `expected [ 'uploading' ] to deeply equal [ 'error' ]` |
| remove the `loadend` terminal guard | canceled-upload test | `expected [ 'error' ] to deeply equal [ 'aborted' ]` |
| narrow 2xx back to `=== 200` | 201 / 204 tests | `expected [ 'error' ] to deeply equal [ 'success' ]` |
| drop the zero-length check | zero-length test | `expected 'present' to be 'absent'` |
| `size === 0` → `!size` | `size: null` test | `expected 'absent' to be 'present'` |
| catch returns `absent` | both fail-open tests | `expected 'absent' to be 'unknown'` |
| widen the predicate to any string | not-applicable test | `expected 'absent' to be 'not-applicable'` |
| move backend resolution outside the try | backend-unresolvable test | `promise rejected "Error: no credentials" instead of resolving` |
| log only on an `absent` verdict | 5 seam tests | `expected [] to have a length of 1` |
| log `url` unconditionally | not-applicable url test | `expected 'some-file…png' to be null` |
| throw on `absent` | 3 seam tests | `promise rejected "Error: media absent" instead of resolving` |
| relocate the probe below the write | ordering test | `expected 42 to be less than 41` |

🔴 **One of those twelve was added this round, because the timeout budget was pinned as a constant rather than as behaviour.** The old tests asserted that `CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS === 2000` and that *an* `AbortSignal` was passed — neither of which can see a probe that declares a 2 s budget and then bounds the request with something else. Measured: mutating the call to `AbortSignal.timeout(600000)` left **all 24 probe tests green, rc 0** — a 10-minute deadline on a user-facing mutation, invisible.

The new test (`hands the store a signal carrying THAT budget, not merely some signal`) spies on `AbortSignal.timeout` and asserts the delivered value against a **literal**, so a mutant that moves the constant *and* the call site together still fails. Both directions were watched go red:

| mutant | result |
|---|---|
| `AbortSignal.timeout(CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS)` → `AbortSignal.timeout(600000)` | `1 failed \| 24 passed (25)` — only the new test, `AssertionError: expected 600000 to be 2000 // Object.is equality` at `created-image-media-probe.test.ts:160` |
| the constant itself `2000` → `600000` | `2 failed \| 23 passed (25)` — the new test **and** the pre-existing constant test, same message |
| unmutated | `25 passed (25)` |

- `pnpm typecheck` — **0 type errors in 152 s** (heap cap 8192 MB).
- `pnpm vitest run --project unit` — **1677 files, 38,642 passed**, 33 skipped, **3 failed**. All 3 are in `eventloop-watchdog.capture.test.ts` (`starvation classifier`) and `moderation.instrumentation.test.ts` — timing tests that race real wall-clock deadlines. 🔴 **Confirmed pre-existing and load-sensitive, not caused by this change, by control rather than by assertion:** a *different* test in that describe block fails on each run, and running the file at the branch head with all six of my edits reverted failed **on both control runs, with two different tests**. `moderation.instrumentation.test.ts` passes in isolation. The four test files this PR touches: **56 passed (56)**.
- `prettier --check` on all 6 changed source files — clean. Negative control: an added `const   x   =    1` made it report `[warn] src/hooks/useCFImageUpload.tsx`, so the check does go red on these paths.
- `eslint` on all 6 files — my new files are clean; the 3 errors and 14 warnings reported all sit in pre-existing untouched regions of `image.service.ts` (lines 211, 4052, 5657) and `useCFImageUpload.tsx:234`.

### 🔴 CI is only PARTIALLY reporting on this head, and the reason is a conflict with `main`

At the current head, `gh pr checks` reports **7 checks, all `SUCCESS`** (stable across two reads):
the five `preview / *` statuses plus `tekton / fixture-bootstrap` and `tekton / typecheck`.
The previous head also carried **13 GitHub-Actions check-runs** (`App unit tests + typecheck`,
`ESLint + Prettier`, the four `Unit tests (n)` shards, `Package unit tests`, `Geometry tests`,
`Schema drift gate`, `event-engine-common pin`, both `Windows dev-env` jobs, and a skipped
`Typecheck`). **Those 13 have not run on this head, and will not until the conflict below is
resolved** — all four workflows are `pull_request`-triggered, and GitHub cannot build the merge
ref for an unmergeable PR, so no event dispatches. So this is **not** a green CI claim: it is
7 green and 13 unrun.

**The conflict is pre-existing, not introduced by this round.** `git merge-tree --write-tree`
against `origin/main` conflicts at the *previous* head as well as this one, in the same single
file — `src/hooks/useCFImageUpload.tsx`, against `44ff54d2d9` (#4573, "relay an image upload
through our own origin when the direct PUT cannot resolve the storage host"), which landed on
`main` and edits the same upload path this PR does.

I deliberately did **not** resolve it: #4573's origin-relay change and this PR's `loadend`
rewrite touch the same terminal-event handling, so merging them is a semantic call about which
statuses a relayed PUT should report — not a mechanical one, and not something to fold silently
into a correction round.

## Deliberately left out

- **The reject in `uploadToCF`** — see the consumer audit above.
- **Extending the probe to the five bypass paths**, above all `linkArticleContentImages`. That one is blocked on the `no-io-in-transaction` constraint, not on effort.
- **An enforcement flag.** Observe-only is enforced by construction, not by a default-off branch.
- **Consolidating the media-key predicate.** #4490 is adding an identical `isProbeableMediaKey` to `@civitai/shared`; this repo forbids stacked PRs, so importing it here would base this change on that unmerged branch. The duplicate is documented at the declaration and must be consolidated by whichever lands second. Closing condition is mechanical: `created-image-media-probe.ts` no longer declares `MEDIA_KEY_RE`.
- **Browser-project tests were not run locally** (Playwright browsers are not installed in my worktree). All 9 `.browser.test.tsx` files that touch this hook `vi.mock` it wholesale, so they stub its internals entirely and cannot be affected — but that is reasoning, not a run. CI covers it.

## Overlap with #4490

Both PRs touch `image.service.ts` and both shift the flipt-eval ledger. The code regions are far apart — #4490 is in `resolveIngestionError` (~line 8060+) and its import edit is at the s3-utils import; mine is in `createImage` (~line 6100) with its import ~20 lines away — so a textual conflict is unlikely, but **whichever merges second must re-run the flipt-eval gate and take the line numbers it prints.** Both are based directly on `main`; neither is stacked.

*(The two claims about #4490's own contents in that paragraph are carried over from the first version of this body and were **not** re-verified this round — I deliberately did not read that branch, since nothing here may be based on it. Treat them as approximate. What I did verify: this round's edits all sit **below** the four ledger-pinned lines, so the gate is unchanged and still green — 12 passed.)*

## Cost, and two measurement caveats a reader should know

**One HEAD per `createImage` call, bounded at 2 s per network attempt.** Most call sites are single-image (a post image, a cover, a block upload, a thumbnail), where this is one bounded round-trip on a mutation that already does several.

🔴 **Two `comics.router.ts` procedures call `createImage` once per input item**, and the first version of this body named only one of them:

| procedure | loop | cap |
|---|---|---|
| `bulkCreatePanels` | `for (let i = 0; i < input.panels.length; i++)` | `panels` `.max(20)` |
| `addReferenceImages` | `for (const img of input.images)` | `images` `.max(10)` |

Both are sequential, so they add up to 20 and up to 10 sequential HEADs respectively.

🔴 **And the 2 s bound is per-attempt, not wall-clock — so the degraded case is bigger than 20 × 2 s.** As `src/utils/s3-utils.ts` records on `checkFileExists` and `headObject`, the signal is shared by every retry attempt but the SDK sleeps *between* attempts on a plain, non-abort-aware timer: a deadline landing mid-backoff lets that sleep run to completion and only the next attempt short-circuits. Worst case per call is therefore the budget **plus one backoff**. `getB2ImageS3Client` sets neither `maxAttempts` nor a request-handler timeout, so the backoff length is whatever the SDK default schedule produces — s3-utils records one measurement against the installed SDK, a 300 ms budget with a ~5 s backoff in flight returning in ~4.7 s. I have not measured this probe's own degraded wall time, so I am not quoting a total; what I will say is that against a degraded store a full 20-panel import adds twenty of those, not forty seconds.

The reason I judged it acceptable rather than restructuring: both loops are *already* N sequential IO round-trips per item — a DB write plus an ingestion call — so this is a proportional addition to an existing sequential-IO path rather than a new failure class, and it is abort-bounded where the existing steps are not. But "proportional" is a claim about shape, not about the absolute number, and the absolute number stays unbounded until `getB2ImageS3Client` sets a `maxAttempts`. If a reviewer disagrees, the cheap fix is to stop awaiting the probe (nothing branches on the verdict) — I kept it awaited so the verdict describes the store's state *at the moment the row is written*, which is the measurement enforcement would later act on.

🔴 **Cover images are a blind spot in this log, and their `absent` count will read as zero for the wrong reason.** `resolveCoverImageId` already runs an *enforcing* existence check immediately before calling `createImage`, so a definitively-absent cover is rejected before it ever reaches this probe. Cover-image defects therefore cannot appear here — that zero is a pre-filter, not evidence. That path also now does two HEADs for the same key; harmless (both bounded, both fail-open) but real. Consolidating the two is a natural follow-up once the shared predicate lands.
