### PR TITLE
fix(moderator): show active buzz-bought membership over lapsed paid row

### DIFF
--- a/apps/moderator/src/lib/server/__tests__/user-lookup-subscription.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/user-lookup-subscription.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Which CustomerSubscription row the User Lookup panel speaks for when a user holds several.
+ *
+ * The bug this guards: `getSubscription` returned the hardcoded `yellow` row regardless of status, so a
+ * `canceled` paid row hid an `active` buzz-bought one and the moderator read "no membership" for a user
+ * who has one. The rows are canned and the selection runs in JS, so these assert the ordering itself —
+ * the whole behaviour — not the SQL.
+ */
+
+const rows = vi.hoisted(() => [] as unknown[]);
+
+vi.mock('$lib/server/db', () => {
+  // Fluent builder ending in `.execute()`, which resolves whatever the current test staged in `rows`.
+  const builder: Record<string, unknown> = {};
+  for (const method of ['selectFrom', 'leftJoin', 'select', 'where', 'orderBy']) {
+    builder[method] = () => builder;
+  }
+  builder.execute = async () => rows;
+  return { dbRead: builder, dbWrite: builder };
+});
+
+const { getSubscription } = await import('../user-lookup.service');
+
+const NOW = new Date('2026-09-07T00:00:00Z');
+const future = new Date('2026-09-26T00:00:00Z');
+const past = new Date('2026-07-25T00:00:00Z');
+
+const row = (over: Record<string, unknown>) => ({
+  productName: null,
+  provider: null,
+  status: 'active',
+  buzzType: 'yellow',
+  cancelAtPeriodEnd: null,
+  canceledAt: null,
+  currentPeriodEnd: future,
+  interval: null,
+  unitAmount: null,
+  currency: null,
+  ...over,
+});
+
+const stage = (next: unknown[]) => {
+  rows.length = 0;
+  rows.push(...next);
+};
+
+describe('user lookup — which subscription row the panel shows', () => {
+  it('returns null when the user has no subscription rows', async () => {
+    stage([]);
+    expect(await getSubscription(1, NOW)).toBeNull();
+  });
+
+  it('prefers an active buzz-bought row over a canceled paid row (the reported repro)', async () => {
+    stage([
+      row({ buzzType: 'yellow', status: 'canceled', currentPeriodEnd: past }),
+      row({ buzzType: 'buzzPurchase', status: 'active', currentPeriodEnd: future }),
+    ]);
+    const picked = await getSubscription(309009, NOW);
+    expect(picked?.buzzType).toBe('buzzPurchase');
+  });
+
+  it('keeps a live paid row ahead of a longer-dated referral grant (the original guard)', async () => {
+    const later = new Date('2027-01-01T00:00:00Z');
+    stage([
+      row({ buzzType: 'referral', status: 'active', currentPeriodEnd: later }),
+      row({ buzzType: 'yellow', status: 'active', currentPeriodEnd: future }),
+    ]);
+    const picked = await getSubscription(1, NOW);
+    expect(picked?.buzzType).toBe('yellow');
+  });
+
+  it('falls back to a lapsed paid row when nothing is live', async () => {
+    stage([
+      row({ buzzType: 'yellow', status: 'canceled', currentPeriodEnd: past }),
+      row({ buzzType: 'referral', status: 'canceled', currentPeriodEnd: past }),
+    ]);
+    const picked = await getSubscription(1, NOW);
+    expect(picked?.buzzType).toBe('yellow');
+  });
+
+  it('does not let a past_due paid row hide an active variant', async () => {
+    stage([
+      row({ buzzType: 'yellow', status: 'past_due', currentPeriodEnd: future }),
+      row({ buzzType: 'buzzPurchase', status: 'active', currentPeriodEnd: future }),
+    ]);
+    const picked = await getSubscription(1, NOW);
+    expect(picked?.buzzType).toBe('buzzPurchase');
+  });
+
+  it('still shows a past_due paid row when it is the only one', async () => {
+    stage([row({ buzzType: 'yellow', status: 'past_due', currentPeriodEnd: future })]);
+    const picked = await getSubscription(1, NOW);
+    expect(picked?.buzzType).toBe('yellow');
+  });
+
+  it('treats a period-ended row as not live even when status is still active', async () => {
+    stage([
+      row({ buzzType: 'yellow', status: 'active', currentPeriodEnd: past }),
+      row({ buzzType: 'buzzPurchase', status: 'active', currentPeriodEnd: future }),
+    ]);
+    const picked = await getSubscription(1, NOW);
+    expect(picked?.buzzType).toBe('buzzPurchase');
+  });
+});

