### PR TITLE
fix(articles): show a processing state instead of 404ing an article m…

### DIFF
--- a/src/components/Article/ArticleProcessing.tsx
+++ b/src/components/Article/ArticleProcessing.tsx
@@ -1,0 +1,33 @@
+import { Container, Loader, Stack, Text, Title } from '@mantine/core';
+import { Meta } from '~/components/Meta/Meta';
+
+/**
+ * Shown to a non-owner for a published article still inside its content-scan window, in place of
+ * the 404 that state used to render. Deliberately says nothing about the article itself — the
+ * viewer has not been cleared to see any of it yet.
+ */
+export function ArticleProcessing() {
+  return (
+    <>
+      {/* The article is expected to resolve within about a minute, so keep this shell out of the
+          index rather than let a crawler cache it as the page's content. */}
+      <Meta title="Article is being processed" deIndex />
+
+      <Container
+        className="flex h-[calc(100%-var(--footer-height))] items-center justify-center"
+        size="sm"
+      >
+        <Stack align="center" gap="md">
+          <Loader size="lg" />
+          <Title order={1} size="h2" ta="center">
+            This article is being processed
+          </Title>
+          <Text size="lg" c="dimmed" ta="center">
+            It was just published or updated, and we&apos;re still reviewing its images. This page
+            will load the article as soon as that finishes.
+          </Text>
+        </Stack>
+      </Container>
+    </>
+  );
+}

--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -19,11 +19,12 @@ import { IconAlertCircle, IconBolt, IconBookmark, IconShare3 } from '@tabler/ico
 import dayjs from '~/shared/utils/dayjs';
 import { truncate } from 'lodash-es';
 import type { InferGetServerSidePropsType } from 'next';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import * as z from 'zod';
 import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import { NotFound } from '~/components/AppLayout/NotFound';
+import { ArticleProcessing } from '~/components/Article/ArticleProcessing';
 import { Page } from '~/components/AppLayout/Page';
 import { ArticleContextMenu } from '~/components/Article/ArticleContextMenu';
 import { ArticleDetailComments } from '~/components/Article/Detail/ArticleDetailComments';
