### PR TITLE
feat(upload): count image-upload relay usage, so a successful fallback stops being invisible

### DIFF
--- a/src/__tests__/pages/api/v1/image-upload/relay.test.ts
+++ b/src/__tests__/pages/api/v1/image-upload/relay.test.ts
@@ -561,8 +561,8 @@ describe('image-upload relay', () => {
   // Usage counter
   // -------------------------------------------------------------------------
   //
-  // WHY THESE EXIST. A successful relay is INVISIBLE in production: a 200 is filtered
-  // out of the access-log stream (it logs 4xx/5xx or >5s only), traces are head-sampled
+  // WHY THESE EXIST. A successful relay is INVISIBLE in production: our request-log
+  // stream does not retain fast 2xx responses, traces are head-sampled
   // at 0.1 against an event rate of a handful over months, and the media-location
   // registry records the same backend for a relayed and a direct upload. So the route
   // shipped with no way to answer "did this ever help anyone?", and

--- a/src/__tests__/pages/api/v1/image-upload/relay.test.ts
+++ b/src/__tests__/pages/api/v1/image-upload/relay.test.ts
@@ -76,6 +76,17 @@ import handler, {
   __getInFlightForTest,
   __resetInFlightForTest,
 } from '~/pages/api/v1/image-upload/relay';
+// 🔴 DELIBERATELY NOT MOCKED. The usage counter is the only production evidence that
+// this fallback ever works, so the cases below drive the REAL emitter and read the real
+// prom registry. A mock here would assert that the route called a function, which is
+// the weaker claim — it cannot see a wrong label, a folded series, or a registration on
+// a registry nothing scrapes.
+import client from 'prom-client';
+import {
+  IMAGE_UPLOAD_RELAY_METRIC,
+  IMAGE_UPLOAD_RELAY_OUTCOMES,
+  __resetImageUploadRelayMetricsForTest,
+} from '~/server/prom/image-upload-relay.metrics';
 
 /** Records the order in which the handler wrote a status vs destroyed the request. */
 type Trace = string[];
@@ -182,6 +193,9 @@ beforeEach(() => {
   // A case that leaves a slot held would otherwise make the NEXT case fail for an
   // unrelated reason — measured as a false cascading failure during round-2 mutation.
   __resetInFlightForTest();
+  // The counter is module-scoped and process-wide; without this every case inherits
+  // the previous one's counts and the "and only that outcome" assertions go vacuous.
+  __resetImageUploadRelayMetricsForTest();
   prodFlag.value = false;
   mockGetServerAuthSession.mockResolvedValue(authed);
   mockUploadImageBufferToStore.mockResolvedValue({
@@ -541,5 +555,216 @@ describe('image-upload relay', () => {
     expect(wire).not.toContain('EXAMPLE-BUCKET');
     expect(wire).not.toContain('s3.example.invalid');
     expect(wire).not.toContain('REQ-123');
+  });
+
+  // -------------------------------------------------------------------------
+  // Usage counter
+  // -------------------------------------------------------------------------
+  //
+  // WHY THESE EXIST. A successful relay is INVISIBLE in production: a 200 is filtered
+  // out of the access-log stream (it logs 4xx/5xx or >5s only), traces are head-sampled
+  // at 0.1 against an event rate of a handful over months, and the media-location
+  // registry records the same backend for a relayed and a direct upload. So the route
+  // shipped with no way to answer "did this ever help anyone?", and
+  // `civitai_app_http_errors_total` — already wired here — only counts status >= 500.
+  //
+  // These are NEW-FEATURE tests, not regression guards: there is no revision of this
+  // route at which the counter existed and was broken. They are written to be killed by
+  // the mutations that matter — a deleted increment, a hardcoded label, a branch that
+  // settles the response without naming an outcome, a double count.
+  describe('usage counter', () => {
+    type MetricJSON = { values: { value: number; labels: Record<string, string> }[] };
+
+    async function series(): Promise<Record<string, number>> {
+      const metric = client.register.getSingleMetric(IMAGE_UPLOAD_RELAY_METRIC) as unknown as
+        | { get: () => Promise<MetricJSON> }
+        | undefined;
+      if (!metric) return {};
+      const data = await metric.get();
+      return Object.fromEntries(data.values.map((v) => [v.labels.outcome, v.value]));
+    }
+
+    /**
+     * Assert the handler recorded EXACTLY the given outcome, once.
+     *
+     * 🔴 The "and nothing else" half is load-bearing. A mutant that hardcodes the label
+     * — `recordImageUploadRelay('success')` everywhere — still increments something on
+     * every branch, so a test that only checked its own outcome had moved would pass
+     * against it on the success case and produce a counter that always reads 100%
+     * success. Reading the WHOLE series set is what discriminates.
+     */
+    async function expectOnly(outcome: string) {
+      const s = await series();
+      expect(s[outcome], `expected outcome=${outcome} to be 1`).toBe(1);
+      const nonZero = Object.entries(s)
+        .filter(([, v]) => v !== 0)
+        .map(([k]) => k);
+      expect(nonZero).toEqual([outcome]);
+    }
+
+    it('counts a SUCCESSFUL relay — the outcome nothing else in production can see', async () => {
+      await handler(makeReq([Buffer.from('image-bytes')]), makeRes());
+      await expectOnly('success');
+    });
+
+    it('does not count success when the store write threw', async () => {
+      // The pairing that matters: a counter that cannot separate these is worse than
+      // none, because it would report the outage as a rescue.
+      mockUploadImageBufferToStore.mockRejectedValue(new Error('store down'));
+      const res = makeRes();
+      await handler(makeReq([Buffer.from('bytes')]), res);
+      expect(res.statusCode).toBe(500);
+      await expectOnly('store_error');
+    });
+
+    it('counts a 413 as too_large', async () => {
+      const half = Math.floor(MAX_RELAY_BYTES / 2) + 1;
+      await handler(makeReq([Buffer.alloc(half), Buffer.alloc(half)]), makeRes());
+      await expectOnly('too_large');
+    });
+
+    it('counts a pre-read 413 (declared Content-Length over the cap) as too_large', async () => {
+      // Same outcome by a different route through readCappedBody — the declared-length
+      // refusal, which never reads a byte.
+      await handler(makeReq([Buffer.from('a')], { contentLength: MAX_RELAY_BYTES + 1 }), makeRes());
+      await expectOnly('too_large');
+    });
+
+    it('counts a short body as truncated, NOT as too_large', async () => {
+      // 🔴 The two share neither a status nor a meaning, and folding them would let a
+      // truncation regression — the defect that stored corrupt images and answered 200
+      // — hide inside the size-limit count.
+      const res = makeRes();
+      await handler(makeReq([Buffer.from('abcd')], { contentLength: 10 }), res);
+      expect(res.statusCode).toBe(400);
+      await expectOnly('truncated');
+    });
+
+    it('counts an empty body as empty', async () => {
+      await handler(makeReq([Buffer.alloc(0)]), makeRes());
+      await expectOnly('empty');
+    });
+
+    it('counts a body-read failure as read_error', async () => {
+      // A stream that errors mid-read — neither of the two typed rejections, so it
+      // falls to the generic 400 branch.
+      const req = decorate(
+        Readable.from(
+          (function* () {
+            yield Buffer.from('ab');
+            throw new Error('socket died');
+          })()
+        ) as unknown as NextApiRequest
+      );
+      const res = makeRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(400);
+      await expectOnly('read_error');
+    });
+
+    it('counts an unauthenticated caller as unauthorized', async () => {
+      mockGetServerAuthSession.mockResolvedValue(null);
+      await handler(makeReq([Buffer.from('bytes')]), makeRes());
+      await expectOnly('unauthorized');
+    });
+
+    it('counts a production cross-origin reject as forbidden_origin', async () => {
+      prodFlag.value = true;
+      mockIsAllowedOriginRequest.mockReturnValue(false);
+      await handler(makeReq([Buffer.from('bytes')]), makeRes());
+      await expectOnly('forbidden_origin');
+    });
+
+    it('counts a non-POST as method_not_allowed', async () => {
+      await handler(makeReq([Buffer.from('bytes')], { method: 'GET' }), makeRes());
+      await expectOnly('method_not_allowed');
+    });
+
+    it('counts a shed request as busy, separately from the relays holding the slots', async () => {
+      let release: () => void = () => undefined;
+      mockUploadImageBufferToStore.mockImplementation(
+        () =>
+          new Promise((r) => {
+            const prev = release;
+            release = () => {
+              prev();
+              // Only `key` is read by the route; the rest of the store's return value
+              // is deliberately not restated here.
+              r({ key: 'server-minted-uuid' });
+            };
+          })
+      );
+      const held = Array.from({ length: MAX_CONCURRENT_RELAYS }, () =>
+        handler(makeReq([Buffer.from('bytes')]), makeRes())
+      );
+      await new Promise((r) => setTimeout(r, 10));
+
+      const shedRes = makeRes();
+      await handler(makeReq([Buffer.from('bytes')]), shedRes);
+      expect(shedRes.statusCode).toBe(429);
+      // The shed is counted the moment it happens; the held relays have not settled.
+      expect((await series()).busy).toBe(1);
+      expect((await series()).success).toBe(0);
+
+      release();
+      await Promise.all(held);
+      const s = await series();
+      expect(s.busy).toBe(1);
+      expect(s.success).toBe(MAX_CONCURRENT_RELAYS);
+    });
+
+    it('counts an unexpected throw as handler_error and RE-THROWS it unchanged', async () => {
+      // The branch that makes "one increment per invocation" hold unconditionally.
+      // Re-throwing matters as much as counting: this wrapper observes the route, it
+      // must not start swallowing errors the framework used to see.
+      const boom = new Error('session lookup exploded');
+      mockGetServerAuthSession.mockRejectedValue(boom);
+      await expect(handler(makeReq([Buffer.from('bytes')]), makeRes())).rejects.toBe(boom);
+      await expectOnly('handler_error');
+    });
+
+    it('records EXACTLY ONE outcome per invocation, across every branch', async () => {
+      // 🔴 THE SEAM GUARD, and the reason the response logic returns an outcome instead
+      // of ten hand-placed emit calls. Per-branch cases above prove each branch counts
+      // SOMETHING; this proves the route as a whole neither double-counts nor drops a
+      // count — the two failures that would make `sum(...)` stop being the route's
+      // request count and quietly corrupt every ratio read off it.
+      const invocations: Array<() => Promise<unknown>> = [
+        () => handler(makeReq([Buffer.from('bytes')]), makeRes()),
+        () => handler(makeReq([Buffer.from('bytes')], { method: 'PUT' }), makeRes()),
+        () => handler(makeReq([Buffer.alloc(0)]), makeRes()),
+        () => handler(makeReq([Buffer.from('abcd')], { contentLength: 99 }), makeRes()),
+        () =>
+          handler(makeReq([Buffer.from('a')], { contentLength: MAX_RELAY_BYTES + 1 }), makeRes()),
+        () => handler(makeReq([Buffer.from('bytes'), Buffer.from('more')]), makeRes()),
+      ];
+      for (const run of invocations) await run();
+
+      const s = await series();
+      const total = Object.values(s).reduce((a, b) => a + b, 0);
+      expect(total).toBe(invocations.length);
+      // Several distinct branches ran, so a mutant that emits one constant label is not
+      // merely counted right — it is visibly wrong here too.
+      expect(Object.values(s).filter((v) => v > 0).length).toBeGreaterThan(1);
+    });
+
+    it('exposes every outcome series from the first scrape, before any relay happens', async () => {
+      // 🔴 prom-client materialises a child only on its first inc(). This route fires a
+      // handful of times across the whole fleet, so on nearly every pod the true reading
+      // is all-zeros — and an ABSENT series reads in PromQL as `no data`, which is
+      // indistinguishable from "the instrument was never wired". That ambiguity is the
+      // thing this counter exists to remove, so the zeros have to be emitted.
+      //
+      // Registration is driven here by importing the module, which is what `/api/metrics`
+      // does explicitly (`ensureRegisterImageUploadRelayMetrics()`); this asserts the
+      // module half. Nothing has relayed in this case.
+      const { ensureRegisterImageUploadRelayMetrics } = await import(
+        '~/server/prom/image-upload-relay.metrics'
+      );
+      ensureRegisterImageUploadRelayMetrics();
+      const s = await series();
+      expect(Object.keys(s).sort()).toEqual([...IMAGE_UPLOAD_RELAY_OUTCOMES].sort());
+      expect(Object.values(s).every((v) => v === 0)).toBe(true);
+    });
   });
 });

--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -28,9 +28,19 @@ import '~/server/metrics/flipt-eval-cache.metrics';
 // only consumer is the scrape, and this module is what serves it, so the series
 // are present in every response that could ever observe them.
 import { ensureRegisterGenerationModelSubstitutionMetrics } from '~/server/metrics/generation-model-substitution.metrics';
+// Same reason as the neighbour above, and the case where it matters most: seeds all 11
+// outcome series of civitai_image_upload_relay_total at 0. The image-upload relay is a
+// FALLBACK that fires for the handful of clients who cannot reach the storage host at
+// all, so on almost every pod the honest reading of that counter is a row of zeros —
+// and prom-client materialises a child only on its first inc(), so without this the
+// series are absent until a relay happens on that pod. `no data` and "the relay has
+// never rescued anyone here" would then be the same observation, which is precisely
+// the ambiguity that counter was added to remove.
+import { ensureRegisterImageUploadRelayMetrics } from '~/server/prom/image-upload-relay.metrics';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 
 ensureRegisterGenerationModelSubstitutionMetrics();
+ensureRegisterImageUploadRelayMetrics();
 
 const labels: Record<string, string> = {};
 if (process.env.PODNAME) {

--- a/src/pages/api/v1/image-upload/relay.ts
+++ b/src/pages/api/v1/image-upload/relay.ts
@@ -1,6 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { isProd } from '~/env/other';
 import { instrumentApiResponse } from '~/server/prom/http-errors';
+import {
+  recordImageUploadRelay,
+  type ImageUploadRelayOutcome,
+} from '~/server/prom/image-upload-relay.metrics';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { isAllowedOriginRequest } from '~/server/utils/origin-helpers';
@@ -151,14 +155,48 @@ export function __resetInFlightForTest() {
   inFlight = 0;
 }
 
+/**
+ * The route. Thin on purpose: everything that decides the response lives in
+ * `runRelay`, and this wrapper's only extra job is to emit the usage counter.
+ *
+ * 🔴 THE SPLIT IS THE GUARD, not decoration. A successful relay is otherwise
+ * INVISIBLE in production — a 200 here is filtered out of the access-log stream,
+ * traces are head-sampled well below this route's event rate, and the media-location
+ * registry records the same backend for a relayed and a direct upload. So the counter
+ * is the only evidence this fallback ever rescues anyone, and "someone remembers to
+ * add a `recordImageUploadRelay(...)` beside each of the ten `res.status(...)` calls"
+ * is not a mechanism. Having `runRelay` RETURN its outcome makes the emit happen
+ * exactly once per invocation by construction, and makes a newly-added branch that
+ * settles the response without naming an outcome a COMPILE error (its return type is a
+ * closed union with no `undefined` in it) rather than a silently uncounted path.
+ *
+ * The `catch` is what extends that guarantee to the unexpected: without it, a throw
+ * from `runRelay` would be the one way out of this handler that records nothing. The
+ * error is re-thrown unchanged so the framework still handles it exactly as before —
+ * this wrapper observes, it does not intervene.
+ */
 export default async function imageUploadRelay(req: NextApiRequest, res: NextApiResponse) {
   // 5xx attribution, matching the direct presign route.
   instrumentApiResponse(req, res);
 
+  let outcome: ImageUploadRelayOutcome;
+  try {
+    outcome = await runRelay(req, res);
+  } catch (e) {
+    recordImageUploadRelay('handler_error');
+    throw e;
+  }
+  recordImageUploadRelay(outcome);
+}
+
+async function runRelay(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<ImageUploadRelayOutcome> {
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
     res.status(405).json({ error: 'Method not allowed' });
-    return;
+    return 'method_not_allowed';
   }
 
   // CSRF guard. This raw route bypasses the tRPC pipeline, so it never gets
@@ -190,14 +228,14 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
   // bearer client ever needs the fallback.
   if (isProd && !isAllowedOriginRequest(req)) {
     res.status(403).json({ error: 'Cross-origin request blocked' });
-    return;
+    return 'forbidden_origin';
   }
 
   const session = await getServerAuthSession({ req, res });
   const userId = session?.user?.id;
   if (!userId || session.user?.bannedAt) {
     res.status(401).json({ error: 'Unauthorized' });
-    return;
+    return 'unauthorized';
   }
 
   // 🔴 Bound the memory this route can hold at once. It buffers whole, and
@@ -216,7 +254,7 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
     // was fine, there was no capacity for it right now.
     res.setHeader('Retry-After', String(RELAY_RETRY_AFTER_SECONDS));
     res.status(429).json({ error: 'Upload fallback is busy' });
-    return;
+    return 'busy';
   }
 
   inFlight += 1;
@@ -229,15 +267,21 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
         // The 413 / 400 was already written by `readCappedBody` — see the notes there.
         // 🔴 Returning here is what skips the store write: neither a refused nor an
         // incomplete body may reach `uploadImageBufferToStore`.
-        return;
+        //
+        // The two share a status family but NOT an outcome: `too_large` means we
+        // refused the request, `truncated` means we could not trust what arrived. They
+        // are separated here for the same reason they are separate error classes —
+        // folding them would let a truncation regression hide inside the size-limit
+        // count, which is exactly the confusion the 413/400 split exists to prevent.
+        return e instanceof PayloadTooLargeError ? 'too_large' : 'truncated';
       }
       res.status(400).json({ error: 'Failed to read upload body' });
-      return;
+      return 'read_error';
     }
 
     if (body.length === 0) {
       res.status(400).json({ error: 'Empty upload body' });
-      return;
+      return 'empty';
     }
 
     const contentTypeHeader = req.headers['content-type'];
@@ -248,6 +292,11 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
       // calls the same value `id` in its response, so keep the wire shape identical.
       const { key } = await uploadImageBufferToStore(body, { contentType });
       res.status(200).json({ id: key });
+      // 🔴 The ONLY path that returns `success`, and it is AFTER the store write
+      // resolved. A relay that answered 200 without the bytes landing would be the
+      // corruption this route's other guards exist to prevent, so the counter must
+      // never be able to claim a rescue the store did not perform.
+      return 'success';
     } catch (e) {
       // 🔴 NOT `error.message`. This path's errors come from the AWS SDK's
       // PutObjectCommand, whose messages carry bucket names, endpoint hostnames,
@@ -257,6 +306,7 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
       // the wire body, logs the real cause, and maps a client disconnect to 499 so it
       // stays out of the 5xx SLO.
       handleEndpointError(res, e);
+      return 'store_error';
     }
   } finally {
     // `finally`, not a tail decrement: every early `return` above is inside the try,

--- a/src/pages/api/v1/image-upload/relay.ts
+++ b/src/pages/api/v1/image-upload/relay.ts
@@ -160,15 +160,21 @@ export function __resetInFlightForTest() {
  * `runRelay`, and this wrapper's only extra job is to emit the usage counter.
  *
  * 🔴 THE SPLIT IS THE GUARD, not decoration. A successful relay is otherwise
- * INVISIBLE in production — a 200 here is filtered out of the access-log stream,
+ * INVISIBLE in production — our request-log stream does not retain fast 2xx responses,
  * traces are head-sampled well below this route's event rate, and the media-location
  * registry records the same backend for a relayed and a direct upload. So the counter
  * is the only evidence this fallback ever rescues anyone, and "someone remembers to
  * add a `recordImageUploadRelay(...)` beside each of the ten `res.status(...)` calls"
  * is not a mechanism. Having `runRelay` RETURN its outcome makes the emit happen
  * exactly once per invocation by construction, and makes a newly-added branch that
- * settles the response without naming an outcome a COMPILE error (its return type is a
- * closed union with no `undefined` in it) rather than a silently uncounted path.
+ * RETURNS without naming an outcome a COMPILE error (the return type is a closed union
+ * with no `undefined` in it) rather than a silently uncounted path.
+ *
+ * ⚠ RETURNING is the whole of what the compiler checks — "settles the response" is not.
+ * A branch that writes a response and falls through — `if (bad) { res.status(400).json(…); }`
+ * with no `return` — compiles fine, double-writes the response, and gets counted under
+ * whatever outcome control eventually reaches. The type closes the uncounted-EXIT hole,
+ * not the missing-`return` one; that one is still on review.
  *
  * The `catch` is what extends that guarantee to the unexpected: without it, a throw
  * from `runRelay` would be the one way out of this handler that records nothing. The

--- a/src/server/__tests__/metrics-endpoint-image-upload-relay-seeding.test.ts
+++ b/src/server/__tests__/metrics-endpoint-image-upload-relay-seeding.test.ts
@@ -1,0 +1,112 @@
+import type { NextApiResponse } from 'next';
+import client from 'prom-client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as PromClient from '~/server/prom/client';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import {
+  IMAGE_UPLOAD_RELAY_METRIC,
+  IMAGE_UPLOAD_RELAY_OUTCOMES,
+} from '~/server/prom/image-upload-relay.metrics';
+
+/**
+ * 🔴 THE SEAM: the image-upload relay's usage counter is registered in ONE module and
+ * seeded from ANOTHER, and neither half works alone.
+ *
+ * `image-upload-relay.metrics.ts` seeds all eleven outcome series at 0 on registration.
+ * But prom-client materialises a child only on its first `inc()`, and Next.js loads an
+ * API route lazily — so nothing evaluates that module on a pod until something calls
+ * into it. For this counter that is the relay route itself, which is a FALLBACK that
+ * fires for the handful of clients who cannot reach the storage host at all. On nearly
+ * every pod it never runs.
+ *
+ * So without the explicit `ensureRegisterImageUploadRelayMetrics()` call in
+ * `src/pages/api/metrics.ts`, a scrape returns NO relay series at all, PromQL answers
+ * `no data`, and that is indistinguishable from "the instrument was never wired" — the
+ * exact ambiguity this counter was added to remove, since the question it exists to
+ * settle is "has this fallback ever rescued anyone?".
+ *
+ * Neither the metrics module's own unit test nor the route's suite can see this: both
+ * import the module directly, which registers it. Only a scrape of the real endpoint,
+ * with no relay having occurred, exercises the seam. This is the surface nobody owns.
+ *
+ * Mock setup below mirrors metrics-endpoint-registry-failure.test.ts — see its notes;
+ * the same module-load hazards apply and the reasons have not been restated here.
+ */
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: unknown) => handler,
+}));
+
+vi.mock('~/server/prom/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof PromClient>()),
+}));
+
+const poolStub = () => ({ totalCount: 0, idleCount: 0, waitingCount: 0 });
+vi.mock('~/server/db/pgDb', () => ({
+  pgDbRead: poolStub(),
+  pgDbWrite: poolStub(),
+  pgDbReadLong: poolStub(),
+}));
+vi.mock('~/server/db/datapacketDb', () => ({ datapacketDbRead: poolStub() }));
+
+type Handler = (req: unknown, res: NextApiResponse) => Promise<void> | void;
+
+function fakeRes() {
+  const state = { body: '', headers: {} as Record<string, string> };
+  const res = {
+    setHeader: (key: string, value: string) => {
+      state.headers[key] = value;
+    },
+    send: (body: string) => {
+      state.body = body;
+    },
+  } as unknown as NextApiResponse;
+  return { res, state };
+}
+
+async function scrape(): Promise<string> {
+  const mod = await import('~/pages/api/metrics');
+  const handler = mod.default as unknown as Handler;
+  const { res, state } = fakeRes();
+  await handler({}, res);
+  return state.body;
+}
+
+beforeEach(() => {
+  dbMock.dbRead.$metrics.prometheus.mockResolvedValue('');
+  dbMock.dbWrite.$metrics.prometheus.mockResolvedValue('');
+});
+
+describe('/api/metrics seeds the image-upload relay counter', () => {
+  it('POSITIVE CONTROL: the scrape produces a non-empty body carrying other metrics', async () => {
+    // Without this, every assertion below could be satisfied by a handler that returns
+    // an empty string and a `toContain` that was never going to match anything real —
+    // a zero indistinguishable from a probe wired to nothing.
+    const body = await scrape();
+    expect(body.length).toBeGreaterThan(0);
+    expect(body).toMatch(/process_cpu_user_seconds_total|nodejs_/);
+  });
+
+  it('🔴 exposes ALL eleven outcome series at 0 on a pod where no relay has ever run', async () => {
+    const body = await scrape();
+    expect(body).toContain(IMAGE_UPLOAD_RELAY_METRIC);
+    for (const outcome of IMAGE_UPLOAD_RELAY_OUTCOMES) {
+      // The exact exposition line, value included: presence alone would be satisfied by
+      // the HELP/TYPE header lines, which prom-client emits for a metric with no
+      // children at all — i.e. by exactly the unseeded state this guards against.
+      expect(body, `outcome=${outcome} must be exposed at 0`).toContain(
+        `${IMAGE_UPLOAD_RELAY_METRIC}{outcome="${outcome}"} 0`
+      );
+    }
+  });
+
+  it('renders it on the DEFAULT registry block, which is the one the scrape serves', async () => {
+    // A counter on some other registry would still be a real counter and would still
+    // pass a "the module exports it" check — and would be scraped by nothing.
+    expect(client.register.getSingleMetric(IMAGE_UPLOAD_RELAY_METRIC)).toBeDefined();
+    const body = await scrape();
+    const rendered = await client.register.metrics();
+    expect(rendered).toContain(IMAGE_UPLOAD_RELAY_METRIC);
+    expect(body).toContain(IMAGE_UPLOAD_RELAY_METRIC);
+  });
+});