--- a/apps/moderator/src/lib/server/user-lookup.service.ts
+++ b/apps/moderator/src/lib/server/user-lookup.service.ts
@@ -769,46 +769,72 @@ export type UserSubscription = {
   currency: string | null;
 };
 
-// CustomerSubscription is unique on (userId, buzzType) — multiple rows per user are by design, and
-// referrals deliberately add a `referral` row that can outlast a paid one. Ordering by period end alone
-// would report the referral grant as the user's plan, so filter to the paid subscription the main app
-// treats as canonical and surface `buzzType` regardless.
-const PAID_BUZZ_TYPE = 'yellow';
+// CustomerSubscription is unique on (userId, buzzType) — multiple rows per user are by design. A paid
+// colour row and the two membership variants (`buzzPurchase`, `referral`) can coexist and disagree, so
+// the panel has to pick one to speak for. Source of truth for these two strings:
+// src/shared/utils/buzz-membership.ts (BUZZ_MEMBERSHIP_SUBSCRIPTION_TYPE) and referral.service.ts.
+const BUZZ_PURCHASE_TYPE = 'buzzPurchase';
+const REFERRAL_TYPE = 'referral';
 
-export async function getSubscription(userId: number): Promise<UserSubscription | null> {
-  const select = [
-    'p.name as productName',
-    'p.provider',
-    'cs.status',
-    'cs.buzzType',
-    'cs.cancelAtPeriodEnd',
-    'cs.canceledAt',
-    'cs.currentPeriodEnd',
-    // Retool's UserSubscriptionStatusAnnual was a second query for exactly this column. Annual vs
-    // monthly is what decides the amount on a refund or a chargeback, so it rides the one query.
-    'pr.interval',
-    'pr.unitAmount',
-    'pr.currency',
-  ] as const;
+// A `buzzType` that names a subscription KIND rather than a Buzz colour is a perks-only variant; every
+// other value is a paid/canonical membership row.
+const isCanonicalRow = (buzzType: string | null) =>
+  buzzType !== BUZZ_PURCHASE_TYPE && buzzType !== REFERRAL_TYPE;
 
-  const paid = await dbRead
+// Live = the statuses the main app counts as a real membership (subscriptions.service.ts uses
+// `['active','trialing']` and excludes past_due/unpaid as failed) AND the period has not ended — status
+// alone is not liveness, since a lapsed row keeps `status = 'active'` until something reconciles it. A
+// past_due/unpaid paid row must NOT outrank an active variant, or it re-hides a working membership.
+const LIVE_STATUSES = new Set(['active', 'trialing']);
+const isLiveRow = (row: UserSubscription, now: Date) =>
+  LIVE_STATUSES.has(row.status) && row.currentPeriodEnd != null && row.currentPeriodEnd > now;
+
+// Which of several coexisting rows the panel shows. NOT a product ruling on "is this user a member" —
+// that shared cross-surface precedence is ticket item 1, still awaiting a decision. This only orders the
+// display so an active membership is never hidden behind a lapsed one: a live paid row wins (keeping a
+// longer-dated referral grant from outranking it), then any live variant (the buzz-bought case the
+// panel used to drop), then a lapsed paid row, then whatever is most recent.
+function displayPriority(row: UserSubscription, now: Date) {
+  const live = isLiveRow(row, now);
+  const canonical = isCanonicalRow(row.buzzType);
+  if (live && canonical) return 3;
+  if (live) return 2;
+  if (canonical) return 1;
+  return 0;
+}
+
+export async function getSubscription(
+  userId: number,
+  now = new Date()
+): Promise<UserSubscription | null> {
+  const rows = (await dbRead
     .selectFrom('CustomerSubscription as cs')
     .leftJoin('Product as p', 'p.id', 'cs.productId')
     .leftJoin('Price as pr', 'pr.id', 'cs.priceId')
-    .select(select)
+    .select([
+      'p.name as productName',
+      'p.provider',
+      'cs.status',
+      'cs.buzzType',
+      'cs.cancelAtPeriodEnd',
+      'cs.canceledAt',
+      'cs.currentPeriodEnd',
+      // Retool's UserSubscriptionStatusAnnual was a second query for exactly this column. Annual vs
+      // monthly is what decides the amount on a refund or a chargeback, so it rides the one query.
+      'pr.interval',
+      'pr.unitAmount',
+      'pr.currency',
+    ])
     .where('cs.userId', '=', userId)
-    .where('cs.buzzType', '=', PAID_BUZZ_TYPE)
-    .executeTakeFirst();
-  if (paid) return paid as UserSubscription;
+    .execute()) as UserSubscription[];
 
-  // No paid row — show whatever they do have rather than nothing, with buzzType visible.
-  const other = await dbRead
-    .selectFrom('CustomerSubscription as cs')
-    .leftJoin('Product as p', 'p.id', 'cs.productId')
-    .leftJoin('Price as pr', 'pr.id', 'cs.priceId')
-    .select(select)
-    .where('cs.userId', '=', userId)
-    .orderBy('cs.currentPeriodEnd', 'desc')
-    .executeTakeFirst();
-  return (other as UserSubscription | undefined) ?? null;
+  if (rows.length === 0) return null;
+
+  return rows.reduce((best, row) => {
+    const byPriority = displayPriority(row, now) - displayPriority(best, now);
+    if (byPriority !== 0) return byPriority > 0 ? row : best;
+    return (row.currentPeriodEnd?.getTime() ?? 0) > (best.currentPeriodEnd?.getTime() ?? 0)
+      ? row
+      : best;
+  });
 }

--- a/apps/moderator/src/routes/retool/user-lookup/SubscriptionPanel.svelte
+++ b/apps/moderator/src/routes/retool/user-lookup/SubscriptionPanel.svelte
@@ -16,6 +16,13 @@
   {:else}
     <div class="flex flex-wrap items-baseline gap-x-2 text-sm">
       <span class="font-medium text-white">{subscription.productName ?? 'Unknown plan'}</span>
+      <!-- A perks-only tier (Buzz-bought or a referral grant) delivers none of the card tier's monthly
+           Buzz, badge or Creator Program access, so it must not read as an ordinary paid membership. -->
+      {#if subscription.buzzType === 'buzzPurchase'}
+        <Badge variant="outline">Buzz-bought</Badge>
+      {:else if subscription.buzzType === 'referral'}
+        <Badge variant="outline">Referral grant</Badge>
+      {/if}
       <!-- Annual against monthly is the fact a refund amount turns on, so it sits with the plan name
            rather than in the detail list below. -->
       {#if subscription.interval}


### PR DESCRIPTION
When a user holds multiple CustomerSubscription rows (paid, buzz-purchased, referral),
the panel was hardcoded to always show the paid row regardless of its status. This hid
active buzz-purchased memberships behind canceled paid rows, causing the moderator to
see "no membership" for users who had active perks.

Implement priority-based selection that prefers:
1. Live paid rows (status active/trialing, period not ended)
2. Live variant rows (buzzPurchase, referral)
3. Lapsed paid rows as fallback
4. Most recent row by period end

Add badges to distinguish non-canonical rows (Buzz-bought, Referral grant) from
paid memberships in the UI, clarifying that these variants deliver perks-only
benefits without the full tier economics.

Tests assert the row ordering itself, canned for repeatability.

Refs: 868m15k0z