@@ -64,7 +65,7 @@ import { useHiddenPreferencesData } from '~/hooks/hidden-preferences';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { constants } from '~/server/common/constants';
-import { isArticlePublished } from '~/server/services/article.service';
+import { getPublishedArticleIngestion } from '~/server/services/article.service';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { getBrowsingLevelLabel } from '~/shared/constants/browsingLevel.constants';
 import {
@@ -125,12 +126,17 @@ export const getServerSideProps = createServerSideProps({
 
       // `getById` is viewer-scoped: it resolves for the owner and moderators and throws
       // NOT_FOUND for everyone else, so this 404s a draft/hidden article for crawlers while
-      // its author still loads it. The publish check keeps a live article out of that branch —
+      // its author still loads it. The ingestion check keeps a live article out of that branch —
       // `getById` also throws NOT_FOUND while a published article is being re-scanned after an
       // edit, and a 404 on an indexed URL is not a state to enter transiently. Any other
       // failure keeps the 200 and lets the client refetch.
-      if (fetched === NOT_FOUND && !(await isArticlePublished(result.data.id)))
-        return { notFound: true };
+      if (fetched === NOT_FOUND) {
+        const ingestion = await getPublishedArticleIngestion(result.data.id);
+        // Blocked is the one published state that can never resolve for the public, so it takes
+        // the 404 rather than serving an indexable shell that only ever renders NotFound.
+        if (ingestion === null || ingestion === ArticleIngestionStatus.Blocked)
+          return { notFound: true };
+      }
 
       const article = fetched === NOT_FOUND ? null : fetched;
 
@@ -186,6 +192,17 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
   const { data: article, isLoading, isRefetching } = trpc.article.getById.useQuery({ id });
   const tippedAmount = useBuzzTippingStore({ entityType: 'Article', entityId: id });
 
+  // `getById` hides a published article from non-owners until its images finish scanning, and a
+  // publish notification links straight into that window — so a refusal is not yet a 404. Poll
+  // while it is transient and pull the article back in once the scan lands, rather than leaving
+  // the reader on a dead end they have to reload out of.
+  const refused = !isLoading && !article && features.articles;
+  const { data: isProcessing, isInitialLoading: checkingProcessing } =
+    trpc.article.isProcessing.useQuery(
+      { id },
+      { enabled: refused, refetchInterval: (query) => (query.state.data === true ? 15_000 : false) }
+    );
+
   // Intersection observer for lazy loading comments
   const { ref: commentsRef, inView: commentsInView } = useInView({
     triggerOnce: true,
@@ -213,6 +230,18 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
 
   const queryUtils = trpc.useUtils();
   const upsertArticleMutation = trpc.article.upsert.useMutation();
+
+  // The poll above stops the moment the scan window closes; this is what turns that into a
+  // rendered article without a reload. Only the true->false edge, so an article that was never
+  // processing (a real 404) doesn't refetch itself.
+  const wasProcessing = React.useRef(false);
+  useEffect(() => {
+    if (isProcessing) wasProcessing.current = true;
+    else if (wasProcessing.current) {
+      wasProcessing.current = false;
+      queryUtils.article.getById.invalidate({ id });
+    }
+  }, [isProcessing, id, queryUtils]);
 
   const { data: myReview } = trpc.article.getMyArticleRatingReview.useQuery(
     { articleId: id },
@@ -248,7 +277,12 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
   const [image] = items;
 
   if (isLoading) return <PageLoader />;
-  if (!article || isBlocked || disableArticles) return <NotFound />;
+  if (!article) {
+    if (disableArticles) return <NotFound />;
+    if (checkingProcessing) return <PageLoader />;
+    return isProcessing ? <ArticleProcessing /> : <NotFound />;
+  }
+  if (isBlocked || disableArticles) return <NotFound />;
 
   const category = article.tags.find((tag) => tag.isCategory);
   const tags = article.tags.filter((tag) => !tag.isCategory);

--- a/src/server/__tests__/article-page-ssr.test.ts
+++ b/src/server/__tests__/article-page-ssr.test.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import { describe, expect, it, vi } from 'vitest';
 import type * as ArticleService from '~/server/services/article.service';
+import { ArticleIngestionStatus } from '~/shared/utils/prisma/enums';
 
 /**
  * `/articles/<id>` SSR: which article states reach a crawler as a 200, and which as a 404.
@@ -19,7 +20,7 @@ type Resolver = (ctx: any) => Promise<any>;
 
 // `vi.hoisted` so these exist before the hoisted page import below runs the module factory.
 const captured = vi.hoisted(() => ({ resolver: undefined as Resolver | undefined }));
-const isArticlePublishedMock = vi.hoisted(() => vi.fn(async () => false));
+const getPublishedArticleIngestionMock = vi.hoisted(() => vi.fn(async () => null as any));
 
 vi.mock('~/server/utils/server-side-helpers', () => ({
   createServerSideProps: ({ resolver }: { resolver: Resolver }) => {
@@ -30,7 +31,7 @@ vi.mock('~/server/utils/server-side-helpers', () => ({
 
 vi.mock('~/server/services/article.service', async (importOriginal) => ({
   ...(await importOriginal<typeof ArticleService>()),
-  isArticlePublished: (...args: [number]) => isArticlePublishedMock(...args),
+  getPublishedArticleIngestion: (...args: [number]) => getPublishedArticleIngestionMock(...args),
 }));
 
 // Module scope, not inside a test: transforming the page's graph (Mantine, tabler, the SCSS
@@ -50,15 +51,15 @@ const draft = {
 
 const run = async ({
   fetchImpl,
-  published = false,
+  ingestion = null,
   clientNav = false,
 }: {
   fetchImpl?: () => Promise<unknown>;
-  published?: boolean;
+  ingestion?: ArticleIngestionStatus | null;
   clientNav?: boolean;
 }) => {
   if (!captured.resolver) throw new Error('resolver was never captured');
-  isArticlePublishedMock.mockResolvedValue(published);
+  getPublishedArticleIngestionMock.mockResolvedValue(ingestion);
 
   return captured.resolver({
     ctx: { query: { id: String(ARTICLE_ID), slug: [SLUG] } },
@@ -78,7 +79,7 @@ const rejectWith = (code: TRPCError['code']) => async () => {
 
 describe('article detail SSR', () => {
   it('404s an article the viewer cannot see and nobody else can either', async () => {
-    const result = await run({ fetchImpl: rejectWith('NOT_FOUND'), published: false });
+    const result = await run({ fetchImpl: rejectWith('NOT_FOUND'), ingestion: null });
 
     expect(result).toEqual({ notFound: true });
   });
@@ -93,12 +94,38 @@ describe('article detail SSR', () => {
     expect(result.gating).toEqual({ contentNsfwLevel: draft.nsfwLevel });
   });
 
-  it('keeps serving a published article that is only unreadable while it re-scans', async () => {
-    const result = await run({ fetchImpl: rejectWith('NOT_FOUND'), published: true });
+  // Pending is the publish window a notification links into; Rescan is the same window re-entered
+  // by an edit to a live article. Both resolve on their own, so neither may 404 an indexed URL.
+  it.each([ArticleIngestionStatus.Pending, ArticleIngestionStatus.Rescan])(
+    'keeps serving a published article that is only unreadable while it scans (%s)',
+    async (ingestion) => {
+      const result = await run({ fetchImpl: rejectWith('NOT_FOUND'), ingestion });
+
+      expect(result.notFound).toBeUndefined();
+      expect(result.redirect).toBeUndefined();
+      expect(result.props).toMatchObject({ id: ARTICLE_ID });
+    }
+  );
+
+  // Error can still recover on a scan retry, so it keeps the 200 even though the viewer-facing
+  // `isProcessing` check deliberately refuses to promise a wait for it.
+  it('keeps serving a published article whose scan errored', async () => {
+    const result = await run({
+      fetchImpl: rejectWith('NOT_FOUND'),
+      ingestion: ArticleIngestionStatus.Error,
+    });
 
     expect(result.notFound).toBeUndefined();
-    expect(result.redirect).toBeUndefined();
     expect(result.props).toMatchObject({ id: ARTICLE_ID });
+  });
+
+  it('404s a published article that was blocked — it never resolves for the public', async () => {
+    const result = await run({
+      fetchImpl: rejectWith('NOT_FOUND'),
+      ingestion: ArticleIngestionStatus.Blocked,
+    });
+
+    expect(result).toEqual({ notFound: true });
   });
 
   it('keeps serving the page when the fetch fails for a reason other than NOT_FOUND', async () => {
@@ -107,6 +134,13 @@ describe('article detail SSR', () => {
     expect(result.notFound).toBeUndefined();
     expect(result.redirect).toBeUndefined();
     expect(result.props).toMatchObject({ id: ARTICLE_ID });
+  });
+
+  it('does not consult ingestion when the article resolved — no wasted query on the happy path', async () => {
+    getPublishedArticleIngestionMock.mockClear();
+    await run({ fetchImpl: async () => draft });
+
+    expect(getPublishedArticleIngestionMock).not.toHaveBeenCalled();
   });
 
   it('leaves client-side navigation alone — the status code is an SSR-only decision', async () => {

--- a/src/server/routers/article.router.ts
+++ b/src/server/routers/article.router.ts
@@ -26,6 +26,7 @@ import {
   getArticles,
   setArticleOfficial,
   getArticleScanStatus,
+  isArticleProcessing,
   getCivitaiEvents,
   getCivitaiNews,
   getDraftArticlesByUserId,
@@ -89,6 +90,13 @@ export const articleRouter = router({
         isModerator: ctx.user?.isModerator,
       })
     ),
+  // Deliberately narrower than `getScanStatus`, which is owner/moderator-facing and returns
+  // per-image blocked/error detail. This answers only "come back in a minute" for a viewer
+  // `getById` just refused, so it must not distinguish Blocked from never-existed.
+  isProcessing: publicProcedure
+    .meta({ requiredScope: TokenScope.ArticlesRead })
+    .input(getByIdSchema)
+    .query(({ input }) => isArticleProcessing(input)),
   getMyDraftArticles: protectedProcedure
     .meta({ requiredScope: TokenScope.ArticlesRead })
     .input(getAllQuerySchema)

--- a/src/server/services/__tests__/article-processing-state.service.test.ts
+++ b/src/server/services/__tests__/article-processing-state.service.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import type * as DbLagHelpers from '~/server/db/db-lag-helpers';
+
+const mockDbRead = dbMock.dbRead;
+
+vi.mock('~/server/db/db-lag-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof DbLagHelpers>()),
+  getDbWithoutLag: vi.fn(async () => mockDbRead),
+}));
+
+import {
+  getPublishedArticleIngestion,
+  isArticleProcessing,
+} from '~/server/services/article.service';
+import { ArticleIngestionStatus, ArticleStatus } from '~/shared/utils/prisma/enums';
+
+const ARTICLE_ID = 34978;
+
+/**
+ * What a non-owner is told about an article `getArticleById` refused them.
+ *
+ * The mapping is the whole point: `getArticleById` gates non-owners on `ingestion = Scanned`, so
+ * every other state is a refusal, and only some of those are worth asking a reader to wait for.
+ * Getting it wrong is not cosmetic in either direction — promising a wait for `Blocked` strands
+ * the reader on a page that never resolves, and refusing one for `Pending` reproduces the hard
+ * 404 that sent published articles to 404 during the Sep 2026 scan incident.
+ */
+describe('article processing state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reads only articles that are published for everyone', async () => {
+    mockDbRead.article.findFirst.mockResolvedValue(null as never);
+
+    await getPublishedArticleIngestion(ARTICLE_ID);
+
+    expect(mockDbRead.article.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: ARTICLE_ID,
+          publishedAt: { not: null },
+          status: ArticleStatus.Published,
+        },
+      })
+    );
+  });
+
+  it('returns null for an article that is not published — a draft is not "processing"', async () => {
+    mockDbRead.article.findFirst.mockResolvedValue(null as never);
+
+    expect(await getPublishedArticleIngestion(ARTICLE_ID)).toBeNull();
+    expect(await isArticleProcessing({ id: ARTICLE_ID })).toBe(false);
+  });
+
+  // Pending is the publish window a notification links straight into. Rescan is the same window
+  // re-entered by an edit, which is how an author 404s their own live article to the public.
+  it.each([ArticleIngestionStatus.Pending, ArticleIngestionStatus.Rescan])(
+    'treats %s as processing — it resolves on its own',
+    async (ingestion) => {
+      mockDbRead.article.findFirst.mockResolvedValue({ ingestion } as never);
+
+      expect(await isArticleProcessing({ id: ARTICLE_ID })).toBe(true);
+    }
+  );
+
+  // Scanned means getArticleById refused for some other reason (blocked by the author, say), so
+  // there is nothing to wait for and the viewer should get the 404 they got before.
+  it.each([
+    ArticleIngestionStatus.Scanned,
+    ArticleIngestionStatus.Blocked,
+    ArticleIngestionStatus.Error,
+  ])('does not promise a wait for %s', async (ingestion) => {
+    mockDbRead.article.findFirst.mockResolvedValue({ ingestion } as never);
+
+    expect(await isArticleProcessing({ id: ARTICLE_ID })).toBe(false);
+  });
+});

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -690,21 +690,36 @@ export const getCivitaiEvents = async () => {
 };
 
 /**
- * Does the article exist as a published article for anyone, regardless of ingestion state?
+ * Ingestion state of an article that is published for everyone, or null if it is not published at
+ * all. Callers apply their own policy to it — the two that exist disagree, deliberately.
  *
- * `getArticleById` additionally requires `ingestion = Scanned` for non-owners, so editing a live
- * article (which sets `Rescan`) makes it throw NOT_FOUND to the public for the length of the scan
- * — minutes, or longer when a scan is stranded. SSR uses this to tell "nobody can ever see this"
- * apart from "temporarily unrenderable", so only the first becomes a 404.
+ * `getArticleById` additionally requires `ingestion = Scanned` for non-owners, so a published
+ * article throws NOT_FOUND to the public until its images finish scanning. An edit to a live
+ * article re-enters that window (upsert sets `Rescan`), so it is not publish-only.
+ *
+ * SSR asks "could this ever render?" and holds its 200 for anything that might still resolve,
+ * because a 404 on an indexed URL is not a state to enter transiently. The viewer-facing
+ * procedure asks the narrower "is it resolving right now?" — `Error` may recover on a retry but
+ * has no bounded wait to promise a reader, and `Blocked` never resolves.
  */
-export const isArticlePublished = async (id: number) => {
+export const getPublishedArticleIngestion = async (
+  id: number
+): Promise<ArticleIngestionStatus | null> => {
   const db = await getDbWithoutLag('article', id);
   const article = await db.article.findFirst({
     where: { id, publishedAt: { not: null }, status: ArticleStatus.Published },
-    select: { id: true },
+    select: { ingestion: true },
   });
 
-  return !!article;
+  return article?.ingestion ?? null;
+};
+
+/** Is the article inside the transient scan window that hides it from non-owners? */
+export const isArticleProcessing = async ({ id }: GetByIdInput) => {
+  const ingestion = await getPublishedArticleIngestion(id);
+  return (
+    ingestion === ArticleIngestionStatus.Pending || ingestion === ArticleIngestionStatus.Rescan
+  );
 };
 
 export type ArticleGetById = AsyncReturnType<typeof getArticleById>;


### PR DESCRIPTION
…id-scan

`getArticleById` gates non-owners on `ingestion = Scanned`, so a published article throws NOT_FOUND to the public until its embedded images finish scanning. A publish notification links straight into that window, so a reader clicking it gets a hard 404 on an article that is fine. Reported as "all articles I see by users when accessed via notifications are all 404s".

The scan defect behind the Sep 2026 report is fixed separately (#4671), which shrank the window from indefinite to about a minute. It did not close it, and notifications are not the only way in: editing a live article sets `Rescan`, so an author fixing a typo 404s their own published article to the entire public for the length of the scan.

SSR already distinguished "nobody can ever see this" from "temporarily unrenderable" and held its 200 for the latter. The client then rendered `<NotFound />` anyway, because `getById` returns nothing either way and the component could not tell the two apart.

- Replace `isArticlePublished` with `getPublishedArticleIngestion`, which returns the ingestion state rather than collapsing five states into a boolean. The two callers need to disagree.
- Add `article.isProcessing`, a narrow public procedure answering only "come back in a minute". Deliberately not `getScanStatus`, which is owner/moderator-facing and returns per-image blocked/error detail.
- Render `ArticleProcessing` for a refusal that is transient, polling every 15s and pulling the article in once the scan lands, so the reader does not sit on a dead end they have to reload out of.
- 404 `Blocked` at SSR. It is the one published state that can never resolve for the public, so serving an indexable shell that only renders NotFound was wrong.

SSR and the viewer check disagree on `Error` on purpose: SSR asks "could this ever render?" and holds the 200 because a retry may recover it, while the reader gets the honest 404 rather than a spinner with no bounded wait behind it.

Both new assertions were revert-checked: dropping `Rescan` from the predicate, and letting `Blocked` keep its 200, each fail in under 10ms naming the behaviour they protect.