### PR TITLE
fix(models): hand the collection showcase off to the collection page instead of paging it

### DIFF
--- a/src/components/Model/CollectionShowcase/CollectionShowcase.browser.test.tsx
+++ b/src/components/Model/CollectionShowcase/CollectionShowcase.browser.test.tsx
@@ -20,13 +20,11 @@ type Overrides = Partial<ReturnType<typeof useModelShowcaseCollection>>;
 function showcaseState(overrides: Overrides = {}) {
   return {
     items: [],
+    collection: { id: 7, itemCount: 2145 },
     isLoading: false,
     isError: false,
     hasNextPage: true,
-    fetchNextPage: vi.fn(),
-    isFetching: false,
     isRefetching: false,
-    pageCount: 1,
     refetch: vi.fn(),
     ...overrides,
   };
@@ -58,35 +56,24 @@ beforeEach(() => {
   useModelShowcaseCollection.mockReset();
 });
 
-describe('CollectionShowcase auto-loading', () => {
-  test('below the page cap it keeps the in-view loader', async () => {
-    useModelShowcaseCollection.mockReturnValue(showcaseState({ items: [item(1)], pageCount: 4 }));
+describe('CollectionShowcase overflow', () => {
+  test('a collection with more items hands off to the collection page', async () => {
+    useModelShowcaseCollection.mockReturnValue(showcaseState({ items: [item(1)] }));
+    render();
+
+    const link = page.getByRole('link', { name: /View all 2,145 models/ });
+    await expect.element(link).toBeInTheDocument();
+    await expect.element(link).toHaveAttribute('href', '/collections/7');
+  });
+
+  test('a collection that fits shows no hand-off', async () => {
+    useModelShowcaseCollection.mockReturnValue(
+      showcaseState({ items: [item(1)], hasNextPage: false })
+    );
     render();
 
     await expect.element(page.getByText('Model 1')).toBeInTheDocument();
-    expect(page.getByRole('button', { name: 'Load more' }).elements()).toHaveLength(0);
-  });
-
-  test('at the page cap it stops auto-loading and offers a manual Load more', async () => {
-    const fetchNextPage = vi.fn();
-    useModelShowcaseCollection.mockReturnValue(
-      showcaseState({ items: [item(1)], pageCount: 5, fetchNextPage })
-    );
-    render();
-
-    const button = page.getByRole('button', { name: 'Load more' });
-    await expect.element(button).toBeInTheDocument();
-    await button.click();
-    expect(fetchNextPage).toHaveBeenCalledTimes(1);
-  });
-
-  test('a failed fetch stops auto-loading rather than retrying on a timer', async () => {
-    useModelShowcaseCollection.mockReturnValue(
-      showcaseState({ items: [item(1)], pageCount: 1, isError: true })
-    );
-    render();
-
-    await expect.element(page.getByRole('button', { name: 'Load more' })).toBeInTheDocument();
+    expect(page.getByRole('link', { name: /View all/ }).elements()).toHaveLength(0);
   });
 });
 
@@ -94,7 +81,7 @@ describe('CollectionShowcase error state', () => {
   test('an errored first page reads as a failure, not as an empty collection', async () => {
     const refetch = vi.fn();
     useModelShowcaseCollection.mockReturnValue(
-      showcaseState({ items: [], pageCount: 0, isError: true, refetch })
+      showcaseState({ items: [], isError: true, refetch })
     );
     render();
 

--- a/src/components/Model/CollectionShowcase/CollectionShowcase.tsx
+++ b/src/components/Model/CollectionShowcase/CollectionShowcase.tsx
@@ -10,6 +10,7 @@ import {
   useMantineTheme,
 } from '@mantine/core';
 import {
+  IconArrowRight,
   IconBookmark,
   IconDownload,
   IconEye,
@@ -22,7 +23,6 @@ import { useRouter } from 'next/router';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
 import { MediaHash } from '~/components/ImageHash/ImageHash';
-import { InViewLoader } from '~/components/InView/InViewLoader';
 import { ElementInView, useElementInView } from '~/components/IntersectionObserver/ElementInView';
 import type { UseQueryModelReturn } from '~/components/Model/model.utils';
 import { useModelShowcaseCollection } from '~/components/Model/model.utils';
@@ -31,27 +31,9 @@ import { AnimatedCount, Metrics } from '~/components/Metrics';
 import { getModelUrl } from '~/utils/string-helpers';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 
-/**
- * `InViewLoader` re-arms 500ms after each load for as long as it stays on screen, and a
- * list this short keeps it there — so uncapped it walks the whole collection, thousands
- * of models on the largest showcases, one rate-limited request at a time.
- */
-const MAX_AUTO_LOADED_PAGES = 5;
-
 export function CollectionShowcase({ modelId, loading }: Props) {
-  const {
-    items = [],
-    isLoading,
-    isError,
-    hasNextPage,
-    fetchNextPage,
-    isFetching,
-    isRefetching,
-    pageCount,
-    refetch,
-  } = useModelShowcaseCollection({ modelId });
-
-  const autoLoad = !isError && pageCount < MAX_AUTO_LOADED_PAGES;
+  const { items = [], collection, isLoading, isError, hasNextPage, isRefetching, refetch } =
+    useModelShowcaseCollection({ modelId });
 
   return (
     <div className="relative">
@@ -66,29 +48,15 @@ export function CollectionShowcase({ modelId, loading }: Props) {
             {items.map((model) => (
               <ShowcaseItem key={model.id} {...model} />
             ))}
-            {hasNextPage &&
-              (autoLoad ? (
-                <InViewLoader
-                  loadFn={fetchNextPage}
-                  loadCondition={!isFetching}
-                  style={{ gridColumn: '1/-1' }}
-                >
-                  <div className="flex items-center justify-center px-4 py-2">
-                    <Loader type="bars" size="sm" />
-                  </div>
-                </InViewLoader>
-              ) : (
-                <div className="flex items-center justify-center px-4 py-2">
-                  <Button
-                    variant="subtle"
-                    size="compact-sm"
-                    loading={isFetching}
-                    onClick={() => fetchNextPage()}
-                  >
-                    Load more
-                  </Button>
-                </div>
-              ))}
+            {hasNextPage && collection && (
+              <Link
+                href={`/collections/${collection.id}`}
+                className="flex items-center justify-center gap-1 px-4 py-3 text-sm font-medium text-blue-6 no-underline hover:bg-gray-1 dark:text-blue-4 dark:hover:bg-dark-5"
+              >
+                View all {collection.itemCount.toLocaleString()} models
+                <IconArrowRight size={14} strokeWidth={2.5} />
+              </Link>
+            )}
           </>
         ) : isError ? (
           <div className="flex flex-col items-center justify-center gap-2 p-2">

--- a/src/components/Model/model.utils.ts
+++ b/src/components/Model/model.utils.ts
@@ -229,9 +229,9 @@ export const useToggleCheckpointCoverageMutation = () => {
 };
 
 /**
- * `model.getAll` is rate limited at the edge, and the 300px list shows under four rows —
- * a page of 10 ran out in a couple of flicks and spent a request on each one. The feed
- * itself runs at the handler default of 100.
+ * The showcase fetches this once and then links out to the collection, so it is the whole
+ * list rather than a page of one — `model.getAll` is rate limited at the edge, and the
+ * widget walking a collection a page at a time is what tripped that limit.
  */
 const SHOWCASE_PAGE_SIZE = 50;
 
@@ -276,7 +276,6 @@ export const useModelShowcaseCollection = ({ modelId }: { modelId: number }) => 
     ...rest,
     collection: showcase,
     items: models,
-    pageCount: data?.pages.length ?? 0,
     isLoading: loadingCollection || loadingModels,
     setShowcaseCollection: handleSetShowcaseCollection,
     settingShowcase: setShowcaseMutation.isPending,


### PR DESCRIPTION
Follow-up to #4673. That PR stopped the model-page collection showcase from walking a whole collection into the Cloudflare rate limit, but it fixed the fetching and left the rendering — the widget still mounts every item it has fetched.

## What's left over

#4673 capped auto-loading at 5 pages and put a manual **Load more** behind the cap. At a page size of 50 that is **250 rows already mounted** when the cap is reached, and unbounded after it: a reader on model `2920517` (2,145 items) can still click the collection into the DOM one page at a time.

The panel those rows live in is an `Accordion.Panel` → `ScrollArea.Autosize mah={300}`, and a row is ~80px, so it shows **under four of them**. Every row off-screen still carries an `ElementInView` observer, an `ImageGuard2`, an `EdgeMedia` and a `Metrics` subscription.

## Change

The showcase fetches one page. When there is more, it renders a link to the collection page instead of a way to keep loading:

```tsx
{hasNextPage && collection && (
  <Link href={`/collections/${collection.id}`} className="…">
    View all {collection.itemCount.toLocaleString()} models
    <IconArrowRight size={14} strokeWidth={2.5} />
  </Link>
)}
```

`getCollectionShowcase` already returns `itemCount`, so the count costs no new query — it is the same number the accordion header shows.

- **`CollectionShowcase.tsx`** — `MAX_AUTO_LOADED_PAGES`, `InViewLoader` and the manual button are gone, replaced by the link row.
- **`model.utils.ts`** — `pageCount` drops out of `useModelShowcaseCollection` (the cap was its only consumer); the `SHOWCASE_PAGE_SIZE` comment now says what 50 means, which is the whole list rather than a page of one.

For that 2,145-item collection: **5 requests → 1**, **250 rows → 50**, and no unbounded tail behind a button.

## Why not virtualize

Virtualization was the other option and it fixes the cheapest of the three costs. Rendering shrinks; the network and the React Query cache do not. Each `model.getAll` page is a full model-card payload — versions, images, metrics, per-user flag reads — fetched with `skipEdgeCache`, so an authenticated reader still hits origin per page and still accumulates every payload. The reader who tripped the 429 would trip it again, one click later.

It is also not the cheap reuse it looks like. `src/components/Auction/VirtualRowList.tsx` binds `getScrollElement` to `useScrollAreaRef()` — the **app** scroll area. The showcase scrolls its own inner `ScrollArea.Autosize`, so this would need a new variant taking the viewport ref, plus `measureElement` against Mantine's viewport div.

Worth revisiting **if** the lighter collection-items endpoint from #4673's review notes lands (id/name/type/baseModel/one image/three counters). A cheap payload makes a long list defensible; today's does not.

## Tradeoffs

- A reader who wants more than 50 items in-panel now clicks through to the collection page. That is the intent — the widget is a teaser, and the collection page has the grid, sort and filters.
- The link is gated on `hasNextPage` alone rather than `collection.itemCount > items.length`. The tighter condition makes the copy exact but hides the escape hatch if `itemCount` ever reads stale, which is the worse failure. Cost of the looser gate: a collection of exactly 50 can read "View all 50 models" with all 50 already listed.

## Tests

The two auto-loading tests in `CollectionShowcase.browser.test.tsx` described behaviour that no longer exists; they are replaced by two hand-off tests. The error-state and empty-state tests are unchanged. 4/4 pass.

Checked against a revert rather than only for passing: stubbing the branch to `false &&` fails `a collection with more items hands off to the collection page` and nothing else, so the link assertion is what carries it — and both possible reverts (re-adding the in-view loader, or re-adding the button) replace that link, so either one trips it.

Also run: `collection-item-count-clamp-wiring.test.ts` 4/4 (the other `itemCount` consumer), and `pnpm run typecheck` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsKLSw5ZdqSUJx7HcLsoV9
