### PR TITLE
Log the rewards-abuse job's decisions to ClickHouse

### DIFF
--- a/src/server/clickhouse/migrations/2026-09-08-rewards-abuse-decision-log.sql
+++ b/src/server/clickhouse/migrations/2026-09-08-rewards-abuse-decision-log.sql
@@ -1,0 +1,71 @@
+-- Rewards abuse decision log — ClickHouse DDL.
+--
+-- Apply this MANUALLY, BEFORE deploying the code that writes to it. We do not auto-run DDL
+-- (same policy as the Postgres migrations).
+--
+-- 🔴 Order matters more than usual here. Inserts in this codebase run
+-- `async_insert=1, wait_for_async_insert=0`, so a write to a table that does not exist is
+-- NOT an error the caller sees. Ship the code first and the job will report success while
+-- logging nothing, for as long as it takes someone to notice.
+--
+-- What this is for: `rewards-abuse-prevention` disables Buzz rewards in bulk, nightly, with
+-- no human in the loop. Before this table the only record of a night's run was an HTTP
+-- response body the scheduler discards, so neither "why is this account not earning" nor
+-- "what would a different threshold have caught" could be answered without re-running the
+-- detection against live data.
+--
+-- One row per flagged IP per run. The config that produced the row is stored beside it, so
+-- reviewing a threshold is a query rather than an experiment.
+
+CREATE TABLE IF NOT EXISTS rewards_abuse_decisions
+(
+  -- When the run happened, and which run this row belongs to. `runId` groups a night together,
+  -- which is what makes a run that flagged nothing distinguishable from a run that did not
+  -- happen at all.
+  time                DateTime,
+  runId               UUID,
+
+  -- Dev and preview both write to production ClickHouse. Without this, a dev run's rows are
+  -- indistinguishable from production history.
+  env                 LowCardinality(String),
+  dryRun              UInt8,
+
+  -- The cluster that was flagged.
+  ip                  String,
+  userIds             Array(Int32),
+  userCount           UInt32,
+  ipUserCount         UInt32,
+  awarded             UInt32,
+
+  -- Which of `userIds` the run actually disabled. Always empty on a dry run. On a live run it
+  -- is a SUBSET of userIds: an account that is Protected, or already Ineligible, is flagged and
+  -- then skipped. This is the column that answers "was this account disabled, and why", as
+  -- opposed to "this account was near something that got caught".
+  disabledUserIds     Array(Int32),
+
+  -- The config that produced this row. Typed columns for the knobs that exist today, so a
+  -- threshold sweep is a plain WHERE; `config` carries the whole parsed object so a knob added
+  -- later is recorded without a migration.
+  awardTypes          Array(String),
+  awardTypePrefixes   Array(String),
+  awardedThreshold    UInt32,
+  userCountThreshold  UInt32,
+  maxUserCount        Nullable(UInt32),
+  requireExclusiveIp  UInt8,
+  config              String,
+
+  -- Run-level, repeated on every row of the run so the table answers questions on its own.
+  usersDisabled       UInt32,
+
+  createdDate         Date DEFAULT toDate(time)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(time)
+ORDER BY (time, ip);
+
+-- No Enum8 anywhere on purpose: a value outside an Enum8 is dropped server-side on an async
+-- insert, so a typo writes zero rows and reports success. LowCardinality(String) costs the
+-- same and cannot fail that way.
+--
+-- No TTL on purpose: the volume is small (a run flags tens to low thousands of rows) and the
+-- point of the table is looking back at what an older config did.

--- a/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
+++ b/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
@@ -6,13 +6,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // config read fails — a sysRedis DOWN (hGet throws) or SLOW/half-open (withSysReadDeadline
 // rejects) must return early WITHOUT touching clickhouse/dbWrite.
 
-const { hGet, withSysReadDeadline, chQuery, createNotification, refresh } = vi.hoisted(() => ({
-  hGet: vi.fn(),
-  withSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
-  chQuery: vi.fn(),
-  createNotification: vi.fn(() => Promise.resolve(undefined)),
-  refresh: vi.fn(() => Promise.resolve(undefined)),
-}));
+const { hGet, withSysReadDeadline, chQuery, createNotification, refresh, chInsert, logToAxiom } =
+  vi.hoisted(() => ({
+    hGet: vi.fn(),
+    withSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+    chQuery: vi.fn(),
+    createNotification: vi.fn(() => Promise.resolve(undefined)),
+    refresh: vi.fn(() => Promise.resolve(undefined)),
+    chInsert: vi.fn(() => Promise.resolve(undefined)),
+    logToAxiom: vi.fn(() => Promise.resolve(undefined)),
+  }));
 
 vi.mock('~/server/redis/client', () => ({
   sysRedis: { hGet },
@@ -21,8 +24,11 @@ vi.mock('~/server/redis/client', () => ({
 }));
 
 vi.mock('~/server/clickhouse/client', () => ({
-  clickhouse: { $query: chQuery },
+  clickhouse: { $query: chQuery, insert: chInsert },
 }));
+
+// The dynamic `import('~/server/logging/client')` on the decision-log failure path.
+vi.mock('~/server/logging/client', () => ({ logToAxiom }));
 
 vi.mock('~/server/redis/caches', () => ({
   userMultipliersCache: { refresh },
@@ -280,5 +286,100 @@ describe('rewards-abuse-prevention — scan bounds and config safety', () => {
 
     await expect(rewardsAbusePrevention.run().result).rejects.toThrow(/SQL-significant characters/);
     expect(chQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe('rewards-abuse-prevention — decision log', () => {
+  const twoClusters = [
+    { ip: '203.0.113.7', user_count: 2, ip_user_count: 2, awarded: 200, user_ids: [1, 2] },
+    { ip: '203.0.113.8', user_count: 2, ip_user_count: 2, awarded: 200, user_ids: [3, 4] },
+  ];
+  type DecisionRow = {
+    runId: string;
+    ip: string;
+    userIds: number[];
+    disabledUserIds: number[];
+    usersDisabled: number;
+  };
+  const rowsWritten = () => chInsert.mock.calls[0]?.[0] as { table: string; values: DecisionRow[] };
+
+  it('writes one row per flagged cluster, carrying the config that flagged it', async () => {
+    chQuery.mockResolvedValue(twoClusters);
+
+    await runWith({ dryRun: true, require_exclusive_ip: true, user_count: 1, awarded: 100 });
+
+    const { table, values } = rowsWritten();
+    expect(table).toBe('rewards_abuse_decisions');
+    expect(values).toHaveLength(2);
+    expect(values[0]).toMatchObject({
+      ip: '203.0.113.7',
+      userIds: [1, 2],
+      userCount: 2,
+      ipUserCount: 2,
+      awarded: 200,
+      dryRun: 1,
+      requireExclusiveIp: 1,
+      userCountThreshold: 1,
+      awardedThreshold: 100,
+    });
+    // One runId for the night, so a run is one query rather than a time range.
+    expect(values[0].runId).toBe(values[1].runId);
+  });
+
+  it('records nobody as disabled on a dry run', async () => {
+    chQuery.mockResolvedValue(twoClusters);
+
+    await runWith({ dryRun: true });
+
+    expect(rowsWritten().values.map((v) => v.disabledUserIds)).toEqual([[], []]);
+  });
+
+  it('records only the accounts the update actually changed', async () => {
+    chQuery.mockResolvedValue(twoClusters);
+    // The flagged set is 1-4; the UPDATE skips 2 (Protected) and 4 (already ineligible).
+    dbQueryRawUnsafe.mockResolvedValue([{ id: 1 }, { id: 3 }]);
+
+    await runWith({});
+
+    const values = rowsWritten().values;
+    expect(values.map((v) => v.disabledUserIds)).toEqual([[1], [3]]);
+    // …and the flagged list is untouched, so the gap between them stays visible.
+    expect(values.map((v) => v.userIds)).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it('still writes a row when the run flagged nothing', async () => {
+    chQuery.mockResolvedValue([]);
+
+    await runWith({});
+
+    const values = rowsWritten().values;
+    expect(values).toHaveLength(1);
+    expect(values[0]).toMatchObject({ ip: '', userIds: [], usersDisabled: 0 });
+  });
+
+  it('does not fail the job when the log write fails', async () => {
+    chQuery.mockResolvedValue(twoClusters);
+    dbQueryRawUnsafe.mockResolvedValue([{ id: 1 }]);
+    chInsert.mockRejectedValueOnce(new Error('clickhouse unreachable'));
+
+    const result = await runWith({});
+
+    // The accounts are already disabled by this point. Failing here would leave the database
+    // changed and the run reported as failed.
+    expect(result).toMatchObject({ usersDisabled: 1 });
+    expect(logToAxiom).toHaveBeenCalledTimes(1);
+  });
+
+  it('CONTROL: the same write succeeding reports no error', async () => {
+    chQuery.mockResolvedValue(twoClusters);
+    dbQueryRawUnsafe.mockResolvedValue([{ id: 1 }]);
+
+    await runWith({});
+
+    expect(chInsert).toHaveBeenCalledTimes(1);
+    expect(logToAxiom).not.toHaveBeenCalled();
   });
 });

--- a/src/server/jobs/rewards-abuse-prevention.ts
+++ b/src/server/jobs/rewards-abuse-prevention.ts
@@ -2,6 +2,7 @@ import { chunk } from 'lodash-es';
 import { v4 as uuid } from 'uuid';
 import * as z from 'zod';
 import { clickhouse } from '~/server/clickhouse/client';
+import { resolveDatabaseEnvironment } from '~/env/database-target';
 import { NotificationCategory } from '~/server/common/enums';
 import { dbWrite } from '~/server/db/client';
 import { createJob } from '~/server/jobs/job';
@@ -99,9 +100,15 @@ export const rewardsAbusePrevention = createJob(
         })) ?? [],
     };
 
-    if (abuseLimits.dryRun) return { ...found, usersDisabled: 0 };
+    const runId = uuid();
+
+    if (abuseLimits.dryRun) {
+      await logDecisions({ runId, abusers, abuseLimits, disabled: new Set(), usersDisabled: 0 });
+      return { ...found, usersDisabled: 0 };
+    }
 
     let usersDisabled = 0;
+    const disabled = new Set<number>();
     const tasks = chunk(usersToDisable, 500).map((chunk) => async () => {
       const affected = await dbWrite.$queryRawUnsafe<{ id: number }[]>(`
         UPDATE "User" u
@@ -130,13 +137,101 @@ export const rewardsAbusePrevention = createJob(
           url: '/articles/5799',
         },
       });
+      for (const user of affected) disabled.add(user.id);
       usersDisabled += affected.length;
     });
     await limitConcurrency(tasks, 3);
 
+    await logDecisions({ runId, abusers, abuseLimits, disabled, usersDisabled });
+
     return { ...found, usersDisabled };
   }
 );
+
+/**
+ * One row per flagged IP, plus the config that flagged it, so reviewing a threshold is a query
+ * rather than a re-run against live data.
+ *
+ * Never throws. The accounts have already been disabled by the time this runs, and losing the
+ * audit trail is worse than losing it silently is bad — but failing the job here would leave the
+ * database changed and the run reported as failed, which is the worse of the two.
+ */
+async function logDecisions({
+  runId,
+  abusers,
+  abuseLimits,
+  disabled,
+  usersDisabled,
+}: {
+  runId: string;
+  abusers: Abuser[] | undefined;
+  abuseLimits: AbuseLimits;
+  disabled: Set<number>;
+  usersDisabled: number;
+}) {
+  const time = new Date().toISOString().replace('T', ' ').slice(0, 19);
+  const config = {
+    env: resolveDatabaseEnvironment(),
+    dryRun: abuseLimits.dryRun ? 1 : 0,
+    awardTypes: abuseLimits.award_types,
+    awardTypePrefixes: abuseLimits.award_type_prefixes,
+    awardedThreshold: abuseLimits.awarded,
+    userCountThreshold: abuseLimits.user_count,
+    maxUserCount: abuseLimits.max_user_count ?? null,
+    requireExclusiveIp: abuseLimits.require_exclusive_ip ? 1 : 0,
+    config: JSON.stringify(abuseLimits),
+  };
+
+  const rows = (abusers ?? []).map((abuser) => ({
+    time,
+    runId,
+    ...config,
+    ip: abuser.ip,
+    userIds: abuser.user_ids,
+    userCount: abuser.user_count,
+    ipUserCount: abuser.ip_user_count ?? abuser.user_count,
+    awarded: abuser.awarded,
+    disabledUserIds: abuser.user_ids.filter((id) => disabled.has(id)),
+    usersDisabled,
+  }));
+
+  // A run that flagged nothing still writes one row, with an empty `ip`. Without it, a quiet
+  // night and a night the job never ran are the same absence — the shape that hid a 79-hour
+  // outage in auto-feature-images.
+  if (!rows.length)
+    rows.push({
+      time,
+      runId,
+      ...config,
+      ip: '',
+      userIds: [],
+      userCount: 0,
+      ipUserCount: 0,
+      awarded: 0,
+      disabledUserIds: [],
+      usersDisabled: 0,
+    });
+
+  try {
+    await clickhouse?.insert({
+      table: 'rewards_abuse_decisions',
+      values: rows,
+      format: 'JSONEachRow',
+    });
+  } catch (error) {
+    const { logToAxiom } = await import('~/server/logging/client');
+    logToAxiom(
+      {
+        type: 'error',
+        name: 'rewards-abuse-decisions-log-failed',
+        message: (error as Error)?.message,
+        runId,
+        rows: rows.length,
+      },
+      'webhooks'
+    ).catch(() => null);
+  }
+}
 
 // `encouragement` writes one buzzEvent type per entity kind (`encouragement:image`,
 // `:comment`, `:article`, …), so an exact-match list silently stops covering the family


### PR DESCRIPTION
Gives `rewards-abuse-prevention` a record of what it did, so a threshold can be reviewed from data instead of by re-running detection against live accounts.

Follow-up to #4677 (merged). Ticket: [868m2zub6](https://app.clickup.com/t/868m2zub6) — the widening ticket [868m28jyp](https://app.clickup.com/t/868m28jyp) is closed, and the decision about whether to enable enforcement moved onto the new one with it. Table shape approved by Justin before it was written.

## 🔴 Merge order: the DDL lands first

`src/server/clickhouse/migrations/2026-09-08-rewards-abuse-decision-log.sql` is applied **by hand**, and it must exist before this code deploys.

Inserts in this codebase run `async_insert=1, wait_for_async_insert=0`, so **writing to a table that does not exist is not an error the caller sees**. Ship the code first and the job reports success while logging nothing, for as long as it takes someone to notice. Nothing in the diff makes that visible, which is why it is at the top of this description rather than in a comment.

## Why

The job disables Buzz rewards in bulk, nightly, with no human in the loop. Its only output was the return value of the job function, which goes into an HTTP response body the scheduler discards — `run-jobs` logs the duration to Axiom and nothing else. So there was no way to answer either of the two questions people actually have:

- *why is this account not earning?*
- *what would a different threshold have caught?*

The second one matters most right now, because the widened detection from #4677 is still switched off behind an unset config field, and the honest way to decide whether to enable enforcement is to look at what it would have done.

## What it records

One row per flagged IP per run:

- **the cluster** — ip, account ids, the matched user count, the total user count on that IP, Buzz awarded
- **the config that flagged it** — as typed columns *and* as the whole parsed object
- **which accounts the run actually disabled**

That last one is the column that answers "why was this account disabled". It is a **subset** of the flagged ids: an account that is `Protected`, or already `Ineligible`, is flagged and then skipped by the update. Without it the table can only say an account was near a cluster that got caught.

Typed threshold columns plus a JSON blob is deliberate. Typed makes a sweep a plain `WHERE`; the blob means a knob added later is recorded without a migration. Only one or the other and either every review starts with a JSON extraction, or the table goes stale the first time someone adds a setting.

**A run that flags nothing still writes one row**, with an empty `ip`. Otherwise a quiet night and a night the job never ran are the same absence — which is the shape that hid a 79-hour outage in `auto-feature-images`.

**`env`** is on every row because dev and preview both write to production ClickHouse in this codebase. Without it a dev run's rows are indistinguishable from production history. It uses the existing `resolveDatabaseEnvironment` helper, including its honest third state of `unknown` rather than guessing.

**No `Enum8` anywhere.** A value outside an Enum8 is dropped server-side on an async insert, so a typo writes zero rows and reports success. `LowCardinality(String)` costs the same and cannot fail that way.

## The writer cannot fail the job

By the time it runs, the accounts have already been disabled. Throwing there would leave the database changed and the run reported as failed, so a failed write is logged to Axiom and swallowed. There is a test for that, and a paired control asserting the successful path logs nothing.

## Why no existing table

Checked all 44 tables matching audit / moderation / activity / event / log / decision, and inspected the five plausible ones column by column.

`retoolAuditLog` was closest — action, outcome, JSON payload, affected — but its `userId` is the **moderator who acted**, alongside their IP, user agent and browser fingerprint. A cron has none of those, and filing automated decisions there would fake a human actor in the table people read to ask which moderator did something. `business_events` turned out to be the deploy timeline written by flux, not by this repo. `moderationRequest` is per-entity content moderation with no room for a cluster. `userActivities` is one row per user with no cluster context.

The codebase's own pattern for reviewable decisions is a purpose-built table — `clickup_triage_decisions` and `support_draft_decisions` both exist, and both record inputs beside outcomes, which is the property that makes a review a query.

## Tests

24 in the job's file, up from 18. Six are new: the config being recorded, one `runId` per night, a dry run recording nobody as disabled, a live run recording only the accounts the update actually changed, the row written when nothing is found, and a failed write not failing the job — with a control asserting the succeeding path stays quiet.

**Mutation-tested rather than trusted green.** Breaking the disabled-ids intersection reddens 2; removing the empty row reddens 1; making the log failure fatal reddens 1.

⚠️ One of those mutations first came out as a **syntax error**, which vitest reports as `Tests no tests`. That reads like a pass when skimming and proves nothing, so it was redone with a mutation that compiles. Worth stating because the same trap is available to anyone re-checking this work.

## Verification

Typecheck clean. ESLint back to the two `no-explicit-any` warnings that predate this branch.

Full unit suite: **39,002 collected, 1 failure** — `src/server/integrations/__tests__/moderation-cache-probe.test.ts`, which is pre-existing and unrelated. It failed identically on #4677 with that change reverted in the same tree, and passes 22/22 in isolation. Not established as failing on `origin/main` generally; only as failing independently of this work.

After the table exists and this deploys, the first run's rows will be read back out to confirm they landed — an insert that does not throw is not evidence here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbTHWSRzK8asgVTBLP3UiP
