### PR TITLE
fix(apps): stop /apps/build flashing the "first app" screen at authors who have apps

### DIFF
--- a/src/components/Apps/AppsBuildBody.browser.test.tsx
+++ b/src/components/Apps/AppsBuildBody.browser.test.tsx
@@ -1,0 +1,410 @@
+import { useEffect, useReducer } from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace import (NOT `typeof import('...')`, which
+// @typescript-eslint/consistent-type-imports rejects) so the spread below keeps the
+// real module's type.
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * `AppsBuildBody` — THE UNSETTLED WINDOW. (clawgate #530; closes audit finding F6 from
+ * civitai#4685, which recorded that this component had no rendered test in any tier.)
+ *
+ * 🔴 THE BUG THIS FILE IS THE REGRESSION TEST FOR. `blocks.getNavSummary` is client-only
+ * (tRPC runs `ssr: false`), and `resolveAppsBuildState` reads its two all-false booleans as
+ * `first-app`. So on `main` before this change EVERY author who has apps rendered state B —
+ * "Ship your first app" — on the server and on the first client paint, and only swapped to
+ * their workbench once the query landed. The wrong screen, briefly, on every visit.
+ *
+ * The analytics could not see it (`view` fires only when `settled`), which is exactly why
+ * it survived a four-round and a two-round audit ladder: nothing that was measured moved.
+ * It takes a RENDERED test, which is what this is.
+ *
+ * ── WHY THE MOCKS ARE SHAPED LIKE THIS ──────────────────────────────────────────
+ * `mocks.isFetched` and `mocks.navSummary` are the query's two observable outputs, driven
+ * independently on purpose: `isFetched` goes true on success OR error while `data` stays
+ * `undefined` forever on an error, and the component keys its wait on the FORMER. Driving
+ * them as one boolean would make the error cohort — the population most worth seeing —
+ * untestable, and it is a cohort this component has already been corrected about once.
+ *
+ * 🔴 THE `getNavSummary` MOCK HONOURS `enabled`, AND THAT IS LOAD-BEARING RATHER THAN
+ * FIDELITY FOR ITS OWN SAKE. A disabled query never runs, so React Query never sets
+ * `isFetched` on it. A mock that ignored `enabled` would return whatever `mocks.isFetched`
+ * says and the permanent-skeleton case below would be structurally unobservable — it would
+ * pass while production hung. (The sibling `AppsSubNav.hydration.browser.test.tsx`
+ * deliberately IGNORES `enabled` because its subject is the `useIsClient` deferral; the
+ * choice is per-suite, not a house style.)
+ */
+
+/** A summary for an author who HAS apps — the cohort the bug hit. */
+const SUMMARY_WITH_APPS = {
+  hasInstalls: false,
+  hasSubmissions: false,
+  hasApprovedApps: false,
+  isReviewer: false,
+  hasEditableApps: true,
+  hasPendingInvites: false,
+};
+
+/** The all-false summary — an author with genuinely nothing yet (real state B). */
+const EMPTY_SUMMARY = { ...SUMMARY_WITH_APPS, hasEditableApps: false };
+
+type TrackedAction = { type: string; details: { action: string; state: string } };
+
+const mocks = vi.hoisted(() => ({
+  isClient: true,
+  isFetched: false,
+  navSummary: undefined as undefined | Record<string, boolean>,
+  flags: { appBlocks: true, appBlocksAuthor: true } as Record<string, boolean>,
+  user: { id: 7, username: 'author', isModerator: false } as null | {
+    id: number;
+    username: string;
+    isModerator?: boolean;
+  },
+  tracked: [] as TrackedAction[],
+  /** What `enabled:` the component actually passed — asserted, not assumed. */
+  lastEnabled: undefined as undefined | boolean,
+}));
+
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => mocks.isClient }));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({ useFeatureFlags: () => mocks.flags }));
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => mocks.user }));
+
+vi.mock('~/components/TrackView/track.utils', () => ({
+  useTrackEvent: () => ({
+    trackAction: (payload: TrackedAction) => {
+      mocks.tracked.push(payload);
+      return Promise.resolve();
+    },
+  }),
+}));
+
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-mock):
+// a hand-written replacement silently breaks every importer the day '~/utils/trpc' grows an
+// export this factory omits — the whole FILE then fails to load with 0 tests collected and
+// no failing assertion.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    blocks: {
+      getNavSummary: {
+        useQuery: (_input: unknown, opts?: { enabled?: boolean }) => {
+          mocks.lastEnabled = opts?.enabled;
+          // A query that never ran never becomes `isFetched`. See the header.
+          if (opts?.enabled === false) return { data: undefined, isFetched: false };
+          return { data: mocks.navSummary, isFetched: mocks.isFetched };
+        },
+      },
+      withdrawPublishRequest: { useMutation: () => ({ mutate: () => undefined, isPending: false }) },
+    },
+    // `MyAppsBody` — mounted by the workbench state. Held in its loading branch; this
+    // suite is about WHICH screen renders, not about the table's contents.
+    appListings: {
+      listMine: { useQuery: () => ({ data: undefined, isLoading: true, error: null }) },
+      listMyOrphanedSubmissions: {
+        useQuery: () => ({ data: undefined, isLoading: true, error: null }),
+      },
+    },
+    useUtils: () => ({
+      appListings: {
+        listMine: { invalidate: () => undefined },
+        listMyOrphanedSubmissions: { invalidate: () => undefined },
+      },
+    }),
+  },
+}));
+
+const { AppsBuildBody } = await import('./AppsBuildBody');
+
+const SKELETON = 'apps-build-skeleton';
+const FIRST_APP = 'apps-build-first-app';
+const PITCH = 'apps-build-pitch';
+const WORKBENCH_CTA = 'apps-build-new-app';
+
+/**
+ * 🔴 RENDER BARRIER — required before every "renders nothing" assertion. `render()` commits
+ * through a React 18 concurrent root on a LATER task, so a synchronous absence assertion
+ * right after `renderWithProviders` reads an EMPTY container and passes whatever the
+ * component does. Render the sentinel alongside and await it first. (Same reasoning, and
+ * the same mutation-found hole, as `AppsSubNav.hydration.browser.test.tsx`.)
+ */
+const RENDER_BARRIER = 'render-barrier';
+const RenderBarrier = () => <div data-testid={RENDER_BARRIER} />;
+
+async function renderBody(node = <AppsBuildBody />) {
+  renderWithProviders(
+    <>
+      <RenderBarrier />
+      {node}
+    </>
+  );
+  await expect.element(page.getByTestId(RENDER_BARRIER)).toBeInTheDocument();
+}
+
+const seen = (testId: string) => page.getByTestId(testId).elements().length;
+
+beforeEach(() => {
+  mocks.isClient = true;
+  mocks.isFetched = false;
+  mocks.navSummary = undefined;
+  mocks.flags = { appBlocks: true, appBlocksAuthor: true };
+  mocks.user = { id: 7, username: 'author', isModerator: false };
+  mocks.tracked = [];
+  mocks.lastEnabled = undefined;
+});
+
+describe('AppsBuildBody — the unsettled window renders a skeleton, never state B', () => {
+  test('🔴 author, summary NOT yet fetched → skeleton, and NO "first app" content', async () => {
+    // The exact production shape: an author whose `getNavSummary` has not landed. On `main`
+    // this rendered state B; this is the assertion that is RED at the base commit.
+    await renderBody();
+
+    await expect.element(page.getByTestId(SKELETON)).toBeInTheDocument();
+    expect(seen(FIRST_APP), 'state-B content rendered during the unsettled window').toBe(0);
+    // Belt and braces on the COPY as well as the testid: a refactor that moved the
+    // `data-testid` off that block would otherwise silently defeat the line above.
+    expect(page.getByText('Ship your first app').elements()).toHaveLength(0);
+    expect(seen(WORKBENCH_CTA)).toBe(0);
+  });
+
+  test('the SERVER render (isClient=false) is the skeleton too, so first paint matches it', async () => {
+    // `useIsClient()` is false on the server AND on the first client paint. Both must
+    // produce the same output or hydration bails — the #418/#425 incident this page's
+    // deferral exists to avoid. Asserting the pre-mount render pins that the fix did not
+    // introduce a server/client split of its own.
+    mocks.isClient = false;
+    mocks.isFetched = true; // even with the query "landed", pre-mount must not use it
+    mocks.navSummary = { ...SUMMARY_WITH_APPS };
+    await renderBody();
+
+    await expect.element(page.getByTestId(SKELETON)).toBeInTheDocument();
+    expect(seen(FIRST_APP)).toBe(0);
+    expect(seen(WORKBENCH_CTA)).toBe(0);
+  });
+
+  test('settled WITH apps → the workbench, and no skeleton left behind', async () => {
+    mocks.isFetched = true;
+    mocks.navSummary = { ...SUMMARY_WITH_APPS };
+    await renderBody();
+
+    await expect.element(page.getByTestId(WORKBENCH_CTA)).toBeInTheDocument();
+    expect(seen(SKELETON)).toBe(0);
+    expect(seen(FIRST_APP)).toBe(0);
+  });
+
+  test('settled with NOTHING → state B really does render (the skeleton is not a permanent stand-in)', async () => {
+    // The positive control for every `seen(FIRST_APP)).toBe(0)` above: the same reader DOES
+    // observe state B when it is the settled answer. Without this the absences could be
+    // satisfied by a component that renders state B never, or by a query wired to nothing.
+    mocks.isFetched = true;
+    mocks.navSummary = { ...EMPTY_SUMMARY };
+    await renderBody();
+
+    await expect.element(page.getByTestId(FIRST_APP)).toBeInTheDocument();
+    await expect.element(page.getByText('Ship your first app')).toBeInTheDocument();
+    expect(seen(SKELETON)).toBe(0);
+  });
+
+  test('settled by an ERROR (isFetched true, data undefined) → state B, not a stuck skeleton', async () => {
+    // `isFetched`, not `data !== undefined`, is the wait's key — deliberately, so an author
+    // whose summary call FAILS still settles. Keyed on the data they would sit under the
+    // skeleton forever, and they are the cohort most worth not stranding.
+    mocks.isFetched = true;
+    mocks.navSummary = undefined;
+    await renderBody();
+
+    await expect.element(page.getByTestId(FIRST_APP)).toBeInTheDocument();
+    expect(seen(SKELETON)).toBe(0);
+  });
+});
+
+describe('AppsBuildBody — states that must NOT gain a loading frame', () => {
+  test('a NON-author gets the pitch immediately, with no skeleton, even pre-mount', async () => {
+    // State A is the only PUBLIC-facing and deliberately-indexable state. Putting a loading
+    // frame in front of it would put a skeleton in the SSR HTML a crawler reads.
+    mocks.flags = { appBlocks: true, appBlocksAuthor: false };
+    mocks.isClient = false;
+    mocks.isFetched = false;
+    await renderBody();
+
+    await expect.element(page.getByTestId(PITCH)).toBeInTheDocument();
+    expect(seen(SKELETON)).toBe(0);
+  });
+
+  test('logged out → the pitch, no skeleton', async () => {
+    mocks.user = null;
+    await renderBody();
+
+    await expect.element(page.getByTestId(PITCH)).toBeInTheDocument();
+    expect(seen(SKELETON)).toBe(0);
+  });
+
+  /**
+   * 🔴 THE PERMANENT-SKELETON HAZARD, PINNED. The PAGE gate is `hasAppsStoreAccess`
+   * (`appListings || appBlocks || appListingsPublicExternal`) while the summary query's
+   * `enabled` requires `appBlocks` — so an author holding `appListings` alone reaches this
+   * page with the query switched OFF. `isFetched` is then false forever, and a wait keyed on
+   * `isAuthor && !(isClient && isFetched)` would render the skeleton until they navigated
+   * away. The fix keys the wait on `enabled` instead; the all-false summary is that viewer's
+   * correct and final answer, so they settle on the first paint.
+   */
+  test('🔴 author whose summary query is DISABLED settles immediately — no permanent skeleton', async () => {
+    mocks.flags = { appBlocks: false, appListings: true, appBlocksAuthor: true };
+    mocks.isFetched = false;
+    mocks.navSummary = undefined;
+    await renderBody();
+
+    // The wiring this case depends on, asserted rather than assumed: if the component ever
+    // stopped disabling the query for this viewer, the test below would be about a different
+    // situation than the one its name claims.
+    expect(mocks.lastEnabled, 'the summary query should be disabled for this viewer').toBe(false);
+    await expect.element(page.getByTestId(FIRST_APP)).toBeInTheDocument();
+    expect(seen(SKELETON)).toBe(0);
+  });
+});
+
+/**
+ * The `view` analytics event, which #530 fenced explicitly: it must still fire exactly once
+ * per mount and only when settled. These drive the REAL `useEffect` + `viewed` ref — the
+ * thing F6 recorded as untested — through a real mount→settle transition.
+ */
+describe('AppsBuildBody — the view event is unchanged by the skeleton', () => {
+  /** Flips the query to "landed with apps" AFTER mount, i.e. a real settle. */
+  function SettleAfterMount() {
+    const [, force] = useReducer((n: number) => n + 1, 0);
+    useEffect(() => {
+      mocks.isFetched = true;
+      mocks.navSummary = { ...SUMMARY_WITH_APPS };
+      force();
+    }, []);
+    return <AppsBuildBody />;
+  }
+
+  test('no view is posted while the skeleton is up', async () => {
+    await renderBody();
+    await expect.element(page.getByTestId(SKELETON)).toBeInTheDocument();
+    expect(mocks.tracked).toEqual([]);
+  });
+
+  /**
+   * Watches `document.body` for a state-B block ever being ADDED, so a block that appeared
+   * for a single commit and was replaced is still caught — an assertion taken after the
+   * transition cannot see it.
+   *
+   * 🔴 IT WATCHES `attributes`, NOT JUST `childList`, AND WITHOUT THAT IT MEASURES NOTHING.
+   * Every branch of `AppsBuildBody` returns a Mantine `Stack` — the same `<div>` at the same
+   * position — so React RECONCILES IN PLACE and the state-B block is never an ADDED NODE. A
+   * childList-only watcher sees the container appear empty and then a `data-testid` quietly
+   * change; it reports a clean zero over a first paint that really did render state B. That
+   * is not reasoning, it is the measured record from this exact fixture at the base commit:
+   *   add DIV#__vitest_1__ inner-first-app=false
+   *   …
+   *   attr data-testid old=apps-build-first-app new=null      ← the only trace B leaves
+   * So a sighting is any node that BECAME state B or STOPPED BEING it, plus the childList
+   * case for completeness.
+   *
+   * 🔴 AND `takeRecords()` IS PROCESSED, NOT DRAINED. The first version ended with
+   * `observer.takeRecords().forEach(() => undefined)`, which EMPTIES the queue and throws the
+   * records away — the callback is a microtask, so anything still queued when the awaited
+   * assertion resolved was discarded unread.
+   *
+   * Both defects were found the same way and it is the only reason either is not still here:
+   * the test was run against the BASE commit and did not go red. A watcher whose zero you
+   * have not watched become non-zero on known-bad code is a claim about the watcher.
+   */
+  function watchForStateB() {
+    const sightings: string[] = [];
+    const consume = (records: MutationRecord[]) => {
+      for (const record of records) {
+        if (record.type === 'attributes') {
+          const now = (record.target as HTMLElement).getAttribute('data-testid');
+          if (now === FIRST_APP) sightings.push('became state B');
+          if (record.oldValue === FIRST_APP) sightings.push('stopped being state B');
+          continue;
+        }
+        for (const node of Array.from(record.addedNodes)) {
+          if (!(node instanceof HTMLElement)) continue;
+          const hit = node.matches(`[data-testid="${FIRST_APP}"]`)
+            ? node
+            : node.querySelector(`[data-testid="${FIRST_APP}"]`);
+          if (hit) sightings.push(`added: ${hit.textContent?.slice(0, 40) ?? ''}`);
+        }
+      }
+    };
+    const observer = new MutationObserver(consume);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeOldValue: true,
+      attributeFilter: ['data-testid'],
+    });
+    return {
+      sightings,
+      /** Flush anything the microtask callback has not delivered yet, then stop. */
+      stop: () => {
+        consume(observer.takeRecords());
+        observer.disconnect();
+      },
+    };
+  }
+
+  test('🔴 mount → settle posts exactly ONE view, for the SETTLED state, and state B is never painted', async () => {
+    const watcher = watchForStateB();
+    try {
+      await renderBody(<SettleAfterMount />);
+      await expect.element(page.getByTestId(WORKBENCH_CTA)).toBeInTheDocument();
+    } finally {
+      watcher.stop();
+    }
+
+    expect(watcher.sightings, 'state B was painted during the mount→settle transition').toEqual(
+      []
+    );
+    expect(mocks.tracked).toEqual([
+      { type: 'AppsBuild_Action', details: { action: 'view', state: 'workbench' } },
+    ]);
+  });
+
+  /**
+   * 🔴 THE CONTROL DRIVES A REAL state-B → workbench TRANSITION, NOT MERELY A PAGE THAT
+   * RENDERS STATE B, AND THE DIFFERENCE IS THE POINT. The assertion above is an ABSENCE, so
+   * its worth is exactly the watcher's ability to observe the trace it is denying — and that
+   * trace is an ATTRIBUTE change on an in-place-reconciled `<div>`. A control that only
+   * mounted state B would be satisfied by the watcher's `childList` branch alone, so the
+   * attribute branch could be broken, the test above could go vacuously green, and this
+   * control would keep passing and vouch for it. Same watcher, same swap, opposite verdict.
+   */
+  test('POSITIVE CONTROL: the watcher sees a state-B → workbench swap (the trace the test above denies)', async () => {
+    mocks.isFetched = true;
+    mocks.navSummary = { ...EMPTY_SUMMARY };
+
+    const watcher = watchForStateB();
+    try {
+      // Awaited, unlike the fire-and-forget renders elsewhere in this file: `rerender` is
+      // only reachable through the resolved result, and an un-awaited render swallows a
+      // mount crash into an empty container (see `renderWithProviders`).
+      const { rerender } = await renderWithProviders(<AppsBuildBody />);
+      await expect.element(page.getByTestId(FIRST_APP)).toBeInTheDocument();
+      mocks.navSummary = { ...SUMMARY_WITH_APPS };
+      await rerender(<AppsBuildBody />);
+      await expect.element(page.getByTestId(WORKBENCH_CTA)).toBeInTheDocument();
+    } finally {
+      watcher.stop();
+    }
+
+    expect(watcher.sightings).toContain('stopped being state B');
+  });
+
+  test('a settled NON-author posts one view for `pitch`', async () => {
+    mocks.flags = { appBlocks: true, appBlocksAuthor: false };
+    await renderBody();
+
+    await expect.element(page.getByTestId(PITCH)).toBeInTheDocument();
+    expect(mocks.tracked).toEqual([
+      { type: 'AppsBuild_Action', details: { action: 'view', state: 'pitch' } },
+    ]);
+  });
+});