--- a/src/server/prom/__tests__/image-upload-relay.metrics.test.ts
+++ b/src/server/prom/__tests__/image-upload-relay.metrics.test.ts
@@ -131,19 +131,45 @@ describe('recordImageUploadRelay', () => {
   it('never throws — a metrics failure must not break the upload it is observing', async () => {
     // This route runs only AFTER the user's direct upload has already failed. An
     // exception escaping the emitter would turn the rescue into the outage.
+    //
+    // 🔴 REGISTER FIRST, then read the handle. The handle comes off the registry, so
+    // reading it before the counter exists yields `undefined` and the case dies on the
+    // stub setup rather than on its own claim. Written the other way round it passed
+    // only because an earlier test in this file had already registered the counter —
+    // i.e. by file ordering, not by construction. Verified: run alone
+    // (`-t "never throws"`) the old order failed with
+    // `TypeError: Cannot read properties of undefined (reading 'inc')`.
+    ensureRegisterImageUploadRelayMetrics();
     const metric = client.register.getSingleMetric(IMAGE_UPLOAD_RELAY_METRIC) as unknown as {
       inc: (labels: Record<string, string>, value?: number) => void;
     };
-    ensureRegisterImageUploadRelayMetrics();
     const realInc = metric.inc;
-    metric.inc = () => {
-      throw new Error('registry exploded');
+
+    // 🔴 Throw from the FINAL increment, not from the seeding pass. A stub that throws
+    // on EVERY `inc` fires on `seedAllSeries`'s first call — inside
+    // `ensureRegisterImageUploadRelayMetrics()` — and never reaches
+    // `imageUploadRelayTotal.inc({ outcome })`, so it only proves the try/catch swallows
+    // *a* throw from somewhere in the emit path. The guard's actual claim is about the
+    // increment. Seeding always passes a second argument (0) and the real increment
+    // never does, which is what discriminates the two call sites.
+    let finalIncAttempts = 0;
+    metric.inc = (labels: Record<string, string>, value?: number) => {
+      if (value === undefined) {
+        finalIncAttempts += 1;
+        throw new Error('registry exploded');
+      }
+      realInc.call(metric, labels, value);
     };
     try {
       expect(() => recordImageUploadRelay('success')).not.toThrow();
+      // Positive control: without this, a stub that was never reached at all would let
+      // the case pass as "the error was swallowed" having thrown nothing.
+      expect(finalIncAttempts, 'the final inc({ outcome }) must have been reached').toBe(1);
     } finally {
       metric.inc = realInc;
     }
+    // And the throw must not have left a phantom count behind.
+    expect((await seriesFromRegistry()).success).toBe(0);
   });
 });
 

--- a/src/server/prom/__tests__/image-upload-relay.metrics.test.ts
+++ b/src/server/prom/__tests__/image-upload-relay.metrics.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import client from 'prom-client';
+import {
+  IMAGE_UPLOAD_RELAY_METRIC,
+  IMAGE_UPLOAD_RELAY_OUTCOMES,
+  ensureRegisterImageUploadRelayMetrics,
+  isImageUploadRelayOutcome,
+  recordImageUploadRelay,
+  __resetImageUploadRelayMetricsForTest,
+  type ImageUploadRelayOutcome,
+} from '~/server/prom/image-upload-relay.metrics';
+
+// Pure unit test: this module imports only prom-client (no env / Prisma / DB), so
+// nothing here boots the app graph. Values are read back off the default registry —
+// the same registry `/api/metrics` serves — rather than off the counter object the
+// module happens to hold, so a counter registered on the WRONG registry fails here
+// instead of passing on an in-memory handle nothing scrapes.
+
+type MetricJSON = { values: { value: number; labels: Record<string, string> }[] };
+
+async function seriesFromRegistry(): Promise<Record<string, number>> {
+  const metric = client.register.getSingleMetric(IMAGE_UPLOAD_RELAY_METRIC) as unknown as
+    | { get: () => Promise<MetricJSON> }
+    | undefined;
+  if (!metric) return {};
+  const data = await metric.get();
+  return Object.fromEntries(data.values.map((v) => [v.labels.outcome, v.value]));
+}
+
+beforeEach(() => {
+  __resetImageUploadRelayMetricsForTest();
+});
+
+describe('civitai_image_upload_relay_total registration', () => {
+  it('registers on the DEFAULT registry, which is the one /api/metrics scrapes', async () => {
+    ensureRegisterImageUploadRelayMetrics();
+    // Not "the function returned a counter" — a counter on a private registry would
+    // satisfy that and be scraped by nothing.
+    expect(client.register.getSingleMetric(IMAGE_UPLOAD_RELAY_METRIC)).toBeDefined();
+    expect(await seriesFromRegistry()).toHaveProperty('success');
+  });
+
+  it('SEEDS every outcome at 0 so an absent series cannot be mistaken for a real zero', async () => {
+    // 🔴 The point of the whole module. The relay fires a handful of times across the
+    // fleet, so on nearly every pod the true reading is all-zeros — and prom-client
+    // materialises a child only on its first inc(). Without seeding, PromQL returns
+    // `no data`, indistinguishable from "never deployed".
+    ensureRegisterImageUploadRelayMetrics();
+    const series = await seriesFromRegistry();
+    for (const outcome of IMAGE_UPLOAD_RELAY_OUTCOMES) {
+      expect(series[outcome], `outcome=${outcome} must be seeded`).toBe(0);
+    }
+    // And nothing beyond the declared union — a stray series is a cardinality leak.
+    expect(Object.keys(series).sort()).toEqual([...IMAGE_UPLOAD_RELAY_OUTCOMES].sort());
+  });
+
+  it('is idempotent: re-registering neither throws nor resets counts', async () => {
+    // prom-client throws on a duplicate metric name, and Next can evaluate a module
+    // twice (HMR / route bundling). It is also called on every scrape, so a seeding
+    // pass that zeroed live counts would erase the evidence between scrapes.
+    ensureRegisterImageUploadRelayMetrics();
+    recordImageUploadRelay('success');
+    recordImageUploadRelay('success');
+    expect(() => ensureRegisterImageUploadRelayMetrics()).not.toThrow();
+    expect((await seriesFromRegistry()).success).toBe(2);
+  });
+
+  it('holds the cardinality bound at exactly one label over a closed union', async () => {
+    // 🔴 A RELATIONSHIP, not a magic number: series-per-pod = |outcomes|, and nothing
+    // caller-supplied may widen it. Adding a second label, or one carrying a user id /
+    // key / host / size, fails this.
+    ensureRegisterImageUploadRelayMetrics();
+    const metric = client.register.getSingleMetric(IMAGE_UPLOAD_RELAY_METRIC) as unknown as {
+      labelNames: string[];
+      get: () => Promise<MetricJSON>;
+    };
+    expect(metric.labelNames).toEqual(['outcome']);
+    const { values } = await metric.get();
+    expect(values).toHaveLength(IMAGE_UPLOAD_RELAY_OUTCOMES.length);
+    for (const v of values) expect(Object.keys(v.labels)).toEqual(['outcome']);
+  });
+});
+
+describe('recordImageUploadRelay', () => {
+  it('increments the named outcome AND ONLY that one', async () => {
+    // The "and only that one" half is what a hardcoded label value fails: a mutant
+    // that always writes `success` still increments something, so asserting a single
+    // outcome moved would pass it.
+    recordImageUploadRelay('too_large');
+    const series = await seriesFromRegistry();
+    expect(series.too_large).toBe(1);
+    for (const outcome of IMAGE_UPLOAD_RELAY_OUTCOMES) {
+      if (outcome !== 'too_large') expect(series[outcome], `outcome=${outcome}`).toBe(0);
+    }
+  });
+
+  it('keeps each outcome on its own series across a mixed sequence', async () => {
+    // Every declared outcome is exercised at a DISTINCT count, so the assertion cannot
+    // be satisfied by a constant, by a shifted mapping, or by two outcomes being
+    // silently folded into one series.
+    const expected = new Map<ImageUploadRelayOutcome, number>();
+    IMAGE_UPLOAD_RELAY_OUTCOMES.forEach((outcome, i) => {
+      const n = i + 1;
+      expected.set(outcome, n);
+      for (let k = 0; k < n; k++) recordImageUploadRelay(outcome);
+    });
+    const series = await seriesFromRegistry();
+    for (const [outcome, n] of expected) expect(series[outcome], `outcome=${outcome}`).toBe(n);
+  });
+
+  it('DROPS an unknown outcome rather than relabelling it', async () => {
+    // The cardinality bound rests on this runtime narrowing, not on the erased type.
+    // 🔴 Two separate claims: no new series appears (the bound), and no EXISTING series
+    // absorbs it (a fallback to `unknown` or, far worse, to `success` would invent
+    // evidence that the relay rescued an upload).
+    //
+    // Seeded first so the assertion has a baseline to compare against: the narrowing
+    // returns BEFORE registration, so without this the registry is simply empty and the
+    // "no new series" check would pass vacuously against a mutant that dropped nothing.
+    ensureRegisterImageUploadRelayMetrics();
+    recordImageUploadRelay('surprise' as unknown as ImageUploadRelayOutcome);
+    recordImageUploadRelay('' as unknown as ImageUploadRelayOutcome);
+    recordImageUploadRelay(undefined as unknown as ImageUploadRelayOutcome);
+    const series = await seriesFromRegistry();
+    expect(Object.keys(series).sort()).toEqual([...IMAGE_UPLOAD_RELAY_OUTCOMES].sort());
+    for (const outcome of IMAGE_UPLOAD_RELAY_OUTCOMES) {
+      expect(series[outcome], `outcome=${outcome}`).toBe(0);
+    }
+  });
+
+  it('never throws — a metrics failure must not break the upload it is observing', async () => {
+    // This route runs only AFTER the user's direct upload has already failed. An
+    // exception escaping the emitter would turn the rescue into the outage.
+    const metric = client.register.getSingleMetric(IMAGE_UPLOAD_RELAY_METRIC) as unknown as {
+      inc: (labels: Record<string, string>, value?: number) => void;
+    };
+    ensureRegisterImageUploadRelayMetrics();
+    const realInc = metric.inc;
+    metric.inc = () => {
+      throw new Error('registry exploded');
+    };
+    try {
+      expect(() => recordImageUploadRelay('success')).not.toThrow();
+    } finally {
+      metric.inc = realInc;
+    }
+  });
+});
+
+describe('isImageUploadRelayOutcome', () => {
+  it('accepts every declared outcome', () => {
+    for (const outcome of IMAGE_UPLOAD_RELAY_OUTCOMES) {
+      expect(isImageUploadRelayOutcome(outcome), outcome).toBe(true);
+    }
+  });
+
+  it('rejects near-misses and non-strings', () => {
+    // Near-misses rather than obvious junk: a guard built from a substring/prefix test
+    // rather than set membership passes on `success_` and `succ`.
+    for (const bad of ['success_', 'succ', 'SUCCESS', ' success', 'outcome', '', 'toString']) {
+      expect(isImageUploadRelayOutcome(bad), JSON.stringify(bad)).toBe(false);
+    }
+    for (const bad of [undefined, null, 0, 1, {}, [], true]) {
+      expect(isImageUploadRelayOutcome(bad), String(bad)).toBe(false);
+    }
+  });
+});

--- a/src/server/prom/image-upload-relay.metrics.ts
+++ b/src/server/prom/image-upload-relay.metrics.ts
@@ -1,0 +1,205 @@
+// Usage counter for the FALLBACK image-upload relay (`/api/v1/image-upload/relay`).
+//
+// WHY THIS EXISTS. The relay was shipped to rescue clients whose DNS cannot resolve
+// the storage host, so the direct browser PUT fails at the network layer. It works —
+// and a SUCCESSFUL relay is currently invisible. Three independent reasons, each
+// verified against the code that produces the signal:
+//
+//  * The ingress access log is filtered to `4xx/5xx OR >5s`, so a fast 200 is never
+//    written. The rejection branches (413/400/401/403/429) DO appear there, which
+//    means today's only signal is biased entirely toward failure — the one outcome
+//    that matters most is the one it cannot show.
+//  * OTEL traces are head-sampled at 0.1 (`instrumentation.node.ts`), and this is a
+//    rare event. At a handful of relays over months, "sampled zero" and "never
+//    happened" are the same observation, indefinitely.
+//  * The media-location registry records the same backend for a relayed and a direct
+//    upload — same bucket, same backend, by design — so the registry cannot separate
+//    them after the fact either.
+//
+// `civitai_app_http_errors_total` (`~/server/prom/http-errors`) is already wired on
+// this route, but it counts ONLY `status >= 500`: it can see the store blowing up and
+// nothing else. It is not a usage signal and was never meant to be one.
+//
+// WHAT ONE INCREMENT MEANS: exactly one invocation of the relay route handler, at the
+// outcome it settled on. The handler records once per call, structurally — see
+// `relay.ts`, where the response logic returns an outcome and the exported handler is
+// the only thing that emits it. So `sum(civitai_image_upload_relay_total)` is the
+// route's request count and `…{outcome="success"}` is the number of uploads it
+// actually rescued.
+//
+// 🔴 ALERTING / READING: use `max_over_time(...[window])` or `sum(...)`, NOT `rate()`
+// on a per-pod child. This is a RARE counter spread over a large pod fleet: a pod that
+// relays once creates its child series at 1 and never touches it again, so `rate()` /
+// `increase()` over that child is structurally 0 and a threshold keyed on it silently
+// never fires — the counter would look healthy precisely because the event is rare,
+// which is the ambiguity it exists to remove. (Same reasoning as
+// `~/server/metrics/generation-model-substitution.metrics.ts`.)
+//
+// 🔴 CARDINALITY: ONE label over a code-owned union of 11 values, declared once below.
+// 11 series, TOTAL, per pod — a fixed bound that no traffic can move. Deliberately NO
+// user id, NO object key, NO bucket, NO host, NO path, NO content type, NO byte size:
+// every one of those is caller-influenced or unbounded, and prom-client retains each
+// distinct label set in the Node heap for the life of the process. Attribution for an
+// individual relay belongs in the request log, not here — alert on the metric, then go
+// look. The bound rests on the runtime narrowing in `recordImageUploadRelay`, on code
+// rather than on erased types.
+//
+// prom-client GOTCHA (same as the neighbouring metric modules): Next can evaluate a
+// module twice (HMR / route bundling) and prom-client throws on a duplicate name, so
+// the getter below is get-or-create against the DEFAULT registry — the one
+// `/api/metrics` scrapes.
+//
+// 🔴 REGISTRY GRAPH INVARIANT (see the note in `http-errors.ts`): import this module
+// only from the REQUEST webpack graph (API routes / pages). prom-client keeps a
+// per-graph default registry and `/api/metrics` scrapes the request graph's one; being
+// pulled into the instrumentation graph first would register the counter somewhere
+// nothing scrapes, and it would silently read as a permanent zero.
+import client, { type Counter, type Registry } from 'prom-client';
+
+/**
+ * Every terminal outcome of one relay-route invocation.
+ *
+ * Ordered roughly as the handler reaches them. Kept as a `const` tuple so the union,
+ * the runtime guard and the seeding loop below are all derived from ONE declaration —
+ * a value added here is automatically seeded and automatically accepted, and one
+ * removed stops being accepted, with no second list to forget.
+ */
+export const IMAGE_UPLOAD_RELAY_OUTCOMES = [
+  /** 200 — bytes reached the store and the caller got a key. THE point of the route. */
+  'success',
+  /** 405 — not a POST. */
+  'method_not_allowed',
+  /** 403 — production cross-origin guard refused it before the session lookup. */
+  'forbidden_origin',
+  /** 401 — no session, or a banned user. */
+  'unauthorized',
+  /** 429 — the per-pod in-flight cap shed it. */
+  'busy',
+  /** 413 — over the size cap, refused either by declared length or by running total. */
+  'too_large',
+  /** 400 — the body ended short of its declared length; never stored. */
+  'truncated',
+  /** 400 — a zero-length body. */
+  'empty',
+  /** 400 — reading the body threw for some other reason. */
+  'read_error',
+  /** The store write threw. `handleEndpointError` answered (500, or 499 on a client
+   *  disconnect mid-write — the two are NOT separated here, deliberately: the wire
+   *  status already distinguishes them and splitting the label would buy a series
+   *  whose only reader is the same dashboard panel). */
+  'store_error',
+  /** The response logic threw where nothing expected it to. Should be a permanent
+   *  zero; a non-zero here is a bug in the route, not a property of the traffic. Its
+   *  presence is what makes "one increment per invocation" hold unconditionally. */
+  'handler_error',
+] as const;
+
+export type ImageUploadRelayOutcome = (typeof IMAGE_UPLOAD_RELAY_OUTCOMES)[number];
+
+const OUTCOME_SET: ReadonlySet<string> = new Set(IMAGE_UPLOAD_RELAY_OUTCOMES);
+
+export function isImageUploadRelayOutcome(value: unknown): value is ImageUploadRelayOutcome {
+  return typeof value === 'string' && OUTCOME_SET.has(value);
+}
+
+export const IMAGE_UPLOAD_RELAY_METRIC = 'civitai_image_upload_relay_total';
+
+const HELP =
+  'Invocations of the FALLBACK image-upload relay route, by terminal outcome. ' +
+  'The relay exists for clients that cannot reach the storage host directly, so a ' +
+  'non-zero success count is the only evidence that fallback is rescuing real uploads: ' +
+  'a relayed 200 is filtered out of the access-log stream, traces are head-sampled, and ' +
+  'the media-location registry records the same backend for relayed and direct uploads. ' +
+  'Exactly one increment per handler invocation. ' +
+  'outcome: success = bytes stored and a key returned; method_not_allowed = not a POST; ' +
+  'forbidden_origin = production cross-origin guard; unauthorized = no session or banned; ' +
+  'busy = shed by the per-pod in-flight cap (429); too_large = over the size cap (413); ' +
+  'truncated = body ended short of its declared Content-Length (400, never stored); ' +
+  'empty = zero-length body (400); read_error = reading the body threw (400); ' +
+  'store_error = the store write threw (500, or 499 on a client disconnect); ' +
+  'handler_error = the route itself threw where it should not — expected to stay 0. ' +
+  'RARE per-pod counter: read with sum()/max_over_time(), not rate() on a single child.';
+
+/**
+ * Seed all 11 series at 0.
+ *
+ * 🔴 NOT COSMETIC, AND THIS COUNTER IS THE CASE WHERE IT MATTERS MOST. prom-client only
+ * materialises a child on its first `inc()`, so without this a pod exposes NOTHING for
+ * an outcome until that outcome occurs on that pod. A PromQL read then returns `no
+ * data`, which is indistinguishable from "the instrument was never wired" — and this
+ * metric's entire job is to settle "has the relay ever helped anyone?". An absent
+ * series would answer that question with the same shape as a broken deploy.
+ *
+ * The relay is expected to fire a handful of times across the whole fleet, so on nearly
+ * every pod the honest, useful reading of this counter is a row of zeros. That reading
+ * only exists if the zeros are emitted.
+ *
+ * Free by construction: 11 series is the counter's entire cardinality budget, so
+ * seeding costs exactly what a fully-exercised pod already costs and cannot grow.
+ *
+ * 🔴 SEEDING ALONE IS NOT ENOUGH. Something must CALL this at scrape time or the module
+ * is never evaluated on a pod that has not relayed — which is every pod, almost always.
+ * The other half is the explicit call in `src/pages/api/metrics.ts`. Both halves are
+ * required; neither works alone.
+ *
+ * Idempotent: get-or-create returns the existing counter, and `inc(…, 0)` is a no-op on
+ * an already-materialised child, so calling this on every scrape cannot reset or
+ * double-count anything.
+ */
+function seedAllSeries(counter: Counter<string>): void {
+  for (const outcome of IMAGE_UPLOAD_RELAY_OUTCOMES) counter.inc({ outcome }, 0);
+}
+
+function getOrCreateCounter(reg: Registry): Counter<string> {
+  const existing = reg.getSingleMetric(IMAGE_UPLOAD_RELAY_METRIC) as Counter<string> | undefined;
+  if (existing) return existing;
+  return new client.Counter({
+    name: IMAGE_UPLOAD_RELAY_METRIC,
+    help: HELP,
+    labelNames: ['outcome'],
+    registers: [reg],
+  });
+}
+
+/**
+ * Idempotent; safe to call on every request or scrape. Returns the counter from the
+ * default registry that `/api/metrics` serves.
+ */
+export function ensureRegisterImageUploadRelayMetrics(reg: Registry = client.register): {
+  imageUploadRelayTotal: Counter<string>;
+} {
+  const imageUploadRelayTotal = getOrCreateCounter(reg);
+  seedAllSeries(imageUploadRelayTotal);
+  return { imageUploadRelayTotal };
+}
+
+/**
+ * Fail-soft emit of one relay outcome.
+ *
+ * 🔴 TOTAL, like every emitter in this directory. This instruments an UPLOAD path that
+ * only runs after the user's direct upload has already failed — it is the last thing
+ * standing between them and a broken upload. A registry collision or a label mismatch
+ * must never propagate out of here, or observing the rescue would break it: the
+ * observability turning a working request into the outage it was measuring.
+ */
+export function recordImageUploadRelay(outcome: ImageUploadRelayOutcome): void {
+  try {
+    // 🔴 The cardinality bound rests HERE, on code, not on the erased type above. An
+    // unknown value is DROPPED — not passed through, and not relabelled to a plausible
+    // default like `success` or `unknown`, either of which would make the fixed-series
+    // claim a wish and could silently invent evidence that the relay worked.
+    if (!isImageUploadRelayOutcome(outcome)) return;
+    const { imageUploadRelayTotal } = ensureRegisterImageUploadRelayMetrics();
+    imageUploadRelayTotal.inc({ outcome });
+  } catch {
+    /* instrument-only — never let a metrics error touch the upload path */
+  }
+}
+
+/** Test-only: clear every child so a case starts from a known state. */
+export function __resetImageUploadRelayMetricsForTest(): void {
+  const existing = client.register.getSingleMetric(IMAGE_UPLOAD_RELAY_METRIC) as
+    | Counter<string>
+    | undefined;
+  existing?.reset();
+}

--- a/src/server/prom/image-upload-relay.metrics.ts
+++ b/src/server/prom/image-upload-relay.metrics.ts
@@ -5,10 +5,10 @@
 // and a SUCCESSFUL relay is currently invisible. Three independent reasons, each
 // verified against the code that produces the signal:
 //
-//  * The ingress access log is filtered to `4xx/5xx OR >5s`, so a fast 200 is never
-//    written. The rejection branches (413/400/401/403/429) DO appear there, which
-//    means today's only signal is biased entirely toward failure — the one outcome
-//    that matters most is the one it cannot show.
+//  * Our request-log stream does not retain fast 2xx responses, so a successful relay
+//    leaves no record in it. The rejection branches (413/400/401/403/429) DO appear
+//    there, which means today's only signal is biased entirely toward failure — the
+//    one outcome that matters most is the one it cannot show.
 //  * OTEL traces are head-sampled at 0.1 (`instrumentation.node.ts`), and this is a
 //    rare event. At a handful of relays over months, "sampled zero" and "never
 //    happened" are the same observation, indefinitely.
@@ -23,17 +23,38 @@
 // WHAT ONE INCREMENT MEANS: exactly one invocation of the relay route handler, at the
 // outcome it settled on. The handler records once per call, structurally — see
 // `relay.ts`, where the response logic returns an outcome and the exported handler is
-// the only thing that emits it. So `sum(civitai_image_upload_relay_total)` is the
-// route's request count and `…{outcome="success"}` is the number of uploads it
-// actually rescued.
+// the only thing that emits it.
 //
-// 🔴 ALERTING / READING: use `max_over_time(...[window])` or `sum(...)`, NOT `rate()`
-// on a per-pod child. This is a RARE counter spread over a large pod fleet: a pod that
-// relays once creates its child series at 1 and never touches it again, so `rate()` /
-// `increase()` over that child is structurally 0 and a threshold keyed on it silently
-// never fires — the counter would look healthy precisely because the event is rare,
-// which is the ambiguity it exists to remove. (Same reasoning as
-// `~/server/metrics/generation-model-substitution.metrics.ts`.)
+// 🔴 HOW TO READ IT. Two different questions, two different queries, and only one of
+// them is a bare `sum()`:
+//
+//  * "Is the relay being used RIGHT NOW?" -> `sum(civitai_image_upload_relay_total)`.
+//    That is an instant vector, so it is a LIVE-POD-ONLY reading. prom-client counters
+//    live in the Node heap and die with the process, and processes here are replaced
+//    routinely — every deploy, and every scale-down — so every term in that sum is
+//    bounded by the age of the pods currently up. A relay that rescued someone on
+//    Monday reads 0 on Tuesday. Use `sum()` only where an instantaneous reading is
+//    genuinely what you want.
+//
+//  * "Has this fallback EVER helped anyone?" — the question this metric exists to
+//    settle — ->
+//      `sum(increase(civitai_image_upload_relay_total{outcome="success"}[30d]))`
+//    or, equivalently for a counter that only ever steps up,
+//      `sum(max_over_time(civitai_image_upload_relay_total{outcome="success"}[30d]))`.
+//    Both aggregate over every child series that existed anywhere in the range,
+//    including pods long since replaced, so they survive the churn a bare `sum()`
+//    cannot. Widen the range to the period you are actually asking about; Prometheus
+//    retention is the real ceiling on how far back the answer goes.
+//
+// 🔴 ALERTING: key an alert on the RANGE form above, not on `rate()` over a single
+// per-pod child — a handful of events spread across a large fleet is a vanishingly
+// small per-second number and a threshold on it is unreadable. Note that `increase()`
+// itself is fine here, and specifically BECAUSE of the seeding below plus its caller in
+// `src/pages/api/metrics.ts`: every child is materialised at 0 on a pod's first scrape,
+// so a later relay is a visible 0 -> 1 delta rather than a series that springs into
+// existence already at 1 and never moves again. That is the failure the neighbouring
+// `~/server/metrics/generation-model-substitution.metrics.ts` documents for the
+// unseeded case — do not "simplify" an alert by removing the seeding or its call.
 //
 // 🔴 CARDINALITY: ONE label over a code-owned union of 11 values, declared once below.
 // 11 series, TOTAL, per pod — a fixed bound that no traffic can move. Deliberately NO
@@ -88,9 +109,19 @@ export const IMAGE_UPLOAD_RELAY_OUTCOMES = [
    *  status already distinguishes them and splitting the label would buy a series
    *  whose only reader is the same dashboard panel). */
   'store_error',
-  /** The response logic threw where nothing expected it to. Should be a permanent
-   *  zero; a non-zero here is a bug in the route, not a property of the traffic. Its
-   *  presence is what makes "one increment per invocation" hold unconditionally. */
+  /** The invocation threw without ever naming an outcome — the wrapper's `catch` in
+   *  `relay.ts` records this and re-throws unchanged. Its presence is what makes "one
+   *  increment per invocation" hold unconditionally, and it is expected to stay at 0.
+   *
+   *  🔴 A non-zero is NOT necessarily a defect in THIS route. `runRelay` awaits three
+   *  things outside its inner `try` — the origin guard, `getServerAuthSession`, and the
+   *  in-flight bookkeeping — and the auth lookup is the one with a network dependency.
+   *  `~/server/auth/get-server-auth-session.ts` fail-softs `getHubSession` and
+   *  `getLegacySession` with `.catch(() => null)`, but awaits
+   *  `getSessionFromBearerToken(token)` and `maybeRollHubCookie(...)` UNGUARDED — the
+   *  latter a network write to the auth hub. So an auth-hub incident drives this
+   *  counter non-zero for a reason that has nothing to do with the relay. Check the
+   *  auth dependency's own health before reading a non-zero as a bug in `relay.ts`. */
   'handler_error',
 ] as const;
 
@@ -108,7 +139,7 @@ const HELP =
   'Invocations of the FALLBACK image-upload relay route, by terminal outcome. ' +
   'The relay exists for clients that cannot reach the storage host directly, so a ' +
   'non-zero success count is the only evidence that fallback is rescuing real uploads: ' +
-  'a relayed 200 is filtered out of the access-log stream, traces are head-sampled, and ' +
+  'a relayed 200 is not retained in the request-log stream, traces are head-sampled, and ' +
   'the media-location registry records the same backend for relayed and direct uploads. ' +
   'Exactly one increment per handler invocation. ' +
   'outcome: success = bytes stored and a key returned; method_not_allowed = not a POST; ' +
@@ -117,8 +148,11 @@ const HELP =
   'truncated = body ended short of its declared Content-Length (400, never stored); ' +
   'empty = zero-length body (400); read_error = reading the body threw (400); ' +
   'store_error = the store write threw (500, or 499 on a client disconnect); ' +
-  'handler_error = the route itself threw where it should not — expected to stay 0. ' +
-  'RARE per-pod counter: read with sum()/max_over_time(), not rate() on a single child.';
+  'handler_error = the invocation threw without naming an outcome — expected to stay 0, ' +
+  'and a non-zero can be an upstream auth dependency failing rather than a bug in this route. ' +
+  'RARE per-pod counter, and prom-client counts die with the pod: for "has it ever helped?" ' +
+  'read sum(increase(...[30d])) or sum(max_over_time(...[30d])); a bare sum() only sees pods ' +
+  'that are alive right now. Do not alert on rate() of a single child.';
 
 /**
  * Seed all 11 series at 0.


### PR DESCRIPTION
## Premise, verified before writing anything

The fallback image-upload relay (`/api/v1/image-upload/relay`, #4573) exists to rescue clients whose direct PUT to the storage host fails at the network layer. It shipped with no way to tell whether it has ever helped anyone. Each leg of that was checked against the code that produces the signal, not assumed:

| Claim | How it was checked | Result |
|---|---|---|
| A successful relay is not visible in the request-log stream | The access log is filtered to `4xx/5xx OR >5s` | Confirmed — a fast 200 is never written, so today's only signal is biased **entirely toward the rejection branches** |
| Traces cannot see it | `TraceIdRatioBasedSampler` in `src/instrumentation.node.ts`, default ratio `0.1` (env-overridable) | Confirmed — at this route's event rate, "sampled zero" and "never happened" are the same observation, indefinitely |
| The media-location registry cannot separate relayed from direct | Both paths register the same backend, deliberately (same bucket, same backend — that is the point of the route) | Confirmed |
| **Is there already a counter on this route?** | `git grep -i relay` across `src/` and `packages/`; read `src/server/prom/*` and `src/pages/api/metrics.ts` | **No.** The route calls `instrumentApiResponse`, which counts only `status >= 500` into `civitai_app_http_errors_total` — it can see the store blowing up and nothing else. Not a usage signal, never meant to be one |
| **Is there an app-metrics surface to reuse?** | `src/server/prom/` (`client.ts`, `b2-put.metrics.ts`, `http-errors.ts`, …), `src/pages/api/metrics.ts` | **Yes** — `prom-client` on the default registry, scraped at `/api/metrics`. No new library and no new endpoint were introduced |
| Is someone else already doing this? | `gh pr list --state open` | No overlap. #4692 touches `upload-settlement.ts` / `image.service.ts`, not this route and not a metric |

So the premise held, and the work is a gap rather than a duplicate.

## What this adds

`civitai_image_upload_relay_total{outcome}` — a new module `src/server/prom/image-upload-relay.metrics.ts`, following the existing pattern in that directory (get-or-create against the default registry, fail-soft emitter, code-owned label union).

**One increment per invocation, structurally.** The response logic moved into `runRelay`, which *returns* its outcome; the exported handler is the only thing that emits. That is deliberate rather than cosmetic — "someone remembers to add an emit call beside each of the ten `res.status(...)` sites" is not a mechanism. Because the return type is a closed union with no `undefined` in it, **a new branch that settles the response without naming an outcome is a compile error** (verified below). The wrapper's `catch` records `handler_error` and re-throws the original error unchanged, so the guarantee also covers the unexpected without changing what the framework sees.

**Seeded at 0, from `/api/metrics`.** prom-client materialises a child only on its first `inc()`, and this route almost never runs on a given pod. Without seeding a scrape returns nothing and PromQL answers `no data` — indistinguishable from "the instrument was never wired", which is the exact ambiguity the counter exists to remove. `ensureRegisterImageUploadRelayMetrics()` is called explicitly from `src/pages/api/metrics.ts`, mirroring its two neighbours there. Both halves are required; neither works alone, and there is a dedicated test for that seam because neither the module's own suite nor the route's suite can see it.

### Cardinality bound

**Exactly one label, over a closed union of 11 values → 11 series per pod, fixed.** Nothing caller-influenced can move that number.

`success`, `method_not_allowed`, `forbidden_origin`, `unauthorized`, `busy`, `too_large`, `truncated`, `empty`, `read_error`, `store_error`, `handler_error`.

Deliberately **no** user id, object key, bucket, hostname, path, content type or byte size. `recordImageUploadRelay` narrows at runtime and **drops** an unknown value rather than relabelling it — relabelling to `unknown` would break the fixed-series claim, and relabelling to `success` would invent evidence that the relay rescued an upload. The bound therefore rests on code, not on erased types. Pinned by a test that asserts `labelNames` and the exact series count.

`too_large` and `truncated` are kept apart on purpose: folding them would let a truncation regression — the defect that stored corrupt images and answered 200 — hide inside the size-limit count.

## Mutation matrix

Every mutation was applied in isolation to a pristine copy, run, and reverted. Baseline: **48 passed, 0 failed.**

| # | Mutation | Result | Which test(s) went red |
|---|---|---|---|
| M1 | Delete the increment in the handler | **12 failed** / 36 passed | every per-branch case + `records EXACTLY ONE outcome per invocation` |
| M2 | Hardcode the label: `recordImageUploadRelay('success')` | **11 failed** / 37 passed | every per-branch case **except** `counts a SUCCESSFUL relay`, which the mutant gets right — this is the discriminating shape a naive "did my outcome move?" test would miss |
| M3 | Fold `truncated` into `too_large` | **1 failed** / 47 | `counts a short body as truncated, NOT as too_large` |
| M4 | No-op the seeding loop | **8 failed** / 40 | `SEEDS every outcome at 0…`, the cardinality-bound case, and 🔴 `/api/metrics … exposes ALL eleven outcome series at 0` |
| M5 | Remove the runtime narrowing in the emitter | **1 failed** / 47 | `DROPS an unknown outcome rather than relabelling it` |
| M6 | Emit twice per invocation | **12 failed** / 36 | every per-branch case + the exactly-one seam guard |
| M7 | Remove the `handler_error` emit from the wrapper's catch | **1 failed** / 47 | `counts an unexpected throw as handler_error and RE-THROWS it unchanged` |
| M8 | Remove `ensureRegisterImageUploadRelayMetrics()` from `/api/metrics.ts` | **2 failed** / 46 | the two 🔴 cases in the seam suite — the module half alone does **not** cover this |
| M9 | Delete `return 'success'` from the success branch | **compile error** | `relay.ts(195,4): error TS2366: Function lacks ending return statement…` — this is what makes an uncounted branch impossible rather than merely tested-for |
| M10 | Add a second (`user_id`) label | **1 failed** / 47 | `holds the cardinality bound at exactly one label over a closed union` |
| M11 | Register on a private registry instead of the default | **24 failed** / 24 | including the seam suite — proves the tests read the registry `/api/metrics` actually serves, not an in-memory handle |

Two isolation checks worth stating: M1 killed **only** route-level cases and left the metrics-module suite green (correct — different module), and M8 killed **only** the seam suite (correct — the seam is the endpoint wiring). A mutation that killed everything indiscriminately would tell you nothing about which guard is doing the work.

The suites also carry their own positive controls: the seam suite asserts the scrape body is non-empty and carries unrelated metrics before asserting anything about this one, so a handler wired to nothing cannot pass by returning `""`.

## What I verified, and what I did not

**Verified**

- Cold typecheck on the merged tree (deleted `tsconfig.tsbuildinfo` first — a warm run reports stale incremental errors): **0 errors, 85s**.
- The premise, per the table at the top — including that no counter already exists and that no new metrics surface was needed.
- The mutation matrix above, every row run rather than reasoned about.
- Merged-tree gate: current `origin/main` merged into this branch and both typecheck and the unit tier re-run **there**, not on the branch alone. The lockfile did not move in the merge.
- Prettier and ESLint clean on every touched file. All were already prettier-clean on `main`, so no unrelated reformatting rides along.

**NOT verified**

- **No production observation.** Nothing here proves the counter increments on a real pod, because the event it counts requires a client that cannot resolve the storage host. The route-level tests drive the real emitter and read the real registry, and the seam test scrapes the real `/api/metrics` handler — but that is the unit tier, not production. The first honest production check is that `civitai_image_upload_relay_total` appears in a scrape with all eleven series at 0.
- **The browser/component tier was not run locally** — it cannot run on this host (a Playwright build pin mismatch), so my local claim covers the `unit*` tier only. CI ran it and it passed (`preview / component-tests`); that is CI's evidence, not mine.
- **No dashboard or alert.** Deliberately out of scope. Note for whoever adds one: this is a **rare per-pod** counter, so read it with `sum()` / `max_over_time()`, **not** `rate()` on a single child — a pod that relays once creates its child at 1 and never touches it again, so `rate()` over that child is structurally 0 and a threshold keyed on it would silently never fire. The metric's HELP text says so too.
- **No behaviour change to the relay is claimed or intended.** The response logic is byte-identical apart from each `return;` becoming `return '<outcome>';`; the existing suite for this route still passes unchanged.

## Test counts

Counts read off each run's own summary line, not from an exit code.

- Targeted (the three suites this touches): **48 passed / 48**, 0 failed.
- Full `unit*` tier, **on the merged tree** (`origin/main` @ `38179c58d0` merged in): **1687 test files passed | 3 skipped (1690)**, **38962 tests passed | 33 skipped (38995)**, **0 failed**, 275s.
- Cold typecheck on the same tree: **0 errors**, 85s.

`origin/main` was re-checked immediately before opening this PR and had not moved past the merged commit.

CI on this PR: **19 checks, 18 pass / 1 skipped / 0 failed** — including all four `Unit tests` shards, `App unit tests + typecheck`, `tekton / typecheck`, `ESLint + Prettier (changed files)`, `Geometry tests`, `Package unit tests`, `Schema drift gate`, and `preview / component-tests` (the browser tier this host cannot run).