--- a/src/components/Apps/AppsBuildBody.browser.test.tsx
+++ b/src/components/Apps/AppsBuildBody.browser.test.tsx
@@ -97,7 +97,9 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
           return { data: mocks.navSummary, isFetched: mocks.isFetched };
         },
       },
-      withdrawPublishRequest: { useMutation: () => ({ mutate: () => undefined, isPending: false }) },
+      withdrawPublishRequest: {
+        useMutation: () => ({ mutate: () => undefined, isPending: false }),
+      },
     },
     // `MyAppsBody` — mounted by the workbench state. Held in its loading branch; this
     // suite is about WHICH screen renders, not about the table's contents.
@@ -360,9 +362,7 @@ describe('AppsBuildBody — the view event is unchanged by the skeleton', () => 
       watcher.stop();
     }
 
-    expect(watcher.sightings, 'state B was painted during the mount→settle transition').toEqual(
-      []
-    );
+    expect(watcher.sightings, 'state B was painted during the mount→settle transition').toEqual([]);
     expect(mocks.tracked).toEqual([
       { type: 'AppsBuild_Action', details: { action: 'view', state: 'workbench' } },
     ]);

--- a/src/components/Apps/AppsBuildBody.tsx
+++ b/src/components/Apps/AppsBuildBody.tsx
@@ -20,7 +20,11 @@ import { CopyableCommand } from '~/components/Apps/CopyableCommand';
 import { EMBEDDED_KIND_LABEL, STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import { GetStartedBody } from '~/components/Apps/GetStartedBody';
 import { MyAppsBody } from '~/components/Apps/MyAppsBody';
-import { resolveAppsBuildState, type AppsBuildState } from '~/components/Apps/appsBuildState';
+import {
+  resolveAppsBuildSettled,
+  resolveAppsBuildState,
+  type AppsBuildState,
+} from '~/components/Apps/appsBuildState';
 import { useTrackEvent } from '~/components/TrackView/track.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -79,10 +83,28 @@ export function AppsBuildBody() {
   // 🔴 THE `enabled` GATE MIRRORS THE PROCEDURE, NOT THE PAGE — the same rule `AppsSubNav`
   // documents. `blocks.getNavSummary` is `protectedProcedure.use(enforceAppBlocksFlag)`,
   // so without `appBlocks` or without a session it short-circuits to an all-false summary
-  // having read nothing; asking anyway would buy a guaranteed round-trip to a guaranteed
-  // answer. All-false is also the CORRECT summary for such a viewer: the workbench they
-  // would resolve to reads `appListings.listMine`, and its Withdraw action carries
-  // `enforceAppBlocksFlag` too.
+  // having read nothing (`enforceAppBlocksFlag` returns `next({ _appBlocksDisabled: true })`
+  // for a QUERY rather than throwing); asking anyway would buy a guaranteed round-trip to a
+  // guaranteed answer. That is the whole justification, and it is about this query only.
+  //
+  // 🔴 THE SECOND HALF OF THIS COMMENT WAS FALSE AND IS RETRACTED — DO NOT RE-DERIVE IT. It
+  // read: "All-false is also the CORRECT summary for such a viewer: the workbench they would
+  // resolve to reads `appListings.listMine`, and its Withdraw action carries
+  // `enforceAppBlocksFlag` too." The Withdraw half is right; the `listMine` half is not.
+  // `appListings.listMine` is `appDeveloperProcedure` = `protectedProcedure.use(
+  // hasAppBlocksAuthor)` (`~/server/trpc`), so it gates on **`appBlocksAuthor`**, not
+  // `appBlocks` — and every viewer in this cohort holds `appBlocksAuthor` by construction,
+  // because that is what made `isAuthor` true. So `listMine` SUCCEEDS for them and their
+  // workbench would have rendered.
+  //
+  // 🔴 SO THE HONEST STATEMENT IS NARROWER: all-false is the only answer this query CAN give
+  // them, not a true description of their account. A viewer holding `app-listings` but not
+  // `app-blocks-enabled` reaches this page (the page gate is `hasAppsStoreAccess`, a
+  // three-flag OR) and is shown "Ship your first app" PERMANENTLY even when they own apps.
+  // That is PRE-EXISTING — it predates the skeleton and this change does not alter that
+  // render — and fixing it means widening what the SUMMARY can answer, which is a server
+  // change to a `blocks.*` procedure and deliberately out of scope here. Recorded rather
+  // than papered over, because the retracted sentence above is what made it look handled.
   // 🔴 HOISTED OUT OF THE OPTIONS OBJECT SO THE WAIT CAN READ IT, AND THAT IS THE WHOLE
   // REASON IT IS A NAMED CONST. `isFetched` NEVER goes true for a query that never ran, so
   // "wait until fetched" would wait FOREVER for a viewer whose `enabled` is false — see
@@ -134,14 +156,23 @@ export function AppsBuildBody() {
   // author holding `appListings` alone reaches this page with the query switched off. Under
   // the old spelling they posted no `view` at all — the same silently-truncated denominator
   // the paragraph above rejects for the error cohort — and once `settled` also gates the
-  // RENDER they would have sat under the skeleton permanently. The all-false summary is
-  // that viewer's CORRECT and FINAL answer (see the `enabled` note above), so they settle
-  // immediately, on the first paint, exactly like a non-author. A non-author is still
-  // covered: `summaryEnabled` includes `isAuthor`, so it is false for them and `pending` is
-  // false, which is why there is no separate `!isAuthor ||` term any more.
+  // RENDER they would have sat under the skeleton permanently. So they settle immediately,
+  // on the first paint, exactly like a non-author. A non-author is still covered:
+  // `summaryEnabled` includes `isAuthor`, so it is false for them too.
+  //
+  // ⚠️ SETTLING THEM IS THE LEAST-WRONG OPTION, NOT A CLAIM THAT THEY ARE SHOWN THE RIGHT
+  // SCREEN. An earlier draft of this paragraph said the all-false summary was "that viewer's
+  // CORRECT and FINAL answer" and cited the `enabled` note above; that note's second half was
+  // false and is now retracted there. FINAL is true — no further answer is coming. CORRECT is
+  // not: that cohort can own apps, and is shown state B regardless. Unchanged by this commit
+  // and out of scope for it; see the retraction above for the mechanism.
+  //
+  // 🔴 THE PREDICATE IS `resolveAppsBuildSettled`, IN `./appsBuildState`, AND IT IS THERE FOR
+  // A REASON: the `component` project that renders this file is UNGATED in CI, so a guard
+  // living only in the browser spec could not fail a future PR. The pure function's truth
+  // table is pinned in the BLOCKING `unit` tier instead. Do not re-inline this expression.
   const viewed = useRef(false);
-  const summaryPending = summaryEnabled && !(isClient && isFetched);
-  const settled = !summaryPending;
+  const settled = resolveAppsBuildSettled({ summaryEnabled, isClient, isFetched });
   useEffect(() => {
     if (viewed.current || !settled) return;
     viewed.current = true;
@@ -164,10 +195,22 @@ export function AppsBuildBody() {
   // phantom-`first-app` inflation the effect above exists to prevent. One boolean, both
   // consumers.
   //
-  // 🔴 AND IT CANNOT SWALLOW STATE A. `settled` is derived from `summaryPending`, which is
-  // `false` whenever the query is not enabled — and it is never enabled for a non-author. So
-  // the pitch, the only PUBLIC-facing and deliberately-indexable state, still renders on the
-  // server with no loading frame in front of it.
+  // 🔴 AND IT CANNOT SWALLOW STATE A. `resolveAppsBuildSettled` answers `true` whenever the
+  // query is not enabled — and it is never enabled for a non-author. So the pitch, the only
+  // PUBLIC-facing and deliberately-indexable state, still renders on the server with no
+  // loading frame in front of it.
+  //
+  // ⚠️ THE FAILURE MODE THIS BUYS, STATED RATHER THAN DISCOVERED LATER: for an author whose
+  // query is ENABLED, nothing bounds the wait. If `getNavSummary` never settles — the client
+  // bundle fails to mount, a hang with no rejection — this renders the skeleton indefinitely,
+  // where the old code rendered state B: the wrong screen, but one carrying three copyable
+  // CLI commands and a live `/apps/submit` CTA. There is no timeout to lean on: the tRPC
+  // links set no `AbortSignal`, and `queryRetry` only fires on a REJECTION, not on a hang. It
+  // is accepted rather than fixed because it needs an already-broken client, and a
+  // settle-deadline fallback would put a SECOND predicate in front of the render — the exact
+  // two-predicate split the paragraph above exists to prevent. If it ever shows up in RUM,
+  // the fix is a deadline inside `resolveAppsBuildSettled`, where both consumers still read
+  // one boolean.
   if (!settled) return <AppsBuildBodySkeleton />;
 
   if (state === 'workbench') {

--- a/src/components/Apps/AppsBuildBody.tsx
+++ b/src/components/Apps/AppsBuildBody.tsx
@@ -15,6 +15,7 @@ import {
   CLI_INSTALL_NPM,
   CLI_RUN_COMMAND,
 } from '~/components/Apps/cliCommands';
+import { AppsBuildBodySkeleton } from '~/components/Apps/AppsBuildBodySkeleton';
 import { CopyableCommand } from '~/components/Apps/CopyableCommand';
 import { EMBEDDED_KIND_LABEL, STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import { GetStartedBody } from '~/components/Apps/GetStartedBody';
@@ -52,8 +53,18 @@ const CREATE_FLOW_HREF = '/apps/submit';
  * author for one frame. `blocks.getNavSummary` is genuinely client-only (tRPC runs
  * `ssr: false`), so its two booleans are absent on the server render; using them
  * un-deferred is the tab-set hydration mismatch (#418/#425) that bailed hydration of the
- * entire `/apps` root once already. So an author renders `first-app` on the server and on
- * the first client paint, and settles to `workbench` after mount if they have anything.
+ * entire `/apps` root once already.
+ *
+ * 🔴 SO AN AUTHOR'S FIRST PAINT IS A SKELETON, NOT A STATE — AND THAT SENTENCE IS THE FIX.
+ * This paragraph used to end "an author renders `first-app` on the server and on the first
+ * client paint, and settles to `workbench` after mount if they have anything", which was an
+ * accurate description of a BUG: `resolveAppsBuildState` reads an unresolved summary
+ * (all-false) as `first-app`, so every author who HAS apps was shown "Ship your first app"
+ * and then swapped. The deferral above is still exactly right — the summary genuinely
+ * cannot be known on the server — but the answer to "what do we render while we do not
+ * know" is `AppsBuildBodySkeleton`, not a guess. Server and first client paint are still
+ * byte-identical, which is all hydration asks; they are now identical to each OTHER and to
+ * nothing the viewer will be told is their state.
  */
 export function AppsBuildBody() {
   const currentUser = useCurrentUser();
@@ -72,8 +83,14 @@ export function AppsBuildBody() {
   // answer. All-false is also the CORRECT summary for such a viewer: the workbench they
   // would resolve to reads `appListings.listMine`, and its Withdraw action carries
   // `enforceAppBlocksFlag` too.
+  // 🔴 HOISTED OUT OF THE OPTIONS OBJECT SO THE WAIT CAN READ IT, AND THAT IS THE WHOLE
+  // REASON IT IS A NAMED CONST. `isFetched` NEVER goes true for a query that never ran, so
+  // "wait until fetched" would wait FOREVER for a viewer whose `enabled` is false — see
+  // `settled` below, where that would have been a permanent skeleton.
+  const summaryEnabled = !!features.appBlocks && !!currentUser && isAuthor;
+
   const { data: summary, isFetched } = trpc.blocks.getNavSummary.useQuery(undefined, {
-    enabled: !!features.appBlocks && !!currentUser && isAuthor,
+    enabled: summaryEnabled,
     staleTime: 60_000,
   });
 
@@ -108,8 +125,23 @@ export function AppsBuildBody() {
   // nothing in the data reveals. They are also the population most worth seeing. (This
   // paragraph is the correction to a comment that already claimed "resolves or errors"
   // while the code only handled "resolves" — the claim was written first and was wrong.)
+  //
+  // 🔴 `summaryEnabled`, NOT `isAuthor`, IS WHAT DECIDES WHETHER THERE IS ANYTHING TO WAIT
+  // FOR — and that is a correction to this predicate, not a restatement of it. It read
+  // `!isAuthor || (isClient && isFetched)`, which is `false` FOREVER for an author whose
+  // query is disabled: `appBlocks` is store-runtime access while the PAGE gate is
+  // `hasAppsStoreAccess` (`appListings || appBlocks || appListingsPublicExternal`), so an
+  // author holding `appListings` alone reaches this page with the query switched off. Under
+  // the old spelling they posted no `view` at all — the same silently-truncated denominator
+  // the paragraph above rejects for the error cohort — and once `settled` also gates the
+  // RENDER they would have sat under the skeleton permanently. The all-false summary is
+  // that viewer's CORRECT and FINAL answer (see the `enabled` note above), so they settle
+  // immediately, on the first paint, exactly like a non-author. A non-author is still
+  // covered: `summaryEnabled` includes `isAuthor`, so it is false for them and `pending` is
+  // false, which is why there is no separate `!isAuthor ||` term any more.
   const viewed = useRef(false);
-  const settled = !isAuthor || (isClient && isFetched);
+  const summaryPending = summaryEnabled && !(isClient && isFetched);
+  const settled = !summaryPending;
   useEffect(() => {
     if (viewed.current || !settled) return;
     viewed.current = true;
@@ -118,6 +150,25 @@ export function AppsBuildBody() {
 
   const onCopyCommand = useCallback(() => track('cli_copy', state), [track, state]);
   const onCreateEntry = useCallback(() => track('create_entry', state), [track, state]);
+
+  // 🔴 THE UNSETTLED WINDOW RENDERS NEITHER B NOR C, AND THAT IS THE BUG FIX. `state` is
+  // computed from an all-false summary until `getNavSummary` lands, and
+  // `resolveAppsBuildState` reads all-false as `first-app` — so every author who HAS apps
+  // used to be shown "Ship your first app" on the server render and on the first client
+  // paint, then swapped to their workbench. Wrong screen, every visit. The skeleton commits
+  // to neither; see `AppsBuildBodySkeleton` for why it deliberately mirrors neither.
+  //
+  // 🔴 IT IS THE SAME `settled` THE `view` EVENT USES, ON PURPOSE. Two predicates here is
+  // how the analytics start describing a screen nobody saw: a render gate that let B through
+  // early, or a view gate that fired under the skeleton, would each re-open exactly the
+  // phantom-`first-app` inflation the effect above exists to prevent. One boolean, both
+  // consumers.
+  //
+  // 🔴 AND IT CANNOT SWALLOW STATE A. `settled` is derived from `summaryPending`, which is
+  // `false` whenever the query is not enabled — and it is never enabled for a non-author. So
+  // the pitch, the only PUBLIC-facing and deliberately-indexable state, still renders on the
+  // server with no loading frame in front of it.
+  if (!settled) return <AppsBuildBodySkeleton />;
 
   if (state === 'workbench') {
     return (

--- a/src/components/Apps/AppsBuildBody.tsx
+++ b/src/components/Apps/AppsBuildBody.tsx
@@ -167,10 +167,15 @@ export function AppsBuildBody() {
   // not: that cohort can own apps, and is shown state B regardless. Unchanged by this commit
   // and out of scope for it; see the retraction above for the mechanism.
   //
-  // 🔴 THE PREDICATE IS `resolveAppsBuildSettled`, IN `./appsBuildState`, AND IT IS THERE FOR
-  // A REASON: the `component` project that renders this file is UNGATED in CI, so a guard
-  // living only in the browser spec could not fail a future PR. The pure function's truth
-  // table is pinned in the BLOCKING `unit` tier instead. Do not re-inline this expression.
+  // 🔴 THE PREDICATE IS `resolveAppsBuildSettled`, IN `./appsBuildState`, so its truth table
+  // can be pinned in the `unit` tier — the browser project that renders THIS file is
+  // report-only everywhere. ⚠️ That is catch-after-landing, NOT block-before-merge: nothing
+  // in this repo blocks a merge on a check (`unit` is `continue-on-error` on a pull request
+  // and `main` requires no status checks). An earlier version of this comment claimed `unit`
+  // was "the BLOCKING tier"; it is not. See `resolveAppsBuildSettled` for the measured detail.
+  // Do not re-inline this expression — and note that nothing ENFORCES that instruction: the
+  // sibling predicates here carry call-site ledger tests, this one deliberately does not,
+  // because a ledger would inherit exactly the same non-enforcement.
   const viewed = useRef(false);
   const settled = resolveAppsBuildSettled({ summaryEnabled, isClient, isFetched });
   useEffect(() => {

--- a/src/components/Apps/AppsBuildBody.tsx
+++ b/src/components/Apps/AppsBuildBody.tsx
@@ -59,7 +59,10 @@ const CREATE_FLOW_HREF = '/apps/submit';
  * un-deferred is the tab-set hydration mismatch (#418/#425) that bailed hydration of the
  * entire `/apps` root once already.
  *
- * 🔴 SO AN AUTHOR'S FIRST PAINT IS A SKELETON, NOT A STATE — AND THAT SENTENCE IS THE FIX.
+ * 🔴 SO THE FIRST PAINT OF AN AUTHOR *WHOSE SUMMARY QUERY RUNS* IS A SKELETON, NOT A STATE —
+ * AND THAT SENTENCE IS THE FIX. The qualifier is load-bearing and this line lacked it for two
+ * rounds: an author without `appBlocks` (admitted by `appListings`) has no query to wait for,
+ * settles on the first paint, and renders state B permanently. See the `enabled` retraction.
  * This paragraph used to end "an author renders `first-app` on the server and on the first
  * client paint, and settles to `workbench` after mount if they have anything", which was an
  * accurate description of a BUG: `resolveAppsBuildState` reads an unresolved summary
@@ -83,7 +86,7 @@ export function AppsBuildBody() {
   // 🔴 THE `enabled` GATE MIRRORS THE PROCEDURE, NOT THE PAGE — the same rule `AppsSubNav`
   // documents. `blocks.getNavSummary` is `protectedProcedure.use(enforceAppBlocksFlag)`,
   // so without `appBlocks` or without a session it short-circuits to an all-false summary
-  // having read nothing (`enforceAppBlocksFlag` returns `next({ _appBlocksDisabled: true })`
+  // having read nothing (`enforceAppBlocksFlag` returns `next({ ctx: { _appBlocksDisabled: true } })`
   // for a QUERY rather than throwing); asking anyway would buy a guaranteed round-trip to a
   // guaranteed answer. That is the whole justification, and it is about this query only.
   //

--- a/src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx
+++ b/src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx
@@ -1,0 +1,92 @@
+import { MantineProvider, Skeleton, Text } from '@mantine/core';
+import * as React from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, test } from 'vitest';
+import { AppsBuildBodySkeleton } from '~/components/Apps/AppsBuildBodySkeleton';
+
+/**
+ * `/apps/build` — WHAT THE SERVER ACTUALLY EMITS FOR THE LOADING STATE.
+ *
+ * 🔴 THIS GUARD IS EARNED BY THE CHANGE THAT ADDED IT, not copied for symmetry. Before
+ * clawgate #530 an author's server render was state B; it is now this skeleton, on EVERY
+ * author's every visit. So any markup defect in it is a defect in production's SSR HTML,
+ * and the two things most worth pinning are exactly the two the store skeleton shipped
+ * broken and had to be corrected for (see `AppListingCardSkeleton.ssr.browser.test.tsx`,
+ * whose header records both):
+ *
+ *   1. that the server emits a REAL skeleton rather than an empty shell — the store's
+ *      first attempt seeded its cell count in a layout effect, which does not run during
+ *      SSR, so it replaced a spinner with literally nothing;
+ *   2. that no `<div>` descends from a `<p>`. Mantine's `Text` renders `<p>` and its
+ *      `Skeleton` renders `<div>`, so the obvious spelling of a text-line bar is invalid
+ *      HTML: a parser auto-closes the `<p>`, React's tree and the parsed DOM disagree, and
+ *      every render is a hydration mismatch. `TextLineSkeleton` passes `component="span"`
+ *      for that reason and this is what stops that becoming an unread comment.
+ *
+ * 🔴 `renderToString` IS THE INSTRUMENT BECAUSE IT RUNS NO EFFECTS — not `useEffect`, not
+ * `useLayoutEffect` — so it reproduces the server's output faithfully even though this
+ * suite runs in a browser where `window` exists.
+ */
+
+function serverHtml(node: React.ReactElement): string {
+  return renderToString(<MantineProvider>{node}</MantineProvider>);
+}
+
+/**
+ * Every `<div …>` appearing between a `<p …>` and its `</p>`.
+ *
+ * 🔴 A DELIBERATELY DUMB STRING SCAN, and it must stay one. Handing the markup to the
+ * browser's parser would be useless: the parser is the thing that AUTO-CLOSES the `<p>`, so
+ * the tree it returns has already silently repaired the offence. The defect lives in the
+ * STRING. (Duplicated from the store skeleton's suite rather than shared — it is four lines
+ * of scanner, and each copy carries its own positive control below, which is the thing that
+ * actually keeps it honest.)
+ */
+function divsInsideParagraphs(html: string): number {
+  let count = 0;
+  const openP = /<p\b[^>]*>/g;
+  let m: RegExpExecArray | null;
+  while ((m = openP.exec(html)) !== null) {
+    const from = m.index + m[0].length;
+    const close = html.indexOf('</p>', from);
+    const segment = close === -1 ? html.slice(from) : html.slice(from, close);
+    count += [...segment.matchAll(/<div\b/g)].length;
+  }
+  return count;
+}
+
+describe('AppsBuildBodySkeleton — the server render', () => {
+  test('POSITIVE CONTROLS — the instrument renders, and the scanner can see a real offence', () => {
+    // (a) `renderToString` produced markup at all. Without this, every assertion below is
+    //     satisfied by the empty string.
+    const html = serverHtml(<AppsBuildBodySkeleton />);
+    expect(html.length, 'renderToString produced nothing').toBeGreaterThan(200);
+
+    // (b) the scanner returns NON-ZERO on markup that genuinely nests a div in a p — the
+    //     exact shape `TextLineSkeleton` would have if `component="span"` were dropped. A
+    //     zero from a scanner that has never been watched go non-zero is not a measurement.
+    const bad = serverHtml(
+      <Text size="sm">
+        {' '}
+        <Skeleton style={{ position: 'absolute' }} />
+      </Text>
+    );
+    expect(divsInsideParagraphs(bad), 'the scanner cannot see an invalid nesting').toBeGreaterThan(
+      0
+    );
+  });
+
+  test('🔴 the server emits a real skeleton, not an empty shell', () => {
+    const html = serverHtml(<AppsBuildBodySkeleton />);
+    expect(html).toContain('apps-build-skeleton');
+    // The live region's announceable text — it is CONTENT, so it has to be in the markup
+    // and not merely an aria-label. See the note in the component.
+    expect(html).toContain('Loading your apps');
+    // The reserved rows are rendered, not deferred to an effect that SSR never runs.
+    expect([...html.matchAll(/mantine-Skeleton-root/g)].length).toBeGreaterThan(1);
+  });
+
+  test('🔴 no <div> descends from a <p> — the hydration-mismatch shape', () => {
+    expect(divsInsideParagraphs(serverHtml(<AppsBuildBodySkeleton />))).toBe(0);
+  });
+});

--- a/src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx
+++ b/src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx
@@ -102,13 +102,23 @@ describe('AppsBuildBodySkeleton — the server render', () => {
    */
   test('🔴 the live region is announceable: role="status" present, aria-busy absent', () => {
     const html = serverHtml(<AppsBuildBodySkeleton />);
+
     // 🔴 ORDER IS DELIBERATE: the FIRST assertion is the positive control for the SECOND.
     // `not.toContain` passes for free against an empty string or a scanner wired to nothing,
     // so on its own it would prove that `aria-busy` is absent from a document this test never
     // read. `role="status"` is an ATTRIBUTE on the SAME element, found by the SAME matcher —
     // so a green first line is what makes the second line an observation.
     expect(html).toContain('role="status"');
-    expect(html).not.toContain('aria-busy');
+
+    // 🔴 SCOPED TO THE LIVE REGION'S OWN TAG, NOT THE WHOLE DOCUMENT — and that is a
+    // correction. A document-wide `expect(html).not.toContain('aria-busy')` makes a claim
+    // far wider than the one the component states: it would go red if a Mantine bump ever
+    // emitted `aria-busy` on a child `<Skeleton>`, which would not falsify "the live region
+    // is not marked busy" at all. An over-strict guard fails on a change that is not a
+    // defect, and gets deleted the first time it does.
+    const region = html.match(/<[^>]*role="status"[^>]*>/);
+    expect(region, 'no element carries role="status"').not.toBeNull();
+    expect(region?.[0]).not.toContain('aria-busy');
   });
 
   test('🔴 no <div> descends from a <p> — the hydration-mismatch shape', () => {

--- a/src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx
+++ b/src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx
@@ -122,13 +122,22 @@ describe('AppsBuildBodySkeleton — the server render', () => {
     expect(region, 'no element carries role="status"').not.toBeNull();
     expect(region?.[0], 'the live region itself is marked busy').not.toContain('aria-busy');
 
-    // 🔴 AND EVERY ANCESTOR — WITHOUT THIS THE NARROWING ABOVE BLINDS THE GUARD. ARIA treats
-    // `aria-busy` on an element CONTAINING a live region as the same instruction to withhold
-    // its announcements, so an ancestor suppresses this region exactly as the region itself
-    // would. MEASURED: wrapping the component in `<div aria-busy="true">` SURVIVES the scoped
-    // assertion alone (4 passed) and dies here. Everything before the region's opening tag is
-    // its ancestors and their preceding siblings — over-broad by exactly the siblings, which
-    // is the right direction to err for a suppression check.
+    // 🔴 AND EVERY ANCESTOR — WITHOUT THIS THE NARROWING ABOVE BLINDS THE GUARD. MEASURED:
+    // wrapping the component in `<div aria-busy="true">` SURVIVES the scoped assertion alone
+    // (4 passed) and dies here. Everything before the region's opening tag is its ancestors
+    // and their preceding siblings — over-broad by exactly the siblings, which is the right
+    // direction to err for a suppression check.
+    //
+    // ⚠️ WHY AN ANCESTOR IS WORTH GUARDING IS NOT A CLAIM I HAVE VERIFIED, AND AN EARLIER
+    // DRAFT OF THIS COMMENT ASSERTED IT AS FACT ("ARIA treats `aria-busy` on an element
+    // containing a live region as the same instruction to withhold its announcements"). That
+    // may well be right, but I checked it against neither the spec nor a screen reader, and
+    // this file has already been through two rounds of replacing one confident sentence with
+    // a differently wrong one. So the honest justification is the narrow one: the
+    // document-wide form this replaced DID cover the ancestor case, the narrowing dropped it
+    // for a reason that only argued about DESCENDANTS, and a dropped case is not something to
+    // re-derive a purpose for. If someone establishes that a busy ancestor cannot suppress
+    // this region, delete this assertion — do not reword it.
     //
     // 🔴 THE LESSON, BECAUSE IT COST A ROUND: when you NARROW a guard, mutate the case you
     // just EXCLUDED, not the case you kept. The previous round re-ran the region mutation,

--- a/src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx
+++ b/src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx
@@ -86,6 +86,31 @@ describe('AppsBuildBodySkeleton — the server render', () => {
     expect([...html.matchAll(/mantine-Skeleton-root/g)].length).toBeGreaterThan(1);
   });
 
+  /**
+   * 🔴 THE A11Y CLAIM, ASSERTED RATHER THAN MERELY WRITTEN. The component's header claims "a
+   * `role="status"` region, not marked busy, with non-hidden text". Both halves were prose
+   * only until this test: the spec above asserts the testid, the sr-only string and the bar
+   * count, none of which would notice `role` being dropped or `aria-busy` being added.
+   *
+   * `aria-busy="true"` on a live region is the standard instruction to WITHHOLD announcements
+   * — and this region UNMOUNTS rather than clearing, so a busy flag here could never flip back
+   * to false and the loading state would announce nothing at all, in markup whose own comment
+   * claims it is the thing that announces. That exact defect shipped in the store skeleton.
+   *
+   * ⚠️ STILL NOT A SCREEN-READER TEST. It pins the two markup properties the claim rests on;
+   * whether a particular AT announces this is untested here and is not asserted anywhere.
+   */
+  test('🔴 the live region is announceable: role="status" present, aria-busy absent', () => {
+    const html = serverHtml(<AppsBuildBodySkeleton />);
+    // 🔴 ORDER IS DELIBERATE: the FIRST assertion is the positive control for the SECOND.
+    // `not.toContain` passes for free against an empty string or a scanner wired to nothing,
+    // so on its own it would prove that `aria-busy` is absent from a document this test never
+    // read. `role="status"` is an ATTRIBUTE on the SAME element, found by the SAME matcher —
+    // so a green first line is what makes the second line an observation.
+    expect(html).toContain('role="status"');
+    expect(html).not.toContain('aria-busy');
+  });
+
   test('🔴 no <div> descends from a <p> — the hydration-mismatch shape', () => {
     expect(divsInsideParagraphs(serverHtml(<AppsBuildBodySkeleton />))).toBe(0);
   });

--- a/src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx
+++ b/src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx
@@ -8,8 +8,9 @@ import { AppsBuildBodySkeleton } from '~/components/Apps/AppsBuildBodySkeleton';
  * `/apps/build` — WHAT THE SERVER ACTUALLY EMITS FOR THE LOADING STATE.
  *
  * 🔴 THIS GUARD IS EARNED BY THE CHANGE THAT ADDED IT, not copied for symmetry. Before
- * clawgate #530 an author's server render was state B; it is now this skeleton, on EVERY
- * author's every visit. So any markup defect in it is a defect in production's SSR HTML,
+ * clawgate #530 an author's server render was state B; it is now this skeleton for every author
+ * WHOSE SUMMARY QUERY RUNS. (Not every author: one without `appBlocks` settles immediately and
+ * still gets state B — the qualifier is the same one `AppsBuildBody` carries.) So any markup defect in it is a defect in production's SSR HTML,
  * and the two things most worth pinning are exactly the two the store skeleton shipped
  * broken and had to be corrected for (see `AppListingCardSkeleton.ssr.browser.test.tsx`,
  * whose header records both):
@@ -106,8 +107,9 @@ describe('AppsBuildBodySkeleton — the server render', () => {
     // 🔴 ORDER IS DELIBERATE: the FIRST assertion is the positive control for the SECOND.
     // `not.toContain` passes for free against an empty string or a scanner wired to nothing,
     // so on its own it would prove that `aria-busy` is absent from a document this test never
-    // read. `role="status"` is an ATTRIBUTE on the SAME element, found by the SAME matcher —
-    // so a green first line is what makes the second line an observation.
+    // read. `role="status"` is an ATTRIBUTE on the SAME element, so a green first line is what
+    // makes the absence assertions below observations. (The scoped checks use a regex rather
+    // than `toContain`, and carry their own `not.toBeNull()` control on the match.)
     expect(html).toContain('role="status"');
 
     // 🔴 SCOPED TO THE LIVE REGION'S OWN TAG, NOT THE WHOLE DOCUMENT — and that is a
@@ -118,7 +120,24 @@ describe('AppsBuildBodySkeleton — the server render', () => {
     // defect, and gets deleted the first time it does.
     const region = html.match(/<[^>]*role="status"[^>]*>/);
     expect(region, 'no element carries role="status"').not.toBeNull();
-    expect(region?.[0]).not.toContain('aria-busy');
+    expect(region?.[0], 'the live region itself is marked busy').not.toContain('aria-busy');
+
+    // 🔴 AND EVERY ANCESTOR — WITHOUT THIS THE NARROWING ABOVE BLINDS THE GUARD. ARIA treats
+    // `aria-busy` on an element CONTAINING a live region as the same instruction to withhold
+    // its announcements, so an ancestor suppresses this region exactly as the region itself
+    // would. MEASURED: wrapping the component in `<div aria-busy="true">` SURVIVES the scoped
+    // assertion alone (4 passed) and dies here. Everything before the region's opening tag is
+    // its ancestors and their preceding siblings — over-broad by exactly the siblings, which
+    // is the right direction to err for a suppression check.
+    //
+    // 🔴 THE LESSON, BECAUSE IT COST A ROUND: when you NARROW a guard, mutate the case you
+    // just EXCLUDED, not the case you kept. The previous round re-ran the region mutation,
+    // watched it still die, and called the narrowing safe — it had only re-tested the half
+    // that was never at risk.
+    expect(
+      html.slice(0, region?.index ?? 0),
+      'an ANCESTOR of the live region is marked busy, which suppresses it'
+    ).not.toContain('aria-busy');
   });
 
   test('🔴 no <div> descends from a <p> — the hydration-mismatch shape', () => {

--- a/src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx
+++ b/src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx
@@ -125,8 +125,15 @@ describe('AppsBuildBodySkeleton — the server render', () => {
     // 🔴 AND EVERY ANCESTOR — WITHOUT THIS THE NARROWING ABOVE BLINDS THE GUARD. MEASURED:
     // wrapping the component in `<div aria-busy="true">` SURVIVES the scoped assertion alone
     // (4 passed) and dies here. Everything before the region's opening tag is its ancestors
-    // and their preceding siblings — over-broad by exactly the siblings, which is the right
-    // direction to err for a suppression check.
+    // and their preceding siblings AND those siblings' whole subtrees — over-broad by exactly
+    // that, which is the right direction to err for a suppression check. (An earlier draft
+    // said "by exactly the siblings", which understated it: the slice is raw markup, so a
+    // sibling's descendants are inside it too.)
+    //
+    // ⚠️ SCOPE, STATED SO IT IS NOT OVER-READ: this spec renders `AppsBuildBodySkeleton`
+    // ALONE, so "every ancestor" means every ancestor INSIDE this component. A busy ancestor
+    // contributed by the page layout or `AppsPageLayout` is out of this test's reach and is
+    // guarded nowhere.
     //
     // ⚠️ WHY AN ANCESTOR IS WORTH GUARDING IS NOT A CLAIM I HAVE VERIFIED, AND AN EARLIER
     // DRAFT OF THIS COMMENT ASSERTED IT AS FACT ("ARIA treats `aria-busy` on an element
@@ -143,8 +150,20 @@ describe('AppsBuildBodySkeleton — the server render', () => {
     // just EXCLUDED, not the case you kept. The previous round re-ran the region mutation,
     // watched it still die, and called the narrowing safe — it had only re-tested the half
     // that was never at risk.
+    // 🔴 THIS ASSERTION NEEDS ITS OWN POSITIVE CONTROL, AND THE `role="status"` LINE ABOVE IS
+    // NOT IT. That line proves the DOCUMENT is non-empty; it says nothing about the SLICE. If
+    // `region.index` were ever 0 the slice is `''` and `not.toContain` passes for free — the
+    // precise vacuous-absence hazard the comment above warns about, reintroduced one assertion
+    // later. Measured today: `region.index` is 882 and the slice holds MantineProvider's
+    // `<style data-mantine-styles>` preamble, so it is non-vacuous — but nothing would say so
+    // if Mantine stopped emitting that.
+    const beforeRegion = html.slice(0, region?.index ?? 0);
     expect(
-      html.slice(0, region?.index ?? 0),
+      beforeRegion.length,
+      'the ancestor slice is empty — the assertion below is vacuous'
+    ).toBeGreaterThan(0);
+    expect(
+      beforeRegion,
       'an ANCESTOR of the live region is marked busy, which suppresses it'
     ).not.toContain('aria-busy');
   });

--- a/src/components/Apps/AppsBuildBodySkeleton.tsx
+++ b/src/components/Apps/AppsBuildBodySkeleton.tsx
@@ -13,10 +13,14 @@ import { Group, Paper, Skeleton, Stack, Text } from '@mantine/core';
  * They were shown the wrong screen, briefly, on every visit. A spinner would not fix that;
  * a state that asserts nothing about which screen is coming does.
  *
- * 🔴 SO THE DESIGN CONSTRAINT IS NEUTRALITY, NOT PARITY. The destination is unknown by
- * construction while this renders, so this must not look like either B or C — it reserves a
- * plausible block and nothing more. Do NOT "improve" it into a pixel-copy of the workbench
- * table: that would be the same defect one screen over, guessing C for an author headed to B.
+ * 🔴 SO THE DESIGN CONSTRAINT IS NEUTRALITY OF CONTENT, NOT OF GEOMETRY — and the distinction
+ * is the whole of it, because an earlier draft of this paragraph said "must not look like
+ * either B or C" and the header below plainly reserves C's shape. That absolute was wrong, not
+ * the header. What this must not do is present CONTENT that asserts a state: no "first app"
+ * copy, no app table, nothing a viewer could read as an answer. What it MAY do is reserve a
+ * band whose geometry matches the likelier destination, which is what the header row does.
+ * Do NOT go further and mock up the workbench TABLE: rows carry apparent content, and that
+ * would be the same defect one screen over, guessing C for an author headed to B.
  *
  * ⚠️ WHAT IT DOES **NOT** CLAIM. Not zero layout shift. The block below settles to either a
  * short empty-state or a paginated table, and no reservation can be right about both. The

--- a/src/components/Apps/AppsBuildBodySkeleton.tsx
+++ b/src/components/Apps/AppsBuildBodySkeleton.tsx
@@ -1,0 +1,107 @@
+import { Group, Paper, Skeleton, Stack, Text } from '@mantine/core';
+
+/**
+ * `/apps/build`'s LOADING state — the window where the page knows the viewer is an
+ * author but does not yet know whether they have apps.
+ *
+ * 🔴 WHAT THIS FIXES, AND IT IS A CORRECTNESS BUG RATHER THAN POLISH. `blocks.getNavSummary`
+ * decides state B (`first-app`) vs state C (`workbench`), and it is client-only (tRPC runs
+ * `ssr: false`). `resolveAppsBuildState` returns `first-app` whenever both of its summary
+ * booleans are false — which is what an unresolved query looks like — so before this
+ * component existed EVERY author who has apps rendered "Ship your first app" on the server
+ * and on the first client paint, and swapped to their workbench once the query landed.
+ * They were shown the wrong screen, briefly, on every visit. A spinner would not fix that;
+ * a state that asserts nothing about which screen is coming does.
+ *
+ * 🔴 SO THE DESIGN CONSTRAINT IS NEUTRALITY, NOT PARITY. The destination is unknown by
+ * construction while this renders, so this must not look like either B or C — it reserves a
+ * plausible block and nothing more. Do NOT "improve" it into a pixel-copy of the workbench
+ * table: that would be the same defect one screen over, guessing C for an author headed to B.
+ *
+ * ⚠️ WHAT IT DOES **NOT** CLAIM. Not zero layout shift. The block below settles to either a
+ * short empty-state or a paginated table, and no reservation can be right about both. The
+ * claim is only that no state-B *content* is shown to an author who is not in state B.
+ * (Contrast `AppListingCardSkeleton`, which DOES claim per-card geometry parity — it knows
+ * exactly what it is reserving for. This one structurally cannot, so it does not say so.)
+ *
+ * Visual language is shared with that component (Mantine `Skeleton` bars over real line
+ * boxes, `role="status"` + sr-only text on the container, decorative bars `aria-hidden`);
+ * the work is deliberately separate — see clawgate #500, which owns the STORE GRID's
+ * skeletons.
+ */
+
+/**
+ * A skeleton bar shaped like ONE line of real text at a given Mantine `size`.
+ *
+ * 🔴 THE `<Text>` IS THE MEASUREMENT, NOT DECORATION — the same technique as
+ * `AppListingCardSkeleton`'s `MetaLineSkeleton`, and duplicated rather than shared
+ * because that one is tuned to the store card's reservation and this one is not
+ * reserving anything specific. Its content is a non-breaking space, so the element's
+ * line box is whatever a real `<Text size={size}>` would produce under the current theme
+ * tokens; the visible bar is an ABSOLUTELY positioned `Skeleton` over it, out of flow, so
+ * it contributes no height of its own. A bar with a hand-picked pixel height would be a
+ * second copy of Mantine's type scale.
+ *
+ * 🔴 `component="span"` ON THE SKELETON IS THE ONLY REASON THIS IS VALID HTML. Mantine's
+ * `Text` renders a `<p>` and its `Skeleton` a `<div>`; a `<div>` may not descend from a
+ * `<p>`, so the parser auto-closes the `<p>` and React's tree stops matching the parsed
+ * DOM — a hydration mismatch on every render of this component. (That exact bug shipped
+ * once in the store skeleton; see the note there.)
+ */
+function TextLineSkeleton({ size, widthPct }: { size: 'sm' | 'xs'; widthPct: number }) {
+  return (
+    <Text size={size} c="dimmed" style={{ position: 'relative' }}>
+      {/* A NON-BREAKING SPACE, not a plain one: whitespace-only text collapses and can
+          leave the element with no line box at all, i.e. no reservation. Written as an
+          escape so it is visible in a diff. */}
+      {'\u00A0'}
+      <Skeleton
+        component="span"
+        style={{ position: 'absolute', top: 0, bottom: 0, left: 0, width: `${widthPct}%` }}
+      />
+    </Text>
+  );
+}
+
+/** How many row bars the reserved block holds. Enough to read as a list, few enough that
+ *  settling to a short empty-state is not a large collapse. Not an estimate of a result
+ *  count — see the "does not claim zero layout shift" note above. */
+const APPS_BUILD_SKELETON_ROWS = 4;
+
+export function AppsBuildBodySkeleton() {
+  return (
+    <Stack gap="lg" data-testid="apps-build-skeleton" role="status">
+      {/* The live region announces its CONTENT, so the announceable text is real text
+          inside it and every decorative bar below is `aria-hidden`. No `aria-busy`: on a
+          live region that is the standard instruction to WITHHOLD announcements, and this
+          region unmounts rather than clearing, so it could never flip back to false.
+          ⚠️ Not verified with a screen reader — the claim is that the markup CAN announce. */}
+      <span className="sr-only">Loading your apps</span>
+
+      {/* The header row, mirroring the workbench's subtitle + `New app` button so the
+          block above the fold does not jump sideways when the state resolves to C. */}
+      <Group justify="space-between" align="center" wrap="wrap" aria-hidden>
+        <div style={{ flexGrow: 1, minWidth: 0, maxWidth: 520 }}>
+          <TextLineSkeleton size="sm" widthPct={100} />
+        </div>
+        {/* Sized like a Mantine default-size `Button`: 36px tall. Width is nominal —
+            the real button's is set by its label, which is not worth a constant. */}
+        <Skeleton height={36} width={116} radius="sm" />
+      </Group>
+
+      <Paper withBorder p="md" radius="sm" aria-hidden>
+        <Stack gap="sm">
+          {Array.from({ length: APPS_BUILD_SKELETON_ROWS }, (_, i) => (
+            <TextLineSkeleton
+              key={i}
+              size="sm"
+              // Cosmetic only: a ragged last row reads as a list rather than a block.
+              // No geometry depends on it.
+              widthPct={i === APPS_BUILD_SKELETON_ROWS - 1 ? 46 : 100}
+            />
+          ))}
+        </Stack>
+      </Paper>
+    </Stack>
+  );
+}

--- a/src/components/Apps/__tests__/appsBuildState.test.ts
+++ b/src/components/Apps/__tests__/appsBuildState.test.ts
@@ -177,7 +177,11 @@ describe('🔴 APPS_BUILD_STATES matches the values the tracker will accept', ()
 });
 
 /**
- * `resolveAppsBuildSettled` — the WHOLE truth table, in the tier CI blocks on.
+ * `resolveAppsBuildSettled` — the WHOLE truth table, in the `unit` tier.
+ *
+ * (That summary line read "in the tier CI blocks on" for one round, eight lines above the
+ * paragraph explaining that these rows block nothing. A summary line is what a hurried reader
+ * takes away, so it was the worst surviving copy of the claim. Nothing here blocks; see below.)
  *
  * 🔴 THIS SUITE EXISTS BECAUSE THE RENDERED PROOF IS OBSERVED NOWHERE. `/apps/build`'s
  * skeleton is guarded by `AppsBuildBody.browser.test.tsx`, in the `component` project — which

--- a/src/components/Apps/__tests__/appsBuildState.test.ts
+++ b/src/components/Apps/__tests__/appsBuildState.test.ts
@@ -66,15 +66,22 @@ describe('🔴 the pre-settle default the CALLER no longer renders', () => {
    * server render and the first client paint BOTH summary booleans are false, and this
    * function answers `first-app` for an author.
    *
-   * 🔴 THAT IS NO LONGER WHAT THE SERVER HTML CONTAINS, AND THIS BLOCK USED TO SAY IT WAS.
-   * Its docstring read "What the function returns for that input is therefore what the
-   * server HTML contains", and its second case was named "an author renders first-app with
-   * no summary". Both were true when written and both are now FALSE at the call site:
-   * `AppsBuildBody` gates the render on `resolveAppsBuildSettled` and emits
-   * `AppsBuildBodySkeleton` for the whole unsettled window, so an author's server HTML is
-   * the skeleton. Corrected here rather than only in `appsBuildState.ts`, because THIS tier
-   * is the one CI blocks on — a maintainer who reads a green `unit` run reads this file, and
-   * the corrected prose in the module lives next to a browser spec no gate runs.
+   * 🔴 THAT IS NO LONGER WHAT THE SERVER HTML CONTAINS **FOR AN AUTHOR WHOSE SUMMARY QUERY IS
+   * ENABLED**, AND THIS BLOCK USED TO SAY IT WAS — WITHOUT THE QUALIFIER, WHICH WAS ALSO
+   * WRONG. Its docstring read "What the function returns for that input is therefore what the
+   * server HTML contains", and its second case was named "an author renders first-app with no
+   * summary"; the first correction then over-swung to a bare "an author's server HTML is the
+   * skeleton". Both absolutes are false, in opposite directions. `AppsBuildBody` gates the
+   * render on `resolveAppsBuildSettled`, which answers `true` — settled, render a state — the
+   * moment the query is not enabled. So an author WITHOUT `appBlocks` (admitted to the page by
+   * `appListings`) still has state B in their server HTML, permanently; only an author whose
+   * query actually runs gets the skeleton. The PR's own browser spec pins that cohort
+   * (`author whose summary query is DISABLED settles immediately — no permanent skeleton`).
+   *
+   * Corrected HERE and not only in `appsBuildState.ts` because a maintainer reading a green
+   * `unit` run reads this file, while the module's prose sits beside a browser spec no gate
+   * runs at all. ⚠️ That is a readership argument, not an enforcement one — see
+   * `resolveAppsBuildSettled` for why "the tier CI blocks on" was itself a false claim.
    *
    * What the cases below still pin is the ARITHMETIC, which is unchanged and correct: for a
    * NON-author it is also still the rendered answer, because a non-author is settled from
@@ -172,13 +179,21 @@ describe('🔴 APPS_BUILD_STATES matches the values the tracker will accept', ()
 /**
  * `resolveAppsBuildSettled` — the WHOLE truth table, in the tier CI blocks on.
  *
- * 🔴 THIS SUITE EXISTS BECAUSE THE RENDERED PROOF CANNOT FAIL A BUILD. `/apps/build`'s
+ * 🔴 THIS SUITE EXISTS BECAUSE THE RENDERED PROOF IS OBSERVED NOWHERE. `/apps/build`'s
  * skeleton is guarded by `AppsBuildBody.browser.test.tsx`, in the `component` project — which
  * `.github/workflows/lint.yml` states plainly is UNGATED: no selector there matches it
  * (`unit*`, `@civitai/*`, `app:*`) and its only CI home is the report-only
- * `preview / component-tests`. A guard that can only report is not a guard against the next
- * PR. The browser spec stays as the evidence that the SCREEN is right; these eight rows are
- * what actually blocks a regression in the predicate that decides it.
+ * `preview / component-tests`.
+ *
+ * ⚠️ THESE ROWS DO NOT "BLOCK" ANYTHING EITHER, AND SAYING THEY DID WAS THIS FILE'S OWN
+ * SECOND FALSE CLAIM. The sentence here read "these eight rows are what actually blocks a
+ * regression", two lines under the criterion "a guard that can only report is not a guard
+ * against the next PR" — which this suite then failed. `unit` is `continue-on-error` on a
+ * pull request (`lint.yml:405`) and `main` requires no status checks at all, so no check in
+ * this repository prevents a merge. What these rows buy is that `unit` DOES run on
+ * `push: [main]` without that flag, so the regression reds the `main` build after it lands
+ * rather than going unobserved. Weaker than blocking, stronger than the browser tier, and
+ * worth having on those terms — not on the ones first written here.
  *
  * 🔴 THE ROW THAT MATTERS IS `summaryEnabled: false` WITH `isFetched: false`. That is an
  * author whose `getNavSummary` is DISABLED (`appBlocks` off while the page gate,
@@ -239,7 +254,7 @@ describe('resolveAppsBuildSettled — the full input table', () => {
       isClient: false,
       isFetched: true,
       expected: false,
-      why: '🔴 pre-mount must NOT consult the query, or SSR and the first client paint diverge and hydration bails',
+      why: 'pre-mount with a fetched query — COMBINATORIAL, not reachable: isClient flips once app-wide, so isClient=false implies an empty tRPC cache',
     },
     {
       summaryEnabled: true,

--- a/src/components/Apps/__tests__/appsBuildState.test.ts
+++ b/src/components/Apps/__tests__/appsBuildState.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   APPS_BUILD_STATES,
+  resolveAppsBuildSettled,
   resolveAppsBuildState,
   type AppsBuildState,
 } from '~/components/Apps/appsBuildState';
@@ -59,13 +60,25 @@ describe('resolveAppsBuildState — the full input table', () => {
   });
 });
 
-describe('🔴 the SSR / first-paint default', () => {
+describe('🔴 the pre-settle default the CALLER no longer renders', () => {
   /**
    * `blocks.getNavSummary` runs client-only (tRPC is configured `ssr: false`), so on the
-   * server render and the first client paint BOTH summary booleans are false. What the
-   * function returns for that input is therefore what the server HTML contains — and it
-   * has to be a state that is CORRECT for the viewer, not merely a placeholder, because
-   * a non-author never gets a second render to correct it.
+   * server render and the first client paint BOTH summary booleans are false, and this
+   * function answers `first-app` for an author.
+   *
+   * 🔴 THAT IS NO LONGER WHAT THE SERVER HTML CONTAINS, AND THIS BLOCK USED TO SAY IT WAS.
+   * Its docstring read "What the function returns for that input is therefore what the
+   * server HTML contains", and its second case was named "an author renders first-app with
+   * no summary". Both were true when written and both are now FALSE at the call site:
+   * `AppsBuildBody` gates the render on `resolveAppsBuildSettled` and emits
+   * `AppsBuildBodySkeleton` for the whole unsettled window, so an author's server HTML is
+   * the skeleton. Corrected here rather than only in `appsBuildState.ts`, because THIS tier
+   * is the one CI blocks on — a maintainer who reads a green `unit` run reads this file, and
+   * the corrected prose in the module lives next to a browser spec no gate runs.
+   *
+   * What the cases below still pin is the ARITHMETIC, which is unchanged and correct: for a
+   * NON-author it is also still the rendered answer, because a non-author is settled from
+   * the first paint and never gets a second render.
    */
   it('a non-author renders pitch with no summary — and never moves off it', () => {
     expect(
@@ -73,7 +86,7 @@ describe('🔴 the SSR / first-paint default', () => {
     ).toBe('pitch');
   });
 
-  it('an author renders first-app with no summary, and may settle FORWARD to workbench', () => {
+  it('an author RESOLVES to first-app with no summary (not rendered), and settles FORWARD to workbench', () => {
     const preMount = resolveAppsBuildState({
       isAuthor: true,
       hasEditableApps: false,
@@ -153,5 +166,107 @@ describe('🔴 APPS_BUILD_STATES matches the values the tracker will accept', ()
       'request_access',
       'view',
     ]);
+  });
+});
+
+/**
+ * `resolveAppsBuildSettled` — the WHOLE truth table, in the tier CI blocks on.
+ *
+ * 🔴 THIS SUITE EXISTS BECAUSE THE RENDERED PROOF CANNOT FAIL A BUILD. `/apps/build`'s
+ * skeleton is guarded by `AppsBuildBody.browser.test.tsx`, in the `component` project — which
+ * `.github/workflows/lint.yml` states plainly is UNGATED: no selector there matches it
+ * (`unit*`, `@civitai/*`, `app:*`) and its only CI home is the report-only
+ * `preview / component-tests`. A guard that can only report is not a guard against the next
+ * PR. The browser spec stays as the evidence that the SCREEN is right; these eight rows are
+ * what actually blocks a regression in the predicate that decides it.
+ *
+ * 🔴 THE ROW THAT MATTERS IS `summaryEnabled: false` WITH `isFetched: false`. That is an
+ * author whose `getNavSummary` is DISABLED (`appBlocks` off while the page gate,
+ * `hasAppsStoreAccess`, admitted them on `appListings`). `isFetched` never goes true for a
+ * query that never ran, so the obvious spelling — `!isAuthor || (isClient && isFetched)` —
+ * answers `false` for them FOREVER and the caller renders a PERMANENT skeleton. It must
+ * answer `true`.
+ */
+describe('resolveAppsBuildSettled — the full input table', () => {
+  const table: Array<{
+    summaryEnabled: boolean;
+    isClient: boolean;
+    isFetched: boolean;
+    expected: boolean;
+    why: string;
+  }> = [
+    // The query never runs: nothing is coming, so it is settled on the FIRST paint —
+    // server render included. All four combinations, so no row can be satisfied by an
+    // implementation that happens to read `isClient` or `isFetched` in this branch.
+    {
+      summaryEnabled: false,
+      isClient: false,
+      isFetched: false,
+      expected: true,
+      why: 'disabled, pre-mount — the permanent-skeleton row',
+    },
+    {
+      summaryEnabled: false,
+      isClient: false,
+      isFetched: true,
+      expected: true,
+      why: 'disabled, pre-mount, stale isFetched must not matter',
+    },
+    {
+      summaryEnabled: false,
+      isClient: true,
+      isFetched: false,
+      expected: true,
+      why: 'disabled, post-mount',
+    },
+    {
+      summaryEnabled: false,
+      isClient: true,
+      isFetched: true,
+      expected: true,
+      why: 'disabled, post-mount, fetched',
+    },
+    // The query runs: settled only once it has actually answered, on the CLIENT.
+    {
+      summaryEnabled: true,
+      isClient: false,
+      isFetched: false,
+      expected: false,
+      why: 'server render — the summary cannot exist yet',
+    },
+    {
+      summaryEnabled: true,
+      isClient: false,
+      isFetched: true,
+      expected: false,
+      why: '🔴 pre-mount must NOT consult the query, or SSR and the first client paint diverge and hydration bails',
+    },
+    {
+      summaryEnabled: true,
+      isClient: true,
+      isFetched: false,
+      expected: false,
+      why: 'mounted, still in flight — the window the skeleton covers',
+    },
+    {
+      summaryEnabled: true,
+      isClient: true,
+      isFetched: true,
+      expected: true,
+      why: 'answered (success OR error)',
+    },
+  ];
+
+  it.each(table)('$why → $expected', ({ summaryEnabled, isClient, isFetched, expected }) => {
+    expect(resolveAppsBuildSettled({ summaryEnabled, isClient, isFetched })).toBe(expected);
+  });
+
+  it('the table is EXHAUSTIVE over its three booleans, and both verdicts occur', () => {
+    // Without this, a row could be dropped in a refactor and the suite would stay green over
+    // a predicate nobody checks at that input. 2^3 = 8 distinct combinations.
+    const seen = new Set(table.map((r) => `${r.summaryEnabled}|${r.isClient}|${r.isFetched}`));
+    expect(seen.size).toBe(8);
+    // …and it is not a table of one answer, which `toBe(expected)` alone would not catch.
+    expect(new Set(table.map((r) => r.expected))).toEqual(new Set([true, false]));
   });
 });

--- a/src/components/Apps/appsBuildState.ts
+++ b/src/components/Apps/appsBuildState.ts
@@ -33,6 +33,14 @@
  * resolves to `pitch` identically on both sides, and an author resolves to `first-app`
  * on both sides and may then move to `workbench` after mount. The state can only ever
  * settle FORWARD, never from workbench back to pitch.
+ *
+ * 🔴 THAT PRE-SETTLE `first-app` IS NOT RENDERED, AND THIS FUNCTION IS NOT WHAT STOPS IT.
+ * Reading all-false as `first-app` is correct ARITHMETIC and was a live wrong-screen bug at
+ * the CALL SITE, which used to render whatever this returned from the very first paint — so
+ * every author with apps saw "Ship your first app" flash. `AppsBuildBody` now renders
+ * `AppsBuildBodySkeleton` until its summary query has settled and only then consults this
+ * function, so do not "fix" the branch below by inventing an `unknown` state: the caller
+ * knows whether it has an answer and this pure function deliberately does not.
  */
 export const APPS_BUILD_STATES = ['pitch', 'first-app', 'workbench'] as const;
 

--- a/src/components/Apps/appsBuildState.ts
+++ b/src/components/Apps/appsBuildState.ts
@@ -53,8 +53,8 @@ export type AppsBuildState = (typeof APPS_BUILD_STATES)[number];
  * IS WEAKER THAN THE ONE THAT WAS HERE FIRST, WHICH SAID "THE ONLY TIER ANYTHING BLOCKS ON".
  * **NOTHING in this repo blocks a merge on a check.** `unit` is report-only on a pull request
  * (`continue-on-error: ${{ github.event_name == 'pull_request' }}`,
- * `.github/workflows/lint.yml:405`, with the deliberate "FLIP TO BLOCKING once…" note at
- * `:357`), and `main` carries branch protection with **no required status checks** at all
+ * `.github/workflows/lint.yml:405`, with the deliberate "REPORT-ONLY to start" /
+ * "FLIP TO BLOCKING once…" note at `:357-365`), and `main` carries branch protection with **no required status checks** at all
  * (`required_status_checks: null`, read live from the API, and stated at `lint.yml:600`).
  *
  * What the move DOES buy, and it is real: the `component` project is report-only

--- a/src/components/Apps/appsBuildState.ts
+++ b/src/components/Apps/appsBuildState.ts
@@ -49,13 +49,22 @@ export type AppsBuildState = (typeof APPS_BUILD_STATES)[number];
 /**
  * Is the `/apps/build` state SETTLED — i.e. may the caller render a state at all?
  *
- * 🔴 THIS LIVES HERE, BESIDE `resolveAppsBuildState`, BECAUSE THE TIER THAT CAN TEST IT IS
- * THE ONLY TIER ANYTHING BLOCKS ON. The rendered proof that an author no longer sees state B
- * mid-load is a `component`-project browser spec, and that project is UNGATED — no selector in
- * `.github/workflows/lint.yml` matches it (`unit*`, `@civitai/*`, `app:*`) and its only CI home
- * is the report-only `preview / component-tests`. So a guard that lived only there could not
- * fail a future PR. Keeping the predicate pure and out here puts its truth table in the
- * BLOCKING `unit` tier; the browser spec stays as the rendered evidence.
+ * 🔴 THIS LIVES HERE SO THE `unit` TIER CAN TEST IT — AND THE HONEST VERSION OF THAT SENTENCE
+ * IS WEAKER THAN THE ONE THAT WAS HERE FIRST, WHICH SAID "THE ONLY TIER ANYTHING BLOCKS ON".
+ * **NOTHING in this repo blocks a merge on a check.** `unit` is report-only on a pull request
+ * (`continue-on-error: ${{ github.event_name == 'pull_request' }}`,
+ * `.github/workflows/lint.yml:405`, with the deliberate "FLIP TO BLOCKING once…" note at
+ * `:357`), and `main` carries branch protection with **no required status checks** at all
+ * (`required_status_checks: null`, read live from the API, and stated at `lint.yml:600`).
+ *
+ * What the move DOES buy, and it is real: the `component` project is report-only
+ * EVERYWHERE — no selector in that workflow matches it (`unit*`, `@civitai/*`, `app:*`) and
+ * its only CI home is the preview pipeline's `preview / component-tests` — whereas `unit`
+ * runs on `push: [main]`, where `continue-on-error` evaluates FALSE. So a regression in this
+ * predicate reds the `main` build AFTER it lands, instead of being observed nowhere. That is
+ * catch-after-landing, not block-before-merge. Do not restate it as the latter.
+ *
+ * The browser spec stays as the rendered evidence that the SCREEN is right.
  *
  * 🔴 `summaryEnabled`, NOT `isAuthor` — AND THAT IS THE WHOLE REASON THIS TAKES THREE INPUTS.
  * `isFetched` never goes true for a query that never ran, so `!isAuthor || (isClient &&

--- a/src/components/Apps/appsBuildState.ts
+++ b/src/components/Apps/appsBuildState.ts
@@ -46,6 +46,38 @@ export const APPS_BUILD_STATES = ['pitch', 'first-app', 'workbench'] as const;
 
 export type AppsBuildState = (typeof APPS_BUILD_STATES)[number];
 
+/**
+ * Is the `/apps/build` state SETTLED — i.e. may the caller render a state at all?
+ *
+ * 🔴 THIS LIVES HERE, BESIDE `resolveAppsBuildState`, BECAUSE THE TIER THAT CAN TEST IT IS
+ * THE ONLY TIER ANYTHING BLOCKS ON. The rendered proof that an author no longer sees state B
+ * mid-load is a `component`-project browser spec, and that project is UNGATED — no selector in
+ * `.github/workflows/lint.yml` matches it (`unit*`, `@civitai/*`, `app:*`) and its only CI home
+ * is the report-only `preview / component-tests`. So a guard that lived only there could not
+ * fail a future PR. Keeping the predicate pure and out here puts its truth table in the
+ * BLOCKING `unit` tier; the browser spec stays as the rendered evidence.
+ *
+ * 🔴 `summaryEnabled`, NOT `isAuthor` — AND THAT IS THE WHOLE REASON THIS TAKES THREE INPUTS.
+ * `isFetched` never goes true for a query that never ran, so `!isAuthor || (isClient &&
+ * isFetched)` is `false` FOREVER for an author whose `getNavSummary` is disabled, and a caller
+ * that gates its RENDER on that never renders anything. See the call site for who that is.
+ *
+ * ⚠️ SETTLED MEANS "NO FURTHER ANSWER IS COMING", NEVER "THE ANSWER IS RIGHT". A viewer whose
+ * summary query is disabled settles immediately on an all-false summary — which is the only
+ * answer that query can give them, and is not necessarily a true description of their account.
+ * The call site documents the one cohort where those two come apart.
+ */
+export function resolveAppsBuildSettled(args: {
+  /** `!!features.appBlocks && !!currentUser && isAuthor` — the query's own `enabled`. */
+  summaryEnabled: boolean;
+  /** `useIsClient()` — false on the server AND on the first client paint. */
+  isClient: boolean;
+  /** the query's `isFetched`: true on success OR error, false while it has never run. */
+  isFetched: boolean;
+}): boolean {
+  return !args.summaryEnabled || (args.isClient && args.isFetched);
+}
+
 export function resolveAppsBuildState(args: {
   /** `isAppDeveloper(user, { appBlocksAuthor })` — SSR-frozen. */
   isAuthor: boolean;


### PR DESCRIPTION
Closes clawgate #530. Closes audit finding **F6** from #4685 (`AppsBuildBody` had no rendered test in any tier, and `viewed.current` was untested).

## The bug

`blocks.getNavSummary` decides state B (`first-app`) vs state C (`workbench`), and it is client-only (tRPC runs `ssr: false`). `resolveAppsBuildState` returns `first-app` whenever both of its summary booleans are false — which is exactly what an unresolved query looks like. So **every author who has apps rendered "Ship your first app"** on the server render and on the first client paint, then swapped to their workbench. The wrong screen, briefly, on every visit.

The analytics could not see it — the `view` event fires only when `settled` — which is why a four-round and a two-round audit ladder both closed clean over it. Nothing that was being measured moved.

## The fix

While the summary query is still pending, render a neutral `AppsBuildBodySkeleton` instead of guessing a state. The **same `settled` boolean** gates the render and the `view` event, so the two cannot disagree about which screen a viewer saw.

The skeleton is deliberately **neutral, not a workbench mock-up**: the destination is unknown by construction while it renders, so committing to C's shape would be the same defect one screen over. It does **not** claim zero layout shift, and says so in the file — contrast `AppListingCardSkeleton`, which knows exactly what it is reserving for.

## 🔴 One behavioural correction rides along, and it is what stops the fix hanging

The old predicate was `settled = !isAuthor || (isClient && isFetched)`. `isFetched` never goes true for a query that never ran — and the query's `enabled` requires `appBlocks`, while the **page** gate is `hasAppsStoreAccess` (`appListings || appBlocks || appListingsPublicExternal`). So an author holding `appListings` alone reaches this page with the summary query switched **off**, and that predicate is `false` for them forever.

Consequences: today they post **no `view` event at all** — the same silently-truncated denominator the existing comment already rejects for the error cohort — and under a wait keyed on `isFetched` they would have sat under the skeleton **permanently**. `settled` now keys on whether there is anything to wait for, so they settle on the first paint, exactly like a non-author.

> 🔴 **Corrected 2026-09-08 (audit round 4).** This paragraph used to end: *"The all-false summary is that viewer's correct and final answer (the `enabled` comment says so)."* **Both halves are false and the code now says so.** `appListings.listMine` is `appDeveloperProcedure` → `hasAppBlocksAuthor`, gated on `appBlocksAuthor` rather than `appBlocks`, and everyone in this cohort holds `appBlocksAuthor` by construction — so their workbench *would* have rendered. The summary is **FINAL** (no further answer is coming) but **not CORRECT**: that cohort can own apps and is shown "Ship your first app" permanently. That is **pre-existing and unchanged by this PR**, and it is disclosed at the `enabled` gate in `AppsBuildBody.tsx`. Left in place rather than edited away because GitHub seeds the squash-merge message from this body, and a merged history asserting the cohort is correctly served is exactly how the follow-up never gets opened.

## Disclosed trade

An author who genuinely has nothing now sees a brief skeleton before state B, where before they got state B immediately. Before the query lands the two states are indistinguishable by construction, so this is not avoidable — and showing established authors the wrong screen on every visit is the worse half of the trade.

## Test matrix — red at base, green at HEAD

New rendered suite `AppsBuildBody.browser.test.tsx` (12 tests) — the first rendered coverage this component has had in any tier — plus `AppsBuildBodySkeleton.ssr.browser.test.tsx` (4).

> ⚠️ **Corrected 2026-09-08.** This said `(3)`, and `+3 SSR = 15` below. It was true when written and was falsified by **this PR's own audit round 1**, which added a fourth SSR test. Same for the `222`-file figure below. See the round-3 comment — a claim true at one commit and falsified by a later commit of the same PR sits inside no audit round's range, which is exactly how all three survived two rounds of re-derivation.

| tree | result |
|---|---|
| `552202a9f9` (`origin/main`), new spec applied to base source | **4 failed \| 8 passed** |
| this branch | **12 passed** (+4 SSR = 16) |

The four that are red at base are the skeleton assertions and the mount→settle transition. The rest are controls and unchanged-path guards, and they pass on both sides on purpose.

### Mutation-checked — each mutant killed by its own assertion

| mutant | killed by | failure |
|---|---|---|
| `settled` reverted to the naive `!isAuthor \|\| (isClient && isFetched)` | *"author whose summary query is DISABLED settles immediately"* — **only** that test | `Cannot find element with locator: getByTestId('apps-build-first-app')` (stuck under the skeleton) |
| the `settled` term dropped from the **analytics** gate alone | both view-event tests | `[event] != []`, and the recorded state is `first-app` rather than `workbench` |
| `component="span"` dropped from the skeleton's bar | *"no `<div>` descends from a `<p>`"* | `expected 5 to be +0` — one per `TextLineSkeleton` |

### 🔴 Two defects in my own test, both found only by running it at the base commit

Recorded because the second is a trap for anyone writing a "was this ever painted" assertion in this codebase:

1. `takeRecords()` was being **drained** (`.forEach(() => undefined)`) rather than processed — the callback is a microtask, so records still queued when the awaited assertion resolved were discarded unread.
2. **Every branch of `AppsBuildBody` returns a Mantine `Stack`**, so React reconciles the same `<div>` **in place** and state B is never an *added node*. A `childList`-only MutationObserver reports a clean zero over a first paint that really did render state B. The measured trace is a single attribute record: `attr data-testid old=apps-build-first-app new=null`.

Both versions passed against base code that paints state B on every author's first render. The watcher now observes `attributes` with `attributeOldValue`, and its positive control drives a real B→workbench swap so it exercises the same branch the absence assertion depends on.

## Verification scope

- `--project component src/components/Apps/AppsBuildBody.browser.test.tsx src/components/Apps/AppsBuildBodySkeleton.ssr.browser.test.tsx` — **16 passed**, ~2s (warm).
- `--project unit src/components/Apps/__tests__ src/shared/utils` — **2004 passed / 95 files**. No call-site ledger broke.
- `pnpm run test:component` (full tier — **223** `.browser.test.tsx` files at HEAD, 221 at base; this said `222`, which was wrong at both ends of the sentence that names them) — my file **passed** (12 tests, 612ms). The run also reported 12 files / 22 tests failing elsewhere; a warm re-run of exactly those 12 gave **2 files / 2 tests**, and a third pass gave **0**. That is drift, not convergence — the cold-cascade signature — and none of the 12 references any module this PR touches (checked with a positive control on the grep).
- `eslint` on all five changed files — clean.
- `pnpm run typecheck` — **0 errors under `src/`**. 31 remain in `packages/*`, all `Cannot find module 'kysely' / '@opentelemetry/context-async-hooks'`: this throwaway worktree has no per-package `node_modules`, which the base clone does. A worktree-setup artifact.

### NOT verified

- **Not exercised in a real browser against production.** No click-path repro of the original flash; the evidence is the red-at-base spec, not a live observation.
- **The back-navigation question in #530 is unanswered, not answered.** I did not measure whether a client-side return to `/apps/build` flashes. The reason to expect it does not is that `isFetched` is query state rather than observer state, so a cached query settles a new observer immediately — that is derived from React Query's state model, **not measured**. `placeholderData` deliberately not added; if a flash is seen in practice that is the follow-up.
- **No screen-reader verification** of the skeleton's live region. The claim is only that the markup *can* announce (a `role="status"` region, not marked busy, with non-hidden text).
- The full component tier was **not** measured at base, so the 12-file failure above is reported as *not attributable to this change*, not as *pre-existing*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvPvg8htuqabcpLXy2m9hc


