### PR TITLE
feat(apps): migrate /apps/installed to /apps/activity — widen past the slot flag, default to the feed, Build to the end of the sub-nav

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -421,6 +421,26 @@ export default defineNextConfig(
           destination: '/apps/build',
           statusCode: 301,
         },
+        // ── `/apps/installed` → `/apps/activity` ───────────────────────────────────
+        // The page was renamed when it stopped being an installs surface: it now opens
+        // on the activity feed, and its gate widened from `appBlocks` (the model-slot
+        // flag) to `appBlocks || appBlocksPages`, so a viewer whose only app usage is a
+        // full-page app reaches it. The page component is MOVED (`installed.tsx` →
+        // `activity.tsx`), not stubbed — same reason as the three rules above.
+        //
+        // 🔴 `statusCode: 301`, matching its neighbours and for the same reason: Next
+        // maps `permanent: true` to 308, and these are GET-only pages whose inbound
+        // links are bookmarks and search results. The two keys are mutually exclusive
+        // in Next's schema.
+        //
+        // Next preserves the query string across a redirect, so an inbound
+        // `/apps/installed?tab=permissions` keeps its `?tab=` — which only became a
+        // meaningful statement when the tabs went URL-backed in the same change.
+        {
+          source: '/apps/installed',
+          destination: '/apps/activity',
+          statusCode: 301,
+        },
         {
           source: '/api/download/training-data/:modelVersionId',
           destination: '/api/download/models/:modelVersionId?type=Training%20Data',

--- a/src/__tests__/pages/apps-activity-redirect.test.ts
+++ b/src/__tests__/pages/apps-activity-redirect.test.ts
@@ -1,0 +1,139 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `/apps/installed` → `/apps/activity`, as a REAL redirect rather than a stub page.
+ *
+ * The page stopped being an installs surface: it opens on the activity feed, its
+ * `Installs` tab is gated on the model-slot flag, and its own gate widened to
+ * `appBlocks || appBlocksPages` so a viewer whose only app usage is a full-page app
+ * reaches it. The route name followed.
+ *
+ * 🔴 THIS READS THE ACTUAL `next.config.mjs` EXPORT AND CALLS `redirects()`. A text scan
+ * of the file would pass on a commented-out entry, on an entry in the wrong array, and
+ * on one whose object never reaches the returned list — all three of which look right in
+ * a diff. Invoking the function is the only check that the rule is one Next will serve.
+ *
+ * Structure and controls deliberately mirror `apps-build-redirects.test.ts`, which is
+ * the same job for the `/apps/build` consolidation; that file owns its own three routes
+ * and this one owns this route, so neither's ledger can absorb the other's silently.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const nextConfig = (await import('../../../next.config.mjs')).default as any;
+
+type Redirect = {
+  source: string;
+  destination: string;
+  permanent?: boolean;
+  statusCode?: number;
+};
+
+const redirects = (await nextConfig.redirects()) as Redirect[];
+
+const RETIRED_ROUTE = '/apps/installed';
+const DESTINATION = '/apps/activity';
+
+describe('the /apps/installed → /apps/activity redirect', () => {
+  it('POSITIVE CONTROL: the redirect list is populated and reachable', () => {
+    // 🔴 Without this, every assertion below could be satisfied by a `find` over an empty
+    // array producing `undefined`. A reassuring "no match" is indistinguishable from a
+    // probe wired to nothing.
+    expect(Array.isArray(redirects)).toBe(true);
+    expect(redirects.length).toBeGreaterThan(5);
+    expect(redirects.some((r) => r.source === '/discord')).toBe(true);
+  });
+
+  it('🔴 /apps/installed 301s to /apps/activity', () => {
+    const rule = redirects.find((r) => r.source === RETIRED_ROUTE);
+    expect(rule, `no redirect rule for ${RETIRED_ROUTE}`).toBeDefined();
+    expect(rule!.destination).toBe(DESTINATION);
+    // 🔴 301, not `permanent: true` — Next maps `permanent` to 308, which preserves the
+    // request METHOD. This is a GET-only page whose inbound links are bookmarks and
+    // search results; 301 is the status those consumers cache and rewrite on. The two
+    // options are mutually exclusive in Next's schema.
+    expect(rule!.statusCode).toBe(301);
+    expect(rule!.permanent).toBeUndefined();
+  });
+
+  it('🔴 it does not land on another redirect', () => {
+    // A 301→301 costs a round trip, and some link-equity and bookmark-rewriting
+    // consumers stop following after the first hop.
+    const sources = new Set(redirects.map((r) => r.source));
+    expect(sources.has(DESTINATION)).toBe(false);
+    // Guard-the-guard: a `sources` set built from an empty list makes the check above
+    // trivially pass. Prove the lookup can hit.
+    expect(sources.has(RETIRED_ROUTE)).toBe(true);
+  });
+
+  it('🔴 the page MOVED — installed.tsx is gone and activity.tsx exists', () => {
+    // A stub whose only job is to redirect is dead code that reads as a live route, and
+    // `appsPageWidths`' fs-walk would then demand a width classification for a page that
+    // never renders. So the component is moved, not emptied.
+    const pagesDir = path.resolve(__dirname, '../../pages/apps');
+    expect(fs.existsSync(pagesDir)).toBe(true); // control: looking in the right place
+    expect(fs.existsSync(path.join(pagesDir, 'installed.tsx'))).toBe(false);
+    expect(fs.existsSync(path.join(pagesDir, 'activity.tsx'))).toBe(true);
+  });
+
+  it('no in-app link still points at /apps/installed', () => {
+    // A link to a redirected route costs a round trip and re-renders the whole shell. The
+    // redirect is for BOOKMARKS and notification URLs already in the wild, not for links
+    // this codebase is still emitting today.
+    const srcDir = path.resolve(__dirname, '../..');
+    const offenders: string[] = [];
+    const linkish = new RegExp(`(?:href|destination)\\s*[=:]\\s*['"]${RETIRED_ROUTE}['"]`);
+    const pushy = new RegExp(`router\\.(?:push|replace)\\(\\s*['"]${RETIRED_ROUTE}['"]`);
+    const walk = (dir: string) => {
+      for (const name of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, name.name);
+        if (name.isDirectory()) {
+          if (name.name === 'node_modules' || name.name === '__screenshots__') continue;
+          walk(full);
+          continue;
+        }
+        if (!/\.(ts|tsx)$/.test(name.name)) continue;
+        // This file names the retired route as DATA. Excluding self is what keeps the
+        // guard from reporting itself.
+        if (full === __filename) continue;
+        const text = fs.readFileSync(full, 'utf8');
+        // Only LINK-shaped occurrences: a quoted string literal in an href/destination
+        // position. Prose in comments that explains the rename is documentation, not a
+        // link — and this change deliberately left some of it.
+        if (linkish.test(text) || pushy.test(text)) {
+          offenders.push(`${path.relative(srcDir, full)} → ${RETIRED_ROUTE}`);
+        }
+      }
+    };
+    walk(srcDir);
+    expect(offenders).toEqual([]);
+  });
+
+  it('🔴 POSITIVE CONTROL for the link walk: it CAN find a link', () => {
+    // The walk above returning `[]` is indistinguishable from a walk whose regexes match
+    // nothing. Feed the same two patterns a string they MUST hit. Without this the whole
+    // sweep is a reassuring zero — the exact failure mode a redirect guard is worst at,
+    // because a missed link still WORKS (via the redirect) and so is never reported.
+    const sample = `<Link href="/apps/installed">x</Link>; router.push('/apps/installed');`;
+    expect(
+      new RegExp(`(?:href|destination)\\s*[=:]\\s*['"]${RETIRED_ROUTE}['"]`).test(sample)
+    ).toBe(true);
+    expect(
+      new RegExp(`router\\.(?:push|replace)\\(\\s*['"]${RETIRED_ROUTE}['"]`).test(sample)
+    ).toBe(true);
+    // …and that the walk reaches a plausible number of files.
+    let count = 0;
+    const walk = (dir: string) => {
+      for (const name of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, name.name);
+        if (name.isDirectory()) {
+          if (name.name === 'node_modules' || name.name === '__screenshots__') continue;
+          walk(full);
+        } else if (/\.(ts|tsx)$/.test(name.name)) count += 1;
+      }
+    };
+    walk(path.resolve(__dirname, '../..'));
+    expect(count).toBeGreaterThan(500);
+  });
+});

--- a/src/components/AppBlocks/AppBlockChromeMobileShell.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromeMobileShell.browser.test.tsx
@@ -377,11 +377,15 @@ describe('AppBlockChrome mobile shell', () => {
   });
 
   test(`REGRESSION — at ${PHONE[0]}x${PHONE[1]} the platform nav is inside the ⋮ sheet`, async () => {
-    // 🔴 RED AT `origin/main`, BEHAVIOURALLY. The failing assertion is the presence of
-    // "Installed apps" after opening the ⋮. That label exists ONLY in the platform-nav
-    // section — the ⋮ menu's own item for the same route is worded "Manage apps" — so
-    // at main, where the ⋮ carries app actions only, it is not reachable from this
-    // trigger at any width.
+    // 🔴 RED AT THE REVISION THAT INTRODUCED IT, BEHAVIOURALLY. The failing assertion is
+    // the presence of the platform nav's own label for the activity route after opening
+    // the ⋮. That label exists ONLY in the platform-nav section — the ⋮ menu's own item
+    // for the same route is worded "Manage apps" — so at the pre-fold revision, where the
+    // ⋮ carries app actions only, it is not reachable from this trigger at any width.
+    //
+    // ⚠️ THE LABEL MOVED WITH THE ROUTE: it read "Installed apps" until `/apps/installed`
+    // became `/apps/activity` and it became "App activity". Same item, same section, same
+    // claim — only the word changed.
     //
     // 🔴 IT IS ASSERTED BY LABEL, NOT BY A TESTID, ON PURPOSE. A testid on the new
     // sheet would go red at main merely by not existing, which proves nothing. A user-
@@ -399,7 +403,7 @@ describe('AppBlockChrome mobile shell', () => {
     expect(sheet, 'the ⋮ must have opened SOME surface').not.toBeNull();
 
     const labels = rowLabels(sheet as HTMLElement);
-    for (const label of ['Marketplace', 'Installed apps', 'My apps']) {
+    for (const label of ['Marketplace', 'App activity', 'My apps']) {
       expect(
         labels,
         `at ${PHONE[0]}px "${label}" must be reachable from the ⋮ — the platform nav folds into ` +

--- a/src/components/AppBlocks/AppBlockChromePlatformNav.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromePlatformNav.browser.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { page } from 'vitest/browser';
 
 // Part A: the app icon opens a Menu of the Civitai App PLATFORM's own pages
-// (Marketplace / Installed apps / My apps / Review). "Review" is gated on
+// (Marketplace / App activity / My apps / Review). "Review" is gated on
 // the viewer's moderator flag. Part B: the ⋯ menu gains a "Permissions &
 // activity" item (only when an appBlockId is threaded) that opens a per-app
 // transparency drawer.
@@ -88,8 +88,8 @@ describe('AppBlockChrome platform-nav menu (Part A)', () => {
     const home = page.getByRole('menuitem', { name: 'Marketplace' }).element();
     expect(home.getAttribute('href')).toBe('/apps');
 
-    const installed = page.getByRole('menuitem', { name: 'Installed apps' }).element();
-    expect(installed.getAttribute('href')).toBe('/apps/installed');
+    const installed = page.getByRole('menuitem', { name: 'App activity' }).element();
+    expect(installed.getAttribute('href')).toBe('/apps/activity');
 
     // Was "My submissions" → `/apps/my-submissions`, then `/apps/mine`; that table is now
     // state C of the consolidated `/apps/build`, and this item was REPOINTED rather than

--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.browser.test.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.browser.test.tsx
@@ -18,6 +18,11 @@ const m = vi.hoisted(() => ({
   grantsSpy: undefined as unknown as ReturnType<typeof vi.fn>,
   buzzSpy: undefined as unknown as ReturnType<typeof vi.fn>,
   scopeSpy: undefined as unknown as ReturnType<typeof vi.fn>,
+  // Store-visibility flags for `AppActivityPanel`'s `App` column. `null` (the default,
+  // and what this file rendered under before) is what `useOptionalFeatureFlags` returns
+  // outside a provider, which fails CLOSED — so a link test run at the default would be
+  // vacuous. The seam test below sets a store-ELIGIBLE viewer deliberately.
+  flags: null as null | Record<string, boolean>,
 }));
 
 // 🔴 `AppActivityPanel`'s `When` column renders `DaysFromNow`, which reads
@@ -29,6 +34,13 @@ vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
 
 vi.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => m.user,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => m.flags ?? {},
+  useOptionalFeatureFlags: () => m.flags,
+  useFeatureFlagsReady: () => true,
+  FeatureFlagsProvider: ({ children }: { children: unknown }) => children,
 }));
 
 vi.mock('~/utils/trpc', () => {
@@ -75,6 +87,7 @@ import { renderWithProviders } from '../../../test/component-setup';
 
 beforeEach(() => {
   m.user = { id: 1, username: 'viewer', isModerator: false };
+  m.flags = null;
   m.grants = [];
   m.buzz = [];
   m.scopes = [];
@@ -201,6 +214,74 @@ describe('AppPermissionsActivityDrawer (Part B — per-app permissions & activit
     // The AppActivityPanel isn't mounted for anon, so the scope-invocation query
     // is never called.
     expect(m.scopeSpy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * 🔴 THE SEAM. `AppActivityPanel`'s `App` column gained a link to
+   * `/apps/store-preview/<slug>`; this drawer is the OTHER mount point, and it sits on top
+   * of a RUNNING full-page app. A top-level `<a>` here navigates the whole window out of
+   * the app the user is in — from a panel they opened to read — and the column is
+   * redundant in this mode anyway, since every row is the same app.
+   *
+   * Verified in ISOLATION the panel is correct either way; the defect this pins lives in
+   * the seam, i.e. in whether the drawer's caller actually reaches the suppressing branch.
+   * So the flags are set to a STORE-ELIGIBLE viewer and the row carries a REAL slug —
+   * neither the flag gate nor a null slug can be why it passes.
+   *
+   * 🔴 RED WITHOUT THE CHANGE: drop `linkable={!appBlockId}` from the panel's
+   * `ActivityAppName` call (or default the prop to `true` unconditionally) and this fails
+   * on `expected 'A' not to be 'A'`, while the whole-account control below stays green.
+   */
+  test('🔴 the App name is PLAIN TEXT in the drawer, even for a store-eligible viewer', async () => {
+    m.flags = { appListings: true };
+    m.scopes = [
+      {
+        id: '1',
+        createdAt: new Date('2026-07-14T10:00:00Z'),
+        appBlockId: 'ab-1',
+        appName: 'My App',
+        appSlug: 'my-app',
+        scope: 'buzz:read:self',
+        endpoint: 'me',
+        statusCode: 200,
+        detail: null,
+      },
+    ];
+    renderWithProviders(
+      <AppPermissionsActivityDrawer appBlockId="ab-1" appName="My App" opened onClose={vi.fn()} />
+    );
+    const name = page.getByTestId('app-activity-app-name');
+    await expect.element(name.first()).toBeInTheDocument();
+    const el = name.first().element();
+    expect(
+      el.tagName,
+      'the drawer must not offer a link that navigates out of the running app'
+    ).not.toBe('A');
+    expect(el.getAttribute('href')).toBeNull();
+  });
+
+  test('POSITIVE CONTROL: the same viewer + row DOES get a link on the whole-account feed', async () => {
+    // Identical flags, identical row, no `appBlockId`. Without this the test above would
+    // be satisfied by a panel that never links at all.
+    m.flags = { appListings: true };
+    m.scopes = [
+      {
+        id: '1',
+        createdAt: new Date('2026-07-14T10:00:00Z'),
+        appBlockId: 'ab-1',
+        appName: 'My App',
+        appSlug: 'my-app',
+        scope: 'buzz:read:self',
+        endpoint: 'me',
+        statusCode: 200,
+        detail: null,
+      },
+    ];
+    renderWithProviders(<AppActivityPanel />);
+    const name = page.getByTestId('app-activity-app-name');
+    await expect.element(name.first()).toBeInTheDocument();
+    expect(name.first().element().tagName).toBe('A');
+    expect(name.first().element().getAttribute('href')).toBe('/apps/store-preview/my-app');
   });
 
   test('a closed drawer does not mount the body (no queries fire)', async () => {

--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.browser.test.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.browser.test.tsx
@@ -20,6 +20,13 @@ const m = vi.hoisted(() => ({
   scopeSpy: undefined as unknown as ReturnType<typeof vi.fn>,
 }));
 
+// 🔴 `AppActivityPanel`'s `When` column renders `DaysFromNow`, which reads
+// `useIsClient()` from `IsClientProvider` and THROWS outside that provider
+// ('missing IsClientContext'). `renderWithProviders` supplies Mantine + a QueryClient
+// only, so the hook is stubbed here rather than the whole app shell being mounted.
+// `true` is the post-mount value, which is the state every assertion below is about.
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+
 vi.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => m.user,
 }));
@@ -156,7 +163,7 @@ describe('AppPermissionsActivityDrawer (Part B — per-app permissions & activit
 
   test('whole-account panel (installed page, no appBlockId) does NOT pass an appBlockId filter — unchanged behaviour', async () => {
     // The shared AppActivityPanel rendered without an appBlockId (the
-    // /apps/installed "Recent activity" tab) must keep fetching the whole-account
+    // /apps/activity "Recent activity" tab) must keep fetching the whole-account
     // feed — neither query carries an appBlockId.
     renderWithProviders(<AppActivityPanel />);
     // Await the rendered empty state so the query hooks have run before asserting.

--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
@@ -12,7 +12,7 @@ import { trpc } from '~/utils/trpc';
  *
  *   1. The JWT scopes they've granted THIS app (`blocks.listMyScopeGrants`,
  *      filtered to this app, rendered via the shared `BlockScopeList` — the same
- *      component the /apps/installed "Apps & permissions" tab uses).
+ *      component the /apps/activity "Apps & permissions" tab uses).
  *   2. A per-app action audit timeline (`AppActivityPanel` with the `appBlockId`
  *      drill-down — Buzz attribution + scope-gated call audit interleaved).
  *

--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
@@ -24,6 +24,17 @@ import { trpc } from '~/utils/trpc';
  * the parent chrome can render this on every run-frame without firing the queries
  * until the user actually opens the panel. (Also keeps `AppBlockChrome`'s own
  * component tests network-free: a closed drawer calls no tRPC hooks.)
+ *
+ * 🔴 THE FEED'S `App` COLUMN IS PLAIN TEXT HERE, NOT A STORE LINK, AND THAT IS A DECISION
+ * RATHER THAN AN OMISSION. `AppActivityPanel` gained a link from the app name to
+ * `/apps/store-preview/<slug>`; this drawer is mounted OVER A RUNNING FULL-PAGE APP, so
+ * that link would be a TOP-LEVEL navigation out of whatever the user was doing inside it
+ * — triggered from a panel they opened to read, with no warning and no way back to their
+ * in-app state. The panel suppresses it whenever it is in per-app drill-down mode
+ * (`linkable={!appBlockId}`), which is exactly the mode this drawer uses; the column is a
+ * label there anyway, since every row is the same app. Not a `target="_blank"`: a second
+ * rendering of one column is how the two come to disagree. Pinned by
+ * `AppPermissionsActivityDrawer.browser.test.tsx`.
  */
 export function AppPermissionsActivityDrawer({
   appBlockId,

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -325,7 +325,7 @@ function storageErrorMessage(err: unknown): string {
  * block can't fake, restyle, or hide it. It's the user-facing safety
  * signal that says "this is a sandboxed app block, not native Civitai UI":
  * a thin top bar with the Civitai app-block badge plus a menu whose
- * "Manage apps" item routes to /apps/installed and a "Hide app" item
+ * "Manage apps" item routes to /apps/activity and a "Hide app" item
  * that locally hides this install for the viewer (a model owner's block shows
  * to every viewer; this lets a viewer dismiss one without affecting the
  * publisher or anyone else). Rendering it here (vs in the sandboxed iframe) is
@@ -551,7 +551,7 @@ export function AppBlockChrome({
   //
   // 🔴 DEFINED BEFORE `appMenuItems` ON PURPOSE. `__tests__/chromeNavAlignsWithSubNav.ts`
   // slices this section out by anchoring on the `Civitai Apps` label and stopping at the
-  // NEXT `<ChromeSurfaceLabel>`, so that the ⋮ menu's own `/apps/installed` item is not
+  // NEXT `<ChromeSurfaceLabel>`, so that the ⋮ menu's own `/apps/activity` item is not
   // keyed onto the platform nav's. Reordering these two consts silently widens that
   // slice.
   const platformNavItems = (
@@ -603,19 +603,19 @@ export function AppBlockChrome({
           the PAGE, not this link, is what decides.
 
           The LABELS are deliberately NOT all identical: the subnav's tabs sit under
-          an "Apps" heading and can afford one-word labels ("Installed", "Review"),
+          an "Apps" heading and can afford one-word labels ("Activity", "Review"),
           whereas these items stand alone over a running app and need the noun
-          ("Installed apps"). "Marketplace" is the one label that is shared verbatim,
+          ("App activity"). "Marketplace" is the one label that is shared verbatim,
           because "Apps home" named a destination the store itself stopped calling
           that. */}
       <ChromeSurfaceItem href="/apps" leftSection={<IconBuildingStore size={14} stroke={1.5} />}>
         Marketplace
       </ChromeSurfaceItem>
       <ChromeSurfaceItem
-        href="/apps/installed"
+        href="/apps/activity"
         leftSection={<IconPlugConnected size={14} stroke={1.5} />}
       >
-        Installed apps
+        App activity
       </ChromeSurfaceItem>
       <ChromeSurfaceItem href="/apps/build" leftSection={<IconCode size={14} stroke={1.5} />}>
         My apps
@@ -676,15 +676,15 @@ export function AppBlockChrome({
     <>
       <ChromeSurfaceLabel>App</ChromeSurfaceLabel>
       {/* 🔴 SAME ROUTE ⇒ SAME ICON, ACROSS BOTH SURFACES. This item and the
-          platform nav's "Installed apps" are different WORDS for the same
-          destination (`/apps/installed`), so they must not be different
+          platform nav's "App activity" are different WORDS for the same
+          destination (`/apps/activity`), so they must not be different
           PICTURES: on a desktop bar the two dropdowns open a few pixels apart, and
           below `sm` they are literally rows of ONE sheet — a user who sees a plug in
           one and a grid in the other has to work out whether they lead to the same
           place. The glyph comes from the store subnav's row for this route
           (`SUB_NAV_LINKS`), exactly as the platform nav's does — the labels stay
           different on purpose ("Manage apps" is the action from inside a running app;
-          "Installed apps" is the destination), because the rule is about the ROUTE,
+          "App activity" is the destination), because the rule is about the ROUTE,
           not the copy.
 
           Pinned by `__tests__/chromeNavAlignsWithSubNav.test.ts`, which checks
@@ -692,7 +692,7 @@ export function AppBlockChrome({
           section — this item is the reason that check is repo-wide rather than
           scoped, since scoping it to one dropdown is what let this site drift. */}
       <ChromeSurfaceItem
-        href="/apps/installed"
+        href="/apps/activity"
         leftSection={<IconPlugConnected size={14} stroke={1.5} />}
       >
         Manage apps

--- a/src/components/AppBlocks/__tests__/chromeNavAlignsWithSubNav.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeNavAlignsWithSubNav.test.ts
@@ -102,7 +102,7 @@ function parseSubNav(src: string): NavEntry[] {
  *
  * 🔴 SCOPED TO THE PLATFORM-NAV SECTION, WHICH IS NOT COSMETIC. The chrome also
  * renders the ⋮ overflow's "Manage apps", which points at the SAME
- * `/apps/installed` with a different, deliberate label. A whole-file scan would key
+ * `/apps/activity` with a different, deliberate label. A whole-file scan would key
  * both onto one href and either compare the wrong row or clobber it. The slice is
  * anchored on the `Civitai Apps` label, which is the section's own heading.
  *
@@ -174,7 +174,7 @@ function parsePlatformNav(src: string): NavEntry[] {
  * 🔴 THIS IS THE REPO-WIDE HALF, AND IT EXISTS BECAUSE THE SCOPED HALF MISSED A
  * SITE. The platform-nav-scoped parser above deliberately ignores the ⋮ overflow
  * menu so that two items pointing at one route cannot be keyed onto each other —
- * but that same scoping meant the ⋮ menu's "Manage apps" (`/apps/installed`) was
+ * but that same scoping meant the ⋮ menu's "Manage apps" (`/apps/activity`) was
  * invisible to the icon rule, and re-iconing only the platform nav left ONE route
  * wearing TWO glyphs a few pixels apart in one bar. The same-route rule has to be
  * enforced over the whole component or it just relocates the drift.
@@ -351,14 +351,14 @@ describe('the app-block chrome platform nav agrees with the store subnav', () =>
 
     // …and the scope control: an item in a LATER section must not be picked up. This
     // is the fixture that would catch the F3 bound going wrong — the ⋮ overflow's own
-    // `/apps/installed` sits after its own `<ChromeSurfaceLabel>App</…>`, and if the
+    // `/apps/activity` sits after its own `<ChromeSurfaceLabel>App</…>`, and if the
     // slice ran past that label the two entries for one route would be keyed onto
     // each other and the icon comparison would be against the wrong row.
     const scoped = parsePlatformNav(`
       <ChromeSurfaceLabel>Civitai Apps</ChromeSurfaceLabel>
       <ChromeSurfaceItem href="/apps" leftSection={<IconBuildingStore />}>Marketplace</ChromeSurfaceItem>
       <ChromeSurfaceLabel>App</ChromeSurfaceLabel>
-      <ChromeSurfaceItem href="/apps/installed" leftSection={<IconApps />}>Manage apps</ChromeSurfaceItem>
+      <ChromeSurfaceItem href="/apps/activity" leftSection={<IconApps />}>Manage apps</ChromeSurfaceItem>
     `);
     expect(scoped.map((e) => e.href)).toEqual(['/apps']);
   });
@@ -475,7 +475,7 @@ describe('the app-block chrome platform nav agrees with the store subnav', () =>
     const nav = parsePlatformNav(code(read(CHROME)));
     expect(nav).toEqual([
       { href: '/apps', label: 'Marketplace', icon: 'IconBuildingStore' },
-      { href: '/apps/installed', label: 'Installed apps', icon: 'IconPlugConnected' },
+      { href: '/apps/activity', label: 'App activity', icon: 'IconPlugConnected' },
       { href: '/apps/build', label: 'My apps', icon: 'IconCode' },
       { href: '/apps/review', label: 'Review', icon: 'IconGavel' },
     ]);
@@ -497,19 +497,19 @@ describe('the app-block chrome platform nav agrees with the store subnav', () =>
 
     // 🔴 THE OTHER THREE DELIBERATELY DIFFER, so this pins the chrome's own copy
     // rather than asserting equality. The subnav's tabs sit under an "Apps"
-    // heading and can afford one-word labels ("Installed", "Review"); these items
+    // heading and can afford one-word labels ("Activity", "Review"); these items
     // stand alone in a dropdown over a running app and need the noun. Asserting
     // equality here would force a wrong "fix" in one file or the other.
-    expect(navByHref.get('/apps/installed')?.label).toBe('Installed apps');
+    expect(navByHref.get('/apps/activity')?.label).toBe('App activity');
     expect(navByHref.get('/apps/build')?.label).toBe('My apps');
     expect(navByHref.get('/apps/review')?.label).toBe('Review');
-    expect(subByHref.get('/apps/installed')?.label).toBe('Installed');
+    expect(subByHref.get('/apps/activity')?.label).toBe('Activity');
   });
 
   it('ONE ROUTE, ONE ICON — every literal-href item in the chrome, both dropdowns', () => {
     // 🔴 THE RULE THIS PR EXISTS TO ENFORCE, APPLIED TO THE WHOLE COMPONENT. Two
     // items may legitimately carry different LABELS for one destination ("Manage
-    // apps" from inside a running app vs "Installed apps" as a destination); they
+    // apps" from inside a running app vs "App activity" as a destination); they
     // may not carry different PICTURES, because the two dropdowns open a few pixels
     // apart in the same bar. Fixing only the platform nav would have relocated the
     // drift rather than removed it, which is what this test is here to prevent.
@@ -558,12 +558,12 @@ describe('the app-block chrome platform nav agrees with the store subnav', () =>
 
     // (c) The pair that actually collided, named explicitly so the regression is
     // legible: two items, one route, and now one icon.
-    const installed = links.filter((l) => l.href === '/apps/installed');
+    const installed = links.filter((l) => l.href === '/apps/activity');
     expect(
       installed.map((l) => l.label).sort(),
-      'the chrome should still offer BOTH `/apps/installed` entries — this rule is about ' +
+      'the chrome should still offer BOTH `/apps/activity` entries — this rule is about ' +
         'their icons, not about removing one of them (that would be a behaviour change).'
-    ).toEqual(['Installed apps', 'Manage apps']);
+    ).toEqual(['App activity', 'Manage apps']);
     expect(new Set(installed.map((l) => l.icon)).size).toBe(1);
 
     // (d) 🔴 THE LEDGER — the SET of routes the chrome links to, owned outright, so this
@@ -574,7 +574,7 @@ describe('the app-block chrome platform nav agrees with the store subnav', () =>
     // item pointing at a route `SUB_NAV_LINKS` already carries, wearing that row's own
     // glyph, satisfies both and is invisible to them. Nor does anything else here close
     // the gap — the `expected glyphs` test enumerates the PLATFORM-NAV slice only, and (c)
-    // enumerates the two `/apps/installed` LABELS only. So an item added to the ⋮ overflow
+    // enumerates the two `/apps/activity` LABELS only. So an item added to the ⋮ overflow
     // was invisible to every assertion in this file. Measured on the PRE-(d) tree: adding
     // `<ChromeSurfaceItem href="/apps/invites" leftSection={<IconMail …/>}>Invites
     // </ChromeSurfaceItem>` to the overflow passed all 8 tests. (d) kills that one now.
@@ -620,7 +620,7 @@ describe('the app-block chrome platform nav agrees with the store subnav', () =>
     //
     // SORTED, so a re-ORDER cannot report a route change that did not happen — this rule
     // is about the SET, and the platform-nav slice's own `toEqual` is what governs order
-    // there. DUPLICATES KEPT: `/apps` and `/apps/installed` each legitimately appear more
+    // there. DUPLICATES KEPT: `/apps` and `/apps/activity` each legitimately appear more
     // than once, and collapsing to a Set would hide an extra item hung on a listed route.
     expect(
       links.map((l) => l.href).sort(),
@@ -638,12 +638,13 @@ describe('the app-block chrome platform nav agrees with the store subnav', () =>
       '/apps', // Marketplace — platform nav
       '/apps', // the compact back chevron — `<ActionIcon component={Link}>`, no leftSection
       '/apps', // the breadcrumb's first crumb — `<Anchor component={Link}>`, no leftSection
-      // 🔴 REPOINTED FROM `/apps/mine`, which 301s here. Sorts BEFORE `/apps/installed`
-      // now ('b' < 'i'), where `/apps/mine` sorted after it — the list is `.sort()`ed, so
-      // the POSITION moving is not a second change to review.
+      // 🔴 REPOINTED TWICE, AND THE SORT POSITION MOVED BOTH TIMES — the list is
+      // `.sort()`ed, so neither move is a second change to review. `/apps/mine` →
+      // `/apps/build` (301) sorted it before `/apps/installed`; `/apps/installed` →
+      // `/apps/activity` (301) then sorted the pair back before it ('a' < 'b').
+      '/apps/activity', // App activity — platform nav
+      '/apps/activity', // Manage apps — ⋮ overflow; the pair (c) governs their labels
       '/apps/build', // My apps — platform nav; the store calls this row "Build"
-      '/apps/installed', // Installed apps — platform nav
-      '/apps/installed', // Manage apps — ⋮ overflow; the pair (c) governs their labels
       '/apps/review', // Review — platform nav, moderator-gated
     ]);
   });
@@ -654,12 +655,12 @@ describe('the app-block chrome platform nav agrees with the store subnav', () =>
     // absent and the rule above would pass over exactly the site it was written for.
     const found = parseAllChromeLinks(`
       <ChromeSurfaceLabel>Civitai Apps</ChromeSurfaceLabel>
-      <ChromeSurfaceItem href="/apps/installed" leftSection={<IconPlugConnected />}>Installed apps</ChromeSurfaceItem>
+      <ChromeSurfaceItem href="/apps/activity" leftSection={<IconPlugConnected />}>App activity</ChromeSurfaceItem>
       <ChromeSurfaceLabel>App</ChromeSurfaceLabel>
-      <ChromeSurfaceItem href="/apps/installed" leftSection={<IconApps />}>Manage apps</ChromeSurfaceItem>
+      <ChromeSurfaceItem href="/apps/activity" leftSection={<IconApps />}>Manage apps</ChromeSurfaceItem>
     `);
     expect(found).toHaveLength(2);
-    expect(found.map((f) => f.label)).toEqual(['Installed apps', 'Manage apps']);
+    expect(found.map((f) => f.label)).toEqual(['App activity', 'Manage apps']);
     // …and it skips a template-literal href (the "Recently run" shape).
     expect(
       parseAllChromeLinks(

--- a/src/components/AppBlocks/__tests__/hiddenBlocks.test.ts
+++ b/src/components/AppBlocks/__tests__/hiddenBlocks.test.ts
@@ -18,7 +18,7 @@ afterEach(() => {
  * Viewer-local "Hide app block" persistence. A model owner's block shows to
  * every viewer; hiding it is a per-viewer, per-instance localStorage flag that
  * never touches the server. BlockSlotClient filters hidden instances out before
- * mount; the /apps/installed "Hidden" tab restores them.
+ * mount; the /apps/activity "Hidden" tab restores them.
  */
 describe('hiddenBlocks', () => {
   it('nothing is hidden by default', () => {

--- a/src/components/AppBlocks/hiddenBlocks.ts
+++ b/src/components/AppBlocks/hiddenBlocks.ts
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react';
  * given block can hide it locally via the host trust-frame's ⋯ menu — the
  * choice lives only in their browser (localStorage), never on the server, so it
  * doesn't affect the publisher's install or other viewers. Hidden blocks can be
- * restored from the "Hidden" tab on /apps/installed.
+ * restored from the "Hidden" tab on /apps/activity.
  *
  * Keyed on `blockInstanceId` (the specific install instance) so hiding a block
  * on one model doesn't hide the same app on another. A little metadata (app +

--- a/src/components/AppLayout/AppHeader/appsNavVisibility.ts
+++ b/src/components/AppLayout/AppHeader/appsNavVisibility.ts
@@ -34,7 +34,7 @@ import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
  * A viewer admitted by the catalog flags alone lands on a page that renders
  * fine — the store, scoped server-side to whatever catalog they may see (the
  * external-only cohort gets `kind='offsite'` listings and nothing else). The
- * block-RUNTIME surfaces behind it (`/apps/installed`, `/apps/run/<slug>`, …)
+ * block-RUNTIME surfaces behind it (`/apps/activity`, `/apps/run/<slug>`, …)
  * keep their own `appBlocks` gates, so showing this entry widens discovery, not
  * capability.
  *

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { useRouter } from 'next/router';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * `/apps/activity` — the PAGE, mounted for real.
+ *
+ * Three acceptance criteria live here because none of them is observable from a pure
+ * module: whether the `Installs` TAB renders, which tab the page OPENS on, and whether
+ * the header still carries a marketplace CTA.
+ *
+ * ── RED AT `origin/main` ──────────────────────────────────────────────────────
+ * Measured by pointing this file at `origin/main`'s `pages/apps/installed.tsx` (the
+ * pre-rename file) with the rest of this branch in place. Every test below fails there,
+ * and each for the reason it names:
+ *   · `opens on Recent activity` — main renders `<Tabs defaultValue="subscriptions">`;
+ *   · `?tab=…` — main's tabs are UNCONTROLLED and read no query at all;
+ *   · `Installs is absent without appBlocks` — main renders the tab unconditionally
+ *     (and would 404 the whole page for that viewer, which is criterion 2's half);
+ *   · `no header CTA` — main renders `actions={<Button …>Browse marketplace</Button>}`.
+ * The exact per-test messages are in the PR body.
+ *
+ * ── WHY THE MOCKS ARE THESE MOCKS ─────────────────────────────────────────────
+ * The page module calls `createServerSideProps` at import time, which pulls the server
+ * graph into a browser bundle — stubbed, exactly as `AppsWideLayout.geometry.test.tsx`
+ * does for the same import. `trpc` is a PROXY rather than a hand-enumerated tree: the
+ * page plus its sub-nav plus three panels touch a dozen procedures between them, and a
+ * literal mock fails with `Cannot read properties of undefined` for every one nobody
+ * remembered — a fixture problem masquerading as a component problem.
+ */
+
+const mocks = vi.hoisted(() => ({
+  flags: {} as Record<string, boolean>,
+}));
+
+/**
+ * 🔴 THE SCAFFOLD'S SHARED ROUTER, NOT A LOCAL `vi.mock('next/router', …)`. A
+ * file-level router mock SILENTLY LOSES to `test/component-setup.tsx`'s (setup files
+ * register last and are not overridden here): `router.query` stays `{}` forever, so a
+ * `?tab=` test can never select anything and reads as a broken feature. That exact trap
+ * is recorded on `AppEditPage.browser.test.tsx`, which hit it first.
+ */
+// `useRouter` here is the scaffold's MOCK (test/component-setup.tsx), which returns a plain
+// singleton object and calls no React hook. Reading it once at module scope is the
+// established idiom in this suite — see `AppEditPage.browser.test.tsx` and
+// `src/tests/pages/payment/success.browser.test.tsx`.
+// eslint-disable-next-line react-hooks/rules-of-hooks -- see above
+const router = useRouter();
+
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => mocks.flags,
+  useOptionalFeatureFlags: () => mocks.flags,
+  useFeatureFlagsReady: () => true,
+  FeatureFlagsProvider: ({ children }: { children: unknown }) => children,
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, username: 'viewer', isModerator: false }),
+}));
+
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-mock).
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const inert = {
+    data: undefined,
+    error: null,
+    isLoading: false,
+    isFetching: false,
+    isPending: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    refetch: vi.fn(),
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    invalidate: vi.fn(),
+  };
+  /** The reads whose CONTENT this file depends on — everything else is inert. */
+  const DATA: Record<string, unknown> = {
+    // EMPTY on purpose: the empty states are where the three surviving marketplace
+    // anchors live, and their presence is one of the criteria under test.
+    'blocks.listMySubscriptions': [],
+    'blocks.listMyScopeGrants': [],
+    'blocks.listMyAppActivity': { pages: [{ items: [], nextCursor: null }] },
+    'blocks.listMyScopeInvocations': { pages: [{ items: [], nextCursor: null }] },
+    'blocks.getNavSummary': {
+      hasInstalls: true,
+      hasSubmissions: false,
+      hasApprovedApps: false,
+      isReviewer: false,
+      hasEditableApps: false,
+      hasPendingInvites: false,
+    },
+  };
+  const node = (data?: unknown): unknown =>
+    new Proxy(
+      {},
+      {
+        get(_t, key: string) {
+          if (key === 'useQuery' || key === 'useInfiniteQuery') {
+            return () => (data === undefined ? inert : { ...inert, data });
+          }
+          if (key === 'useMutation') return () => inert;
+          if (key === 'invalidate' || key === 'fetch') return vi.fn();
+          if (key === 'then') return undefined; // never look thenable to await
+          return node();
+        },
+      }
+    );
+  const root: unknown = new Proxy(
+    {},
+    {
+      get(_t, router: string) {
+        if (router === 'useUtils') return () => node();
+        if (router === 'useQueries') return () => [];
+        if (router === 'then') return undefined;
+        return new Proxy(
+          {},
+          {
+            get(_t2, proc: string) {
+              if (proc === 'then') return undefined;
+              return node(DATA[`${router}.${proc}`]);
+            },
+          }
+        );
+      },
+    }
+  );
+  return { ...(await importOriginal<typeof TrpcMod>()), trpc: root };
+});
+
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  createServerSideProps: () => async () => ({ props: {} }),
+}));
+
+// The page renders `<Meta>`, which calls `useBrowserRouter()` — that hook THROWS
+// ('missing context') without a `BrowserRouterProvider`, which `renderWithProviders`
+// deliberately doesn't mount. Unmocked it takes the whole page render down (empty
+// <body>), so every assertion burns its timeout. Same stub `AppEditPage.browser.test.tsx`
+// uses, for the same reason.
+vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
+// Stubbed so the refused-viewer case asserts on a marker this file owns rather than on
+// whatever copy the shared 404 currently carries.
+vi.mock('~/components/AppLayout/NotFound', () => ({
+  NotFound: () => <div data-testid="mock-notfound">not found</div>,
+}));
+
+const AppActivityPage = (await import('~/pages/apps/activity')).default;
+
+/** The page's OWN tabs, not the `/apps/*` sub-nav (a `nav` landmark, role `tab` too). */
+const pageTabs = () =>
+  Array.from(document.querySelectorAll('[role="tab"]')).filter((el) => !el.closest('nav'));
+
+const pageTab = (label: string) => pageTabs().find((el) => (el.textContent ?? '').trim() === label);
+
+const selectedPageTab = () => pageTabs().find((el) => el.getAttribute('aria-selected') === 'true');
+
+/** Anchors to `/apps` OUTSIDE the sub-nav — i.e. the page's own marketplace links. */
+const bodyMarketplaceLinks = () =>
+  Array.from(document.querySelectorAll('a[href="/apps"]')).filter((el) => !el.closest('nav'));
+
+beforeEach(() => {
+  mocks.flags = { appBlocks: true, appBlocksPages: true, appListings: true };
+  router.query = {};
+  router.pathname = '/apps/activity';
+  vi.mocked(router.replace).mockClear();
+});
+
+describe('the page opens on Recent activity', () => {
+  test('🔴 with no ?tab, Recent activity is the selected tab', async () => {
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    expect(selectedPageTab()?.textContent?.trim()).toBe('Recent activity');
+  });
+
+  test('🔴 NEGATIVE CONTROL: ?tab= really can select a DIFFERENT tab', async () => {
+    // Without this, the assertion above is satisfied by a page that ignores the query
+    // entirely and happens to default to the right tab — which is half of what
+    // `origin/main` did.
+    router.query = { tab: 'permissions' };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    expect(selectedPageTab()?.textContent?.trim()).toBe('Apps & permissions');
+  });
+
+  test('🔴 a repeated / unknown ?tab falls back rather than selecting nothing', async () => {
+    router.query = { tab: 'no-such-tab' };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    expect(selectedPageTab()?.textContent?.trim()).toBe('Recent activity');
+  });
+
+  test('🔴 switching a tab REWRITES the URL (replace, not push)', async () => {
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Apps & permissions/ })).toBeInTheDocument();
+    await page.getByRole('tab', { name: /Apps & permissions/ }).click();
+    expect(router.replace).toHaveBeenCalledTimes(1);
+    const [url, as, opts] = vi.mocked(router.replace).mock.calls[0] as unknown as [
+      { pathname: string; query: Record<string, unknown> },
+      undefined,
+      { shallow?: boolean }
+    ];
+    expect(url.pathname).toBe('/apps/activity');
+    expect(url.query).toEqual({ tab: 'permissions' });
+    expect(as).toBeUndefined();
+    // `shallow` is what keeps a tab click from re-running `getServerSideProps`.
+    expect(opts?.shallow).toBe(true);
+  });
+
+  test('…and switching BACK to the default drops the key rather than writing it', async () => {
+    router.query = { tab: 'permissions' };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    await page.getByRole('tab', { name: /Recent activity/ }).click();
+    const [url] = vi.mocked(router.replace).mock.calls[0] as unknown as [
+      { query: Record<string, unknown> }
+    ];
+    expect(url.query).toEqual({});
+  });
+});
+
+describe('🔴 the Installs tab is gated on the SLOT flag', () => {
+  test('present for a viewer WITH appBlocks', async () => {
+    mocks.flags = { appBlocks: true, appBlocksPages: false, appListings: true };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    expect(pageTab('Installs'), 'a slot-flag viewer must get the Installs tab').toBeDefined();
+  });
+
+  test('🔴 ABSENT for a viewer with appBlocksPages but NOT appBlocks', async () => {
+    // The cohort criterion 2 widened the page for. They have activity and no slot
+    // install, so the tab's own content — subscriptions and per-model installs — is
+    // exactly what they cannot have.
+    mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: true };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    expect(
+      pageTab('Installs'),
+      'the Installs tab must be hidden without appBlocks'
+    ).toBeUndefined();
+    // …and the page is still a page: the other three tabs render.
+    expect(pageTabs().map((el) => el.textContent?.trim())).toEqual([
+      'Recent activity',
+      'Apps & permissions',
+      'Hidden',
+    ]);
+  });
+
+  test('🔴 …and the page still LOADS for that viewer (criterion 2, client half)', async () => {
+    // The page body re-checks the gate with `canAccessAppsActivity`. If that had stayed
+    // on `appBlocks` alone this would render `<NotFound />` and no tabs at all — which is
+    // what makes the tab test above non-vacuous rather than a test of a 404.
+    mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: true };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    expect(pageTabs().length).toBeGreaterThan(0);
+  });
+
+  test('🔴 NEGATIVE CONTROL: NEITHER runtime flag renders no tabs at all', async () => {
+    // Guards the three cases above against a body that renders the page unconditionally.
+    mocks.flags = { appBlocks: false, appBlocksPages: false, appListings: true };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByTestId('mock-notfound')).toBeInTheDocument();
+    expect(pageTabs()).toHaveLength(0);
+  });
+});
+
+describe('🔴 the header marketplace CTA is gone; the empty-state anchors remain', () => {
+  test('the activity tab offers exactly ONE way to /apps — the empty state, not a header button', async () => {
+    // 🔴 STRUCTURAL, NOT COPY-MATCHED. `origin/main` rendered TWO `/apps` anchors in the
+    // page body on this tab: the `AppsPageLayout` `actions` button AND `EmptyActivity`'s
+    // anchor. One survives. Counting them is what makes this fail if the button comes
+    // back under different words.
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    // THREE, not one: Mantine's `Tabs.Panel` is `keepMounted` by default, so every
+    // panel's children are in the DOM regardless of which tab is selected. That is what
+    // makes ONE assertion cover all three empty states — `EmptyActivity`, the Installs
+    // `EmptyState` and the permissions `EmptyState`.
+    expect(
+      bodyMarketplaceLinks().map((el) => el.textContent?.trim()),
+      'the header CTA is back, or an empty-state anchor is gone'
+    ).toEqual(['Browse the marketplace', 'Browse the marketplace', 'Browse the marketplace']);
+  });
+
+  test('🔴 NEGATIVE CONTROL: the count is not trivially "whatever renders"', async () => {
+    // At `origin/main` this same query returns FOUR anchors — the three empty states plus
+    // the `AppsPageLayout` `actions` button, whose text is `Browse marketplace` (no
+    // "the"). So the assertion above is red there on both the length AND the extra
+    // member, and neither half is a copy match against a string this test invented.
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    expect(bodyMarketplaceLinks().length).toBeGreaterThan(0);
+    expect(
+      bodyMarketplaceLinks().some((el) => el.textContent?.trim() === 'Browse marketplace'),
+      'the removed header CTA is back'
+    ).toBe(false);
+  });
+});

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -89,6 +89,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
     'blocks.listMyScopeInvocations': { pages: [{ items: [], nextCursor: null }] },
     'blocks.getNavSummary': {
       hasInstalls: true,
+      hasActivity: true,
       hasSubmissions: false,
       hasApprovedApps: false,
       isReviewer: false,
@@ -285,6 +286,47 @@ describe('🔴 the header marketplace CTA is gone; the empty-state anchors remai
       bodyMarketplaceLinks().map((el) => el.textContent?.trim()),
       'the header CTA is back, or an empty-state anchor is gone'
     ).toEqual(['Browse the marketplace', 'Browse the marketplace', 'Browse the marketplace']);
+  });
+
+  /**
+   * 🔴 …AND THOSE ANCHORS ARE THEMSELVES STORE-GATED, which is a gap THIS PR OPENED.
+   *
+   * `/apps` SSR-gates on `resolveAppsPageAccess` → `hasAppsStoreAccess` =
+   * `appListings || appBlocks || appListingsPublicExternal`. `appBlocksPages` is NOT one
+   * of those three. So the moment this page widened to `appBlocks || appBlocksPages`, a
+   * viewer holding `appBlocksPages` ALONE could load it and be handed a marketplace link
+   * that answers `notFound` — the #3899 / #4668 defect class (an affordance into a 404),
+   * introduced by the widening rather than by a drifted rule.
+   *
+   * ── THE MUTATION CHECK ───────────────────────────────────────────────────────
+   * Delete the `canSeeStore &&` guard from `EmptyState` in `pages/apps/activity.tsx` and
+   * the first test below fails on its OWN assertion — the anchor list it requires to be
+   * empty comes back non-empty. The two tests above (which run with `appListings: true`)
+   * stay green under that mutant, so the red is attributable to the gate.
+   */
+  test('🔴 a page-apps-only viewer gets NO marketplace anchor anywhere on the page', async () => {
+    // The exact cohort criterion 2 admitted: the PAGE gate passes on `appBlocksPages`,
+    // the STORE gate passes on nothing.
+    mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: false };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    expect(
+      bodyMarketplaceLinks().map((el) => el.textContent?.trim()),
+      'a link into a `notFound` was offered to a viewer with no store access'
+    ).toEqual([]);
+    // …and the page itself still rendered, so the empty anchor list is not the empty list
+    // of a 404. Two empty states mount for this viewer (activity + permissions); the
+    // Installs panel is slot-flag-gated away.
+    expect(page.getByText(/No activity yet/).elements().length).toBeGreaterThan(0);
+  });
+
+  test('POSITIVE CONTROL: adding the STORE flag alone brings the anchors back', async () => {
+    // Same runtime flags, one store flag added. Without this the assertion above would
+    // also be satisfied by empty states that lost their CTA for everyone.
+    mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: true };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    expect(bodyMarketplaceLinks().length).toBeGreaterThan(0);
   });
 
   test('🔴 NEGATIVE CONTROL: the count is not trivially "whatever renders"', async () => {

--- a/src/components/Apps/AppActivityPanel.browser.test.tsx
+++ b/src/components/Apps/AppActivityPanel.browser.test.tsx
@@ -159,6 +159,13 @@ const SCOPE_ITEMS = [
   },
 ];
 
+// 🔴 `AppActivityPanel`'s `When` column renders `DaysFromNow`, which reads
+// `useIsClient()` from `IsClientProvider` and THROWS outside that provider
+// ('missing IsClientContext'). `renderWithProviders` supplies Mantine + a QueryClient
+// only, so the hook is stubbed here rather than the whole app shell being mounted.
+// `true` is the post-mount value, which is the state every assertion below is about.
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+
 vi.mock('~/utils/trpc', () => ({
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {

--- a/src/components/Apps/AppActivityPanel.storeGate.browser.test.tsx
+++ b/src/components/Apps/AppActivityPanel.storeGate.browser.test.tsx
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace import (NOT `typeof import('...')`, which
+// @typescript-eslint/consistent-type-imports rejects) so the spread below keeps the real
+// module's type.
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * 🔒 `AppActivityPanel` — the `App` column's name link, and its STORE gate.
+ *
+ * ── THE DEFECT CLASS THIS PINS ────────────────────────────────────────────────
+ * The name links to `/apps/store-preview/<slug>`. That route
+ * `getServerSideProps`-gates on `resolveAppsPageAccess` → `hasAppsStoreAccess` and
+ * returns `notFound`, and `appListings.getAppDetail` resolves a `StoreVisibilityScope`
+ * of `none` and throws NOT_FOUND. So an UNGATED link is an affordance into a 404 — the
+ * class civitai#4668 shipped and civitai#4685 exists to prevent, and the reason
+ * `AppNameCrumb` already solves this exact problem the exact same way.
+ *
+ * 🔴 EVERY TEST HERE IS RED ON PRE-CHANGE CODE, but for two DIFFERENT reasons, and only
+ * one of them is the gate:
+ *   · the `plain text` cases were red because `origin/main` rendered a plain `<Text>`
+ *     with NO testid at all, so the query found nothing — i.e. they are red for the
+ *     absence of the feature, not for the gate;
+ *   · the `link` case is the one that fails if the gate is DELETED while the feature
+ *     exists, which is the mutation the acceptance criterion names.
+ * Both directions are asserted because a gate that hides the link from EVERYONE passes
+ * the first set and is just as wrong.
+ *
+ * ── THE MUTATION CHECK ────────────────────────────────────────────────────────
+ * Deleting `!canSeeStore ||` from `ActivityAppName`'s early return makes
+ * `🔴 an ineligible viewer gets PLAIN TEXT, not a link` fail on its OWN assertion —
+ * `expect(el.tagName, 'an ineligible viewer must not be given an anchor').not.toBe('A')`
+ * — rather than on another test's error. MEASURED, not asserted:
+ *
+ *   AssertionError: an ineligible viewer must not be given an anchor:
+ *   expected 'A' not to be 'A' // Object.is equality
+ *
+ * and `🔴 FAILS CLOSED with no FeatureFlags provider at all` dies alongside it, on the
+ * same claim from the `null`-flags direction. The three eligible-viewer tests stay
+ * GREEN under that mutant, which is what makes the red attributable to the gate.
+ *
+ * ── WHY THE FLAGS ARE MOCKED AT THE PROVIDER ─────────────────────────────────
+ * The component reads `useOptionalFeatureFlags()`, which is `useContext` — outside a
+ * provider it returns `null`, and `hasAppsStoreAccess(null)` is `false`. Stubbing the
+ * hook is what lets the ELIGIBLE arm exist at all; the `null` behaviour (fail closed)
+ * gets its own test with the hook returning `null` explicitly.
+ */
+
+const ROW = {
+  id: 'sc_1',
+  createdAt: new Date(Date.now() - 20 * 60 * 1000), // 20 minutes ago
+  appBlockId: 'apb_1',
+  appName: 'Lighthouse',
+  appSlug: 'lighthouse',
+  scope: 'buzz:read:self',
+  endpoint: 'me',
+  statusCode: 200,
+  detail: null,
+};
+
+const mocks = vi.hoisted(() => ({
+  flags: null as null | Record<string, boolean>,
+}));
+
+// `DaysFromNow` reads `useIsClient()` from this provider and THROWS outside it;
+// `renderWithProviders` supplies Mantine + a QueryClient only. `true` is the post-mount
+// value, which is the state every assertion here is about.
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => mocks.flags ?? {},
+  useOptionalFeatureFlags: () => mocks.flags,
+  useFeatureFlagsReady: () => true,
+  FeatureFlagsProvider: ({ children }: { children: unknown }) => children,
+}));
+
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-mock): a
+// hand-written replacement silently breaks every other importer the day `~/utils/trpc` gains
+// an export this factory omits — the whole FILE then fails to load, 0 tests collected, no
+// failing assertion.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const inert = {
+    data: undefined,
+    error: null,
+    isLoading: false,
+    isFetching: false,
+    isPending: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  };
+  const page1 = <T,>(items: T[]) => ({ ...inert, data: { pages: [{ items, nextCursor: null }] } });
+  return {
+    ...(await importOriginal<typeof TrpcMod>()),
+    trpc: {
+      blocks: {
+        listMyAppActivity: { useInfiniteQuery: () => page1([]) },
+        listMyScopeInvocations: { useInfiniteQuery: () => page1([ROW]) },
+      },
+      modelVersion: { getVersionsByIds: { useQuery: () => ({ ...inert, data: [] }) } },
+      useQueries: () => [],
+    },
+  };
+});
+
+const { AppActivityPanel } = await import('~/components/Apps/AppActivityPanel');
+
+const appName = () => page.getByTestId('app-activity-app-name');
+
+beforeEach(() => {
+  mocks.flags = null;
+});
+
+describe('the App column links to the store detail — GATED', () => {
+  test('🔴 an ineligible viewer gets PLAIN TEXT, not a link', async () => {
+    // 🔴 THIS IS THE MUTATION-CHECKED ASSERTION. Delete `!canSeeStore ||` from
+    // `ActivityAppName` and this test fails HERE, on the tag name and the missing
+    // `href` — not on another test's error.
+    mocks.flags = { appBlocks: false, appListings: false, appListingsPublicExternal: false };
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(appName()).toBeInTheDocument();
+    const el = appName().element();
+    // 🔴 ASSERTED AS "NOT AN ANCHOR, NO href" RATHER THAN AS A TAG LITERAL. Mantine's
+    // `<Text>` renders a `<p>`, and pinning `'P'` would make this test about Mantine's
+    // default element instead of about the gate. The claim that matters is that the
+    // viewer is not handed a navigable link — and the `an eligible viewer` case below is
+    // the positive control that keeps `not.toBe('A')` from being vacuous.
+    expect(el.tagName, 'an ineligible viewer must not be given an anchor').not.toBe('A');
+    expect(el.getAttribute('href'), 'a 404 affordance was rendered').toBeNull();
+    expect(el.textContent).toContain('Lighthouse');
+  });
+
+  test('🔴 FAILS CLOSED with no FeatureFlags provider at all', async () => {
+    // `useOptionalFeatureFlags` returns `null` outside its provider, and
+    // `hasAppsStoreAccess(null)` is `false`. The absence of flags must REMOVE the
+    // affordance, never grant it — the reason this component uses the optional hook.
+    mocks.flags = null;
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(appName()).toBeInTheDocument();
+    expect(appName().element().tagName).not.toBe('A');
+    expect(appName().element().getAttribute('href')).toBeNull();
+  });
+
+  test('an eligible viewer gets a REAL link to getListingDetailHref(slug)', async () => {
+    // 🔴 THE OTHER DIRECTION. Without this, a gate that hid the link from everyone —
+    // or a component that never renders one — passes the two tests above.
+    mocks.flags = { appListings: true };
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(appName()).toBeInTheDocument();
+    const el = appName().element();
+    expect(el.tagName).toBe('A');
+    // The canonical helper's output, asserted as a LITERAL rather than by calling the
+    // helper — deriving the expectation from the implementation would pass whatever it
+    // produced.
+    expect(el.getAttribute('href')).toBe('/apps/store-preview/lighthouse');
+  });
+
+  // The gate is `hasAppsStoreAccess`, a three-way OR. Asserting ONE flag would not see a
+  // mutant that dropped the other two. `test.each` rather than a loop inside one test:
+  // the harness unmounts between TESTS, and re-rendering into an already-mounted
+  // container inside one test finds nothing.
+  test.each(['appListings', 'appBlocks', 'appListingsPublicExternal'])(
+    '%s ALONE opens the link',
+    async (flag) => {
+      mocks.flags = { [flag]: true };
+      renderWithProviders(<AppActivityPanel />);
+      await expect.element(appName()).toBeInTheDocument();
+      expect(appName().element().tagName, `${flag} alone should open the link`).toBe('A');
+    }
+  );
+});
+
+describe('the When column is RELATIVE, with the absolute time still in the tooltip', () => {
+  test('🔴 renders a relative string, not a YYYY-MM-DD HH:mm stamp', async () => {
+    mocks.flags = { appListings: true };
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(appName()).toBeInTheDocument();
+    const when = document.querySelector('table tbody tr:first-child > td');
+    expect(when, 'no first cell').not.toBeNull();
+    const text = when!.textContent ?? '';
+    // dayjs `fromNow()` for a 20-minute-old row.
+    expect(text).toMatch(/ago$/);
+    // 🔴 NEGATIVE CONTROL for the line above: `/ago$/` would also match a cell that
+    // happened to end in those letters. The absolute stamp `origin/main` rendered must
+    // be GONE from the visible text.
+    expect(text).not.toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+
+  test('🔴 the absolute instant survives — in the tooltip label AND as `datetime`', async () => {
+    // The relative string is the readable half; losing the exact instant would make the
+    // audit feed unusable for the question it exists to answer.
+    mocks.flags = { appListings: true };
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(appName()).toBeInTheDocument();
+    const time = document.querySelector('table tbody tr:first-child > td time');
+    expect(time, 'DaysFromNow should render a <time> element').not.toBeNull();
+    // `DaysFromNow` puts the formatted instant on both attributes.
+    expect(time!.getAttribute('datetime')).toBeTruthy();
+    expect(time!.getAttribute('title')).toBeTruthy();
+    // Mantine's Tooltip keeps its label on the wrapped child's `aria-describedby`
+    // target only while open, so the durable assertion is the wrapper's own presence:
+    // the cell still carries the tooltip-bearing element it did before.
+    const cell = document.querySelector('table tbody tr:first-child > td');
+    expect(cell!.firstElementChild).not.toBeNull();
+  });
+});

--- a/src/components/Apps/AppActivityPanel.storeGate.browser.test.tsx
+++ b/src/components/Apps/AppActivityPanel.storeGate.browser.test.tsx
@@ -48,7 +48,19 @@ import type * as TrpcMod from '~/utils/trpc';
  * gets its own test with the hook returning `null` explicitly.
  */
 
-const ROW = {
+type ScopeRow = {
+  id: string;
+  createdAt: Date;
+  appBlockId: string;
+  appName: string;
+  appSlug: string | null;
+  scope: string;
+  endpoint: string;
+  statusCode: number;
+  detail: null;
+};
+
+const ROW: ScopeRow = {
   id: 'sc_1',
   createdAt: new Date(Date.now() - 20 * 60 * 1000), // 20 minutes ago
   appBlockId: 'apb_1',
@@ -62,6 +74,9 @@ const ROW = {
 
 const mocks = vi.hoisted(() => ({
   flags: null as null | Record<string, boolean>,
+  // Mutable so a test can drive the EMPTY-state branch (the marketplace-CTA gate) and
+  // the unresolvable-listing branch (`appSlug: null`) without a second mock factory.
+  scopeRows: undefined as unknown[] | undefined,
 }));
 
 // `DaysFromNow` reads `useIsClient()` from this provider and THROWS outside it;
@@ -97,7 +112,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
     trpc: {
       blocks: {
         listMyAppActivity: { useInfiniteQuery: () => page1([]) },
-        listMyScopeInvocations: { useInfiniteQuery: () => page1([ROW]) },
+        listMyScopeInvocations: { useInfiniteQuery: () => page1(mocks.scopeRows ?? [ROW]) },
       },
       modelVersion: { getVersionsByIds: { useQuery: () => ({ ...inert, data: [] }) } },
       useQueries: () => [],
@@ -111,6 +126,7 @@ const appName = () => page.getByTestId('app-activity-app-name');
 
 beforeEach(() => {
   mocks.flags = null;
+  mocks.scopeRows = undefined;
 });
 
 describe('the App column links to the store detail — GATED', () => {
@@ -172,7 +188,139 @@ describe('the App column links to the store detail — GATED', () => {
   );
 });
 
-describe('the When column is RELATIVE, with the absolute time still in the tooltip', () => {
+/**
+ * 🔒 A ROW WITH NO RESOLVABLE LISTING GETS PLAIN TEXT — the half of `AppNameCrumb` this
+ * component did NOT copy.
+ *
+ * The crumb withholds its link on TWO conditions: the flag gate AND the listing failing
+ * to resolve ("Omitted → no store cluster … not a broken link"). `ActivityAppName` copied
+ * only the flag half, and the server made that fatal: both feeds emitted
+ * `appSlug: r.appBlock?.blockId ?? r.appBlockId`, whose fallback is the AppBlock PRIMARY
+ * KEY, not the `block_id` that `AppListing.slug` mirrors. So an unresolved join produced
+ * `/apps/store-preview/<pk>` — a link that can only 404. The service now emits `null`
+ * there (see "the appSlug contract" in `user-app-surface.service`), and this pins the
+ * consumer's side of that contract.
+ */
+describe('a row whose listing does not resolve (appSlug: null)', () => {
+  test('🔴 renders PLAIN TEXT, not a link, for an ELIGIBLE viewer', async () => {
+    // 🔴 THE VIEWER IS ELIGIBLE ON PURPOSE. With `appListings: false` this would pass for
+    // the flag gate's reason and say nothing about the slug, which is the whole point.
+    mocks.flags = { appListings: true };
+    mocks.scopeRows = [{ ...ROW, appSlug: null }];
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(appName()).toBeInTheDocument();
+    const el = appName().element();
+    expect(el.tagName, 'a row with no listing slug must not be given an anchor').not.toBe('A');
+    expect(el.getAttribute('href')).toBeNull();
+    // The name still shows — withholding the LINK must not withhold the identity.
+    expect(el.textContent).toContain('Lighthouse');
+  });
+
+  test('🔴 …and the slug BADGE is dropped rather than printing the primary key', async () => {
+    // The badge rendered `item.appSlug` unconditionally, so on the same rows it printed
+    // the AppBlock id as though it were the app's public slug.
+    mocks.flags = { appListings: true };
+    mocks.scopeRows = [{ ...ROW, appSlug: null }];
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(appName()).toBeInTheDocument();
+    const cell = document.querySelector('table tbody tr:first-child > td:nth-child(2)');
+    expect(cell, 'no App cell').not.toBeNull();
+    expect(cell!.textContent?.trim()).toBe('Lighthouse');
+    // POSITIVE CONTROL for the line above: with a real slug the badge IS rendered, so
+    // this is not an assertion satisfied by a badge that never renders at all.
+    expect(cell!.textContent).not.toContain('apb_1');
+  });
+
+  test('POSITIVE CONTROL: with a real slug the badge renders beside the link', async () => {
+    mocks.flags = { appListings: true };
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(appName()).toBeInTheDocument();
+    const cell = document.querySelector('table tbody tr:first-child > td:nth-child(2)');
+    expect(cell!.textContent).toContain('lighthouse');
+    expect(appName().element().tagName).toBe('A');
+  });
+});
+
+/**
+ * 🔒 THE PER-APP DRILL-DOWN SUPPRESSES THE LINK ENTIRELY — `linkable={!appBlockId}`.
+ *
+ * The drill-down caller is the run-frame's "Permissions & activity" drawer, mounted OVER
+ * A RUNNING FULL-PAGE APP. A top-level `<a>` there navigates the whole window out of the
+ * app the user is using, from a panel they opened to READ — and the column is redundant
+ * in that mode anyway, since every row is the same app. Asserted for an ELIGIBLE viewer
+ * with a REAL slug, so neither the flag gate nor a null slug can be the reason it passes.
+ */
+describe('per-app drill-down: the App name is never a top-level navigation', () => {
+  test('🔴 appBlockId set ⇒ plain text, even for an eligible viewer with a real slug', async () => {
+    mocks.flags = { appListings: true };
+    renderWithProviders(<AppActivityPanel appBlockId="apb_1" />);
+    await expect.element(appName()).toBeInTheDocument();
+    const el = appName().element();
+    expect(
+      el.tagName,
+      'the drawer must not offer a link that navigates out of the running app'
+    ).not.toBe('A');
+    expect(el.getAttribute('href')).toBeNull();
+    expect(el.textContent).toContain('Lighthouse');
+  });
+
+  test('POSITIVE CONTROL: the SAME viewer + row DOES get a link on the whole-account feed', async () => {
+    // Identical flags, identical row — only `appBlockId` differs. Without this the test
+    // above would pass against a component that never links.
+    mocks.flags = { appListings: true };
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(appName()).toBeInTheDocument();
+    expect(appName().element().tagName).toBe('A');
+  });
+});
+
+/**
+ * 🔒 THE EMPTY STATE'S `/apps` ANCHOR IS STORE-GATED.
+ *
+ * `/apps` SSR-gates on `hasAppsStoreAccess` = `appListings || appBlocks ||
+ * appListingsPublicExternal`. `appBlocksPages` is NOT one of those disjuncts, while
+ * `/apps/activity` now admits `appBlocks || appBlocksPages` — so the cohort this PR
+ * widened the page for could reach this empty state and be handed a link the marketplace
+ * answers `notFound` for. Same 404-affordance class as the `App` column above.
+ *
+ * ── THE MUTATION CHECK ──────────────────────────────────────────────────────
+ * Delete the `canSeeStore &&` guard from `EmptyActivity` and the first test here fails on
+ * its OWN assertion (the anchor it asserts absent is present); the positive control below
+ * stays green, which is what attributes the red to the gate rather than to the render.
+ */
+describe('the empty state offers /apps only to a viewer /apps would serve', () => {
+  const cta = () => document.querySelectorAll('a[href="/apps"]');
+
+  test('🔴 a page-apps-only viewer gets NO marketplace link', async () => {
+    // The exact newly-admitted cohort: the page's gate passes on `appBlocksPages`, the
+    // store's does not pass at all.
+    mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: false };
+    mocks.scopeRows = [];
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(page.getByText(/No activity yet/)).toBeInTheDocument();
+    expect(cta(), 'a link into a `notFound` was rendered for a store-less viewer').toHaveLength(0);
+  });
+
+  test('POSITIVE CONTROL: a store-visible viewer still gets it', async () => {
+    // Without this, "no anchor" would also be satisfied by an empty state that lost its
+    // CTA for everyone.
+    mocks.flags = { appListings: true };
+    mocks.scopeRows = [];
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(page.getByText(/No activity yet/)).toBeInTheDocument();
+    expect(cta()).toHaveLength(1);
+  });
+
+  test('FAILS CLOSED with no FeatureFlags provider at all', async () => {
+    mocks.flags = null;
+    mocks.scopeRows = [];
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(page.getByText(/No activity yet/)).toBeInTheDocument();
+    expect(cta()).toHaveLength(0);
+  });
+});
+
+describe('the When column is RELATIVE, and the absolute instant survives on the <time>', () => {
   test('🔴 renders a relative string, not a YYYY-MM-DD HH:mm stamp', async () => {
     mocks.flags = { appListings: true };
     renderWithProviders(<AppActivityPanel />);
@@ -188,7 +336,7 @@ describe('the When column is RELATIVE, with the absolute time still in the toolt
     expect(text).not.toMatch(/\d{4}-\d{2}-\d{2}/);
   });
 
-  test('🔴 the absolute instant survives — in the tooltip label AND as `datetime`', async () => {
+  test('🔴 the absolute instant survives — as `title` AND as `datetime`', async () => {
     // The relative string is the readable half; losing the exact instant would make the
     // audit feed unusable for the question it exists to answer.
     mocks.flags = { appListings: true };
@@ -199,10 +347,56 @@ describe('the When column is RELATIVE, with the absolute time still in the toolt
     // `DaysFromNow` puts the formatted instant on both attributes.
     expect(time!.getAttribute('datetime')).toBeTruthy();
     expect(time!.getAttribute('title')).toBeTruthy();
-    // Mantine's Tooltip keeps its label on the wrapped child's `aria-describedby`
-    // target only while open, so the durable assertion is the wrapper's own presence:
-    // the cell still carries the tooltip-bearing element it did before.
     const cell = document.querySelector('table tbody tr:first-child > td');
     expect(cell!.firstElementChild).not.toBeNull();
+  });
+
+  /**
+   * 🔴 ONE HOVER, ONE TOOLTIP. The cell used to wrap `DaysFromNow` in a Mantine
+   * `Tooltip label={item.createdAt.toString()}`, while `DaysFromNow` renders its own
+   * `<time title={day.format()}>`. Both fire on the SAME hover, and they format the same
+   * instant differently (`Date.prototype.toString()` — "Mon Sep 08 2026 14:05:00 GMT+0000
+   * (Coordinated Universal Time)" — vs dayjs `format()` — "2026-09-08T14:05:00+00:00"), so
+   * a reader got two boxes disagreeing about how to spell one time.
+   *
+   * 🔴 IT HAS TO BE A HOVER, AND THE FIRST VERSION OF THIS GUARD WAS VACUOUS BECAUSE IT
+   * WAS NOT. Asserting the DOM at render time — counting `[title]` nodes in the cell, or
+   * looking for `aria-describedby` — cannot see this at all: a CLOSED Mantine `Tooltip`
+   * adds no attribute and no element, so the wrapped and unwrapped markup are IDENTICAL
+   * until someone hovers. Measured: with the `<Tooltip>` re-added around `DaysFromNow`,
+   * the structural version passed 17/17. Only the floating surface it mounts ON HOVER
+   * distinguishes them, so that is what is asserted.
+   *
+   * The poll is bounded and its discriminating power is measured, not assumed: under the
+   * re-added wrapper `role="tooltip"` appears well inside the window (Mantine's default
+   * `openDelay` is 0), and the guard fails on its own assertion.
+   */
+  test('🔴 hovering the When cell raises NO second tooltip over the native one', async () => {
+    mocks.flags = { appListings: true };
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(appName()).toBeInTheDocument();
+
+    const time = document.querySelector('table tbody tr:first-child > td time');
+    expect(time, 'DaysFromNow should render a <time> element').not.toBeNull();
+    // The native affordance the row genuinely owns — asserted first so "no tooltip
+    // appeared" cannot be satisfied by a cell that lost its hover text entirely.
+    expect(time!.getAttribute('title')).toBeTruthy();
+
+    // `withinPortal` is Mantine's default, so a raised tooltip lands on `document.body`
+    // rather than inside the cell — query the document.
+    await page.getByText(/ago$/).hover();
+    let raised: string[] = [];
+    for (let i = 0; i < 20; i++) {
+      raised = Array.from(document.querySelectorAll('[role="tooltip"]')).map(
+        (el) => el.textContent ?? ''
+      );
+      if (raised.length > 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    expect(
+      raised,
+      'a second tooltip was re-added over `DaysFromNow`, which already owns `title` — ' +
+        'one hover then shows the same instant twice, in two different formats'
+    ).toEqual([]);
   });
 });

--- a/src/components/Apps/AppActivityPanel.tsx
+++ b/src/components/Apps/AppActivityPanel.tsx
@@ -8,7 +8,6 @@ import {
   Stack,
   Table,
   Text,
-  Tooltip,
 } from '@mantine/core';
 import { IconHistory } from '@tabler/icons-react';
 import Link from 'next/link';
@@ -182,14 +181,42 @@ export function humaniseScopeEndpoint(
  * The `href` comes from the CANONICAL `getListingDetailHref`, never a concatenation
  * here: one function owns the store-detail path (and its `encodeURIComponent`), so a
  * route change cannot leave this call site pointing at the old one.
+ *
+ * 🔴 THERE ARE THREE WAYS TO GET PLAIN TEXT, AND ALL THREE ARE DELIBERATE — the flag
+ * gate above, a NULL `slug`, and `linkable={false}`. The middle one is the copy of
+ * `AppNameCrumb` this component originally MISSED: the crumb withholds the link when the
+ * listing does not resolve, and this one only copied the flag half. The row's `appSlug`
+ * is now null exactly when the server could not resolve a real listing slug (see "the
+ * appSlug contract" in `~/server/services/blocks/user-app-surface.service`), so a null
+ * here means "there is no listing to open", not "the caller forgot".
  */
-export function ActivityAppName({ name, slug }: { name: string; slug: string }) {
+export function ActivityAppName({
+  name,
+  slug,
+  linkable = true,
+}: {
+  name: string;
+  /** `AppBlock.blockId`, or NULL when the row has no resolvable store listing. */
+  slug: string | null;
+  /**
+   * 🔴 `false` SUPPRESSES THE LINK REGARDLESS OF THE VIEWER'S FLAGS, and the caller that
+   * passes it is the PER-APP drill-down (the run-frame's "Permissions & activity"
+   * drawer). Two reasons, and the first is the one that matters: that drawer is mounted
+   * OVER A RUNNING FULL-PAGE APP, so a top-level `<a>` navigation destroys whatever the
+   * user was doing inside it — with no warning, from a panel they opened to READ. The
+   * second is that in drill-down mode every row is the same app, so the column is a
+   * label rather than a destination. Not a `target="_blank"`: a second mechanism for the
+   * same column is how the two renderings come to disagree.
+   */
+  linkable?: boolean;
+}) {
   const features = useOptionalFeatureFlags();
   const canSeeStore = hasAppsStoreAccess(features);
 
-  // Ineligible viewer (or no slug on the row): the pre-change static text, with the
-  // same testid so nothing downstream has to branch on the gate.
-  if (!canSeeStore || !slug) {
+  // Ineligible viewer, no listing slug on the row, or a caller that suppressed the link:
+  // the pre-change static text, with the same testid so nothing downstream has to branch
+  // on the gate.
+  if (!linkable || !canSeeStore || !slug) {
     return (
       <Text size="sm" fw={500} className="truncate" data-testid="app-activity-app-name">
         {name}
@@ -242,7 +269,8 @@ type ActivityFeedRow =
       createdAt: Date;
       appBlockId: string;
       appName: string;
-      appSlug: string;
+      /** NULL when the server could not resolve a listing slug — see the service. */
+      appSlug: string | null;
       scope: string;
       usdAmountCents: number;
       status: string;
@@ -253,7 +281,8 @@ type ActivityFeedRow =
       createdAt: Date;
       appBlockId: string;
       appName: string;
-      appSlug: string;
+      /** NULL when the server could not resolve a listing slug — see the service. */
+      appSlug: string | null;
       scope: string;
       endpoint: string;
       statusCode: number;
@@ -436,26 +465,48 @@ export function AppActivityPanel({
           {items.map((item) => (
             <Table.Tr key={item.id}>
               <Table.Td>
-                {/* 🔴 RELATIVE, WITH THE ABSOLUTE STAMP KEPT IN THE TOOLTIP. "20m ago"
+                {/* 🔴 RELATIVE, WITH THE ABSOLUTE STAMP STILL ONE HOVER AWAY. "20m ago"
                     is what a reader of an audit feed actually wants — the question is
-                    "was this just now?", not "what wall-clock minute was it?" — and the
-                    exact instant is one hover away, unchanged from before.
-                    `DaysFromNow` renders a `<time datetime>` (so the machine-readable
-                    instant is in the DOM too) and returns `null` until `useIsClient`
-                    goes true, which is what keeps a relative string from being
-                    server-rendered and then hydrating to a different one. */}
-                <Tooltip label={item.createdAt.toString()}>
-                  <Text size="xs">
-                    <DaysFromNow date={item.createdAt} />
-                  </Text>
-                </Tooltip>
+                    "was this just now?", not "what wall-clock minute was it?".
+                    `DaysFromNow` renders a `<time title dateTime>` (so the exact instant
+                    is BOTH the native hover text and machine-readable in the DOM) and
+                    returns `null` until `useIsClient` goes true, which is what keeps a
+                    relative string from being server-rendered and then hydrating to a
+                    different one.
+
+                    🔴 NO MANTINE `Tooltip` WRAPPER — it used to be here and it was a
+                    DOUBLE tooltip: `DaysFromNow`'s own `title` attribute fires the
+                    browser's native tip while Mantine floated a second one, on the same
+                    hover, showing the SAME instant in a DIFFERENT format
+                    (`Date.prototype.toString()` vs dayjs `format()`). One hover, two
+                    boxes, two spellings of one time. The `<time>` element already owns
+                    this affordance; do not re-wrap it.
+
+                    `live` — an audit feed is a tab people leave open. Without it every
+                    relative string freezes at mount and "20m ago" silently means an hour;
+                    with it each row re-renders on a 15s interval. */}
+                <Text size="xs">
+                  <DaysFromNow date={item.createdAt} live />
+                </Text>
               </Table.Td>
               <Table.Td>
                 <Group gap={6} wrap="nowrap">
-                  <ActivityAppName name={item.appName} slug={item.appSlug} />
-                  <Badge size="xs" variant="outline">
-                    {item.appSlug}
-                  </Badge>
+                  {/* `linkable` is FALSE in per-app drill-down (the run-frame drawer) —
+                      see the prop's own docstring: a top-level navigation out of a
+                      RUNNING full-page app is not something a read-only panel may do. */}
+                  <ActivityAppName
+                    name={item.appName}
+                    slug={item.appSlug}
+                    linkable={!appBlockId}
+                  />
+                  {/* Only when there IS a slug. The badge used to render `item.appSlug`
+                      unconditionally, which on an unresolvable row printed the AppBlock
+                      PRIMARY KEY as though it were the app's public slug. */}
+                  {item.appSlug && (
+                    <Badge size="xs" variant="outline">
+                      {item.appSlug}
+                    </Badge>
+                  )}
                 </Group>
               </Table.Td>
               <Table.Td>
@@ -521,7 +572,23 @@ export function AppActivityPanel({
   );
 }
 
+/**
+ * 🔴 THE `/apps` ANCHOR IS GATED ON `hasAppsStoreAccess`, AND IT IS THE SAME 404-AFFORDANCE
+ * CLASS AS THE `App` COLUMN'S LINK ABOVE — not polish. `/apps` SSR-gates on
+ * `resolveAppsPageAccess` → `hasAppsStoreAccess` = `appListings || appBlocks ||
+ * appListingsPublicExternal`. `appBlocksPages` is NOT one of those disjuncts, while
+ * `/apps/activity` now admits `appBlocks || appBlocksPages` — so this PR's newly-admitted
+ * cohort (page-apps-only, no `appBlocks`) can reach this empty state and would be handed
+ * a link the marketplace answers `notFound` for. The CTA is omitted rather than reworded:
+ * a viewer with no store has nowhere to browse, so there is no honest destination.
+ *
+ * `useOptionalFeatureFlags`, not `useFeatureFlags`, for the reason {@link ActivityAppName}
+ * gives: this panel renders in the run-frame drawer and in isolation under test, and a
+ * throwing hook would turn "no flags here" into a crashed panel. `null` → `false` → no
+ * link, i.e. it fails CLOSED.
+ */
 function EmptyActivity() {
+  const canSeeStore = hasAppsStoreAccess(useOptionalFeatureFlags());
   return (
     <Center py="md">
       <Stack align="center" gap="xs">
@@ -530,9 +597,11 @@ function EmptyActivity() {
           No activity yet. This feed populates whenever an app runs a generation, calls a
           scope-gated Civitai API, or sources a Buzz purchase on your behalf.
         </Text>
-        <Anchor component={Link} href="/apps" size="sm">
-          Browse the marketplace
-        </Anchor>
+        {canSeeStore && (
+          <Anchor component={Link} href="/apps" size="sm" data-testid="apps-empty-marketplace-link">
+            Browse the marketplace
+          </Anchor>
+        )}
       </Stack>
     </Center>
   );

--- a/src/components/Apps/AppActivityPanel.tsx
+++ b/src/components/Apps/AppActivityPanel.tsx
@@ -13,7 +13,10 @@ import {
 import { IconHistory } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useMemo } from 'react';
-import { formatDate } from '~/utils/date-helpers';
+import { getListingDetailHref } from '~/components/Apps/appListingCardView';
+import { DaysFromNow } from '~/components/Dates/DaysFromNow';
+import { useOptionalFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
 import { trpc } from '~/utils/trpc';
 import {
   describeBlockAction,
@@ -23,10 +26,11 @@ import {
 
 /**
  * Shared per-viewer app-activity timeline. Extracted from
- * `src/pages/apps/installed.tsx` (W5 v0.5) so the same interleaved feed can be
- * reused both there (whole-account view) AND on the run-frame "Permissions &
- * activity" drawer scoped to a single app (`appBlockId`). DRY: the humanise
- * helpers + row shape live here, in one tested place, instead of duplicated.
+ * `src/pages/apps/activity.tsx` (W5 v0.5, when that page was `/apps/installed`) so
+ * the same interleaved feed can be reused both there (whole-account view) AND on the
+ * run-frame "Permissions & activity" drawer scoped to a single app (`appBlockId`).
+ * DRY: the humanise helpers + row shape live here, in one tested place, instead of
+ * duplicated.
  *
  * Two cursor-paginated tRPC queries — `blocks.listMyAppActivity` (Buzz
  * attribution) + `blocks.listMyScopeInvocations` (scope-gated call audit) —
@@ -37,7 +41,7 @@ import {
  * fetch + client filter would under-report this app's Buzz behind other apps'
  * rows on page 1). A client-side `item.appBlockId` check is kept as cheap
  * belt-and-suspenders. When `appBlockId` is omitted the feed is whole-account —
- * exactly the /apps/installed behaviour, unchanged.
+ * exactly the /apps/activity behaviour, unchanged.
  *
  * `enabled` gates the queries: pass `false` for an anonymous viewer (these
  * procedures are `protectedProcedure`, so firing them unauthenticated just
@@ -153,6 +157,58 @@ export function humaniseScopeEndpoint(
   }
   if (endpoint === 'user-settings:write') return '';
   return endpoint;
+}
+
+/**
+ * The `App` cell's name — a LINK to the app's store detail for a viewer who can open
+ * it, and the pre-change plain `<Text>` for everyone else.
+ *
+ * 🔴 THE GATE IS `hasAppsStoreAccess`, AND IT IS NOT OPTIONAL POLISH. The destination
+ * `/apps/store-preview/<slug>` `getServerSideProps`-gates on exactly this predicate
+ * (via `resolveAppsPageAccess`) and returns `notFound`, and `appListings.getAppDetail`
+ * resolves a `StoreVisibilityScope` of `none` and throws NOT_FOUND. An ungated link is
+ * therefore a 404 affordance — the defect class civitai#4668 shipped and civitai#4685
+ * exists to prevent. This is `AppNameCrumb`'s solution copied rather than re-derived;
+ * see that file for the full argument.
+ *
+ * 🔴 IT READS THE FLAGS THROUGH `useOptionalFeatureFlags`, NOT `useFeatureFlags`, AND
+ * THAT IS A FAIL-CLOSED DECISION. `useFeatureFlags` THROWS outside its provider. This
+ * panel is mounted from `/apps/activity` AND from the run-frame's permissions drawer,
+ * and it is rendered in isolation under test; making it throw would turn "flags are
+ * unavailable here" into a crashed panel. The optional hook returns `null` there, and
+ * `hasAppsStoreAccess(null)` is `false` — so the absence of flags removes the link
+ * instead of granting it.
+ *
+ * The `href` comes from the CANONICAL `getListingDetailHref`, never a concatenation
+ * here: one function owns the store-detail path (and its `encodeURIComponent`), so a
+ * route change cannot leave this call site pointing at the old one.
+ */
+export function ActivityAppName({ name, slug }: { name: string; slug: string }) {
+  const features = useOptionalFeatureFlags();
+  const canSeeStore = hasAppsStoreAccess(features);
+
+  // Ineligible viewer (or no slug on the row): the pre-change static text, with the
+  // same testid so nothing downstream has to branch on the gate.
+  if (!canSeeStore || !slug) {
+    return (
+      <Text size="sm" fw={500} className="truncate" data-testid="app-activity-app-name">
+        {name}
+      </Text>
+    );
+  }
+
+  return (
+    <Anchor
+      component={Link}
+      href={getListingDetailHref(slug)}
+      size="sm"
+      fw={500}
+      className="truncate"
+      data-testid="app-activity-app-name"
+    >
+      {name}
+    </Anchor>
+  );
 }
 
 function ScopeStatusBadge({ statusCode }: { statusCode: number }) {
@@ -380,15 +436,23 @@ export function AppActivityPanel({
           {items.map((item) => (
             <Table.Tr key={item.id}>
               <Table.Td>
+                {/* 🔴 RELATIVE, WITH THE ABSOLUTE STAMP KEPT IN THE TOOLTIP. "20m ago"
+                    is what a reader of an audit feed actually wants — the question is
+                    "was this just now?", not "what wall-clock minute was it?" — and the
+                    exact instant is one hover away, unchanged from before.
+                    `DaysFromNow` renders a `<time datetime>` (so the machine-readable
+                    instant is in the DOM too) and returns `null` until `useIsClient`
+                    goes true, which is what keeps a relative string from being
+                    server-rendered and then hydrating to a different one. */}
                 <Tooltip label={item.createdAt.toString()}>
-                  <Text size="xs">{formatDate(item.createdAt, 'YYYY-MM-DD HH:mm')}</Text>
+                  <Text size="xs">
+                    <DaysFromNow date={item.createdAt} />
+                  </Text>
                 </Tooltip>
               </Table.Td>
               <Table.Td>
                 <Group gap={6} wrap="nowrap">
-                  <Text size="sm" fw={500} className="truncate">
-                    {item.appName}
-                  </Text>
+                  <ActivityAppName name={item.appName} slug={item.appSlug} />
                   <Badge size="xs" variant="outline">
                     {item.appSlug}
                   </Badge>

--- a/src/components/Apps/AppSettingsModal.tsx
+++ b/src/components/Apps/AppSettingsModal.tsx
@@ -109,7 +109,7 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
   // from `block.manifest.settings` would therefore render NO fields. Fetch the
   // install-needed bits (settings meta + declared scopes) from the
   // authenticated `getInstallConfig` procedure instead, keyed on appBlockId.
-  // The "Manage" path (/apps/installed) passes the FULL manifest, so its
+  // The "Manage" path (/apps/activity) passes the FULL manifest, so its
   // `manifest.settings` is already populated; the fetched value matches it.
   const { data: installConfig, isLoading: installConfigLoading } =
     trpc.blocks.getInstallConfig.useQuery({ appBlockId: block.id }, { staleTime: 60_000 });

--- a/src/components/Apps/AppsBuildBody.browser.test.tsx
+++ b/src/components/Apps/AppsBuildBody.browser.test.tsx
@@ -41,6 +41,7 @@ import type * as TrpcMod from '~/utils/trpc';
 /** A summary for an author who HAS apps — the cohort the bug hit. */
 const SUMMARY_WITH_APPS = {
   hasInstalls: false,
+  hasActivity: false,
   hasSubmissions: false,
   hasApprovedApps: false,
   isReviewer: false,

--- a/src/components/Apps/AppsPageLayout.chromeAlignment.browser.test.tsx
+++ b/src/components/Apps/AppsPageLayout.chromeAlignment.browser.test.tsx
@@ -192,8 +192,11 @@ describe('the /apps route set that renders the shared chrome', () => {
       '/apps',
       '/apps/[appBlockId]/edit',
       '/apps/[appBlockId]/revenue',
+      // 🔴 `/apps/activity` SORTS BEFORE `/apps/build` — it is `/apps/installed`
+      // repointed ('a' < 'b', where 'i' > 'b'), so the position moving is not a second
+      // change to review.
+      '/apps/activity',
       '/apps/build',
-      '/apps/installed',
       '/apps/invites',
       '/apps/listing/[appListingId]/edit',
       '/apps/revenue',

--- a/src/components/Apps/AppsPageLayout.tsx
+++ b/src/components/Apps/AppsPageLayout.tsx
@@ -44,7 +44,7 @@ import {
  * Which flag depends on the surface, and the two are NOT interchangeable: the
  * STORE surfaces (`/apps`, `/apps/store-preview/<slug>`) gate on the shared
  * `hasAppsStoreAccess` predicate (`appListings || appBlocks`), while the block-
- * RUNTIME surfaces (`/apps/installed`, `/apps/review`, `/apps/my-submissions`,
+ * RUNTIME surfaces (`/apps/activity`, `/apps/review`, `/apps/my-submissions`,
  * `/apps/revenue`) gate on `appBlocks` alone because they need the runtime, not
  * just the catalog.
  */

--- a/src/components/Apps/AppsSubNav.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.browser.test.tsx
@@ -27,7 +27,7 @@ import { renderWithProviders } from '../../../test/component-setup';
 // GONE, replaced by a single "Build" row pointing at `/apps/build`; the two retired
 // routes 301 there and `/apps/submit` keeps its route but has no tab. Marketplace stopped
 // being unconditional and is now gated on `c.canSeeStore`. The full table, in order:
-//   Build (/apps/build) · Marketplace (/apps) · Installed (/apps/installed) ·
+//   Build (/apps/build) · Marketplace (/apps) · Activity (/apps/activity) ·
 //   Invites (/apps/invites) · Revenue (/apps/revenue) · Review (/apps/review)
 //
 // The sub-nav uses the Mantine **Tabs** LOOK but is wrapped in a real
@@ -173,13 +173,13 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
   test('with an all-false summary the conditional tabs are hidden', async () => {
     renderWithProviders(<AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps" />);
     // None of the summary-driven tabs should render.
-    expect(tab('Installed').elements()).toHaveLength(0);
+    expect(tab('Activity').elements()).toHaveLength(0);
     expect(tab('Invites').elements()).toHaveLength(0);
     expect(tab('Revenue').elements()).toHaveLength(0);
     expect(tab('Review').elements()).toHaveLength(0);
   });
 
-  test('Installed shows ONLY when hasInstalls', async () => {
+  test('Activity shows ONLY when hasInstalls', async () => {
     renderWithProviders(
       <AppsSubNavView
         summary={{ ...NONE, hasInstalls: true }}
@@ -187,7 +187,7 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
         currentPath="/apps"
       />
     );
-    await expect.element(tab('Installed')).toBeInTheDocument();
+    await expect.element(tab('Activity')).toBeInTheDocument();
     // The other conditionals stay hidden.
     expect(tab('Invites').elements()).toHaveLength(0);
     expect(tab('Revenue').elements()).toHaveLength(0);
@@ -240,10 +240,10 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
         currentPath="/apps"
       />
     );
-    await expect.element(tab('Installed')).toBeInTheDocument();
+    await expect.element(tab('Activity')).toBeInTheDocument();
     // …and STILL no tab from the two unwired flags: the bar is exactly Marketplace +
-    // Installed, so the pinned literal catches a mutant that wires either of them in.
-    expect(renderedTabs()).toEqual(['Marketplace', 'Installed']);
+    // Activity, so the pinned literal catches a mutant that wires either of them in.
+    expect(renderedTabs()).toEqual(['Marketplace', 'Activity']);
   });
 
   test('Revenue shows ONLY when hasApprovedApps', async () => {
@@ -255,7 +255,7 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
       />
     );
     await expect.element(tab('Revenue')).toBeInTheDocument();
-    expect(tab('Installed').elements()).toHaveLength(0);
+    expect(tab('Activity').elements()).toHaveLength(0);
     expect(tab('Invites').elements()).toHaveLength(0);
     expect(tab('Review').elements()).toHaveLength(0);
   });
@@ -269,7 +269,7 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
       />
     );
     await expect.element(tab('Review')).toBeInTheDocument();
-    expect(tab('Installed').elements()).toHaveLength(0);
+    expect(tab('Activity').elements()).toHaveLength(0);
     expect(tab('Invites').elements()).toHaveLength(0);
     expect(tab('Revenue').elements()).toHaveLength(0);
   });
@@ -278,14 +278,19 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
     renderWithProviders(<AppsSubNavView summary={ALL} context={AUTHOR} currentPath="/apps" />);
     await expect.element(tab('Review')).toBeInTheDocument();
     // Pinned as an ORDERED literal, not a presence loop: order is a real property of this
-    // bar (build → discovery → manage → revenue → moderate) and a presence loop cannot
+    // bar (discovery → manage → revenue → build → moderate) and a presence loop cannot
     // see a row that moved.
+    //
+    // 🔴 `Build` MOVED TO SECOND-TO-LAST, and this literal is what makes that a checked
+    // fact rather than a claim in a comment. It led the table until the `/apps/activity`
+    // rename; it is the narrowest-audience tab here, so leading with it put the smallest
+    // cohort's destination in the position that reads as "what this bar is for".
     expect(renderedTabs()).toEqual([
-      'Build',
       'Marketplace',
-      'Installed',
+      'Activity',
       'Invites',
       'Revenue',
+      'Build',
       'Review',
     ]);
   });
@@ -308,7 +313,7 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
     await expect.element(tab('Review')).toBeInTheDocument();
     // Marketplace is present because this viewer HAS store access; Build and Invites are
     // the two rows the capabilities remove.
-    expect(renderedTabs()).toEqual(['Marketplace', 'Installed', 'Revenue', 'Review']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Activity', 'Revenue', 'Review']);
   });
 });
 
@@ -348,7 +353,7 @@ describe('AppsSubNavView (Build is gated on canBuild)', () => {
     );
     // Positive control: the bar IS rendered…
     await expect.element(tab('Marketplace')).toBeInTheDocument();
-    await expect.element(tab('Installed')).toBeInTheDocument();
+    await expect.element(tab('Activity')).toBeInTheDocument();
     // …and Build is absent from it.
     expect(tab('Build').elements()).toHaveLength(0);
   });
@@ -380,7 +385,7 @@ describe('AppsSubNavView (Build is gated on canBuild)', () => {
     // "simplified" to `c.isAuthor`.
     renderWithProviders(<AppsSubNavView summary={NONE} context={BUILDER} currentPath="/apps" />);
     await expect.element(tab('Build')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
   });
 });
 
@@ -415,9 +420,9 @@ describe('AppsSubNavView (Marketplace is gated on canSeeStore)', () => {
       <AppsSubNavView summary={TWO_SUMMARY_TABS} context={NO_STORE} currentPath="/apps" />
     );
     // Positive control: the bar renders, on the two summary-driven rows.
-    await expect.element(tab('Installed')).toBeInTheDocument();
+    await expect.element(tab('Activity')).toBeInTheDocument();
     await expect.element(tab('Review')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Installed', 'Review']);
+    expect(renderedTabs()).toEqual(['Activity', 'Review']);
     expect(tab('Marketplace').elements()).toHaveLength(0);
   });
 
@@ -426,7 +431,7 @@ describe('AppsSubNavView (Marketplace is gated on canSeeStore)', () => {
       <AppsSubNavView summary={TWO_SUMMARY_TABS} context={NOT_AUTHOR} currentPath="/apps" />
     );
     await expect.element(tab('Marketplace')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Marketplace', 'Installed', 'Review']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Activity', 'Review']);
     expect(tab('Marketplace').element().getAttribute('href')).toBe('/apps');
   });
 });
@@ -487,12 +492,12 @@ describe('AppsSubNavView (the collapse, and the canBuild gate that keeps it live
     await expect
       .element(page.getByRole('navigation', { name: 'App sections' }))
       .toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
   });
 
   test('🔴 Build is ABSENT for a store-visible viewer WITHOUT the capability', async () => {
     // The cohort the defect would have 404'd. Given an install so the bar clears the
-    // floor on Marketplace + Installed, making this an assertion about the TAB rather
+    // floor on Marketplace + Activity, making this an assertion about the TAB rather
     // than about the bar.
     renderWithProviders(
       <AppsSubNavView
@@ -502,7 +507,7 @@ describe('AppsSubNavView (the collapse, and the canBuild gate that keeps it live
       />
     );
     await expect.element(tab('Marketplace')).toBeInTheDocument(); // positive control
-    await expect.element(tab('Installed')).toBeInTheDocument();
+    await expect.element(tab('Activity')).toBeInTheDocument();
     expect(tab('Build').elements()).toHaveLength(0);
   });
 
@@ -518,14 +523,22 @@ describe('AppsSubNavView (the collapse, and the canBuild gate that keeps it live
       .getByRole('tab')
       .elements()
       .map((el) => el.getAttribute('href'));
-    expect(hrefs).toEqual(['/apps/build', '/apps']); // non-empty: the check below can fail
+    expect(hrefs).toEqual(['/apps', '/apps/build']); // non-empty: the check below can fail
     expect(hrefs).not.toContain('/apps/get-started');
   });
 
-  test('it leads the bar — Build is the FIRST tab when it renders', async () => {
+  test('🔴 it sits SECOND-TO-LAST, before Review — not first', async () => {
+    // 🔴 IT USED TO LEAD THE BAR, AND THIS TEST USED TO ASSERT THAT. The claim moved with
+    // the row: `Build` is the narrowest-audience tab here (`canAccessAppsBuild`), so
+    // leading with it put the smallest cohort's destination in the position that reads as
+    // "what this bar is for". Pinned by POSITION rather than by "not first", because the
+    // decision is a specific slot — after the consumer surfaces, before the moderator one.
     renderWithProviders(<AppsSubNavView summary={ALL} context={AUTHOR} currentPath="/apps" />);
     await expect.element(tab('Build')).toBeInTheDocument();
-    expect(renderedTabs()[0]).toBe('Build');
+    const tabs = renderedTabs();
+    expect(tabs[0]).toBe('Marketplace');
+    expect(tabs[tabs.length - 2]).toBe('Build');
+    expect(tabs[tabs.length - 1]).toBe('Review');
   });
 
   test('a summary flag alone brings the bar back (one install, no canBuild)', async () => {
@@ -539,7 +552,7 @@ describe('AppsSubNavView (the collapse, and the canBuild gate that keeps it live
     await expect
       .element(page.getByRole('navigation', { name: 'App sections' }))
       .toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Marketplace', 'Installed']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Activity']);
   });
 
   // 🔴 NEGATIVE CONTROL for the counts above. Every assertion in this block is
@@ -551,7 +564,7 @@ describe('AppsSubNavView (the collapse, and the canBuild gate that keeps it live
     renderWithProviders(<AppsSubNavView summary={ALL} context={BUILDER} currentPath="/apps" />);
     await expect.element(tab('Build')).toBeInTheDocument();
     expect(tab('Invites').elements()).toHaveLength(0);
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace', 'Installed', 'Revenue', 'Review']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Activity', 'Revenue', 'Build', 'Review']);
   });
 });
 
@@ -583,11 +596,11 @@ describe('AppsSubNavView (active tab reflects the current route)', () => {
       <AppsSubNavView
         summary={{ ...NONE, hasInstalls: true }}
         context={AUTHOR}
-        currentPath="/apps/installed"
+        currentPath="/apps/activity"
       />
     );
-    await expect.element(tab('Installed')).toBeInTheDocument();
-    const installed = tab('Installed').element();
+    await expect.element(tab('Activity')).toBeInTheDocument();
+    const installed = tab('Activity').element();
     expect(installed.getAttribute('aria-selected')).toBe('true');
   });
 
@@ -599,10 +612,10 @@ describe('AppsSubNavView (active tab reflects the current route)', () => {
       <AppsSubNavView
         summary={{ ...NONE, hasInstalls: true }}
         context={AUTHOR}
-        currentPath="/apps/installed"
+        currentPath="/apps/activity"
       />
     );
-    await expect.element(tab('Installed')).toBeInTheDocument();
+    await expect.element(tab('Activity')).toBeInTheDocument();
     const marketplace = tab('Marketplace').element();
     expect(marketplace.getAttribute('aria-selected')).toBe('false');
   });
@@ -636,7 +649,7 @@ describe('AppsSubNavView (active tab reflects the current route)', () => {
       <AppsSubNavView summary={ALL} context={AUTHOR} currentPath="/apps/submit" />
     );
     await expect.element(tab('Build')).toBeInTheDocument(); // the bar IS rendered
-    for (const name of ['Build', 'Marketplace', 'Installed', 'Invites', 'Revenue', 'Review']) {
+    for (const name of ['Build', 'Marketplace', 'Activity', 'Invites', 'Revenue', 'Review']) {
       expect(tab(name).element().getAttribute('aria-selected'), `${name} is selected`).toBe(
         'false'
       );
@@ -648,11 +661,11 @@ describe('AppsSubNavView (active tab reflects the current route)', () => {
   // the tabs that DID render.
   test('with Build hidden, the active route still lights the right tab', async () => {
     renderWithProviders(
-      <AppsSubNavView summary={ALL} context={NOT_AUTHOR} currentPath="/apps/installed" />
+      <AppsSubNavView summary={ALL} context={NOT_AUTHOR} currentPath="/apps/activity" />
     );
-    await expect.element(tab('Installed')).toBeInTheDocument();
+    await expect.element(tab('Activity')).toBeInTheDocument();
     expect(tab('Build').elements()).toHaveLength(0);
-    expect(tab('Installed').element().getAttribute('aria-selected')).toBe('true');
+    expect(tab('Activity').element().getAttribute('aria-selected')).toBe('true');
     // Every other rendered tab is unselected — exactly one highlight.
     for (const name of ['Marketplace', 'Revenue', 'Review']) {
       expect(tab(name).element().getAttribute('aria-selected')).toBe('false');
@@ -670,7 +683,7 @@ describe('AppsSubNavView (active tab reflects the current route)', () => {
     await expect.element(tab('Marketplace')).toBeInTheDocument();
     expect(tab('Build').elements()).toHaveLength(0);
     expect(tab('Marketplace').element().getAttribute('aria-selected')).toBe('true');
-    expect(tab('Installed').element().getAttribute('aria-selected')).toBe('false');
+    expect(tab('Activity').element().getAttribute('aria-selected')).toBe('false');
   });
 });
 
@@ -686,7 +699,7 @@ describe('AppsSubNavView (each tab navigates to its route)', () => {
       // create buttons and the `?edit=` deep link, not from this bar.
       ['Build', '/apps/build'],
       ['Marketplace', '/apps'],
-      ['Installed', '/apps/installed'],
+      ['Activity', '/apps/activity'],
       // The collaborator inbox: `appCollaborators.listMyPendingInvites`. Owner-INDEPENDENT
       // — an invitee who owns nothing reaches every other tab's page empty.
       ['Invites', '/apps/invites'],
@@ -732,13 +745,13 @@ describe('AppsSubNavView (keyboard: arrow keys scan, do not auto-navigate)', () 
       />
     );
     // Wait for the async render before reaching into the DOM synchronously.
-    await expect.element(tab('Installed')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace', 'Installed']);
+    await expect.element(tab('Activity')).toBeInTheDocument();
+    expect(renderedTabs()).toEqual(['Marketplace', 'Activity', 'Build']);
 
     const marketplace = tab('Marketplace').element() as HTMLElement;
-    const installed = tab('Installed').element() as HTMLElement;
+    const installed = tab('Activity').element() as HTMLElement;
 
-    // Marketplace (= current route) is the selected tab; Installed is not.
+    // Marketplace (= current route) is the selected tab; Activity is not.
     expect(marketplace.getAttribute('aria-selected')).toBe('true');
     expect(installed.getAttribute('aria-selected')).toBe('false');
 
@@ -747,10 +760,10 @@ describe('AppsSubNavView (keyboard: arrow keys scan, do not auto-navigate)', () 
     expect(document.activeElement).toBe(marketplace);
     await userEvent.keyboard('{ArrowRight}');
 
-    // Focus moved to Installed (keyboard-reachable scan)…
+    // Focus moved to Activity (keyboard-reachable scan)…
     expect(document.activeElement).toBe(installed);
     // …but selection (aria-selected, driven by the route) did NOT follow focus.
-    // If activateTabWithKeyboard were on, Installed would now be aria-selected=true.
+    // If activateTabWithKeyboard were on, Activity would now be aria-selected=true.
     expect(installed.getAttribute('aria-selected')).toBe('false');
     expect(marketplace.getAttribute('aria-selected')).toBe('true');
   });
@@ -773,15 +786,15 @@ describe('AppsSubNavView (keyboard: arrow keys scan, do not auto-navigate)', () 
 describe('isActiveAppsRoute / activeAppsTab (route-matching helpers)', () => {
   test('/apps matches ONLY the exact marketplace route', () => {
     expect(isActiveAppsRoute('/apps', '/apps')).toBe(true);
-    expect(isActiveAppsRoute('/apps', '/apps/installed')).toBe(false);
+    expect(isActiveAppsRoute('/apps', '/apps/activity')).toBe(false);
     expect(isActiveAppsRoute('/apps', '/apps/run/foo')).toBe(false);
   });
 
   test('sub-routes match exact + deeper child paths (prefix)', () => {
-    expect(isActiveAppsRoute('/apps/installed', '/apps/installed')).toBe(true);
-    expect(isActiveAppsRoute('/apps/installed', '/apps/installed/123')).toBe(true);
-    expect(isActiveAppsRoute('/apps/installedX', '/apps/installed')).toBe(false);
-    expect(isActiveAppsRoute('/apps/build', '/apps/installed')).toBe(false);
+    expect(isActiveAppsRoute('/apps/activity', '/apps/activity')).toBe(true);
+    expect(isActiveAppsRoute('/apps/activity', '/apps/activity/123')).toBe(true);
+    expect(isActiveAppsRoute('/apps/activityX', '/apps/activity')).toBe(false);
+    expect(isActiveAppsRoute('/apps/build', '/apps/activity')).toBe(false);
   });
 
   test('activeAppsTab resolves the active tab href, or null when none matches', () => {
@@ -874,7 +887,7 @@ describe('AppsSubNavView (Invites is gated on the author capability)', () => {
       />
     );
     await expect.element(tab('Build')).toBeInTheDocument(); // the bar IS rendered
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
     expect(tab('Invites').elements()).toHaveLength(0);
   });
 
@@ -911,6 +924,6 @@ describe('AppsSubNavView (Invites is gated on the author capability)', () => {
     await expect
       .element(page.getByRole('navigation', { name: 'App sections' }))
       .toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace', 'Invites']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Invites', 'Build']);
   });
 });

--- a/src/components/Apps/AppsSubNav.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.browser.test.tsx
@@ -49,6 +49,7 @@ import { renderWithProviders } from '../../../test/component-setup';
 
 const NONE: AppsNavSummary = {
   hasInstalls: false,
+  hasActivity: false,
   hasSubmissions: false,
   hasApprovedApps: false,
   isReviewer: false,
@@ -58,6 +59,7 @@ const NONE: AppsNavSummary = {
 
 const ALL: AppsNavSummary = {
   hasInstalls: true,
+  hasActivity: true,
   hasSubmissions: true,
   hasApprovedApps: true,
   isReviewer: true,
@@ -179,7 +181,7 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
     expect(tab('Review').elements()).toHaveLength(0);
   });
 
-  test('Activity shows ONLY when hasInstalls', async () => {
+  test('Activity shows when hasInstalls', async () => {
     renderWithProviders(
       <AppsSubNavView
         summary={{ ...NONE, hasInstalls: true }}
@@ -192,6 +194,54 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
     expect(tab('Invites').elements()).toHaveLength(0);
     expect(tab('Revenue').elements()).toHaveLength(0);
     expect(tab('Review').elements()).toHaveLength(0);
+  });
+
+  /**
+   * 🔴 THE ROW-LEVEL HALF OF THE `hasActivity` FIX, AND THE ASSERTION THAT MATTERS: a
+   * viewer with ACTIVITY and ZERO INSTALLS must get the tab.
+   *
+   * That viewer is not hypothetical, they are the cohort `/apps/installed` →
+   * `/apps/activity` was renamed for. A full-page app (`/apps/run/<slug>`) is STATELESS by
+   * design — `/apps/run`'s own header, Decision 2: "no `block_user_subscriptions` row, no
+   * migration" — so someone who only runs page apps has generations, scope-gated API
+   * calls and Buzz spends in the feed, and `hasInstalls: false` forever. The row shipped
+   * as `visible: (s) => s.hasInstalls`, which is dark for exactly them while
+   * `/apps/activity` (gated on `appBlocks || appBlocksPages`) serves them.
+   *
+   * 🔴 RED WITHOUT THE CHANGE, AND FOR THIS TEST'S OWN REASON. Restore
+   * `visible: (s) => s.hasInstalls` and this fails on `expect.element(tab('Activity'))`
+   * timing out — no Activity tab renders — while `Activity shows when hasInstalls` above
+   * stays green. A test that only asserted the summary FIELD exists could not tell those
+   * two implementations apart.
+   */
+  test('🔴 Activity shows for hasActivity with NO installs (the page-app cohort)', async () => {
+    renderWithProviders(
+      <AppsSubNavView
+        summary={{ ...NONE, hasActivity: true }}
+        context={NOT_AUTHOR}
+        currentPath="/apps"
+      />
+    );
+    await expect.element(tab('Activity')).toBeInTheDocument();
+    // …and it is the ONLY conditional tab this summary lights, so the pass cannot be a
+    // row that became unconditional.
+    expect(tab('Invites').elements()).toHaveLength(0);
+    expect(tab('Revenue').elements()).toHaveLength(0);
+    expect(tab('Review').elements()).toHaveLength(0);
+  });
+
+  test('NEGATIVE CONTROL: neither installs nor activity ⇒ no Activity tab', async () => {
+    // Guards both cases above against a row that renders for everyone. (The all-false
+    // case above asserts the same thing among four tabs; this one names the pair.)
+    renderWithProviders(
+      <AppsSubNavView
+        summary={{ ...NONE, hasInstalls: false, hasActivity: false, isReviewer: true }}
+        context={AUTHOR}
+        currentPath="/apps"
+      />
+    );
+    await expect.element(tab('Review')).toBeInTheDocument();
+    expect(tab('Activity').elements()).toHaveLength(0);
   });
 
   /**

--- a/src/components/Apps/AppsSubNav.hydration.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.hydration.browser.test.tsx
@@ -53,6 +53,7 @@ import type * as TrpcMod from '~/utils/trpc';
 
 const ALL_TRUE_SUMMARY = {
   hasInstalls: true,
+  hasActivity: true,
   hasSubmissions: true,
   hasApprovedApps: true,
   isReviewer: true,
@@ -217,6 +218,7 @@ describe('AppsSubNav container — hydration-safe conditional tabs', () => {
     mocks.navSummary = {
       ...ALL_TRUE_SUMMARY,
       hasInstalls: false,
+      hasActivity: false,
       hasApprovedApps: false,
       isReviewer: false,
       hasPendingInvites: false,
@@ -455,6 +457,7 @@ describe('AppsSubNav container — the Build tab keys off canAccessAppsBuild', (
 describe('AppsSubNav container — hides entirely below two tabs', () => {
   const EMPTY_SUMMARY = {
     hasInstalls: false,
+    hasActivity: false,
     hasSubmissions: false,
     hasApprovedApps: false,
     isReviewer: false,

--- a/src/components/Apps/AppsSubNav.hydration.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.hydration.browser.test.tsx
@@ -141,7 +141,7 @@ async function renderSubNav() {
 // hidden until after mount. `Invites` is included and is the strongest of the four: it
 // reads BOTH the summary and `context.isAuthor`, so a mutant that lifted it out of the
 // deferral would leak an author-only tab into the SSR set.
-const CONDITIONAL = ['Installed', 'Invites', 'Revenue', 'Review'] as const;
+const CONDITIONAL = ['Activity', 'Invites', 'Revenue', 'Review'] as const;
 
 beforeEach(() => {
   mocks.isClient = false;
@@ -162,7 +162,7 @@ describe('AppsSubNav container — hydration-safe conditional tabs', () => {
     // The two capability-driven tabs render — their inputs are SSR-frozen.
     await expect.element(tab('Build')).toBeInTheDocument();
     await expect.element(tab('Marketplace')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
 
     // The conditional tabs MUST NOT render pre-mount — this is what keeps the first
     // client paint identical to the SSR HTML (the fix). Before the fix, the query
@@ -176,15 +176,15 @@ describe('AppsSubNav container — hydration-safe conditional tabs', () => {
     mocks.isClient = true; // after mount / hydration has matched
     await renderSubNav();
 
-    for (const name of ['Build', 'Marketplace', ...CONDITIONAL]) {
+    for (const name of ['Marketplace', 'Build', ...CONDITIONAL]) {
       await expect.element(tab(name)).toBeInTheDocument();
     }
     expect(renderedTabs()).toEqual([
-      'Build',
       'Marketplace',
-      'Installed',
+      'Activity',
       'Invites',
       'Revenue',
+      'Build',
       'Review',
     ]);
   });
@@ -195,7 +195,7 @@ describe('AppsSubNav container — hydration-safe conditional tabs', () => {
     await renderSubNav();
 
     await expect.element(tab('Marketplace')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
     for (const name of CONDITIONAL) {
       expect(tab(name).elements()).toHaveLength(0);
     }
@@ -224,7 +224,7 @@ describe('AppsSubNav container — hydration-safe conditional tabs', () => {
     };
     await renderSubNav();
     await expect.element(tab('Build')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
     for (const retired of ['My apps', 'My submissions', 'Create', 'Build apps']) {
       expect(tab(retired).elements(), `a tab named "${retired}" is rendered`).toHaveLength(0);
     }
@@ -285,7 +285,7 @@ describe('AppsSubNav container — SSR tab set === first client render', () => {
     mocks.navSummary = undefined;
     await renderSubNav();
     await expect.element(tab('Marketplace')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
   });
 
   test('NON-AUTHOR, first client paint (query data PRESENT) → the identical set', async () => {
@@ -294,7 +294,7 @@ describe('AppsSubNav container — SSR tab set === first client render', () => {
     mocks.navSummary = { ...ALL_TRUE_SUMMARY }; // the prod condition that broke hydration
     await renderSubNav();
     await expect.element(tab('Marketplace')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
   });
 
   test('AUTHOR, server render (no query data) → Build + Marketplace', async () => {
@@ -303,7 +303,7 @@ describe('AppsSubNav container — SSR tab set === first client render', () => {
     mocks.navSummary = undefined;
     await renderSubNav();
     await expect.element(tab('Marketplace')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
   });
 
   test('AUTHOR, first client paint (query data PRESENT, invites pending) → the identical set', async () => {
@@ -315,7 +315,7 @@ describe('AppsSubNav container — SSR tab set === first client render', () => {
     // Non-empty on BOTH sides of the pair: the capability gates applied on the first
     // paint (Build is here pre-mount) while the summary gate did NOT — including the
     // author-only `Invites`, whose summary flag is true in this fixture.
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
     expect(tab('Invites').elements()).toHaveLength(0);
   });
 
@@ -326,8 +326,8 @@ describe('AppsSubNav container — SSR tab set === first client render', () => {
     mocks.isClient = true;
     mocks.navSummary = { ...ALL_TRUE_SUMMARY };
     await renderSubNav();
-    await expect.element(tab('Installed')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace', 'Installed', 'Revenue', 'Review']);
+    await expect.element(tab('Activity')).toBeInTheDocument();
+    expect(renderedTabs()).toEqual(['Marketplace', 'Activity', 'Revenue', 'Build', 'Review']);
     // Invites is the one tab the author gate removes — this viewer has a pending invite
     // in the summary and still must not get it.
     expect(renderedTabs()).not.toContain('Invites');
@@ -417,7 +417,7 @@ describe('AppsSubNav container — the Build tab keys off canAccessAppsBuild', (
     mocks.navSummary = { ...ALL_TRUE_SUMMARY }; // hasPendingInvites: true
     await renderSubNav();
     await expect.element(tab('Build')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace', 'Installed', 'Revenue', 'Review']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Activity', 'Revenue', 'Build', 'Review']);
     expect(tab('Invites').elements()).toHaveLength(0);
   });
 
@@ -441,7 +441,7 @@ describe('AppsSubNav container — the Build tab keys off canAccessAppsBuild', (
     mocks.navSummary = undefined;
     await renderSubNav();
     await expect.element(tab('Build')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
   });
 });
 
@@ -481,7 +481,7 @@ describe('AppsSubNav container — hides entirely below two tabs', () => {
     await expect
       .element(page.getByRole('navigation', { name: 'App sections' }))
       .toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Marketplace', 'Installed']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Activity']);
   });
 
   test('🔴 …and so is appBlocksGetStarted, on the OTHERWISE IDENTICAL viewer', async () => {
@@ -493,6 +493,6 @@ describe('AppsSubNav container — hides entirely below two tabs', () => {
     await expect
       .element(page.getByRole('navigation', { name: 'App sections' }))
       .toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
   });
 });

--- a/src/components/Apps/AppsSubNav.ssrHydration.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.ssrHydration.browser.test.tsx
@@ -50,6 +50,7 @@ import type * as TrpcMod from '~/utils/trpc';
 
 type Summary = {
   hasInstalls: boolean;
+  hasActivity: boolean;
   hasSubmissions: boolean;
   hasApprovedApps: boolean;
   isReviewer: boolean;
@@ -59,6 +60,7 @@ type Summary = {
 
 const ALL_TRUE: Summary = {
   hasInstalls: true,
+  hasActivity: true,
   hasSubmissions: true,
   hasApprovedApps: true,
   isReviewer: true,

--- a/src/components/Apps/AppsSubNav.ssrHydration.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.ssrHydration.browser.test.tsx
@@ -248,7 +248,7 @@ describe('AppsSubNav — real SSR → hydrate', () => {
     expect(html).toContain('/apps"'); // the Marketplace anchor
     // …while the SUMMARY-driven tabs are absent even though the client cache below is
     // full…
-    expect(html).not.toContain('/apps/installed');
+    expect(html).not.toContain('/apps/activity');
     expect(html).not.toContain('/apps/review');
     // …and no retired row came back. `/apps/get-started` in particular is now a 301 to
     // `/apps/build`, so a tab still pointing there would route every click through a
@@ -279,7 +279,7 @@ describe('AppsSubNav — real SSR → hydrate', () => {
     expect(html).toContain('Build');
     // …while the summary-driven tabs are NOT (those are still deferred) — including
     // `Invites`, the one row that reads BOTH the summary and `isAuthor`.
-    expect(html).not.toContain('/apps/installed');
+    expect(html).not.toContain('/apps/activity');
     expect(html).not.toContain('/apps/invites');
     expect(html).not.toContain('/apps/review');
     for (const route of RETIRED_ROUTES) {

--- a/src/components/Apps/AppsSubNav.storeGate.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.storeGate.browser.test.tsx
@@ -40,6 +40,7 @@ import type * as TrpcMod from '~/utils/trpc';
 
 const ALL_TRUE_SUMMARY = {
   hasInstalls: true,
+  hasActivity: true,
   hasSubmissions: true,
   hasApprovedApps: true,
   isReviewer: true,

--- a/src/components/Apps/AppsSubNav.storeGate.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.storeGate.browser.test.tsx
@@ -185,11 +185,11 @@ describe('AppsSubNav — store-visibility gate matches resolveAppsPageAccess', (
       // first two retired routes 301 there and `/apps/submit` kept its route without a
       // tab. `hasSubmissions`/`hasEditableApps` are true in this summary and light
       // nothing, which is the property that keeps the row hydration-safe.
-      'Build',
       'Marketplace',
-      'Installed',
+      'Activity',
       'Invites',
       'Revenue',
+      'Build',
       'Review',
     ]);
   });
@@ -218,7 +218,7 @@ describe('AppsSubNav — store-visibility gate matches resolveAppsPageAccess', (
     mocks.flags = { appListings: true, appBlocks: false, appBlocksAuthor: true };
     await renderSubNav();
     await expect.element(tab('Marketplace')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
     expect(page.getByRole('navigation', { name: 'App sections' }).elements()).toHaveLength(1);
   });
 });
@@ -257,7 +257,7 @@ describe('AppsSubNav — no store access ⇒ no Marketplace tab, by two independ
 
     await expect.element(tab('Marketplace')).toBeInTheDocument();
     expect(tab('Marketplace').element().getAttribute('href')).toBe('/apps');
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
   });
 
   test('🔴 the external-only cohort is admitted too (appListingsPublicExternal)', async () => {
@@ -272,7 +272,7 @@ describe('AppsSubNav — no store access ⇒ no Marketplace tab, by two independ
     await renderSubNav();
 
     await expect.element(tab('Marketplace')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
   });
 });
 
@@ -315,7 +315,7 @@ describe('AppsSubNav — the collapse still hides the bar for a one-tab viewer',
     await renderSubNav();
 
     await expect.element(tab('Build')).toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
   });
 
   test('a logged-out viewer with the store flag and no build capability gets no bar', async () => {
@@ -389,7 +389,7 @@ describe('AppsSubNav — the container gate is store access ALONE (the get-start
     await expect.element(tab('Build')).toBeInTheDocument();
     expect(tab('Build').element().getAttribute('href')).toBe('/apps/build');
     // Non-author, `appBlocks` off ⇒ summary query disabled ⇒ exactly the two frozen tabs.
-    expect(renderedTabs()).toEqual(['Build', 'Marketplace']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Build']);
   });
 
   test('🔴 store access but NO build capability → a bar with NO Build tab', async () => {
@@ -418,7 +418,7 @@ describe('AppsSubNav — the container gate is store access ALONE (the get-start
     await expect
       .element(page.getByRole('navigation', { name: 'App sections' }))
       .toBeInTheDocument();
-    expect(renderedTabs()).toEqual(['Marketplace', 'Installed']);
+    expect(renderedTabs()).toEqual(['Marketplace', 'Activity']);
     expect(tab('Build').elements()).toHaveLength(0);
   });
 
@@ -454,7 +454,7 @@ describe('AppsSubNav — the getNavSummary query gate stays on appBlocks', () =>
     await expect.element(tab('Marketplace')).toBeInTheDocument();
     expect(mocks.navSummaryEnabled.length).toBeGreaterThan(0); // the hook did run
     expect(mocks.navSummaryEnabled.every((e) => e === false)).toBe(true);
-    for (const name of ['Installed', 'Invites', 'Revenue', 'Review']) {
+    for (const name of ['Activity', 'Invites', 'Revenue', 'Review']) {
       expect(tab(name).elements()).toHaveLength(0);
     }
   });

--- a/src/components/Apps/AppsSubNav.tsx
+++ b/src/components/Apps/AppsSubNav.tsx
@@ -27,7 +27,7 @@ import {
  * which tabs to show.
  */
 export type AppsNavSummary = {
-  /** ≥1 install/subscription → show "Installed". */
+  /** ≥1 install/subscription → show "Activity". */
   hasInstalls: boolean;
   /**
    * ≥1 publish request. Drove a "My submissions" tab, then widened "My apps".
@@ -128,7 +128,15 @@ type SubNavLink = {
 };
 
 /**
- * Tab order = build → discovery → manage → revenue → moderate.
+ * Tab order = discovery → manage → revenue → build → moderate.
+ *
+ * 🔴 `Build` MOVED FROM FIRST TO SECOND-TO-LAST (before `Review`), and the order is the
+ * claim. This bar's leading tab is the one it asserts you came here for, and for the
+ * overwhelming majority of viewers that is not authoring: `Build` is gated on
+ * `canAccessAppsBuild`, while `Marketplace` and `Activity` are the two consumer
+ * surfaces. Leading with `Build` put the narrowest audience's tab in the widest
+ * audience's first position. `Review` stays last because it is the moderator surface
+ * and reads as the end of the table rather than part of the user's own path.
  *
  * 🔴 EVERY ROW'S PREDICATE IS ITS PAGE'S OWN GATE, RESTATED AS A VIEWER FACT ON
  * {@link AppsNavContext} — never a raw flag read inside the predicate, and never a rule
@@ -158,40 +166,6 @@ type SubNavLink = {
  */
 const SUB_NAV_LINKS: SubNavLink[] = [
   /**
-   * The consolidated BUILD surface. It leads the table because it is the front door for
-   * someone who has not built anything yet, and it is now the ONLY authoring entry in
-   * this bar.
-   *
-   * 🔴 THIS ROW REPLACED THREE: "Build apps" (`/apps/get-started`), "Create"
-   * (`/apps/submit`) and "My apps" (`/apps/mine`). Those three were largely one another's
-   * content — get-started was static marketing whose every CTA pointed off-platform, and
-   * `/apps/submit`'s on-platform branch was the same copy-paste wall a second time — so a
-   * developer's path was three tabs that mostly showed each other. `/apps/build` is
-   * state-aware instead: pitch → first-app → workbench. The two retired routes 301 to it;
-   * `/apps/submit` KEEPS its route (the `?edit=<listingId>` deep link from the store card
-   * and the listing-detail ⋮ menus resolves there via `getOwnerEditHref`) and simply
-   * stops having a tab.
-   *
-   * 🔴 NOT `c.isAuthor`, AND NOT `!!features.appBlocksGetStarted` — `c.canBuild`, which
-   * is {@link canAccessAppsBuild} verbatim. `hasSubmissions` / `hasEditableApps` are
-   * deliberately ABSENT from this predicate even though they decide what the page
-   * RENDERS: they come from the client-only `getNavSummary`, and a tab that appeared
-   * after mount for an author with apps is the tab-set hydration mismatch this file
-   * already survived once. The page's own state machine reads them; the tab does not
-   * need to.
-   *
-   * Hydration-safe for the reason written out on the predicate: all of its inputs are
-   * SSR-seeded and frozen, and neither `appBlocksAuthor` nor `appBlocksGetStarted` is
-   * `toggleable`, so `computeUserFeatureFlagsOverlay` cannot move them between the
-   * server render and the first client paint.
-   */
-  {
-    href: '/apps/build',
-    label: 'Build',
-    icon: IconCode,
-    visible: (_s, c) => c.canBuild,
-  },
-  /**
    * 🔴 GATED ON STORE ACCESS AS OF THIS CHANGE — it was `() => true`, and that
    * unconditional predicate was a KNOWN, DOCUMENTED 404 exposure (see the note on
    * `AppsNavContext.canSeeStore`): `/apps` gates on `resolveAppsPageAccess`, so a viewer
@@ -208,9 +182,25 @@ const SUB_NAV_LINKS: SubNavLink[] = [
     icon: IconBuildingStore,
     visible: (_s, c) => c.canSeeStore,
   },
+  /**
+   * 🔴 REPOINTED AND RELABELLED: `/apps/installed` → `/apps/activity`, `Installed` →
+   * `Activity`. The route 301s (see `next.config.mjs`), the page opens on the activity
+   * feed, and its gate widened past the model-slot flag — so "Installed" named one tab
+   * of four and refused a cohort that has activity without a single install.
+   *
+   * ⚠️ THE PREDICATE IS DELIBERATELY UNCHANGED, and that is not an oversight — it is the
+   * one place this row is knowingly narrower than its page. `s.hasInstalls` comes from
+   * `getNavSummary`, which is gated on `appBlocks`; the PAGE now admits
+   * `appBlocks || appBlocksPages`. So a pages-only viewer can load `/apps/activity` and
+   * has no tab pointing at it. That is the SAFE direction of the #3899 / #4668 defect
+   * class (an unreachable page, never a tab into a 404), and closing it properly means
+   * widening `blocks.getNavSummary`'s own gate — a server change on a `blocks.*`
+   * procedure, which this change deliberately does not touch. Recorded here rather than
+   * left to be re-derived.
+   */
   {
-    href: '/apps/installed',
-    label: 'Installed',
+    href: '/apps/activity',
+    label: 'Activity',
     icon: IconPlugConnected,
     visible: (s) => s.hasInstalls,
   },
@@ -243,13 +233,53 @@ const SUB_NAV_LINKS: SubNavLink[] = [
     icon: IconCurrencyDollar,
     visible: (s) => s.hasApprovedApps,
   },
+  /**
+   * The consolidated BUILD surface — the ONLY authoring entry in this bar.
+   *
+   * 🔴 IT USED TO LEAD THE TABLE, ON THE ARGUMENT THAT IT IS "the front door for someone
+   * who has not built anything yet". That sentence is now false and is not merely
+   * relocated: the row sits second-to-last, and the reason is on the table's own
+   * docstring — its audience is the narrowest of any consumer tab here, so leading with
+   * it put the smallest cohort's destination in the position that reads as "what this
+   * page is for". The front-door claim was always about the PITCH (state A of
+   * `/apps/build`), which is one of three states the row resolves to.
+   *
+   * 🔴 THIS ROW REPLACED THREE: "Build apps" (`/apps/get-started`), "Create"
+   * (`/apps/submit`) and "My apps" (`/apps/mine`). Those three were largely one another's
+   * content — get-started was static marketing whose every CTA pointed off-platform, and
+   * `/apps/submit`'s on-platform branch was the same copy-paste wall a second time — so a
+   * developer's path was three tabs that mostly showed each other. `/apps/build` is
+   * state-aware instead: pitch → first-app → workbench. The two retired routes 301 to it;
+   * `/apps/submit` KEEPS its route (the `?edit=<listingId>` deep link from the store card
+   * and the listing-detail ⋮ menus resolves there via `getOwnerEditHref`) and simply
+   * stops having a tab.
+   *
+   * 🔴 NOT `c.isAuthor`, AND NOT `!!features.appBlocksGetStarted` — `c.canBuild`, which
+   * is {@link canAccessAppsBuild} verbatim. `hasSubmissions` / `hasEditableApps` are
+   * deliberately ABSENT from this predicate even though they decide what the page
+   * RENDERS: they come from the client-only `getNavSummary`, and a tab that appeared
+   * after mount for an author with apps is the tab-set hydration mismatch this file
+   * already survived once. The page's own state machine reads them; the tab does not
+   * need to.
+   *
+   * Hydration-safe for the reason written out on the predicate: all of its inputs are
+   * SSR-seeded and frozen, and neither `appBlocksAuthor` nor `appBlocksGetStarted` is
+   * `toggleable`, so `computeUserFeatureFlagsOverlay` cannot move them between the
+   * server render and the first client paint.
+   */
+  {
+    href: '/apps/build',
+    label: 'Build',
+    icon: IconCode,
+    visible: (_s, c) => c.canBuild,
+  },
   { href: '/apps/review', label: 'Review', icon: IconGavel, visible: (s) => s.isReviewer },
 ];
 
 /**
  * Returns true when `current` is on the `href` route. `/apps` (the
  * marketplace) must match EXACTLY so it isn't lit on every `/apps/*` child;
- * the sub-routes match on prefix so deep paths (e.g. `/apps/installed?tab=...`
+ * the sub-routes match on prefix so deep paths (e.g. `/apps/activity/<x>`
  * or `/apps/run/<slug>` under the parent) keep the right tab active.
  */
 export function isActiveAppsRoute(href: string, current: string): boolean {
@@ -420,7 +450,7 @@ export function AppsSubNav() {
   // short-circuits rather than throwing, returning the ALL-FALSE summary without
   // running a single DB read. So for an `app-listings`-only viewer, widening this
   // `enabled` would buy a guaranteed round-trip to a guaranteed all-false answer.
-  // The conditional tabs it feeds (Installed / Invites / Revenue / Review) all point at
+  // The conditional tabs it feeds (Activity / Invites / Revenue / Review) all point at
   // pages that themselves 404 without `appBlocks`, so all-false is also the CORRECT tab
   // set for that viewer. If the server proc ever moves to `enforceAppListingsReadFlag`,
   // move this with it.
@@ -435,7 +465,7 @@ export function AppsSubNav() {
   // bar. After the consolidation EVERY row in `SUB_NAV_LINKS` implies store access:
   //   • Build      — `canAccessAppsBuild` has `hasAppsStoreAccess` as a hard AND;
   //   • Marketplace— `c.canSeeStore` IS `hasAppsStoreAccess`;
-  //   • Installed / Invites / Revenue / Review — all driven by `getNavSummary`, whose
+  //   • Activity / Invites / Revenue / Review — all driven by `getNavSummary`, whose
   //     `enabled` requires `features.appBlocks`, and `appBlocks` is one of the three
   //     disjuncts of `hasAppsStoreAccess`, so the summary is all-false without it.
   // So a viewer this gate would have admitted on the second term alone qualifies for ZERO

--- a/src/components/Apps/AppsSubNav.tsx
+++ b/src/components/Apps/AppsSubNav.tsx
@@ -27,8 +27,20 @@ import {
  * which tabs to show.
  */
 export type AppsNavSummary = {
-  /** ≥1 install/subscription → show "Activity". */
+  /** ≥1 install/subscription (a `block_user_subscriptions` row) — half of "Activity". */
   hasInstalls: boolean;
+  /**
+   * ≥1 row in EITHER table the activity feed walks — `block_buzz_attribution` (as the
+   * SPENDER) or `block_scope_invocations` — the OTHER half of "Activity".
+   *
+   * 🔴 IT IS NOT REDUNDANT WITH {@link hasInstalls}, AND THE GAP IS A WHOLE COHORT. An
+   * install is a SLOT subscription; a FULL-PAGE app (`/apps/run/<slug>`) is stateless by
+   * design and creates no subscription row at all. So a viewer who only ever runs page
+   * apps has activity — generations, scope-gated API calls, Buzz spends — and
+   * `hasInstalls: false`. Neither flag implies the other: an install with no usage yet is
+   * the mirror case.
+   */
+  hasActivity: boolean;
   /**
    * ≥1 publish request. Drove a "My submissions" tab, then widened "My apps".
    *
@@ -62,6 +74,7 @@ export type AppsNavSummary = {
 
 const EMPTY_SUMMARY: AppsNavSummary = {
   hasInstalls: false,
+  hasActivity: false,
   hasSubmissions: false,
   hasApprovedApps: false,
   isReviewer: false,
@@ -188,21 +201,33 @@ const SUB_NAV_LINKS: SubNavLink[] = [
    * feed, and its gate widened past the model-slot flag — so "Installed" named one tab
    * of four and refused a cohort that has activity without a single install.
    *
-   * ⚠️ THE PREDICATE IS DELIBERATELY UNCHANGED, and that is not an oversight — it is the
-   * one place this row is knowingly narrower than its page. `s.hasInstalls` comes from
-   * `getNavSummary`, which is gated on `appBlocks`; the PAGE now admits
-   * `appBlocks || appBlocksPages`. So a pages-only viewer can load `/apps/activity` and
-   * has no tab pointing at it. That is the SAFE direction of the #3899 / #4668 defect
-   * class (an unreachable page, never a tab into a 404), and closing it properly means
-   * widening `blocks.getNavSummary`'s own gate — a server change on a `blocks.*`
-   * procedure, which this change deliberately does not touch. Recorded here rather than
-   * left to be re-derived.
+   * 🔴 BOTH TERMS ARE LOAD-BEARING; NEITHER IS A RESTATEMENT OF THE OTHER, AND
+   * "SIMPLIFYING" THIS BACK TO `s.hasInstalls` RE-HIDES THE PAGE FROM THE COHORT THE
+   * RENAME WIDENED IT FOR. They name two different facts:
+   *   • `hasInstalls` — a `block_user_subscriptions` row, i.e. a SLOT install. That is
+   *     what the "Installs" tab inside the page shows, and it is what the `appBlocks`
+   *     slot flag governs.
+   *   • `hasActivity` — a row in either table the FEED walks (`block_buzz_attribution` as
+   *     spender, `block_scope_invocations`). A full-page app is STATELESS by design —
+   *     `/apps/run`'s own header, Decision 2: "no `block_user_subscriptions` row, no
+   *     migration" — so someone who only runs page apps has a populated feed and ZERO
+   *     installs. Keyed on installs alone, this row was dark for exactly them: the page
+   *     admitted them (`appBlocks || appBlocksPages`) and no tab pointed at it.
+   * An install with no usage yet is the mirror case, which is why the OR keeps both.
+   *
+   * ⚠️ A RESIDUAL NARROWNESS SURVIVES, deliberately, and it is the SAFE direction of the
+   * #3899 / #4668 class (an unreachable page, never a tab into a 404): both flags come
+   * from `getNavSummary`, whose `enabled` and whose server middleware are gated on
+   * `appBlocks`, while the page admits `appBlocks || appBlocksPages`. A viewer holding
+   * `appBlocksPages` WITHOUT `appBlocks` still gets an all-false summary and no tab.
+   * Closing that means moving the procedure's own gate, which is a wider blast radius
+   * than this row (every flag on the summary would widen with it).
    */
   {
     href: '/apps/activity',
     label: 'Activity',
     icon: IconPlugConnected,
-    visible: (s) => s.hasInstalls,
+    visible: (s) => s.hasInstalls || s.hasActivity,
   },
   /**
    * 🔴 NEEDS `c.isAuthor` AS WELL AS ITS SUMMARY FLAG. `/apps/invites`
@@ -450,10 +475,20 @@ export function AppsSubNav() {
   // short-circuits rather than throwing, returning the ALL-FALSE summary without
   // running a single DB read. So for an `app-listings`-only viewer, widening this
   // `enabled` would buy a guaranteed round-trip to a guaranteed all-false answer.
-  // The conditional tabs it feeds (Activity / Invites / Revenue / Review) all point at
-  // pages that themselves 404 without `appBlocks`, so all-false is also the CORRECT tab
-  // set for that viewer. If the server proc ever moves to `enforceAppListingsReadFlag`,
-  // move this with it.
+  //
+  // ⚠️ THE OLD JUSTIFICATION HERE IS NOW FALSE AND IS CORRECTED RATHER THAN DELETED,
+  // because it is the plausible-sounding reason someone will decide this gate is
+  // airtight. It read: the conditional tabs "all point at pages that themselves 404
+  // without `appBlocks`, so all-false is also the CORRECT tab set for that viewer."
+  // `/apps/activity` NO LONGER 404s without `appBlocks` — it gates on
+  // `canAccessAppsActivity` = `appBlocks || appBlocksPages`. So for a viewer holding
+  // `appBlocksPages` but not `appBlocks`, all-false is NOT the correct tab set: the page
+  // would serve them and this gate hides the only route to it. That is the residual
+  // narrowness recorded on the Activity row, and it is the SAFE direction (an
+  // unreachable page, not a tab into a 404) — but do not re-derive the retired claim as
+  // proof that no gap exists. Invites / Revenue / Review are still `appBlocks`-gated
+  // pages, so the sentence remains true for them. If the server proc ever moves to
+  // `enforceAppListingsReadFlag` — or gains `appBlocksPages` — move this with it.
   const { data } = trpc.blocks.getNavSummary.useQuery(undefined, {
     enabled: !!features.appBlocks && !!currentUser,
     staleTime: 60_000,

--- a/src/components/Apps/AppsSubNav.tsx
+++ b/src/components/Apps/AppsSubNav.tsx
@@ -222,6 +222,14 @@ const SUB_NAV_LINKS: SubNavLink[] = [
    * `appBlocksPages` WITHOUT `appBlocks` still gets an all-false summary and no tab.
    * Closing that means moving the procedure's own gate, which is a wider blast radius
    * than this row (every flag on the summary would widen with it).
+  // ⚠️ …AND THAT RESIDUAL IS NARROWER THAN THE SENTENCE ABOVE IMPLIES — corrected after an
+  // audit, because as written it invites a future widening of a `blocks.*` flag gate to
+  // close a gap that is effectively EMPTY. That cohort is refused by `/apps/run` itself
+  // (`[[...path]].tsx` requires BOTH `appBlocks` and `appBlocksPages`) and cannot install
+  // (slot installs are `appBlocks`-gated), so going forward they can generate NO activity
+  // at all: an all-false summary is the CORRECT tab set for them, not a deprivation. The
+  // only way they hold rows is a historical `appBlocks` grant since revoked. Do not widen
+  // the procedure's gate for this.
    */
   {
     href: '/apps/activity',

--- a/src/components/Apps/AppsWideLayout.geometry.test.tsx
+++ b/src/components/Apps/AppsWideLayout.geometry.test.tsx
@@ -13,7 +13,7 @@
  *
  *   · `AppsTableColgroup` — percentage widths on every column except the primary, which
  *     is left `auto` so the surplus lands there.
- *   · `AppsCardGrid` — `/apps/installed`'s cards step to a second column exactly where the
+ *   · `AppsCardGrid` — `/apps/activity`'s cards step to a second column exactly where the
  *     surplus appeared, so a card's own width stops tracking the container and the
  *     name→Manage gap stops growing.
  *
@@ -61,13 +61,13 @@
  * ─────────────────────────────────────────────────────────────────────────────
  * ⚠️ WHAT THIS FILE DOES NOT PROVE, STATED SO NOBODY READS IT AS PROVEN
  * ─────────────────────────────────────────────────────────────────────────────
- * The `/apps/installed` block below mounts the real `InstalledAppCard` inside
+ * The `/apps/activity` block below mounts the real `InstalledAppCard` inside
  * `AppsCardGrid` — but the GRID IS SUPPLIED BY THE TEST, so these assertions say "the card
  * behaves correctly when it is in the grid", not "the page puts it in one". Measured
  * against `origin/main`'s components with only the new module scaffolded in, the two
  * installed tests PASSED while the four table tests went red — i.e. this file alone cannot
  * see the page reverting to a `Stack`. That claim is `__tests__/appsWideLayout.test.ts`'s
- * "🔴 /apps/installed uses the card GRID, and no longer caps its body", which is red at
+ * "🔴 /apps/activity uses the card GRID, and no longer caps its body", which is red at
  * `origin/main` for exactly that reason. Two guards, one for the mechanism and one for its
  * adoption; neither is a substitute for the other.
  */
@@ -164,7 +164,12 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
           items: [
             {
               id: 'sc_1',
-              createdAt: new Date('2026-09-01T00:00:00Z'),
+              // 🔴 A FIXED OFFSET FROM `now`, NOT AN ABSOLUTE INSTANT. The `When` cell
+              // renders `DaysFromNow`, so an absolute fixture would render a string that
+              // GROWS with wall-clock time ('7 days ago' → 'a year ago') and quietly
+              // change the column widths this file measures. 20 minutes always renders
+              // '20 minutes ago'.
+              createdAt: new Date(Date.now() - 20 * 60 * 1000),
               appBlockId: 'ab_9',
               appName: 'Lighthouse',
               appSlug: 'lighthouse',
@@ -225,7 +230,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
   );
   return { ...(await importOriginal<typeof TrpcMod>()), trpc: root };
 });
-// `/apps/installed`'s module calls `createServerSideProps` at import time, which pulls the
+// `/apps/activity`'s module calls `createServerSideProps` at import time, which pulls the
 // server graph into a browser bundle. Stubbed so the page's `InstalledAppCard` — the REAL
 // card whose gap this file measures — can be imported without it.
 vi.mock('~/server/utils/server-side-helpers', () => ({
@@ -236,7 +241,7 @@ const { AppsPageLayout } = await import('~/components/Apps/AppsPageLayout');
 const { AppsCardGrid } = await import('~/components/Apps/appsWideLayout');
 const { UnifiedReviewList } = await import('~/components/Apps/UnifiedReviewList');
 const { MyAppsBodyView } = await import('~/components/Apps/MyAppsBody');
-const { InstalledAppCard } = await import('~/pages/apps/installed');
+const { InstalledAppCard } = await import('~/pages/apps/activity');
 const { ActivePreviewsPanel } = await import('~/components/Apps/ActivePreviewsPanel');
 const { OffsiteReportsQueue } = await import('~/components/Apps/OffsiteReviewQueue');
 const { AppActivityPanel } = await import('~/components/Apps/AppActivityPanel');
@@ -936,7 +941,7 @@ describe('/apps/review reports — the other table a ledger cannot help', () => 
   });
 });
 
-describe('/apps/installed activity — the table that a ledger cannot help', () => {
+describe('/apps/activity activity — the table that a ledger cannot help', () => {
   /**
    * 🔴 THIS TABLE IS DELIBERATELY UNLEDGERED, and this arm is what keeps that decision
    * honest — `__tests__/appsWideLayout.test.ts` requires it BY NAME for the `no-surplus`
@@ -1006,9 +1011,19 @@ describe('/apps/installed activity — the table that a ledger cannot help', () 
     // The mechanism behind the height, so a future change that keeps the height constant
     // some other way is still legible. `When` broke a `YYYY-MM-DD HH:mm` stamp across three
     // lines under the shipped ledger; `Detail`'s monospace ref broke across two.
+    //
+    // 🔴 THE `When` READ DRILLS TO THE `<time>`, AND THAT IS A MEASUREMENT FIX RATHER
+    // THAN A SOFTENING. `lineCount` is `Range.getClientRects().length`, which returns one
+    // rect PER BOX in the range — so once `When` became `<Text><time>…</time></Text>`
+    // (the `DaysFromNow` relative stamp) the wrapper's range held the `<time>` box AND its
+    // text box and returned 2 with nothing having wrapped. Measured: the row-height arm
+    // above stayed at 36.19 across all four widths through that change, which is the
+    // independent proof that the cell is still one line. Reading the text-bearing element
+    // is what makes this arm about WRAPPING again.
     const linesPerWidth = await atEachWidth(panel, () => {
       const cells = Array.from(document.querySelectorAll('table tbody tr:first-child > td'));
-      return [lineCount(cells[0].firstElementChild), lineCount(cells[3].firstElementChild)];
+      const when = cells[0].querySelector('time') ?? cells[0].firstElementChild;
+      return [lineCount(when), lineCount(cells[3].firstElementChild)];
     });
     expect(linesPerWidth).toEqual([
       [1, 1],
@@ -1101,9 +1116,9 @@ describe('🔴 NO LEDGER MAKES ITS ROWS TALLER AT A NARROWER WIDTH', () => {
   });
 });
 
-// ── /apps/installed — the 640px dead gap ─────────────────────────────────────
+// ── /apps/activity — the 640px dead gap ─────────────────────────────────────
 
-describe('/apps/installed — the space-between row keeps its control near its content', () => {
+describe('/apps/activity — the space-between row keeps its control near its content', () => {
   /**
    * The gap between the app NAME's right edge and the Manage button's left edge.
    *

--- a/src/components/Apps/BlockScopeList.tsx
+++ b/src/components/Apps/BlockScopeList.tsx
@@ -6,7 +6,7 @@ import { SCOPE_DESCRIPTIONS } from '~/server/services/blocks/scope-descriptions.
 /**
  * Renders a block's declared JWT scopes as a badge + friendly-description
  * list. Shared by the install/manage modal (pre-Save disclosure — UX audit
- * H3) and the /apps/installed "Apps & permissions" panel so the two surfaces
+ * H3) and the /apps/activity "Apps & permissions" panel so the two surfaces
  * never drift. Unknown scopes (not in SCOPE_DESCRIPTIONS) render as a bare
  * badge with an italic "(no description)" — keeping the description map a soft
  * contract so new scopes ship without breaking the UI.

--- a/src/components/Apps/PublisherSubscriptionBanner.tsx
+++ b/src/components/Apps/PublisherSubscriptionBanner.tsx
@@ -102,7 +102,7 @@ export function PublisherSubscriptionBanner({ modelId, modelType }: Props) {
               {sub.manifest.name ?? sub.blockId}
             </Text>
             <Group gap={6}>
-              <Anchor component={Link} href="/apps/installed" size="xs">
+              <Anchor component={Link} href="/apps/activity" size="xs">
                 Edit subscription
               </Anchor>
               <Button

--- a/src/components/Apps/__tests__/appsActivityTabs.test.ts
+++ b/src/components/Apps/__tests__/appsActivityTabs.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ACTIVITY_TAB_QUERY_KEY,
+  ACTIVITY_TAB_VALUES,
+  activityTabQuery,
+  DEFAULT_ACTIVITY_TAB,
+  isActivityTab,
+  resolveActivityTab,
+} from '~/components/Apps/appsActivityTabs';
+
+/**
+ * The `/apps/activity` `?tab=` contract.
+ *
+ * 🔴 NEW-FEATURE COVERAGE, NOT REGRESSION COVERAGE, and the distinction matters here:
+ * there is nothing to be red against at `origin/main` because the tabs were
+ * UNCONTROLLED (`<Tabs defaultValue="subscriptions">`) and the query string was never
+ * read. The behavioural claim that IS red at `origin/main` — "the page opens on Recent
+ * activity, and `?tab=` selects on load" — is asserted in
+ * `AppActivityPage.tabs.browser.test.tsx`, which mounts the real page.
+ */
+
+describe('the tab ledger', () => {
+  it('is the four tabs the page renders, in render order', () => {
+    // A ledger, not a floor: a loop over a set nobody pinned passes vacuously when the
+    // set shrinks, and this set decides which `?tab=` values are honoured.
+    expect([...ACTIVITY_TAB_VALUES]).toEqual([
+      'activity',
+      'subscriptions',
+      'permissions',
+      'hidden',
+    ]);
+  });
+
+  it('🔴 the DEFAULT is the activity feed, not the installs list', () => {
+    // The whole point of the rename. `origin/main` opened on `subscriptions`.
+    expect(DEFAULT_ACTIVITY_TAB).toBe('activity');
+    expect(ACTIVITY_TAB_QUERY_KEY).toBe('tab');
+  });
+});
+
+describe('isActivityTab', () => {
+  it('accepts exactly the ledger', () => {
+    for (const value of ACTIVITY_TAB_VALUES) expect(isActivityTab(value)).toBe(true);
+  });
+
+  it('🔴 NEGATIVE CONTROL: rejects non-tabs, including prototype keys', () => {
+    // Without this the accept loop above could be satisfied by `() => true`. The
+    // prototype keys are the `dispatch-table-indexed-with-an-untrusted-key` hazard:
+    // `?tab=constructor` is a value any visitor can send.
+    for (const value of [
+      'installs',
+      '',
+      'constructor',
+      'toString',
+      '__proto__',
+      undefined,
+      null,
+      42,
+      ['activity'],
+    ]) {
+      expect(isActivityTab(value), `${String(value)} must not be a tab`).toBe(false);
+    }
+  });
+});
+
+describe('resolveActivityTab', () => {
+  const OPEN = { canSeeInstalls: true };
+  const SLOTLESS = { canSeeInstalls: false };
+
+  it('an absent / unknown / prototype-key value falls back to the default', () => {
+    for (const raw of [undefined, null, '', 'nope', 'constructor', '__proto__', 7]) {
+      expect(resolveActivityTab(raw, OPEN)).toBe('activity');
+    }
+  });
+
+  it('🔴 a known tab is honoured — the deep link actually selects', () => {
+    // NEGATIVE CONTROL for the fallback above: a resolver that always returned the
+    // default would satisfy every case in the previous test.
+    expect(resolveActivityTab('permissions', OPEN)).toBe('permissions');
+    expect(resolveActivityTab('hidden', OPEN)).toBe('hidden');
+    expect(resolveActivityTab('subscriptions', OPEN)).toBe('subscriptions');
+  });
+
+  it('takes the FIRST entry of a repeated query key rather than choking on the array', () => {
+    // Next hands back `string[]` for `?tab=a&tab=b`. Handing an array to `Tabs.value`
+    // selects nothing and renders an empty panel under a bar with no active tab.
+    expect(resolveActivityTab(['permissions', 'hidden'], OPEN)).toBe('permissions');
+    expect(resolveActivityTab([], OPEN)).toBe('activity');
+  });
+
+  it('🔴 `?tab=subscriptions` falls back for a viewer WITHOUT the slot flag', () => {
+    // That tab is not rendered for them, so selecting it would leave the bar with no
+    // active tab over an empty panel — a blank page with no error. This is a link a
+    // page-only viewer can legitimately receive.
+    expect(resolveActivityTab('subscriptions', SLOTLESS)).toBe('activity');
+    // …and the OTHER tabs are unaffected by that flag — the fallback is scoped to the
+    // gated tab, not applied to everything.
+    expect(resolveActivityTab('permissions', SLOTLESS)).toBe('permissions');
+    expect(resolveActivityTab('hidden', SLOTLESS)).toBe('hidden');
+  });
+});
+
+describe('activityTabQuery', () => {
+  it('🔴 the DEFAULT tab drops the key rather than writing ?tab=activity', () => {
+    expect(activityTabQuery('activity', { tab: 'hidden' })).toEqual({});
+    expect(activityTabQuery('activity')).toEqual({});
+  });
+
+  it('a non-default tab writes the key', () => {
+    expect(activityTabQuery('permissions')).toEqual({ tab: 'permissions' });
+  });
+
+  it('🔴 preserves every OTHER key on the route, in both directions', () => {
+    // This function owns ONE key. A spread that dropped the rest would silently discard
+    // whatever a future filter puts there.
+    expect(activityTabQuery('hidden', { foo: 'bar', tab: 'permissions' })).toEqual({
+      foo: 'bar',
+      tab: 'hidden',
+    });
+    expect(activityTabQuery('activity', { foo: 'bar', tab: 'permissions' })).toEqual({
+      foo: 'bar',
+    });
+  });
+
+  it('does not mutate the query object it was handed', () => {
+    const current = { tab: 'permissions', foo: 'bar' };
+    activityTabQuery('activity', current);
+    expect(current).toEqual({ tab: 'permissions', foo: 'bar' });
+  });
+});

--- a/src/components/Apps/__tests__/appsPageWidths.test.ts
+++ b/src/components/Apps/__tests__/appsPageWidths.test.ts
@@ -589,7 +589,7 @@ describe('🔴 the card-list column ladder steps exactly where the surplus appea
     );
 
   test('one column through the OLD container, two in the current one', () => {
-    // The whole justification for `/apps/installed` becoming a grid: it must change
+    // The whole justification for `/apps/activity` becoming a grid: it must change
     // nothing a 1440 or 1920 monitor showed, and spend the 640px the ultrawide pass
     // added. A min column of 1200 is what puts the step between the two.
     expect(columnsAt(1408)).toBe(1); // 1440 viewport
@@ -897,8 +897,8 @@ describe('every /apps page on disk is classified', () => {
         // consolidated into this (301s), and `/apps/submit` KEEPS its route but lost its
         // sub-nav row. So the set SHRANK by two — which is exactly the direction this
         // ledger exists to make visible, and the reason it is a `toEqual` and not a floor.
+        '/apps/activity',
         '/apps/build',
-        '/apps/installed',
         '/apps/invites',
         '/apps/listing/[appListingId]/edit',
         // 🔴 'revenue' sorts BEFORE 'review' — they diverge at index 9, 'e' < 'i'.

--- a/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
+++ b/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
@@ -91,6 +91,16 @@ const SRC = path.resolve(__dirname, '../../..');
  *    `appBlocks` alone — a second RUNTIME flag, not the store predicate, so the
  *    distinction this paragraph draws is unaffected.)
  *
+ *    🔴 `pages/apps/activity.tsx` IS NEVERTHELESS IN THE LEDGER, AND THAT IS NOT A
+ *    CONTRADICTION — read the distinction rather than "fixing" it. Its PAGE gate is
+ *    still `canAccessAppsActivity`; what is store-gated is ONE affordance inside it,
+ *    the empty state's `/apps` anchor. `/apps` gates on `hasAppsStoreAccess`, and
+ *    `appBlocksPages` is not one of that predicate's three disjuncts — so once this
+ *    page widened to `appBlocks || appBlocksPages`, an ungated anchor became a link
+ *    into a `notFound` for the newly-admitted cohort. Same shape, same reason, as
+ *    `components/Apps/AppActivityPanel.tsx` below. A page can be gated on the runtime
+ *    and still contain a link that must be gated on the store.
+ *
  * 2. The user-menu entry is IN the ledger now (#3907, resolved), and its module
  *    lives outside `components/Apps` — `components/AppLayout/AppHeader/
  *    appsNavVisibility.ts` — which is why `SCAN_ROOTS` carries that directory
@@ -122,6 +132,10 @@ const STORE_GATE_SITES = [
   'components/Apps/AppsSubNav.tsx',
   'components/Apps/RelatedListings.tsx',
   'components/Apps/resolveAppsPageAccess.ts',
+  // 🔴 THE EMPTY-STATE `/apps` ANCHOR ON `/apps/activity` — the sibling of the panel
+  // entry above, and the reason note 1 in this header carries an explicit carve-out. The
+  // page itself is runtime-gated; this ONE anchor points at a store-gated route.
+  'pages/apps/activity.tsx',
   'pages/apps/index.tsx',
   'pages/apps/store-preview/[slug].tsx',
 ] as const;

--- a/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
+++ b/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
@@ -83,10 +83,13 @@ const SRC = path.resolve(__dirname, '../../..');
  *
  * ── NOT in this ledger, on purpose ──────────────────────────────────────────
  *
- * 1. The block-RUNTIME surfaces (`/apps/installed`, `/apps/review`,
- *    `/apps/my-submissions`, `/apps/revenue`, `/apps/run/<slug>`) gate on
- *    `appBlocks` ALONE because they need the runtime, not just the catalog.
- *    Sweeping them in here would be a silent access widening.
+ * 1. The block-RUNTIME surfaces (`/apps/activity`, `/apps/review`,
+ *    `/apps/my-submissions`, `/apps/revenue`, `/apps/run/<slug>`) gate on the
+ *    RUNTIME flags because they need the runtime, not just the catalog.
+ *    Sweeping them in here would be a silent access widening. (`/apps/activity`
+ *    takes `appBlocks || appBlocksPages` via `canAccessAppsActivity` rather than
+ *    `appBlocks` alone — a second RUNTIME flag, not the store predicate, so the
+ *    distinction this paragraph draws is unaffected.)
  *
  * 2. The user-menu entry is IN the ledger now (#3907, resolved), and its module
  *    lives outside `components/Apps` — `components/AppLayout/AppHeader/
@@ -106,6 +109,15 @@ const SRC = path.resolve(__dirname, '../../..');
  */
 const STORE_GATE_SITES = [
   'components/AppLayout/AppHeader/appsNavVisibility.ts',
+  // 🔴 THE `App` COLUMN'S NAME LINK ON `/apps/activity`. It points at
+  // `/apps/store-preview/<slug>`, which `getServerSideProps`-gates on
+  // `resolveAppsPageAccess` and answers `notFound` for — so an UNGATED link there is a
+  // 404 affordance, the #4668 defect class. The panel renders a plain `<Text>` instead
+  // for an ineligible viewer, and reads the flags through `useOptionalFeatureFlags` so
+  // the absence of a provider fails CLOSED. Note this file is NOT a store SURFACE: its
+  // own page gate is `canAccessAppsActivity`, and only this one affordance inside it is
+  // store-gated.
+  'components/Apps/AppActivityPanel.tsx',
   'components/Apps/AppListingsMarketplaceBody.tsx',
   'components/Apps/AppsSubNav.tsx',
   'components/Apps/RelatedListings.tsx',
@@ -366,19 +378,43 @@ describe('the masker (validate the instrument before reading its verdict)', () =
     expect(masked).not.toContain('any other installs');
   });
 
-  it('🔴 the real installed.tsx keeps its post-apostrophe code visible', () => {
+  it('🔴 the real activity.tsx keeps its post-apostrophe code visible', () => {
     // Anchored on the FILE that broke it, not a fixture: a synthetic case can be
     // fixed while the real one still desyncs (different JSX nesting, entities…).
-    const raw = read('pages/apps/installed.tsx');
-    const masked = maskNonCode(raw, 'installed.tsx');
+    // 🔴 THE FILE MOVED, THE ANCHOR DID NOT: this was `pages/apps/installed.tsx` until
+    // the `/apps/activity` rename. Same file, same apostrophe, same trigger — repointed
+    // rather than deleted, because the defect it pins is about THIS file's JSX.
+    const raw = read('pages/apps/activity.tsx');
+    const masked = maskNonCode(raw, 'activity.tsx');
     expect(raw).toMatch(/app's/); // the trigger is still present upstream
-    // Both live gates sit AFTER it (~line 460 and ~500) and must remain readable.
+    // The live gate sits AFTER it and must remain readable.
     expect(masked.match(/features\.appBlocks/g) ?? []).toHaveLength(
       (raw.match(/features\.appBlocks/g) ?? []).length
     );
     // Blanking must be bounded: the file cannot be mostly spaces.
-    const blanked = masked.split('').filter((c) => c === ' ').length;
-    expect(blanked / masked.length).toBeLessThan(0.55);
+    //
+    // 🔴 THE BOUND MOVED 0.55 → 0.65, AND THE OLD NUMBER WAS NOT A MARGIN — IT WAS A
+    // COINCIDENCE. Measured on `origin/main`'s copy of this file the ratio was 0.5486
+    // against a 0.55 bound, i.e. 0.0014 of headroom: adding a few lines of DOCUMENTATION
+    // to the page (or one longer JSX string, which masks as blanks too) tripped it, which
+    // is a fact about comment density and nothing to do with the masker. Measured here
+    // after the `/apps/activity` rename: 0.5648.
+    //
+    // The re-cut bound is still discriminating, and the control below is what proves it
+    // rather than asserting it: the defect this test exists for — a phantom string opened
+    // by the ASCII apostrophe running to EOF — blanks the whole tail of the file and lands
+    // far above 0.65.
+    const spaceRatio = (text: string) =>
+      text.split('').filter((c) => c === ' ').length / text.length;
+    expect(spaceRatio(masked)).toBeLessThan(0.65);
+
+    // 🔴 NEGATIVE CONTROL, ON THE REAL FILE: a bound nobody has watched fire is a claim
+    // about a number. Reproduce the historical desync — everything after the apostrophe
+    // blanked — and confirm it exceeds the bound the live value passes.
+    const apostrophe = raw.indexOf("app's");
+    expect(apostrophe, 'the trigger moved; re-point this control').toBeGreaterThan(-1);
+    const desynced = raw.slice(0, apostrophe) + raw.slice(apostrophe).replace(/[^\n]/g, ' ');
+    expect(spaceRatio(desynced)).toBeGreaterThan(0.65);
   });
 
   it('nested quotes, templates and regex literals do not desync it either', () => {

--- a/src/components/Apps/__tests__/appsWideLayout.test.ts
+++ b/src/components/Apps/__tests__/appsWideLayout.test.ts
@@ -623,14 +623,14 @@ describe('🔴 every HEADED table under /apps is enumerated, not remembered', ()
     for (const s of twoShaped) expect(s.ledgerRefs.length).toBe(2);
   });
 
-  test('🔴 /apps/installed uses the card GRID *on the installed-apps list*, and no longer caps its body', () => {
+  test('🔴 /apps/activity uses the card GRID *on the installed-apps list*, and no longer caps its body', () => {
     // 🔴 THE testId IS LOAD-BEARING, NOT DECORATION. This asserted `/<AppsCardGrid\b/`
     // over the whole file, and the same change added two OTHER `AppsCardGrid` call sites
     // to it (the grants tab and the hidden tab) — so the guard stopped being able to see
     // the case it exists for. Measured: reverting ONLY the installed-apps list to
     // `<Stack gap="md">`, i.e. undoing the headline fix on the one route whose 640px
     // defect was measured, passed unit 124/124 and geometry 27/27.
-    const src = codeOf('src/pages/apps/installed.tsx');
+    const src = codeOf('src/pages/apps/activity.tsx');
     expect(src).toMatch(/<AppsCardGrid\s+testId="apps-installed-apps-grid"/);
     // The other two lists are grids as well, named individually for the same reason.
     expect(src).toMatch(/<AppsCardGrid\s+testId="apps-installed-grants-grid"/);
@@ -712,7 +712,7 @@ describe('appsCardGridColumnsAt — the auto-fill ladder', () => {
   test('🔴 the Hidden tab really does pass its own gap', () => {
     // The other half: the equivalence above is about numbers, this is about the call site
     // the numbers are for. Deleting the prop is what the arithmetic cannot see.
-    const src = codeOf('src/pages/apps/installed.tsx');
+    const src = codeOf('src/pages/apps/activity.tsx');
     expect(src).toMatch(/<AppsCardGrid\s+testId="apps-installed-hidden-grid"\s+gap=\{12\}/);
   });
 

--- a/src/components/Apps/__tests__/groupSubscriptionsByApp.test.ts
+++ b/src/components/Apps/__tests__/groupSubscriptionsByApp.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { groupSubscriptionsByApp, type SubscriptionRecord } from '../groupSubscriptionsByApp';
 
 /**
- * Pure unit tests for the /apps/installed one-row-per-app grouping. Node-env
+ * Pure unit tests for the /apps/activity one-row-per-app grouping. Node-env
  * vitest (no jsdom / RTL) — the consuming card UI in installed.tsx reduces to
  * "render whatever groupSubscriptionsByApp returns".
  */

--- a/src/components/Apps/__tests__/resolveActivityPageAccess.test.ts
+++ b/src/components/Apps/__tests__/resolveActivityPageAccess.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { canAccessAppsActivity } from '~/shared/utils/app-blocks-access';
+import { resolveActivityPageAccess } from '~/components/Apps/resolveActivityPageAccess';
+
+/**
+ * 🔒 THE `/apps/activity` SSR GATE.
+ *
+ * 🔴 THE ASSERTION WITH A MEASURED RED ON PRE-CHANGE CODE is
+ * `a viewer holding appBlocksPages but NOT appBlocks is admitted`. The page's gate at
+ * `origin/main` (then `pages/apps/installed.tsx`) read
+ *
+ *     if (!features?.appBlocks) return { notFound: true };
+ *
+ * so that viewer got `notFound`. That is the dishonest half of calling the page
+ * "Activity": `appBlocks` is the model-SLOT flag, while `/apps/run/<slug>` — the
+ * full-page app runtime — is gated on `appBlocksPages`. Someone who has only ever run a
+ * full-page app has generations, scope-gated API calls and Buzz spends recorded against
+ * them, and not one slot install.
+ *
+ * The rest of this file is new-feature coverage for a new module, and is labelled as
+ * such rather than counted as regression coverage.
+ */
+
+const LOGIN = '/login?returnUrl=%2Fapps%2Factivity';
+const USER = { id: 7 };
+
+describe('resolveActivityPageAccess', () => {
+  it('🔴 admits a viewer holding appBlocksPages but NOT appBlocks (RED at origin/main)', () => {
+    expect(
+      resolveActivityPageAccess({
+        features: { appBlocks: false, appBlocksPages: true },
+        user: USER,
+        loginDestination: LOGIN,
+      })
+    ).toEqual({ props: {} });
+  });
+
+  it('admits a viewer holding appBlocks but NOT appBlocksPages (the pre-change cohort)', () => {
+    expect(
+      resolveActivityPageAccess({
+        features: { appBlocks: true, appBlocksPages: false },
+        user: USER,
+        loginDestination: LOGIN,
+      })
+    ).toEqual({ props: {} });
+  });
+
+  it('🔴 NEGATIVE CONTROL: a viewer with NEITHER runtime flag gets notFound', () => {
+    // Without this, every "admits" assertion above could be satisfied by a resolver that
+    // returns `props` unconditionally.
+    expect(
+      resolveActivityPageAccess({
+        features: { appBlocks: false, appBlocksPages: false },
+        user: USER,
+        loginDestination: LOGIN,
+      })
+    ).toEqual({ notFound: true });
+  });
+
+  it('fails CLOSED on absent / null / empty features', () => {
+    for (const features of [undefined, null, {}] as const) {
+      expect(resolveActivityPageAccess({ features, user: USER, loginDestination: LOGIN })).toEqual({
+        notFound: true,
+      });
+    }
+  });
+
+  it('🔒 the FLAG gate runs BEFORE the session check', () => {
+    // Order is the disclosure property: an ungated visitor must learn nothing from the
+    // response, not even that the route exists. If the session check ran first, a
+    // signed-out ungated visitor would get a login redirect naming the route.
+    expect(
+      resolveActivityPageAccess({ features: {}, user: null, loginDestination: LOGIN })
+    ).toEqual({ notFound: true });
+  });
+
+  it('redirects a signed-out but GATED viewer to login rather than 404ing them', () => {
+    expect(
+      resolveActivityPageAccess({
+        features: { appBlocksPages: true },
+        user: null,
+        loginDestination: LOGIN,
+      })
+    ).toEqual({ redirect: { destination: LOGIN, permanent: false } });
+  });
+
+  it('positive control: the shared predicate really does refuse someone, on EACH term', () => {
+    // Guards the cases above against the predicate having collapsed to a constant, and
+    // does it per-term so a gate that ignored one input still reds here.
+    expect(canAccessAppsActivity({ appBlocks: true, appBlocksPages: false })).toBe(true);
+    expect(canAccessAppsActivity({ appBlocks: false, appBlocksPages: true })).toBe(true);
+    expect(canAccessAppsActivity({ appBlocks: false, appBlocksPages: false })).toBe(false);
+    expect(canAccessAppsActivity(null)).toBe(false);
+  });
+});

--- a/src/components/Apps/__tests__/subNavRowsMatchPageGates.test.ts
+++ b/src/components/Apps/__tests__/subNavRowsMatchPageGates.test.ts
@@ -1,8 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
-import { canAccessAppsBuild, hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
+import {
+  canAccessAppsActivity,
+  canAccessAppsBuild,
+  hasAppsStoreAccess,
+} from '~/shared/utils/app-blocks-access';
 import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
+import { resolveActivityPageAccess } from '~/components/Apps/resolveActivityPageAccess';
 import { resolveBuildPageAccess } from '~/components/Apps/resolveBuildPageAccess';
 
 /**
@@ -10,18 +15,29 @@ import { resolveBuildPageAccess } from '~/components/Apps/resolveBuildPageAccess
  * GATE ON THE PAGE IT POINTS AT — plus a structural check that binds the whole table.
  *
  * 🔴 SCOPE, STATED EXACTLY, BECAUSE AN EARLIER REVISION OF THIS HEADER CLAIMED "EVERY
- * SUB-NAV ROW" AND MEANT ONE. Two rows are compared to their page's resolver:
- *   • Marketplace → `/apps`       vs `resolveAppsPageAccess`
- *   • Build       → `/apps/build` vs `resolveBuildPageAccess`
- * Those are the two whose visibility is a FLAG decision, and therefore the two that can
- * drift from a page gate. The remaining four (Activity / Invites / Revenue / Review) key
- * off `getNavSummary` DATA — `s.hasInstalls`, `s.isReviewer`, … — which is a server answer
- * about this user, not a rule restated at the row, so there is no second copy to disagree
- * with. They are covered by the `no row is unconditionally visible` check below, which is
- * a property of the TABLE and does bind all six.
+ * SUB-NAV ROW" AND MEANT ONE. Three rows are pinned against their page:
+ *   • Marketplace → `/apps`          vs `resolveAppsPageAccess`   (flag ⟺ flag)
+ *   • Build       → `/apps/build`    vs `resolveBuildPageAccess`  (flag ⟺ flag)
+ *   • Activity    → `/apps/activity` vs `canAccessAppsActivity`   (see below)
  *
- * Reading as coverage while providing none is worse than none, so: if a fifth row ever
- * gains a flag term, it belongs in the loop set above and this list must grow with it.
+ * The first two are the rows whose visibility is a pure FLAG decision, and therefore the
+ * two that can drift from a page gate by restating it wrongly.
+ *
+ * ⚠️ THE CLAIM THAT USED TO SIT HERE IS NOW FALSE, AND IS CORRECTED RATHER THAN DELETED
+ * BECAUSE IT IS WHY THE ACTIVITY ROW WENT UNCHECKED. It read: the four summary-driven
+ * rows "key off `getNavSummary` DATA … a server answer about this user, not a rule
+ * restated at the row, so there is no second copy to disagree with." That is still true
+ * of Invites / Revenue / Review. It is NOT true of Activity: its predicate is a
+ * hand-written DISJUNCTION over two summary fields (`hasInstalls || hasActivity`), and
+ * choosing WHICH fields to OR is exactly a rule restated at the row. The row shipped as
+ * `s.hasInstalls` alone while `/apps/activity` admits `appBlocks || appBlocksPages` — so
+ * a viewer whose only app usage is a stateless FULL-PAGE app (no `block_user_subscriptions`
+ * row, ever) could load the page and had no tab pointing at it. Nothing here saw it,
+ * because nothing here looked at that row at all.
+ *
+ * Reading as coverage while providing none is worse than none, so: if a fourth row ever
+ * gains a flag term or a hand-written predicate, it belongs in the set above and this
+ * list must grow with it.
  *
  * THE DEFECT CLASS. A tab offered to a cohort whose destination answers `notFound`. It
  * has shipped here twice — #3899 ("Create" was store-gated while `/apps/submit` is
@@ -119,6 +135,7 @@ function evaluate(expr: string, s: Summary, c: Context): boolean {
 /** Every summary flag false; every context capability false. */
 const NO_SUMMARY: Summary = {
   hasInstalls: false,
+  hasActivity: false,
   hasSubmissions: false,
   hasApprovedApps: false,
   isReviewer: false,
@@ -325,6 +342,99 @@ describe('🔴 no sub-nav row offers a page its own gate would refuse', () => {
     expect(canAccessAppsBuild(null, { appListings: true })).toBe(false);
     // the get-started disjunct opens it for a non-author
     expect(canAccessAppsBuild(null, { appListings: true, appBlocksGetStarted: true })).toBe(true);
+  });
+
+  /**
+   * 🔴 THE ACTIVITY ROW — the one this file's header used to declare out of scope, on the
+   * argument that a summary-driven row has "no second copy to disagree with". It has one:
+   * WHICH summary fields the predicate ORs together is a rule written at the row, and it
+   * was written too narrowly.
+   *
+   * THE SHIPPED DEFECT, restated so the assertion is readable. `hasInstalls` is a
+   * `block_user_subscriptions` row — a SLOT install. A full-page app
+   * (`/apps/run/<slug>`) is stateless BY DESIGN and creates no such row, so a viewer whose
+   * only app usage is page apps has a populated activity feed and `hasInstalls: false`
+   * forever. `/apps/activity` admits them (`appBlocks || appBlocksPages`); the row keyed
+   * on installs alone did not. That is the MIRROR of #3899 / #4668 — an unreachable page
+   * rather than a tab into a 404 — which is the safe direction and still a defect.
+   *
+   * 🔴 MEASURED RED ON THE PRE-FIX ROW. Restore `visible: (s) => s.hasInstalls` and this
+   * case fails on its own assertion at the first `hasInstalls=false, hasActivity=true`
+   * cell; the two flag-row cases above and the structural check below stay green, which
+   * is what makes the red attributable to THIS row.
+   *
+   * The whole (installs × activity) space is enumerated against TWO summary bases — one
+   * with every other flag false and one with every other flag true — plus a varying
+   * context, so a predicate that quietly reads a third field, or a capability, fails here
+   * instead of passing on a lucky fixture.
+   */
+  it('Activity is visible exactly when the viewer has installs OR activity', () => {
+    const row = rows.find((r) => r.href === '/apps/activity');
+    expect(row, 'the Activity row is missing from SUB_NAV_LINKS').toBeDefined();
+
+    const OTHERS_TRUE: Summary = { ...ALL_SUMMARY, hasInstalls: false, hasActivity: false };
+
+    for (const base of [NO_SUMMARY, OTHERS_TRUE])
+      for (const hasInstalls of [false, true])
+        for (const hasActivity of [false, true])
+          for (const store of [false, true])
+            for (const author of [false, true]) {
+              const summary: Summary = { ...base, hasInstalls, hasActivity };
+              const tabVisible = evaluate(
+                row!.visible,
+                summary,
+                context({ store, author, getStarted: false })
+              );
+              expect(
+                tabVisible,
+                `hasInstalls=${hasInstalls} hasActivity=${hasActivity} ` +
+                  `(others=${base === NO_SUMMARY ? 'false' : 'true'} store=${store} ` +
+                  `author=${author}): the Activity TAB is ` +
+                  `${tabVisible ? 'VISIBLE' : 'hidden'}. It must key on BOTH terms: an ` +
+                  `install is a slot subscription, activity is stateless full-page-app ` +
+                  `usage that writes no subscription row. Dropping either term hides ` +
+                  `\`/apps/activity\` from a cohort the page serves.`
+              ).toBe(hasInstalls || hasActivity);
+            }
+  });
+
+  /**
+   * 🔴 THE PAGE-GATE TIE. The case above pins the row against a RULE; this pins that rule
+   * against the page's REAL resolver, so "installs OR activity" cannot quietly become a
+   * private convention nobody checks against `/apps/activity` itself.
+   *
+   * The cohort that makes `hasActivity` load-bearing is the one holding `appBlocksPages`
+   * without `appBlocks`. `resolveActivityPageAccess` — the page's own
+   * `getServerSideProps` resolver, called here rather than restated — admits them, and
+   * their `hasInstalls` is structurally false. So `hasActivity` is the ONLY summary
+   * signal that can ever light this row for them.
+   */
+  it('🔴 the page ADMITS the cohort whose only possible signal is hasActivity', () => {
+    const row = rows.find((r) => r.href === '/apps/activity');
+    expect(row, 'the Activity row is missing from SUB_NAV_LINKS').toBeDefined();
+
+    const admits = (features: Record<string, boolean>) =>
+      'props' in
+      resolveActivityPageAccess({ features, user: { id: 1 }, loginDestination: '/login' });
+
+    // The page really does serve a pages-only viewer …
+    expect(admits({ appBlocksPages: true }), 'the page gate narrowed back to appBlocks').toBe(true);
+    // … and really does refuse someone (so the line above is not vacuous).
+    expect(admits({})).toBe(false);
+    // …the shared predicate agrees, per-term, so neither disjunct can be dropped silently.
+    expect(canAccessAppsActivity({ appBlocks: true })).toBe(true);
+    expect(canAccessAppsActivity({ appBlocksPages: true })).toBe(true);
+    expect(canAccessAppsActivity({})).toBe(false);
+
+    // …and for that viewer, activity WITHOUT installs must light the tab.
+    expect(
+      evaluate(
+        row!.visible,
+        { ...NO_SUMMARY, hasActivity: true },
+        context({ store: true, author: false, getStarted: false })
+      ),
+      'a viewer the page serves — page-app activity, zero slot installs — has no tab'
+    ).toBe(true);
   });
 
   /**

--- a/src/components/Apps/__tests__/subNavRowsMatchPageGates.test.ts
+++ b/src/components/Apps/__tests__/subNavRowsMatchPageGates.test.ts
@@ -14,7 +14,7 @@ import { resolveBuildPageAccess } from '~/components/Apps/resolveBuildPageAccess
  *   • Marketplace → `/apps`       vs `resolveAppsPageAccess`
  *   • Build       → `/apps/build` vs `resolveBuildPageAccess`
  * Those are the two whose visibility is a FLAG decision, and therefore the two that can
- * drift from a page gate. The remaining four (Installed / Invites / Revenue / Review) key
+ * drift from a page gate. The remaining four (Activity / Invites / Revenue / Review) key
  * off `getNavSummary` DATA — `s.hasInstalls`, `s.isReviewer`, … — which is a server answer
  * about this user, not a rule restated at the row, so there is no second copy to disagree
  * with. They are covered by the `no row is unconditionally visible` check below, which is

--- a/src/components/Apps/appsActivityTabs.ts
+++ b/src/components/Apps/appsActivityTabs.ts
@@ -1,0 +1,83 @@
+/**
+ * The `/apps/activity` tab set, as DATA plus the pure `?tab=` resolver.
+ *
+ * 🔴 THE TABS ARE URL-BACKED, AND THEY WERE NOT BEFORE. The page used to render
+ * `<Tabs defaultValue="subscriptions">` — uncontrolled, no query state — while
+ * `isActiveAppsRoute`'s own comment claimed `/apps/installed?tab=…` existed. It did
+ * not: a deep link silently landed on the default tab, and "the page opens on Recent
+ * activity" was untestable because nothing observable carried the selection.
+ *
+ * Extracted here (pure, React-free, no Mantine/tRPC) so the resolution rules run in
+ * the node-env `unit` project rather than only in the report-only browser tier. Same
+ * precedent as `resolveAppsPageAccess.ts` / `appsStoreQueryParams.ts`.
+ */
+
+/**
+ * Every tab the page can render, in RENDER ORDER.
+ *
+ * 🔴 `activity` LEADS, and that is the rename made real rather than a cosmetic
+ * reorder: the route is called `/apps/activity`, so the feed is what it must open on.
+ */
+export const ACTIVITY_TAB_VALUES = ['activity', 'subscriptions', 'permissions', 'hidden'] as const;
+
+export type ActivityTab = (typeof ACTIVITY_TAB_VALUES)[number];
+
+/** The tab a bare `/apps/activity` opens on. */
+export const DEFAULT_ACTIVITY_TAB: ActivityTab = 'activity';
+
+/** The query-string key the selection round-trips through. */
+export const ACTIVITY_TAB_QUERY_KEY = 'tab';
+
+export function isActivityTab(value: unknown): value is ActivityTab {
+  return typeof value === 'string' && (ACTIVITY_TAB_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Resolve the tab to render from the raw `router.query.tab` value.
+ *
+ * `raw` is deliberately `unknown`: Next hands back `string | string[] | undefined`
+ * (repeat the key and you get an array), and a component that assumed `string` would
+ * put an array into `Tabs.value` and render no active tab at all. The array case takes
+ * the FIRST entry, which is what every other query reader in this area does.
+ *
+ * 🔴 A TAB THE VIEWER CANNOT SEE FALLS BACK TO THE DEFAULT, IT DOES NOT RENDER EMPTY.
+ * `Installs` is gated on `features.appBlocks` (the slot flag), so
+ * `/apps/activity?tab=subscriptions` is a link a page-only viewer can legitimately
+ * receive — from a teammate, a bookmark taken before a flag moved, or their own
+ * history. Handing that value to `Tabs.value` selects a tab that is not in the list
+ * and Mantine renders a bar with nothing active over an empty panel: a blank page with
+ * no error. Falling back is the only outcome that is a page.
+ */
+export function resolveActivityTab(raw: unknown, opts: { canSeeInstalls: boolean }): ActivityTab {
+  const first = Array.isArray(raw) ? raw[0] : raw;
+  if (!isActivityTab(first)) return DEFAULT_ACTIVITY_TAB;
+  if (first === 'subscriptions' && !opts.canSeeInstalls) return DEFAULT_ACTIVITY_TAB;
+  return first;
+}
+
+/** Next's `ParsedUrlQuery` shape, named so the helper below can round-trip it. */
+export type ActivityRouteQuery = Record<string, string | string[] | undefined>;
+
+/**
+ * The `query` object for a tab selection, given the route's CURRENT query.
+ *
+ * 🔴 THE DEFAULT TAB DROPS THE KEY RATHER THAN WRITING `?tab=activity`. The canonical
+ * URL for the page's own default is the bare route — otherwise every arrival that
+ * touches a tab and comes back leaves a redundant parameter in the address bar and in
+ * anything that copies it. Other keys on the route are preserved untouched: this
+ * function owns ONE key, and a spread that dropped the rest would silently discard
+ * whatever a future filter puts there.
+ */
+export function activityTabQuery(
+  tab: ActivityTab,
+  // Typed concretely rather than as `Record<string, unknown>` so the result drops
+  // straight into `router.replace`'s `ParsedUrlQueryInput` without a cast — an `unknown`
+  // value is not assignable there, and casting at the call site is how a wrong shape
+  // gets in.
+  currentQuery: ActivityRouteQuery = {}
+): ActivityRouteQuery {
+  const next = { ...currentQuery };
+  if (tab === DEFAULT_ACTIVITY_TAB) delete next[ACTIVITY_TAB_QUERY_KEY];
+  else next[ACTIVITY_TAB_QUERY_KEY] = tab;
+  return next;
+}

--- a/src/components/Apps/appsPageWidths.ts
+++ b/src/components/Apps/appsPageWidths.ts
@@ -135,7 +135,7 @@ export function appsMeasureCss(measure: AppsMeasure): number | string {
  * The narrowest column a `/apps/*` CARD LIST may be laid out in before it starts
  * putting cards SIDE BY SIDE instead of stretching each one across the container.
  *
- * 🔴 THIS EXISTS FOR `/apps/installed`, AND FOR ONE MEASURED DEFECT. That page is a
+ * 🔴 THIS EXISTS FOR `/apps/activity`, AND FOR ONE MEASURED DEFECT. That page is a
  * `Stack` of full-width cards whose header rows are
  * `<Group justify="space-between" wrap="nowrap">` — content on the left, the control
  * that acts on it on the right. Raising the container to 2560 therefore moved the
@@ -209,7 +209,7 @@ export const APPS_CARD_LIST_GAP = 16;
  * ✅ THE SIBLING ROUTES NOW SPEND IT — this note used to say they did not. Every route
  * in {@link APPS_FULL_MEASURE_PAGES} lays out at up to 2528px of content, and the
  * surplus goes into COLUMN WIDTHS rather than padding: the tables carry a proportional
- * `<colgroup>` whose PRIMARY column takes the slack, and `/apps/installed`'s card list
+ * `<colgroup>` whose PRIMARY column takes the slack, and `/apps/activity`'s card list
  * steps to a second grid column. Both mechanisms live in
  * `~/components/Apps/appsWideLayout` — read {@link APPS_CARD_LIST_MIN_COLUMN} for the
  * measured 640px dead-gap defect the card half fixes.
@@ -387,8 +387,8 @@ export type AppsMeasuredRoute = keyof typeof APPS_PAGE_MEASURES;
  */
 export const APPS_FULL_MEASURE_PAGES = [
   '/apps',
+  '/apps/activity',
   '/apps/build',
-  '/apps/installed',
   '/apps/revenue',
   '/apps/review',
   '/apps/review/[publishRequestId]',

--- a/src/components/Apps/appsWideLayout.tsx
+++ b/src/components/Apps/appsWideLayout.tsx
@@ -19,7 +19,7 @@ import {
  * 🔴 THE DEFECT IS A GAP, NOT A CLIP. Nothing was cut off — a table's columns simply
  * stayed at their content width and the table distributed the extra 640px as PADDING,
  * which on a `space-between` row lands entirely between a row's content and the control
- * that acts on it. Measured on `/apps/installed`, where THREE
+ * that acts on it. Measured on `/apps/activity`, where THREE
  * `Group justify="space-between" wrap="nowrap"` rows (in `PinnedInstallRow`,
  * `InstalledAppCard` and `HiddenBlocksPanel`) each moved their button 640px further from
  * the name it belongs to. `/apps/review` had the same shape and had been "fixed" by
@@ -305,7 +305,7 @@ export const APPS_ACTIVE_PREVIEWS_COLUMNS: AppsTableColumns = [3, 2, 2, 2, null]
 /**
  * 🔴 THERE IS NO `APPS_ACTIVITY_COLUMNS`, AND THAT IS A MEASURED DECISION.
  *
- * `/apps/installed`'s activity tab (`AppActivityPanel`) carried one for two rounds and it
+ * `/apps/activity`'s activity tab (`AppActivityPanel`) carried one for two rounds and it
  * was wrong both times — first with `Detail` primary (a fixed monospace ref), then with
  * shares set from a 1408 measurement, which squeezed three columns below their content at
  * every width a real desktop uses. Measured on a rich `tip` row, ROW HEIGHT:
@@ -317,7 +317,9 @@ export const APPS_ACTIVE_PREVIEWS_COLUMNS: AppsTableColumns = [3, 2, 2, 2, null]
  *
  * Round 3 was 79% taller than natural at 1440 — `When` broke a `YYYY-MM-DD HH:mm` stamp
  * across THREE lines, and `App` sat pinned at its 108.52 min-content from 768 through 2560
- * so a long name was ellipsised identically on both.
+ * so a long name was ellipsised identically on both. (`When` no longer renders that stamp
+ * — see the re-measurement at the foot of this comment. The natural row height is still
+ * 36.19 at all four widths, so this table's rows are unchanged.)
  *
  * 🔴 AND NO LEDGER FIXES IT, WHICH IS THE POINT. This table's max-content sum (~735px) is
  * the container's content width AT 768, so there is no surplus to place at the narrow end.
@@ -333,6 +335,39 @@ export const APPS_ACTIVE_PREVIEWS_COLUMNS: AppsTableColumns = [3, 2, 2, 2, null]
  * a share larger than its cell needs is padding relabelled — rules out the second. The
  * table is EXEMPT; the guard in `__tests__/appsWideLayout.test.ts` records that as a
  * `no-surplus` exemption and requires a geometry arm to keep proving it.
+ *
+ * ── 🔴 RE-MEASURED AFTER `When` WENT RELATIVE (`DaysFromNow`) ─────────────────
+ *
+ * The numbers above were taken with `When` rendering a fixed-width `YYYY-MM-DD HH:mm`
+ * stamp. It now renders `20 minutes ago`, so the measurement no longer described the
+ * table and was redone rather than inherited. Same fixture (one rich `tip` row), same
+ * four viewports, `AppsWideLayout.geometry.test.tsx`:
+ *
+ *   WHEN | APP | ACTION | DETAIL | STATUS, natural layout, cell widths in px
+ *
+ *   before   @768    119.67 | 177.34 | 194.36 | 179.09 |  65.53
+ *            @1200   189.94 | 281.44 | 308.44 | 284.23 | 103.95
+ *            @1440   228.95 | 339.27 | 371.81 | 342.63 | 125.34
+ *            @2560   411.09 | 609.14 | 667.58 | 615.19 | 225.00   ← the row above
+ *
+ *   after    @768    108.39 | 180.58 | 197.91 | 182.38 |  66.75
+ *            @1200   172.02 | 286.59 | 314.08 | 289.44 | 105.88
+ *            @1440   207.38 | 345.47 | 378.63 | 348.91 | 127.63
+ *            @2560   372.33 | 620.30 | 679.80 | 626.45 | 229.13
+ *
+ *   ROW HEIGHT        36.19 at 768 / 1200 / 1440 / 2560 — UNCHANGED, both before and
+ *                     after. That is the value the exemption rests on.
+ *
+ * 🔴 THE CONCLUSION SURVIVES, AND SO DOES THE REASON FOR IT. `When` gave up ~10% of its
+ * width at every viewport (38.76px at 2560) and the other four columns absorbed it
+ * proportionally — the table stayed at its natural distribution, it did not develop a
+ * surplus. The `no-surplus` argument is a claim about max-content sum vs container width
+ * at 768, and a narrower `When` makes that sum SMALLER, i.e. it moves further away from
+ * the case a ledger could help. Nothing here re-opens the decision.
+ *
+ * (The `before` @2560 row reproduces the recorded `natural @2560` figures exactly, which
+ * is the control on the re-measurement: the instrument agrees with the number that was
+ * already in this comment before it was pointed at anything new.)
  */
 
 /**
@@ -438,7 +473,7 @@ export const APPS_LEGACY_CONTENT_WIDTH = APPS_LEGACY_CONTAINER_WIDTH - APPS_CONT
  * `child=1200`, and `document.scrollWidth` **unchanged** — so the card is 1200px wide
  * inside a 358px grid, CLIPPED, with no scrollbar and no page-level overflow to notice
  * it by. Nothing on screen says the content is cut off. That matters because this
- * component converted three phone-reachable `Stack`s on `/apps/installed` into grids, so
+ * component converted three phone-reachable `Stack`s on `/apps/activity` into grids, so
  * the narrow case is a real users' case rather than a theoretical one, and it is pinned
  * at a phone viewport in `AppsWideLayout.geometry.test.tsx`.
  *
@@ -460,7 +495,7 @@ export function AppsCardGrid({
    * Track gap in px. Defaults to {@link APPS_CARD_LIST_GAP} (Mantine `md`).
    *
    * 🔴 IT IS A PROP BECAUSE THE PROVENANCE RULE APPLIES TO SPACING TOO. The lists this
-   * replaced did not all use the same gap — `/apps/installed`'s Hidden tab was
+   * replaced did not all use the same gap — `/apps/activity`'s Hidden tab was
    * `<Stack gap="sm">` (12px) — and defaulting every one of them to 16 would have moved
    * something a 1440 monitor shows, which is precisely what
    * `APPS_CARD_LIST_MIN_COLUMN`'s "nothing a 1440 or 1920 monitor shows changes" claim

--- a/src/components/Apps/groupSubscriptionsByApp.ts
+++ b/src/components/Apps/groupSubscriptionsByApp.ts
@@ -5,7 +5,7 @@ import type { SubscriptionRecord } from '~/server/schema/blocks/subscription.sch
 export type { SubscriptionRecord };
 
 /**
- * One row in the unified /apps/installed Installs tab — one entry per
+ * One row in the unified /apps/activity Installs tab — one entry per
  * installed app (keyed on appBlockId), collapsing the two blanket
  * "surfaces" (publisher / viewer) plus any pinned-to-a-specific-model
  * subscriptions into a single record.

--- a/src/components/Apps/resolveActivityPageAccess.ts
+++ b/src/components/Apps/resolveActivityPageAccess.ts
@@ -1,0 +1,49 @@
+/**
+ * SSR access decision for `/apps/activity` (the renamed `/apps/installed`).
+ *
+ * Pure, React-free and standalone so the GATING INVARIANT is unit-testable in the
+ * node-env `unit` project — the tier that actually blocks — without importing the
+ * page's React/Mantine/tRPC module graph. Same extraction precedent as
+ * `resolveAppsPageAccess.ts` and `resolveBuildPageAccess.ts`, for the same reason.
+ *
+ * 🔒 GATING INVARIANT (do not violate):
+ *   - The FLAG gate is FIRST. It is `canAccessAppsActivity` — the SHARED predicate,
+ *     never re-spelled here — so the SSR gate and the page body's client re-check
+ *     cannot drift apart.
+ *   - `appBlocks || appBlocksPages`, NOT `appBlocks` alone. The old page gated on the
+ *     SLOT flag, which refused every viewer whose only app usage is a FULL-PAGE app
+ *     (`/apps/run/<slug>`, gated on `appBlocksPages`). Those viewers have activity —
+ *     generations, scope-gated API calls, Buzz spends — recorded against them and no
+ *     slot install at all, so the old gate was calling the page "your activity" while
+ *     refusing the people who had some.
+ *   - The SESSION check is SECOND, and it stays a login REDIRECT rather than a 404.
+ *     This is a per-viewer account surface: a signed-out visitor with a bookmark has a
+ *     coherent next step, unlike an ungated one. Order matters — flag first means an
+ *     ungated visitor learns nothing from the response, not even that the route exists.
+ */
+import {
+  canAccessAppsActivity,
+  type AppsActivityFeatureFlags,
+} from '~/shared/utils/app-blocks-access';
+
+export type ActivityPageAccessResult =
+  | { notFound: true }
+  | { redirect: { destination: string; permanent: false } }
+  | { props: Record<string, never> };
+
+export function resolveActivityPageAccess(args: {
+  // The SHARED flag type (derived from `FeatureAccess`) — renaming either flag at GA
+  // is a compile error here rather than a silently narrowed gate.
+  features?: AppsActivityFeatureFlags;
+  /** The resolved session user, or null/undefined when signed out. */
+  user?: { id?: number } | null;
+  /** Where to send a signed-out viewer. Built by the caller from `getLoginLink`. */
+  loginDestination: string;
+}): ActivityPageAccessResult {
+  // 🔒 FLAG GATE FIRST — before anything is learned about the session.
+  if (!canAccessAppsActivity(args.features)) return { notFound: true };
+  if (!args.user) {
+    return { redirect: { destination: args.loginDestination, permanent: false } };
+  }
+  return { props: {} };
+}

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -19,12 +19,12 @@ import {
   IconEyeOff,
   IconHistory,
   IconPlugConnected,
-  IconPlus,
   IconSettings,
   IconShieldLock,
   IconTrash,
 } from '@tabler/icons-react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { useMemo } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
@@ -41,26 +41,30 @@ import type {
 } from '~/server/schema/blocks/subscription.schema';
 import { BlockScopeList } from '~/components/Apps/BlockScopeList';
 import { AppActivityPanel } from '~/components/Apps/AppActivityPanel';
+import {
+  ACTIVITY_TAB_QUERY_KEY,
+  activityTabQuery,
+  isActivityTab,
+  resolveActivityTab,
+} from '~/components/Apps/appsActivityTabs';
+import { resolveActivityPageAccess } from '~/components/Apps/resolveActivityPageAccess';
+import { canAccessAppsActivity } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { formatDate } from '~/utils/date-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
+/** 🔴 The gate is the SHARED `resolveActivityPageAccess`, never an inline flag read —
+ *  and it is `appBlocks || appBlocksPages`. See `canAccessAppsActivity`. */
 export const getServerSideProps = createServerSideProps({
   useSession: true,
-  resolver: async ({ features, session, ctx }) => {
-    if (!features?.appBlocks) return { notFound: true };
-    if (!session?.user) {
-      return {
-        redirect: {
-          destination: getLoginLink({ returnUrl: ctx.resolvedUrl }),
-          permanent: false,
-        },
-      };
-    }
-    return { props: {} };
-  },
+  resolver: async ({ features, session, ctx }) =>
+    resolveActivityPageAccess({
+      features,
+      user: session?.user,
+      loginDestination: getLoginLink({ returnUrl: ctx.resolvedUrl }),
+    }),
 });
 
 const PIN_LATEST_VALUE = '__latest__';
@@ -456,10 +460,21 @@ function HiddenBlocksPanel() {
   );
 }
 
-export default function InstalledAppsPage() {
+export default function AppActivityPage() {
   const features = useFeatureFlags();
+  const router = useRouter();
+  // 🔴 The Installs tab's gate is the `appBlocks` SLOT flag; the PAGE's is
+  // `appBlocks || appBlocksPages`. A tab's predicate is its content's own gate,
+  // restated — and this one is NON-VACUOUS only because the page gate widened.
+  const canSeeInstalls = !!features.appBlocks;
   const { data: subs, isLoading } = trpc.blocks.listMySubscriptions.useQuery(undefined, {
-    enabled: !!features.appBlocks,
+    enabled: canSeeInstalls,
+  });
+
+  // 🔴 URL-backed, controlled tabs. `resolveActivityTab` returns the default for an
+  // absent value, so an empty first-render `router.query` renders what SSR did.
+  const activeTab = resolveActivityTab(router.query[ACTIVITY_TAB_QUERY_KEY], {
+    canSeeInstalls,
   });
 
   const groupedApps = useMemo(() => groupSubscriptionsByApp(subs ?? []), [subs]);
@@ -493,69 +508,48 @@ export default function InstalledAppsPage() {
     openAppSettingsModal({ block, existingByScope });
   }
 
-  if (!features.appBlocks) return <NotFound />;
+  // The client-side re-check reads the SAME predicate the SSR gate does, so the two
+  // cannot answer differently for one viewer.
+  if (!canAccessAppsActivity(features)) return <NotFound />;
 
   return (
     <>
-      <Meta title="Installed Apps — Civitai" deIndex />
+      <Meta title="App activity — Civitai" deIndex />
       <AppsPageLayout
-        title="Your installed apps"
-        subtitle="Manage where Civitai Apps show up across the site."
-        actions={
-          <Button
-            component={Link}
-            href="/apps"
-            leftSection={<IconPlus size={16} />}
-            variant="default"
-          >
-            Browse marketplace
-          </Button>
-        }
+        title="Your app activity"
+        subtitle="What Civitai Apps have done on your behalf, what they can access, and where they show up."
       >
-        <Tabs defaultValue="subscriptions" variant="outline">
+        {/* 🔴 CONTROLLED, NOT `defaultValue` — that is what puts the selection in the
+            URL. `replace` + `shallow`: no re-run of `getServerSideProps`, and no history
+            entry per click (which would turn Back into a tab-by-tab rewind). */}
+        <Tabs
+          value={activeTab}
+          onChange={(value) => {
+            if (!isActivityTab(value)) return;
+            void router.replace(
+              { pathname: router.pathname, query: activityTabQuery(value, router.query) },
+              undefined,
+              { shallow: true }
+            );
+          }}
+          variant="outline"
+        >
           <Tabs.List>
-            <Tabs.Tab value="subscriptions" leftSection={<IconPlugConnected size={14} />}>
-              Installs
-            </Tabs.Tab>
-            <Tabs.Tab value="permissions" leftSection={<IconShieldLock size={14} />}>
-              Apps & permissions
-            </Tabs.Tab>
             <Tabs.Tab value="activity" leftSection={<IconHistory size={14} />}>
               Recent activity
+            </Tabs.Tab>
+            {canSeeInstalls && (
+              <Tabs.Tab value="subscriptions" leftSection={<IconPlugConnected size={14} />}>
+                Installs
+              </Tabs.Tab>
+            )}
+            <Tabs.Tab value="permissions" leftSection={<IconShieldLock size={14} />}>
+              Apps & permissions
             </Tabs.Tab>
             <Tabs.Tab value="hidden" leftSection={<IconEyeOff size={14} />}>
               Hidden
             </Tabs.Tab>
           </Tabs.List>
-
-          <Tabs.Panel value="subscriptions" pt="md">
-            {isLoading ? (
-              <Center py="xl">
-                <Loader />
-              </Center>
-            ) : groupedApps.length === 0 ? (
-              <EmptyState label="Nothing installed yet — browse the marketplace." />
-            ) : (
-              /* A GRID, NOT A `Stack` — the 640px dead-gap fix. Rationale + the measured
-                 ladder: `APPS_CARD_LIST_MIN_COLUMN` in `~/components/Apps/appsPageWidths`. */
-              <AppsCardGrid testId="apps-installed-apps-grid">
-                {groupedApps.map((app) => (
-                  <InstalledAppCard key={app.appBlockId} app={app} onManage={handleManage} />
-                ))}
-              </AppsCardGrid>
-            )}
-          </Tabs.Panel>
-
-          <Tabs.Panel value="permissions" pt="md">
-            <Stack gap="sm">
-              <Text size="sm" c="dimmed">
-                What each app you've installed can request, and where you have it. This is a
-                reflection of the current state — to revoke access, remove the install or
-                subscription on the Subscriptions tab.
-              </Text>
-              <ScopeGrantsPanel />
-            </Stack>
-          </Tabs.Panel>
 
           <Tabs.Panel value="activity" pt="md">
             <Stack gap="sm">
@@ -564,6 +558,39 @@ export default function InstalledAppsPage() {
                 API call (read profile, read model, etc.).
               </Text>
               <AppActivityPanel />
+            </Stack>
+          </Tabs.Panel>
+
+          {/* 🔴 THE PANEL IS GATED TOO. A `Tabs.Panel` with no tab is unreachable but
+              still MOUNTS its children on every render. */}
+          {canSeeInstalls && (
+            <Tabs.Panel value="subscriptions" pt="md">
+              {isLoading ? (
+                <Center py="xl">
+                  <Loader />
+                </Center>
+              ) : groupedApps.length === 0 ? (
+                <EmptyState label="Nothing installed yet — browse the marketplace." />
+              ) : (
+                /* A GRID, NOT A `Stack` — the 640px dead-gap fix. Rationale + the measured
+                   ladder: `APPS_CARD_LIST_MIN_COLUMN` in `~/components/Apps/appsPageWidths`. */
+                <AppsCardGrid testId="apps-installed-apps-grid">
+                  {groupedApps.map((app) => (
+                    <InstalledAppCard key={app.appBlockId} app={app} onManage={handleManage} />
+                  ))}
+                </AppsCardGrid>
+              )}
+            </Tabs.Panel>
+          )}
+
+          <Tabs.Panel value="permissions" pt="md">
+            <Stack gap="sm">
+              <Text size="sm" c="dimmed">
+                What each app you've installed can request, and where you have it. This is a
+                reflection of the current state — to revoke access, remove the install or
+                subscription on the Installs tab.
+              </Text>
+              <ScopeGrantsPanel />
             </Stack>
           </Tabs.Panel>
 

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -34,7 +34,7 @@ import { AppsCardGrid } from '~/components/Apps/appsWideLayout';
 import { groupSubscriptionsByApp } from '~/components/Apps/groupSubscriptionsByApp';
 import type { GroupedApp } from '~/components/Apps/groupSubscriptionsByApp';
 import { useHiddenBlockList, unhideBlock } from '~/components/AppBlocks/hiddenBlocks';
-import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { useFeatureFlags, useOptionalFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import type {
   AvailableBlock,
   SubscriptionRecord,
@@ -48,7 +48,7 @@ import {
   resolveActivityTab,
 } from '~/components/Apps/appsActivityTabs';
 import { resolveActivityPageAccess } from '~/components/Apps/resolveActivityPageAccess';
-import { canAccessAppsActivity } from '~/shared/utils/app-blocks-access';
+import { canAccessAppsActivity, hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { formatDate } from '~/utils/date-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
@@ -307,7 +307,22 @@ export function InstalledAppCard({ app, onManage }: InstalledAppCardProps) {
   );
 }
 
+/**
+ * 🔴 THE `/apps` ANCHOR IS GATED ON `hasAppsStoreAccess`, AND THE GAP IT CLOSES IS THIS
+ * PR'S OWN. `/apps` SSR-gates on `resolveAppsPageAccess` → `hasAppsStoreAccess` =
+ * `appListings || appBlocks || appListingsPublicExternal`. `appBlocksPages` is NOT one of
+ * those disjuncts — but this PAGE now admits `appBlocks || appBlocksPages`. So the cohort
+ * criterion 2 widened the page for can hold `appBlocksPages` ALONE, load this page, and
+ * be offered a marketplace link that answers `notFound`: the #3899 / #4668 defect class
+ * (an affordance into a 404), reintroduced by the widening rather than by a drifted rule.
+ *
+ * The CTA is OMITTED rather than reworded — a viewer with no store has no destination, so
+ * there is no honest link text. `useOptionalFeatureFlags` (not `useFeatureFlags`) so the
+ * absence of a provider REMOVES the affordance instead of throwing; same fail-closed
+ * decision as `ActivityAppName`.
+ */
 function EmptyState({ label }: { label: string }) {
+  const canSeeStore = hasAppsStoreAccess(useOptionalFeatureFlags());
   return (
     <Center py="md">
       <Stack align="center" gap="xs">
@@ -315,9 +330,11 @@ function EmptyState({ label }: { label: string }) {
         <Text size="sm" c="dimmed">
           {label}
         </Text>
-        <Anchor component={Link} href="/apps" size="sm">
-          Browse the marketplace
-        </Anchor>
+        {canSeeStore && (
+          <Anchor component={Link} href="/apps" size="sm" data-testid="apps-empty-marketplace-link">
+            Browse the marketplace
+          </Anchor>
+        )}
       </Stack>
     </Center>
   );

--- a/src/pages/apps/revenue.tsx
+++ b/src/pages/apps/revenue.tsx
@@ -44,7 +44,7 @@ export default function AppBlocksDashboardPage() {
         subtitle={
           <>
             Revenue share and analytics for your apps. Payouts are batched weekly; see{' '}
-            <Anchor component={Link} href="/apps/installed">
+            <Anchor component={Link} href="/apps/activity">
               Apps
             </Anchor>{' '}
             to manage installations.

--- a/src/server/routers/__tests__/blocks.router.getNavSummary.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getNavSummary.test.ts
@@ -126,6 +126,7 @@ const otherModUser = { id: 99, isModerator: true, tier: 'free', username: 'mod2'
 
 const ALL_FALSE = {
   hasInstalls: false,
+  hasActivity: false,
   hasSubmissions: false,
   hasApprovedApps: false,
   isReviewer: false,
@@ -137,6 +138,8 @@ beforeEach(() => {
   mockIsAppBlocksEnabled.mockReset();
   mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
   mockDbRead.blockUserSubscription.findFirst.mockReset();
+  mockDbRead.blockBuzzAttribution.findFirst.mockReset();
+  mockDbRead.blockScopeInvocation.findFirst.mockReset();
   mockDbRead.appBlockPublishRequest.findFirst.mockReset();
   mockDbRead.appBlock.findFirst.mockReset();
   mockDbRead.appListing.findFirst.mockReset();
@@ -144,6 +147,8 @@ beforeEach(() => {
   mockDbRead.appOwnershipTransfer.findFirst.mockReset();
   // Default: nothing exists for anyone.
   mockDbRead.blockUserSubscription.findFirst.mockResolvedValue(null);
+  mockDbRead.blockBuzzAttribution.findFirst.mockResolvedValue(null);
+  mockDbRead.blockScopeInvocation.findFirst.mockResolvedValue(null);
   mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
   mockDbRead.appBlock.findFirst.mockResolvedValue(null);
   mockDbRead.appListing.findFirst.mockResolvedValue(null);
@@ -184,6 +189,7 @@ describe('getNavSummary — booleans reflect existence', () => {
     const result = await caller.getNavSummary();
     expect(result).toEqual({
       hasInstalls: false,
+      hasActivity: false,
       hasSubmissions: false,
       hasApprovedApps: false,
       isReviewer: true, // flag-on user is a mod pre-GA
@@ -227,12 +233,105 @@ describe('getNavSummary — booleans reflect existence', () => {
     const result = await caller.getNavSummary();
     expect(result).toEqual({
       hasInstalls: true,
+      hasActivity: false,
       hasSubmissions: true,
       hasApprovedApps: true,
       isReviewer: true,
       hasEditableApps: false,
       hasPendingInvites: false,
     });
+  });
+});
+
+/**
+ * 🔴 `hasActivity` — THE FLAG THAT LETS THE `Activity` TAB SEE A FULL-PAGE-APP VIEWER.
+ *
+ * ── THE DEFECT ───────────────────────────────────────────────────────────────
+ * The sub-nav's Activity row keyed on `hasInstalls` alone, i.e. on a
+ * `block_user_subscriptions` row — a SLOT install. A full-page app
+ * (`/apps/run/<slug>`) is STATELESS by design and writes no such row ("no
+ * `block_user_subscriptions` row, no migration"), so a viewer who only ever runs page
+ * apps has a populated activity feed and NO tab pointing at it. Widening the PAGE's gate
+ * to `appBlocks || appBlocksPages` did not fix that — the tab is what was missing.
+ *
+ * ── WHY THESE TWO TABLES AND NOT ANY OTHER ───────────────────────────────────
+ * They are the two the FEED walks: `listMyAppActivity` reads `block_buzz_attribution`
+ * filtered on the SPENDER's `userId`, and `listMyScopeInvocations` reads
+ * `block_scope_invocations` on the same column (both in
+ * `~/server/services/blocks/user-app-surface.service`). A probe on a table the feed does
+ * NOT read would light a tab over a page that renders "No activity yet" — the mirror of
+ * the defect being fixed. That correspondence is what the per-table cases below assert.
+ *
+ * ── RED WITHOUT THE CHANGE ───────────────────────────────────────────────────
+ * Delete the `hasActivity` key from the procedure's return and every test in this block
+ * fails on its own assertion (`expected undefined to be true`). Delete only ONE of the
+ * two disjuncts and exactly one of the two per-table cases fails.
+ */
+describe('getNavSummary — hasActivity (page-app activity, no installs)', () => {
+  it('🔴 a BUZZ-ATTRIBUTION row alone lights hasActivity — with hasInstalls FALSE', async () => {
+    mockDbRead.blockBuzzAttribution.findFirst.mockResolvedValue({ id: 'bba_1' });
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.getNavSummary();
+    expect(result.hasActivity).toBe(true);
+    // The whole point: this viewer has NO subscription row.
+    expect(result.hasInstalls).toBe(false);
+  });
+
+  it('🔴 a SCOPE-INVOCATION row alone lights hasActivity — with hasInstalls FALSE', async () => {
+    mockDbRead.blockScopeInvocation.findFirst.mockResolvedValue({ id: '42' });
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.getNavSummary();
+    expect(result.hasActivity).toBe(true);
+    expect(result.hasInstalls).toBe(false);
+  });
+
+  it('NEGATIVE CONTROL: an INSTALL alone does not light hasActivity', async () => {
+    // Without this the two cases above are satisfied by `hasActivity` being wired to
+    // anything at all, including `hasInstalls` itself.
+    mockDbRead.blockUserSubscription.findFirst.mockResolvedValue({ id: 'bus_1' });
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.getNavSummary();
+    expect(result.hasInstalls).toBe(true);
+    expect(result.hasActivity).toBe(false);
+  });
+
+  it('both probes empty ⇒ false (the flag is not constant-true)', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    expect((await caller.getNavSummary()).hasActivity).toBe(false);
+  });
+
+  it('each activity probe is scoped to ctx.user.id and selects only id (LIMIT 1)', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(otherModUser) as never);
+    await caller.getNavSummary();
+
+    const buzzArgs = mockDbRead.blockBuzzAttribution.findFirst.mock.calls[0][0];
+    // `userId` is the SPENDER on this table, not the app owner — the same column the
+    // feed filters on. An owner-scoped probe would light the tab for the wrong person.
+    expect(buzzArgs.where).toEqual({ userId: otherModUser.id });
+    expect(buzzArgs.select).toEqual({ id: true });
+
+    const scopeArgs = mockDbRead.blockScopeInvocation.findFirst.mock.calls[0][0];
+    expect(scopeArgs.where.userId).toBe(otherModUser.id);
+    expect(scopeArgs.select).toEqual({ id: true });
+  });
+
+  it('🔴 the scope probe MIRRORS the feed: external-OAuth rows are excluded', async () => {
+    // The global feed keeps `app-block` + synthetic dev-tunnel rows
+    // (`appBlockId IS NOT NULL OR syntheticAppId IS NOT NULL`) and drops external-OAuth
+    // rows, which carry BOTH columns null. Without this term an external-OAuth-only
+    // viewer gets an Activity tab whose feed says "No activity yet".
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await caller.getNavSummary();
+    const where = mockDbRead.blockScopeInvocation.findFirst.mock.calls[0][0].where;
+    expect(where.OR).toEqual([{ appBlockId: { not: null } }, { syntheticAppId: { not: null } }]);
+  });
+
+  it('flag OFF: neither activity probe runs', async () => {
+    mockIsAppBlocksEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    expect((await caller.getNavSummary()).hasActivity).toBe(false);
+    expect(mockDbRead.blockBuzzAttribution.findFirst).not.toHaveBeenCalled();
+    expect(mockDbRead.blockScopeInvocation.findFirst).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/routers/__tests__/blocks.router.getNavSummary.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getNavSummary.test.ts
@@ -1,3 +1,4 @@
+import { GLOBAL_SCOPE_ACTIVITY_OR } from '~/server/services/blocks/scope-activity-predicate';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
 
@@ -323,6 +324,23 @@ describe('getNavSummary — hasActivity (page-app activity, no installs)', () =>
     const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
     await caller.getNavSummary();
     const where = mockDbRead.blockScopeInvocation.findFirst.mock.calls[0][0].where;
+
+    // 🔴 IDENTITY, NOT EQUALITY — and that distinction is the whole guard. An audit WALKED the
+    // previous version of this check: it replaced the spread with a differently-spelled
+    // divergent predicate, left the `GLOBAL_SCOPE_ACTIVITY_OR` mention alive in a comment, and
+    // updated this test's own literal — the edit a developer making that change would make —
+    // and every suite stayed green (67/67) while the probe and the feed silently diverged.
+    // A `toEqual` against a literal cannot tell "read the shared constant" from "re-spelled
+    // the same clause"; `toBe` on the array reference can only pass if the object the router
+    // handed Prisma IS the exported one. That makes the single-sourcing structural instead of
+    // spelled — the exact upgrade this ladder keeps having to make.
+    expect(
+      where.OR,
+      'the probe did not pass the SHARED predicate to Prisma — it re-spelled its own copy'
+    ).toBe(GLOBAL_SCOPE_ACTIVITY_OR.OR);
+
+    // …and the shared constant still means what the feed needs. Kept as a second, cheap
+    // assertion so a change to the constant itself is not invisible here.
     expect(where.OR).toEqual([{ appBlockId: { not: null } }, { syntheticAppId: { not: null } }]);
   });
 

--- a/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
+++ b/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
@@ -168,7 +168,7 @@ describe('blocks.listMySubscriptions (guarded)', () => {
 
   // GA-relax (gotcha #66): the manage-page reflection queries are now
   // protectedProcedure (not moderatorProcedure) — a logged-in non-mod reads
-  // their OWN subscriptions, since /apps/installed is reachable by any user the
+  // their OWN subscriptions, since /apps/activity is reachable by any user the
   // per-user appBlocks flag admits. Scoped to ctx.user.id, so no cross-user read.
   it('allows a non-mod authed viewer — returns their own subscriptions', async () => {
     mockListUserSubscriptions.mockResolvedValue([]);

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -412,7 +412,7 @@ export const appsStorageRouter = router({
       ).catch(() => {});
       // User-facing audit: unify the W4 storage feed into the same Activity
       // tab that surfaces workflow + scope events. Axiom log above stays
-      // for ops/debug visibility; this row populates /apps/installed.
+      // for ops/debug visibility; this row populates /apps/activity.
       void (async () => {
         const { recordScopeInvocation } = await import(
           '~/server/services/blocks/user-app-surface.service'

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -2389,14 +2389,14 @@ export const blocksRouter = router({
   }),
 
   /**
-   * W5 v0 — reflection surface for /apps/installed. One row per app the
+   * W5 v0 — reflection surface for /apps/activity. One row per app the
    * current user has either installed on a model OR subscribed to. Counts
    * + scope intersections derived from existing tables (no grant schema
    * yet — that's W5 v1). See user-app-surface.service.ts for shape.
    */
   // GA-relax (gotcha #66, manage-page half): own-data reflection query scoped
   // to ctx.user.id. moderator→protected + the appBlocks flag below. The
-  // /apps/installed page already gates per-user on features.appBlocks, so the
+  // /apps/activity page already gates per-user on features.appBlocks, so the
   // old moderator gate just broke this tab for non-mods on flag-public surfaces.
   listMyScopeGrants: protectedProcedure.use(enforceAppBlocksFlag).query(async ({ ctx }) => {
     if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) return [];
@@ -2408,7 +2408,7 @@ export const blocksRouter = router({
   /**
    * W5 v0 — chronological feed of `block_buzz_attribution` rows where the
    * current user is the spender (NOT the app owner). Powers the activity
-   * panel on /apps/installed so users can audit what apps have spent
+   * panel on /apps/activity so users can audit what apps have spent
    * Buzz on their behalf.
    *
    * Cursor pagination by id (createdAt desc, id desc tiebreak); cap 100
@@ -2452,7 +2452,7 @@ export const blocksRouter = router({
    *
    * Identifying the target row by the subscription's `id` (not the
    * blockInstanceId) — blanket subscriptions don't have a blockInstance
-   * Id, and the management UI on /apps/installed reads `id` off the
+   * Id, and the management UI on /apps/activity reads `id` off the
    * SubscriptionRecord directly.
    */
   // GA-relax (gotcha #66): own-data management action. moderator→protected +
@@ -2579,7 +2579,7 @@ export const blocksRouter = router({
 
   /**
    * Lists every user-subscription row (both scopes) for the current viewer.
-   * Used by the management UI at /apps/installed. The app_block row is
+   * Used by the management UI at /apps/activity. The app_block row is
    * denormalised onto each subscription so the UI can render block name,
    * icon, and target slot without a second round-trip.
    */
@@ -4641,7 +4641,7 @@ export const blocksRouter = router({
       if (genClaimKey) await finalizeGenIdempotency(genClaimKey, genResult);
 
       // Log the workflow submission to the per-user activity feed so
-      // /apps/installed → Activity shows "this app ran a workflow on
+      // /apps/activity → Activity shows "this app ran a workflow on
       // your behalf at time T". Without this, generations that spend
       // existing balance (the common case) leave NO trace anywhere —
       // block_buzz_attribution only covers Buzz PURCHASES from inside

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -2609,6 +2609,7 @@ export const blocksRouter = router({
   getNavSummary: protectedProcedure.use(enforceAppBlocksFlag).query(async ({ ctx }) => {
     const allFalse = {
       hasInstalls: false,
+      hasActivity: false,
       hasSubmissions: false,
       hasApprovedApps: false,
       isReviewer: false,
@@ -2624,24 +2625,61 @@ export const blocksRouter = router({
     // `status: 'accepted'` consent filter in the codebase and failed
     // `app-access.call-site-ledger.test.ts` on the growth — one home, one filter.
     const { resolveAppsNavAccess } = await import('~/server/services/blocks/app-access.service');
-    const [install, submission, approvedApp, navAccess] = await Promise.all([
-      dbRead.blockUserSubscription.findFirst({
-        where: { userId: user.id },
-        select: { id: true },
-      }),
-      dbRead.appBlockPublishRequest.findFirst({
-        where: { submittedByUserId: user.id },
-        select: { id: true },
-      }),
-      dbRead.appBlock.findFirst({
-        where: { app: { userId: user.id }, status: 'approved' },
-        select: { id: true },
-      }),
-      resolveAppsNavAccess(user.id),
-    ]);
+    const [install, buzzActivity, scopeActivity, submission, approvedApp, navAccess] =
+      await Promise.all([
+        dbRead.blockUserSubscription.findFirst({
+          where: { userId: user.id },
+          select: { id: true },
+        }),
+        // 🔴 THE TWO ACTIVITY PROBES BELOW ARE THE TWO TABLES `/apps/activity` ACTUALLY
+        // WALKS — `listMyAppActivity` reads `block_buzz_attribution` filtered on the
+        // SPENDER's `userId`, and `listMyScopeInvocations` reads
+        // `block_scope_invocations` on the same column (both in
+        // `~/server/services/blocks/user-app-surface.service`). They are NOT a proxy for
+        // "the user did something app-ish": a probe on a table the feed does not read
+        // would light a tab over an empty page, which is the mirror of the defect this
+        // whole row exists to close.
+        dbRead.blockBuzzAttribution.findFirst({
+          where: { userId: user.id },
+          select: { id: true },
+        }),
+        // The scope-invocation half MIRRORS the feed's own WHERE clause, including the
+        // external-OAuth exclusion: the global feed keeps `app-block` and synthetic
+        // dev-tunnel rows (`appBlockId IS NOT NULL OR syntheticAppId IS NOT NULL`) and
+        // drops external-OAuth rows, which carry BOTH columns null. Without that term an
+        // external-OAuth-only viewer would be shown an Activity tab whose feed renders
+        // "No activity yet". Both columns are PRE-EXISTING, so this read is safe whether
+        // or not the `source`/`oauth_client_id` migration has been applied.
+        dbRead.blockScopeInvocation.findFirst({
+          where: {
+            userId: user.id,
+            OR: [{ appBlockId: { not: null } }, { syntheticAppId: { not: null } }],
+          },
+          select: { id: true },
+        }),
+        dbRead.appBlockPublishRequest.findFirst({
+          where: { submittedByUserId: user.id },
+          select: { id: true },
+        }),
+        dbRead.appBlock.findFirst({
+          where: { app: { userId: user.id }, status: 'approved' },
+          select: { id: true },
+        }),
+        resolveAppsNavAccess(user.id),
+      ]);
 
     return {
       hasInstalls: install !== null,
+      /**
+       * 🔴 ACTIVITY IS NOT INSTALLS, AND THAT IS THE WHOLE REASON THIS FIELD EXISTS.
+       * `hasInstalls` is a `block_user_subscriptions` row — a SLOT subscription. A
+       * FULL-PAGE app (`/apps/run/<slug>`) is stateless by design and writes no such row
+       * ("no `block_user_subscriptions` row, no migration" — the run route's own header),
+       * so a viewer who only ever runs page apps has a populated activity feed and
+       * `hasInstalls: false`. Keying the Activity tab on installs alone hid the page from
+       * exactly the cohort the `/apps/installed` → `/apps/activity` rename widened it for.
+       */
+      hasActivity: buzzActivity !== null || scopeActivity !== null,
       hasSubmissions: submission !== null,
       hasApprovedApps: approvedApp !== null,
       isReviewer: isAppReviewer(user),

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1,4 +1,4 @@
-import { GLOBAL_SCOPE_ACTIVITY_OR } from '~/server/services/blocks/user-app-surface.service';
+import { GLOBAL_SCOPE_ACTIVITY_OR } from '~/server/services/blocks/scope-activity-predicate';
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
 import {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1,3 +1,4 @@
+import { GLOBAL_SCOPE_ACTIVITY_OR } from '~/server/services/blocks/user-app-surface.service';
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
 import {
@@ -2653,7 +2654,10 @@ export const blocksRouter = router({
         dbRead.blockScopeInvocation.findFirst({
           where: {
             userId: user.id,
-            OR: [{ appBlockId: { not: null } }, { syntheticAppId: { not: null } }],
+            // 🔴 IMPORTED, NEVER RE-SPELLED — see GLOBAL_SCOPE_ACTIVITY_OR. A second copy of
+            // this OR is the exact drift an audit demonstrated: tighten the feed, update the
+            // feed's own literal, and both suites stay green while this probe over-matches.
+            ...GLOBAL_SCOPE_ACTIVITY_OR,
           },
           select: { id: true },
         }),

--- a/src/server/schema/blocks/subscription.schema.ts
+++ b/src/server/schema/blocks/subscription.schema.ts
@@ -87,7 +87,7 @@ export type UpsertSubscriptionInput = z.infer<typeof upsertSubscriptionSchema>;
  * `availableVersions` is the list of approved publish_request versions
  * for the underlying app, newest-first. Empty when the app has no
  * recorded publish requests (pre-W1 hackathon rows). Powers the version
- * Select on /apps/installed for pinned subscriptions.
+ * Select on /apps/activity for pinned subscriptions.
  */
 export type SubscriptionRecord = {
   id: string;

--- a/src/server/services/__tests__/app-blocks-flag.external-scope.seam.test.ts
+++ b/src/server/services/__tests__/app-blocks-flag.external-scope.seam.test.ts
@@ -399,7 +399,7 @@ describe('🔴 the external-ONLY viewer: reachable, and scoped to offsite', () =
   });
 
   it('🔴 does NOT widen any block-RUNTIME surface', async () => {
-    // `/apps/installed`, `/apps/run/<slug>`, the `blocks.*` procs and the author
+    // `/apps/activity`, `/apps/run/<slug>`, the `blocks.*` procs and the author
     // surfaces gate on `appBlocks` / `appBlocksPages` / `appBlocksAuthor` alone.
     // The external cohort must reach the CATALOG and nothing else.
     const features = clientFeatures(makeUser({ id: 777 }));

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -2691,7 +2691,7 @@ export class BlockRegistry {
     //   (a) Render "Pinned to: <Model Name>" badges on the management UI
     //       for pinned subscriptions, without a second per-row round-trip.
     //   (b) List available approved versions per app for the version pin
-    //       Select on /apps/installed. Empty array when the app has no
+    //       Select on /apps/activity. Empty array when the app has no
     //       publish_request rows (pre-W1 hackathon apps).
     const pinnedModelIds = new Set<number>();
     for (const row of rows) {

--- a/src/server/services/blocks/__tests__/scopeActivityPredicate.test.ts
+++ b/src/server/services/blocks/__tests__/scopeActivityPredicate.test.ts
@@ -1,81 +1,66 @@
 import { describe, expect, it } from 'vitest';
-import { GLOBAL_SCOPE_ACTIVITY_OR } from '~/server/services/blocks/user-app-surface.service';
+import { GLOBAL_SCOPE_ACTIVITY_OR } from '~/server/services/blocks/scope-activity-predicate';
 
 /**
- * 🔴 THE SEAM BETWEEN `getNavSummary`'s `hasActivity` PROBE AND THE ACTIVITY FEED ITSELF.
+ * 🔴 THE SHAPE OF THE SHARED SCOPE-ACTIVITY PREDICATE. The two call sites that must agree —
+ * `blocks.getNavSummary`'s `hasActivity` probe (does the viewer get an Activity TAB?) and
+ * `listMyScopeInvocations` (what does that tab CONTAIN?) — are pinned by IDENTITY in their own
+ * suites, not here:
+ *   · `blocks.router.getNavSummary.test.ts` → `expect(where.OR).toBe(GLOBAL_SCOPE_ACTIVITY_OR.OR)`
+ *   · `user-app-surface.orchestration.test.ts` → the same `toBe` on the feed's `where.OR`
+ * This file only pins what the constant MEANS.
  *
- * The nav probe decides whether a viewer is offered an Activity TAB; the feed decides what that
- * tab CONTAINS. They must agree about which scope-invocation rows count as activity, or one of
- * two defects ships:
- *   · probe wider than feed  → a tab over a page reading "No activity yet";
- *   · probe narrower than feed → the no-tab bug this PR exists to fix, silently restored.
- *
- * 🔴 THIS FILE EXISTS BECAUSE THE TWO-COPY VERSION WAS DEMONSTRATED TO DRIFT SILENTLY, not
- * argued to. Both sides previously asserted their own `where` against a hand-copied literal in
- * their own suite. An audit tightened the FEED's clause and updated the FEED's own literal —
- * exactly the edit a developer making that change would make — and **both suites stayed green,
- * 65/65**, while the probe over-matched. Neither guard could see the other move. That is the
- * "docstring names a RELATIONSHIP, body inspects one SIDE" shape.
- *
- * 🔴 SO THE FIX IS THE EXPORT, AND THIS FILE ONLY PINS THAT THE EXPORT IS WHAT BOTH SIDES READ.
- * `GLOBAL_SCOPE_ACTIVITY_OR` now lives once in `user-app-surface.service.ts`; the feed spreads
- * it and `blocks.router.ts` imports it. Change the predicate there and BOTH move by
- * construction — which is a stronger guarantee than any assertion, and is why the test below
- * deliberately does NOT re-spell the clause as a third literal. A third copy would recreate the
- * very defect this closes.
+ * 🔴 IT USED TO TRY TO DO BOTH JOBS, AND THE SECOND ONE WAS WALKABLE — recorded because the
+ * replacement is the lesson. It asserted that the string `GLOBAL_SCOPE_ACTIVITY_OR` appeared
+ * somewhere in `blocks.router.ts` and that a 29-character literal did not. An audit walked it
+ * in one edit: swap the spread for a differently-spelled divergent predicate, leave the symbol
+ * alive in a COMMENT, update the router test's own literal — and **67/67 stayed green** while
+ * the probe and the feed diverged, silently restoring the no-tab defect this change exists to
+ * fix. A guard on WORDS is satisfied by re-wording; only a guard on the VALUE that reached
+ * Prisma can tell "read the shared constant" from "re-spelled the same clause". Hence `toBe`,
+ * in the suites that can observe the actual call, and no file-scanning here.
  */
-describe('🔴 the scope-activity predicate is single-sourced', () => {
+describe('🔴 the shared scope-activity predicate', () => {
   it('is a non-empty OR over exactly the two columns that mark an in-platform row', () => {
-    // Structural, not a spelling: an external-OAuth row carries NEITHER column, so an OR over
-    // these two is what excludes it. Asserting the SHAPE rather than a copied literal keeps
-    // this from becoming the third copy.
+    // Structural rather than a spelling: an external-OAuth row carries NEITHER column, so an
+    // OR over exactly these two is what excludes it. Asserting the shape rather than copying
+    // the clause keeps this from becoming a third literal to drift against.
     expect(Array.isArray(GLOBAL_SCOPE_ACTIVITY_OR.OR)).toBe(true);
     expect(GLOBAL_SCOPE_ACTIVITY_OR.OR.length).toBeGreaterThan(0);
 
     const columns = GLOBAL_SCOPE_ACTIVITY_OR.OR.map((clause) => Object.keys(clause)[0]).sort();
     expect(columns).toEqual(['appBlockId', 'syntheticAppId']);
 
-    // Every disjunct must be an EXISTENCE test. `{ appBlockId: someValue }` would silently
-    // narrow the feed to one app while still passing a key-name check.
+    // Every disjunct must be an EXISTENCE test. `{ appBlockId: someValue }` would narrow the
+    // feed to a single app while still satisfying a key-name check.
     for (const clause of GLOBAL_SCOPE_ACTIVITY_OR.OR) {
       expect(Object.values(clause)[0]).toEqual({ not: null });
     }
   });
 
-  it('🔴 both call sites READ this symbol rather than re-spelling the clause', async () => {
-    // The guarantee is structural — one exported object, two importers — so what this pins is
-    // that neither side has quietly reintroduced its own copy. A literal `OR: [{ appBlockId`
-    // in either file is that regression, and it is what this asserts against.
+  it('lives in a LEAF module — importing it must not drag a service into a caller graph', async () => {
+    // 🔴 THIS IS WHY THE CONSTANT MOVED. It briefly lived in `user-app-surface.service.ts`,
+    // which put that heavy service into `blocks.router.ts`'s STATIC import graph — the exact
+    // thing that router's five `await import(…)` sites exist to avoid, and which four router
+    // suites' one-key `vi.mock` factories would have tripped over. A leaf module whose only
+    // import is TYPE-ONLY costs nothing at runtime.
     const fs = await import('fs/promises');
     const path = await import('path');
-    const root = path.resolve(__dirname, '../../../..'); // -> src/
-
-    const router = await fs.readFile(path.join(root, 'server/routers/blocks.router.ts'), 'utf8');
-    const service = await fs.readFile(
-      path.join(root, 'server/services/blocks/user-app-surface.service.ts'),
+    const src = await fs.readFile(
+      path.resolve(__dirname, '../scope-activity-predicate.ts'),
       'utf8'
     );
 
-    // Positive control: the symbol is genuinely present in both, so a zero below is a real
-    // absence rather than a mis-typed path or an unread file.
-    expect(router, 'the router does not reference the shared predicate at all').toContain(
-      'GLOBAL_SCOPE_ACTIVITY_OR'
-    );
-    expect(service, 'the service does not reference the shared predicate at all').toContain(
+    // Positive control: the file was actually read and holds the constant.
+    expect(src, 'the leaf module does not define the constant').toContain(
       'GLOBAL_SCOPE_ACTIVITY_OR'
     );
 
-    // The router must not carry its own spelling of the clause.
-    expect(
-      router.includes('{ appBlockId: { not: null } }'),
-      'blocks.router.ts re-spells the scope-activity OR instead of importing GLOBAL_SCOPE_ACTIVITY_OR — that is the second copy whose drift is silent'
-    ).toBe(false);
-
-    // The service may spell it EXACTLY ONCE — inside the exported constant itself.
-    const spellings = [...service.matchAll(/\{ appBlockId: \{ not: null \} \}/g)].length;
-    expect(
-      spellings,
-      'the scope-activity OR is spelled more than once in the service — the export should be its only definition'
-    ).toBe(1);
+    // Every import in it must be type-only, so nothing here can reach a runtime graph.
+    const imports = [...src.matchAll(/^import\s+(type\s+)?/gm)];
+    expect(imports.length, 'the leaf module has no imports to classify').toBeGreaterThan(0);
+    for (const m of imports) {
+      expect(m[1], `a VALUE import in the leaf module: ${m[0].trim()}`).toBeTruthy();
+    }
   });
 });

--- a/src/server/services/blocks/__tests__/scopeActivityPredicate.test.ts
+++ b/src/server/services/blocks/__tests__/scopeActivityPredicate.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { GLOBAL_SCOPE_ACTIVITY_OR } from '~/server/services/blocks/user-app-surface.service';
+
+/**
+ * 🔴 THE SEAM BETWEEN `getNavSummary`'s `hasActivity` PROBE AND THE ACTIVITY FEED ITSELF.
+ *
+ * The nav probe decides whether a viewer is offered an Activity TAB; the feed decides what that
+ * tab CONTAINS. They must agree about which scope-invocation rows count as activity, or one of
+ * two defects ships:
+ *   · probe wider than feed  → a tab over a page reading "No activity yet";
+ *   · probe narrower than feed → the no-tab bug this PR exists to fix, silently restored.
+ *
+ * 🔴 THIS FILE EXISTS BECAUSE THE TWO-COPY VERSION WAS DEMONSTRATED TO DRIFT SILENTLY, not
+ * argued to. Both sides previously asserted their own `where` against a hand-copied literal in
+ * their own suite. An audit tightened the FEED's clause and updated the FEED's own literal —
+ * exactly the edit a developer making that change would make — and **both suites stayed green,
+ * 65/65**, while the probe over-matched. Neither guard could see the other move. That is the
+ * "docstring names a RELATIONSHIP, body inspects one SIDE" shape.
+ *
+ * 🔴 SO THE FIX IS THE EXPORT, AND THIS FILE ONLY PINS THAT THE EXPORT IS WHAT BOTH SIDES READ.
+ * `GLOBAL_SCOPE_ACTIVITY_OR` now lives once in `user-app-surface.service.ts`; the feed spreads
+ * it and `blocks.router.ts` imports it. Change the predicate there and BOTH move by
+ * construction — which is a stronger guarantee than any assertion, and is why the test below
+ * deliberately does NOT re-spell the clause as a third literal. A third copy would recreate the
+ * very defect this closes.
+ */
+describe('🔴 the scope-activity predicate is single-sourced', () => {
+  it('is a non-empty OR over exactly the two columns that mark an in-platform row', () => {
+    // Structural, not a spelling: an external-OAuth row carries NEITHER column, so an OR over
+    // these two is what excludes it. Asserting the SHAPE rather than a copied literal keeps
+    // this from becoming the third copy.
+    expect(Array.isArray(GLOBAL_SCOPE_ACTIVITY_OR.OR)).toBe(true);
+    expect(GLOBAL_SCOPE_ACTIVITY_OR.OR.length).toBeGreaterThan(0);
+
+    const columns = GLOBAL_SCOPE_ACTIVITY_OR.OR.map((clause) => Object.keys(clause)[0]).sort();
+    expect(columns).toEqual(['appBlockId', 'syntheticAppId']);
+
+    // Every disjunct must be an EXISTENCE test. `{ appBlockId: someValue }` would silently
+    // narrow the feed to one app while still passing a key-name check.
+    for (const clause of GLOBAL_SCOPE_ACTIVITY_OR.OR) {
+      expect(Object.values(clause)[0]).toEqual({ not: null });
+    }
+  });
+
+  it('🔴 both call sites READ this symbol rather than re-spelling the clause', async () => {
+    // The guarantee is structural — one exported object, two importers — so what this pins is
+    // that neither side has quietly reintroduced its own copy. A literal `OR: [{ appBlockId`
+    // in either file is that regression, and it is what this asserts against.
+    const fs = await import('fs/promises');
+    const path = await import('path');
+    const root = path.resolve(__dirname, '../../../..'); // -> src/
+
+    const router = await fs.readFile(path.join(root, 'server/routers/blocks.router.ts'), 'utf8');
+    const service = await fs.readFile(
+      path.join(root, 'server/services/blocks/user-app-surface.service.ts'),
+      'utf8'
+    );
+
+    // Positive control: the symbol is genuinely present in both, so a zero below is a real
+    // absence rather than a mis-typed path or an unread file.
+    expect(router, 'the router does not reference the shared predicate at all').toContain(
+      'GLOBAL_SCOPE_ACTIVITY_OR'
+    );
+    expect(service, 'the service does not reference the shared predicate at all').toContain(
+      'GLOBAL_SCOPE_ACTIVITY_OR'
+    );
+
+    // The router must not carry its own spelling of the clause.
+    expect(
+      router.includes('{ appBlockId: { not: null } }'),
+      'blocks.router.ts re-spells the scope-activity OR instead of importing GLOBAL_SCOPE_ACTIVITY_OR — that is the second copy whose drift is silent'
+    ).toBe(false);
+
+    // The service may spell it EXACTLY ONCE — inside the exported constant itself.
+    const spellings = [...service.matchAll(/\{ appBlockId: \{ not: null \} \}/g)].length;
+    expect(
+      spellings,
+      'the scope-activity OR is spelled more than once in the service — the export should be its only definition'
+    ).toBe(1);
+  });
+});

--- a/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
@@ -1,3 +1,4 @@
+import { GLOBAL_SCOPE_ACTIVITY_OR } from '~/server/services/blocks/scope-activity-predicate';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
@@ -493,6 +494,16 @@ describe('listMyScopeInvocations', () => {
     const { listMyScopeInvocations } = await import('../user-app-surface.service');
     await listMyScopeInvocations({ userId: 42 });
     const arg = mockDbRead.blockScopeInvocation.findMany.mock.calls[0][0];
+    // 🔴 IDENTITY FIRST — the feed's half of the guard the probe now carries. `toEqual`
+    // against the literal below cannot distinguish "spread the shared constant" from
+    // "re-spelled the same clause here", and an audit walked exactly that ambiguity on the
+    // probe side (67/67 green over a divergent copy). `toBe` on the array reference can only
+    // pass if what reached Prisma IS the exported object.
+    expect(
+      arg.where.OR,
+      'the feed did not pass the SHARED predicate to Prisma — it re-spelled its own copy'
+    ).toBe(GLOBAL_SCOPE_ACTIVITY_OR.OR);
+
     expect(arg.where).toEqual({
       userId: 42,
       // app-block row (appBlockId set) → matched by predicate 1;
@@ -509,7 +520,12 @@ describe('listMyScopeInvocations', () => {
     const { listMyScopeInvocations } = await import('../user-app-surface.service');
     // A pre-approval dev-tunnel invocation: no AppBlock row, synthetic ref set.
     mockDbRead.blockScopeInvocation.findMany.mockResolvedValue([
-      invocationRow({ id: 7n, appBlockId: null, appBlock: null, syntheticAppId: 'ephemeral-my-app' }),
+      invocationRow({
+        id: 7n,
+        appBlockId: null,
+        appBlock: null,
+        syntheticAppId: 'ephemeral-my-app',
+      }),
     ]);
     const result = await listMyScopeInvocations({ userId: 42 });
     // The mapper returns the row (does not crash on a null appBlockId) — it is
@@ -544,9 +560,7 @@ describe('listMyScopeInvocations', () => {
   it('emits a nextCursor when the page is full and silently ignores a malformed inbound cursor', async () => {
     const { listMyScopeInvocations } = await import('../user-app-surface.service');
     // 1 more row than limit → hasNext + nextCursor is the last visible id.
-    const rows = Array.from({ length: 3 }, (_, i) =>
-      invocationRow({ id: BigInt(100 - i) })
-    );
+    const rows = Array.from({ length: 3 }, (_, i) => invocationRow({ id: BigInt(100 - i) }));
     mockDbRead.blockScopeInvocation.findMany.mockResolvedValue(rows);
     const result = await listMyScopeInvocations({
       userId: 42,

--- a/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
@@ -280,14 +280,32 @@ describe('listMyAppActivity', () => {
     expect(result.items[0].appName).toBe('gen-from-model');
   });
 
-  it('falls back to appBlockId when appBlock relation is null (defensive)', async () => {
+  /**
+   * 🔴 THIS TEST USED TO ASSERT `appSlug` FELL BACK TO `appBlockId`, AND THAT EXPECTATION
+   * WAS THE DEFECT WRITTEN DOWN. `appBlockId` is the FOREIGN KEY — the AppBlock's `id` —
+   * while `appSlug` is consumed as a store slug: `ActivityAppName` builds
+   * `/apps/store-preview/<slug>` from it, and `AppListing.slug` mirrors
+   * `AppBlock.blockId`, never the id. So the "defensive" fallback handed the UI a primary
+   * key dressed as a slug and produced a link that can only 404 — offered precisely on
+   * the rows where the app is least resolvable.
+   *
+   * The two halves are now deliberately DIFFERENT, which is the whole point:
+   *   • `appName` keeps the fallback — a display string with no navigational meaning.
+   *   • `appSlug` goes NULL — there is no listing to link to, and the consumer renders
+   *     plain text (`AppNameCrumb`'s rule, applied at the source).
+   */
+  it('🔴 appSlug is NULL when the appBlock relation is null — never the primary key', async () => {
     const { listMyAppActivity } = await import('../user-app-surface.service');
     mockDbRead.blockBuzzAttribution.findMany.mockResolvedValue([
       row({ appBlock: null, appBlockId: 'apb_x' }),
     ]);
     const result = await listMyAppActivity({ userId: 42 });
+    // The DISPLAY name still degrades to an identifier rather than to nothing.
     expect(result.items[0].appName).toBe('apb_x');
-    expect(result.items[0].appSlug).toBe('apb_x');
+    expect(
+      result.items[0].appSlug,
+      'the AppBlock PRIMARY KEY was emitted as a store slug — /apps/store-preview/<pk> 404s'
+    ).toBeNull();
   });
 
   it('orderBy is createdAt desc + id desc tiebreak', async () => {
@@ -498,6 +516,29 @@ describe('listMyScopeInvocations', () => {
     // present in the dev's own audit feed, restoring the pre-PR behaviour.
     expect(result.items).toHaveLength(1);
     expect(result.items[0].id).toBe('7');
+    // 🔴 …AND ITS `appSlug` IS NULL, NOT THE PRIMARY KEY. This is the LIVE instance of
+    // the fallback defect, not a defensive one: a synthetic dev-tunnel row genuinely has
+    // no AppBlock, so `?? r.appBlockId` used to emit an id (or, here, `null`'s
+    // stand-in) into a value the UI turns into `/apps/store-preview/<slug>`. There is no
+    // listing for a pre-approval app, so there must be no link. See "the appSlug
+    // contract" in the service.
+    expect(result.items[0].appSlug).toBeNull();
+  });
+
+  it('🔴 appSlug is NULL when the AppBlock join fails on a row that HAS an appBlockId', async () => {
+    // The other shape: `appBlockId` is set (a real FK) but the relation did not resolve.
+    // The old fallback emitted that FK — an `AppBlock.id` — as the store slug. Split from
+    // the synthetic case above so each dies for its own reason.
+    const { listMyScopeInvocations } = await import('../user-app-surface.service');
+    mockDbRead.blockScopeInvocation.findMany.mockResolvedValue([
+      invocationRow({ id: 8n, appBlockId: 'apb_orphan', appBlock: null }),
+    ]);
+    const result = await listMyScopeInvocations({ userId: 42 });
+    expect(result.items[0].appSlug).toBeNull();
+    // POSITIVE CONTROL for the assertion above: a resolvable row DOES carry its slug, so
+    // "null" is not simply what this feed always returns.
+    mockDbRead.blockScopeInvocation.findMany.mockResolvedValue([invocationRow({ id: 9n })]);
+    expect((await listMyScopeInvocations({ userId: 42 })).items[0].appSlug).toBe('who-am-i');
   });
 
   it('emits a nextCursor when the page is full and silently ignores a malformed inbound cursor', async () => {

--- a/src/server/services/blocks/scope-activity-predicate.ts
+++ b/src/server/services/blocks/scope-activity-predicate.ts
@@ -1,0 +1,42 @@
+import type { Prisma } from '@prisma/client';
+
+/**
+ * 🔴 THE ONE DEFINITION OF "a scope invocation that COUNTS as app activity".
+ *
+ * An `app-block` row carries `appBlockId`; a synthetic dev-tunnel row carries `syntheticAppId`;
+ * an EXTERNAL-OAUTH row carries NEITHER and must be excluded — otherwise an external-OAuth-only
+ * viewer is handed an Activity tab over a feed that reads "No activity yet".
+ *
+ * Read by exactly two call sites, which must never disagree:
+ *   · `listMyScopeInvocations` (the FEED) — what the Activity page shows;
+ *   · `blocks.getNavSummary`'s `hasActivity` probe — whether the Activity TAB is offered.
+ * Probe wider than feed ⇒ a tab over an empty page. Probe narrower ⇒ the no-tab defect this
+ * whole change exists to fix.
+ *
+ * ── WHY THIS IS ITS OWN LEAF MODULE ──────────────────────────────────────────────
+ * 🔴 IT LIVED IN `user-app-surface.service.ts` FOR ONE ROUND AND THAT PUT A HEAVY SERVICE INTO
+ * A HOT ROUTER'S STATIC GRAPH. `blocks.router.ts` deliberately keeps that service OUT of its
+ * eager imports — it says so at its own `await import(…)` sites, and
+ * `blocks.router.workflow.test.ts` calls the module "REAL, heavy" and mocks it so its first
+ * real import does not serialise the module runner. Importing a shared constant from it made
+ * all five of those lazy imports graph-inert, and silently re-armed the cost the pattern
+ * exists to avoid: an import added to the service later — say `image.service` to resolve app
+ * art — would land in the router's eager graph with nothing to flag it.
+ *
+ * It also broke four router suites' one-key `vi.mock` factories in waiting: they stub that
+ * service with `recordScopeInvocation` alone, so the first nav-summary case added there would
+ * have thrown `No "GLOBAL_SCOPE_ACTIVITY_OR" export is defined on the … mock`. A leaf module
+ * with a TYPE-ONLY Prisma import costs nothing at runtime and removes both hazards.
+ *
+ * ── AND WHY IT IS TYPED AGAINST PRISMA ───────────────────────────────────────────
+ * 🔴 A LOOSER ANNOTATION ERASED A REAL COMPILE-TIME CHECK, MEASURED. The first version was
+ * `{ OR: Array<Record<string, { not: null }>> }`, chosen only to dodge a readonly-tuple error.
+ * `Record<string, …>` does not constrain KEY NAMES: an audit typo'd `appBlockId` → `appBlokId`
+ * inside the constant and `pnpm run typecheck` reported **0 errors**, where the same typo in
+ * the pre-refactor inline literal reported `TS2561 … 'appBlokId' does not exist in type
+ * 'BlockScopeInvocationWhereInput'`. Typing the array as Prisma's own input restores that and
+ * compiles clean, so the loose form bought nothing.
+ */
+export const GLOBAL_SCOPE_ACTIVITY_OR: { OR: Prisma.BlockScopeInvocationWhereInput[] } = {
+  OR: [{ appBlockId: { not: null } }, { syntheticAppId: { not: null } }],
+};

--- a/src/server/services/blocks/scope-descriptions.constants.ts
+++ b/src/server/services/blocks/scope-descriptions.constants.ts
@@ -3,7 +3,7 @@
  *
  * Shared by:
  *   - /apps/review (mod-facing manifest viewer)
- *   - /apps/installed (viewer-facing "what does this app claim" section)
+ *   - /apps/activity (viewer-facing "what does this app claim" section)
  *
  * Unknown scope/slot ids render as bare chips without a description —
  * keeping this map a soft contract means new scopes ship without breaking

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -174,12 +174,43 @@ export type AppActivityItem = {
   createdAt: Date;
   appBlockId: string;
   appName: string;
-  appSlug: string;
+  /**
+   * The app's STORE-LISTING slug (`AppBlock.blockId`), or NULL when the row's AppBlock
+   * does not resolve. See "the appSlug contract" below — it is never an `AppBlock.id`.
+   */
+  appSlug: string | null;
   blockInstanceId: string;
   scope: string;
   usdAmountCents: number;
   status: string;
 };
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * THE `appSlug` CONTRACT — shared by BOTH activity feeds below.
+ *
+ * 🔴 `appSlug` IS A STORE-LISTING SLUG OR IT IS NULL — IT IS NEVER AN `AppBlock` PRIMARY
+ * KEY, AND THE FALLBACK THAT MADE IT ONE WAS A GUARANTEED 404.
+ *
+ * Both feeds used to emit `appSlug: r.appBlock?.blockId ?? r.appBlockId`. Those two
+ * columns are not interchangeable: `AppBlock.blockId` is the SLUG that `AppListing.slug`
+ * mirrors (`app-listing-mapper.ts` writes `slug: ab.blockId`) and that
+ * `/apps/run/<slug>` resolves, while `appBlockId` is the FOREIGN KEY — the AppBlock's
+ * `id`. So whenever the join did NOT resolve, the fallback handed the UI a primary key
+ * dressed as a slug, and `ActivityAppName` rendered `/apps/store-preview/<pk>`: a link
+ * that can only 404, offered precisely on the rows where the app is least resolvable.
+ * That join genuinely does come back null — a scope-invocation row's `appBlockId` is
+ * NULLABLE (a pre-approval App-Dev-Tunnel spend writes `appBlockId: null` +
+ * `syntheticAppId`), and a `Restrict`-deleted AppBlock leaves the same shape.
+ *
+ * The fix is a NULL, not a better fallback: a row with no resolvable AppBlock has no
+ * listing to link to, and the consumer's job is to render plain text. That is
+ * `AppNameCrumb`'s rule ("Omitted → no store cluster … not a broken link"), applied at
+ * the source rather than re-derived per call site — and it is deliberately NOT a
+ * per-row client fetch, which on a paginated table would be an N+1.
+ *
+ * `appName` keeps its `?? r.appBlockId` tail on purpose: that is a DISPLAY string with no
+ * navigational meaning, so a last-resort identifier there is worse-looking, not broken.
+ * ──────────────────────────────────────────────────────────────────────────── */
 
 export type AppActivityPage = {
   items: AppActivityItem[];
@@ -258,7 +289,9 @@ export async function listMyAppActivity({
       createdAt: r.attributedAt,
       appBlockId: r.appBlockId,
       appName,
-      appSlug: r.appBlock?.blockId ?? r.appBlockId,
+      // NULL, not `?? r.appBlockId` — see "the appSlug contract" above. `appBlockId` is
+      // the FK (AppBlock.id), and emitting it here produced `/apps/store-preview/<pk>`.
+      appSlug: r.appBlock?.blockId ?? null,
       blockInstanceId: r.blockInstanceId,
       scope: r.scope,
       usdAmountCents: r.usdAmountCents,
@@ -333,7 +366,13 @@ export type ScopeInvocationItem = {
   createdAt: Date;
   appBlockId: string;
   appName: string;
-  appSlug: string;
+  /**
+   * The app's STORE-LISTING slug (`AppBlock.blockId`), or NULL when the row's AppBlock
+   * does not resolve — which on THIS feed is a live case, not a theoretical one: a
+   * pre-approval App-Dev-Tunnel spend writes `appBlockId: null` + `syntheticAppId`. See
+   * "the appSlug contract" above `AppActivityItem`.
+   */
+  appSlug: string | null;
   blockInstanceId: string;
   scope: string;
   endpoint: string;
@@ -447,7 +486,9 @@ export async function listMyScopeInvocations(opts: {
       createdAt: r.invokedAt,
       appBlockId: r.appBlockId,
       appName,
-      appSlug: r.appBlock?.blockId ?? r.appBlockId,
+      // NULL, not `?? r.appBlockId` — see "the appSlug contract" above. `appBlockId` is
+      // the FK (AppBlock.id), and emitting it here produced `/apps/store-preview/<pk>`.
+      appSlug: r.appBlock?.blockId ?? null,
       blockInstanceId: r.blockInstanceId,
       scope: r.scope,
       endpoint: r.endpoint,

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -117,9 +117,7 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
   for (const row of subs) {
     if (!row.appBlock) continue;
     const isPinned =
-      row.slotId !== null &&
-      Array.isArray(row.targetModelIds) &&
-      row.targetModelIds.length > 0;
+      row.slotId !== null && Array.isArray(row.targetModelIds) && row.targetModelIds.length > 0;
     const existing = byAppBlock.get(row.appBlockId);
     if (existing) {
       if (isPinned) existing.modelInstallCount += row.targetModelIds.length;
@@ -218,6 +216,27 @@ export type AppActivityPage = {
 };
 
 const APP_ACTIVITY_MAX_LIMIT = 100;
+
+/**
+ * 🔴 THE ONE DEFINITION OF "a scope invocation that COUNTS as app activity", exported so
+ * `blocks.getNavSummary`'s `hasActivity` probe can import it instead of keeping a second copy.
+ *
+ * An `app-block` row has `appBlockId`; a synthetic dev-tunnel row has `syntheticAppId`; an
+ * EXTERNAL-OAUTH row has NEITHER, and must be excluded — otherwise an external-OAuth-only
+ * viewer is handed an Activity tab over a feed that says "No activity yet".
+ *
+ * 🔴 WHY THIS IS EXPORTED RATHER THAN WRITTEN TWICE. It was written twice, and an audit
+ * DEMONSTRATED the drift rather than arguing it: tightening the FEED's clause and updating the
+ * feed's own test literal — exactly what someone making that change would do — left BOTH
+ * sides' suites green (65/65) while the probe silently over-matched. Each test asserted its own
+ * side against a hand-copied literal, so neither could see the other move. That is the
+ * "docstring names a RELATIONSHIP, body inspects one SIDE" defect. One export closes it: a
+ * future edit here moves the probe by construction, and `__tests__/scopeActivityPredicate.test.ts`
+ * pins that both call sites read THIS symbol rather than re-spelling it.
+ */
+export const GLOBAL_SCOPE_ACTIVITY_OR: { OR: Array<Record<string, { not: null }>> } = {
+  OR: [{ appBlockId: { not: null } }, { syntheticAppId: { not: null } }],
+};
 
 /**
  * Paginated, viewer-scoped activity feed. Walks `block_buzz_attribution`
@@ -448,9 +467,7 @@ export async function listMyScopeInvocations(opts: {
     // client types (CI-regenerated; may lag locally).
     where: {
       userId: opts.userId,
-      ...(opts.appBlockId
-        ? { appBlockId: opts.appBlockId }
-        : { OR: [{ appBlockId: { not: null } }, { syntheticAppId: { not: null } }] }),
+      ...(opts.appBlockId ? { appBlockId: opts.appBlockId } : GLOBAL_SCOPE_ACTIVITY_OR),
     } as unknown as Prisma.BlockScopeInvocationWhereInput,
     orderBy: [{ invokedAt: 'desc' }, { id: 'desc' }],
     take: cappedLimit + 1,
@@ -471,9 +488,7 @@ export async function listMyScopeInvocations(opts: {
   const hasNext = rows.length > cappedLimit;
   const visible = hasNext ? rows.slice(0, cappedLimit) : rows;
   const nextCursor =
-    hasNext && visible.length > 0
-      ? visible[visible.length - 1]!.id.toString()
-      : null;
+    hasNext && visible.length > 0 ? visible[visible.length - 1]!.id.toString() : null;
 
   const items: ScopeInvocationItem[] = visible.map((r) => {
     const manifest = (r.appBlock?.manifest ?? {}) as { name?: unknown };
@@ -600,15 +615,18 @@ export async function recordScopeInvocation(opts: {
     // an FK violation so a deleted REAL app on the normal path keeps the historical
     // "log, no row" behaviour (never mislabelled synthetic).
     const isFkViolation =
-      typeof err === 'object' &&
-      err !== null &&
-      (err as { code?: unknown }).code === 'P2003';
+      typeof err === 'object' && err !== null && (err as { code?: unknown }).code === 'P2003';
     // Gate the synthetic path on a SYNTHETIC-id PREFIX, not merely `dev && P2003`.
     // A dev token can carry a REAL `apb_<ulid>` appBlockId whose AppBlock row was
     // deleted between mint and spend — that FK-fails too, but it is NOT synthetic,
     // so it must keep the historical "log, no row" behaviour (never mislabelled
     // `synthetic_app_id = <real id>`). Only a genuine synthetic namespace retries.
-    if (opts.dev && isFkViolation && opts.appBlockId != null && isSyntheticAppBlockId(opts.appBlockId)) {
+    if (
+      opts.dev &&
+      isFkViolation &&
+      opts.appBlockId != null &&
+      isSyntheticAppBlockId(opts.appBlockId)
+    ) {
       try {
         // `appBlockId: null` + `syntheticAppId` require the schema change in this
         // PR (BlockScopeInvocation.appBlockId → nullable, + synthetic_app_id).

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -14,6 +14,7 @@
  */
 
 import { Prisma } from '@prisma/client';
+import { GLOBAL_SCOPE_ACTIVITY_OR } from '~/server/services/blocks/scope-activity-predicate';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import {
@@ -216,27 +217,6 @@ export type AppActivityPage = {
 };
 
 const APP_ACTIVITY_MAX_LIMIT = 100;
-
-/**
- * 🔴 THE ONE DEFINITION OF "a scope invocation that COUNTS as app activity", exported so
- * `blocks.getNavSummary`'s `hasActivity` probe can import it instead of keeping a second copy.
- *
- * An `app-block` row has `appBlockId`; a synthetic dev-tunnel row has `syntheticAppId`; an
- * EXTERNAL-OAUTH row has NEITHER, and must be excluded — otherwise an external-OAuth-only
- * viewer is handed an Activity tab over a feed that says "No activity yet".
- *
- * 🔴 WHY THIS IS EXPORTED RATHER THAN WRITTEN TWICE. It was written twice, and an audit
- * DEMONSTRATED the drift rather than arguing it: tightening the FEED's clause and updating the
- * feed's own test literal — exactly what someone making that change would do — left BOTH
- * sides' suites green (65/65) while the probe silently over-matched. Each test asserted its own
- * side against a hand-copied literal, so neither could see the other move. That is the
- * "docstring names a RELATIONSHIP, body inspects one SIDE" defect. One export closes it: a
- * future edit here moves the probe by construction, and `__tests__/scopeActivityPredicate.test.ts`
- * pins that both call sites read THIS symbol rather than re-spelling it.
- */
-export const GLOBAL_SCOPE_ACTIVITY_OR: { OR: Array<Record<string, { not: null }>> } = {
-  OR: [{ appBlockId: { not: null } }, { syntheticAppId: { not: null } }],
-};
 
 /**
  * Paginated, viewer-scoped activity feed. Walks `block_buzz_attribution`

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -1,5 +1,5 @@
 /**
- * W5 v0 — reflection surface for /apps/installed.
+ * W5 v0 — reflection surface for /apps/activity.
  *
  * Provides the two read-only views the v0 ships:
  *   - `listMyScopeGrants`: aggregates per-app, "what JWT scopes does this
@@ -64,7 +64,7 @@ export type ScopeGrantSurface = {
  * for "what an app can do today" shouldn't surface installs the user
  * has explicitly toggled off. Subscriptions are included regardless of
  * the enabled flag because the row IS the user's claim of intent (the
- * toggle on `/apps/installed` already lets them turn it off).
+ * toggle on `/apps/activity` already lets them turn it off).
  */
 export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurface[]> {
   // Post kill_per_model_installs: every install — blanket OR per-model-
@@ -278,7 +278,7 @@ export async function listMyAppActivity({
  * `setSubscriptionPinnedVersion` is the write path that replaces the
  * removed `setInstallPinnedVersion`.
  *
- * The /apps/installed surface uses `BlockRegistry.listUserSubscriptions`
+ * The /apps/activity surface uses `BlockRegistry.listUserSubscriptions`
  * for the read side (it already returns availableVersions + pinned model
  * names + slotId / pinnedVersion on each row), so there is no separate
  * "list my model installs" call anymore.
@@ -390,7 +390,7 @@ export async function listMyScopeInvocations(opts: {
     appBlock: { blockId: string; manifest: unknown } | null;
   };
   const rows = (await dbRead.blockScopeInvocation.findMany({
-    // This is the BLOCK-token activity feed (/apps/installed). Unified scope-usage
+    // This is the BLOCK-token activity feed (/apps/activity). Unified scope-usage
     // audit: EXTERNAL-OAuth invocations now share this table but carry a NULL
     // `appBlockId` (+ `source = 'external-oauth'`); exclude them here so they don't
     // leak into a block-semantic UI. But NOT every null-`appBlockId` row is

--- a/src/shared/utils/app-blocks-access.ts
+++ b/src/shared/utils/app-blocks-access.ts
@@ -8,7 +8,7 @@ import type { StoreVisibilityScope } from '~/shared/utils/store-visibility-scope
  * (`/apps/submit`, `/apps/my-submissions`, `/apps/revenue`, and the
  * per-app `/apps/[appBlockId]/revenue`). These are the surfaces for people
  * who BUILD and earn from apps, as opposed to the consumer surfaces
- * (`/apps`, `/apps/installed`) which any user with `features.appBlocks`
+ * (`/apps`, `/apps/activity`) which any user with `features.appBlocks`
  * can use.
  *
  * Today = moderators only (pre-GA). This mirrors the existing `/apps/submit`
@@ -237,10 +237,13 @@ export type AppsStoreFeatureFlags =
  * driven against one fake Flipt config —
  * `server/services/__tests__/app-blocks-flag.external-scope.seam.test.ts`.
  *
- * 🔴 This is NOT the gate for the block-RUNTIME surfaces. `/apps/installed`,
+ * 🔴 This is NOT the gate for the block-RUNTIME surfaces. `/apps/activity`,
  * `/apps/review`, `/apps/my-submissions`, `/apps/revenue`, `/apps/run/<slug>`
- * and the `blocks.*` tRPC procedures gate on `appBlocks` alone, on purpose —
- * they need the runtime, not just the catalog. Widening them is a product
+ * and the `blocks.*` tRPC procedures gate on the RUNTIME flags, on purpose —
+ * they need the runtime, not just the catalog. (`/apps/activity` is the one that
+ * takes `appBlocks || appBlocksPages` rather than `appBlocks` alone; see
+ * {@link canAccessAppsActivity} for why the page flag is a second disjunct there
+ * and nowhere else.) Widening them is a product
  * decision, not a mechanical alignment; do not sweep them into this predicate.
  * The external-only cohort in particular must NOT reach them: they hold neither
  * `appBlocks` nor `appListings`, and adding this third term here leaves those
@@ -250,6 +253,56 @@ export type AppsStoreFeatureFlags =
  */
 export function hasAppsStoreAccess(features: AppsStoreFeatureFlags): boolean {
   return !!features?.appListings || !!features?.appBlocks || !!features?.appListingsPublicExternal;
+}
+
+/**
+ * The flag shape {@link canAccessAppsActivity} needs — the two App-Blocks RUNTIME
+ * flags. Derived from `FeatureAccess` (type-only import) so a rename at GA breaks
+ * here at compile time rather than silently degrading the gate to one term.
+ */
+export type AppsActivityFeatureFlags =
+  | Partial<Pick<FeatureAccess, 'appBlocks' | 'appBlocksPages'>>
+  | null
+  | undefined;
+
+/**
+ * App Blocks — the `/apps/activity` (per-viewer app ACTIVITY) surface gate:
+ * `appBlocks || appBlocksPages`.
+ *
+ * 🔒 THE SINGLE SOURCE OF TRUTH for "may this viewer reach /apps/activity", consumed
+ * by the page's SSR resolver (`~/components/Apps/resolveActivityPageAccess`) and
+ * by the page body's client-side re-check. Two callers, one function — the
+ * shared-predicate pattern {@link canAccessAppsBuild} exists for, and for the same
+ * recorded reason: a tab or a body gate written separately from its page's SSR gate
+ * WILL drift (#3899, PR #4668).
+ *
+ * 🔴 THE SECOND DISJUNCT IS THE WHOLE POINT OF THE `/apps/installed` → `/apps/activity`
+ * RENAME. The page used to gate on `appBlocks` alone, which is the SLOT flag — it
+ * governs the `BlockSlot` mount on model pages. Someone who has only ever run a
+ * FULL-PAGE app (`/apps/run/<slug>`, gated on `appBlocksPages`) has app activity —
+ * generations, scope-gated API calls, Buzz spends — and no slot install at all.
+ * Calling the page "Activity" while refusing them is the dishonest half of the rename.
+ *
+ * 🔴 IT IS NOT `hasAppsStoreAccess`. That predicate governs the CATALOG (`/apps`,
+ * the listing detail) and carries `appListingsPublicExternal`, the external-only
+ * cohort that holds neither runtime flag. This page reads `blocks.*` procedures, all
+ * of which gate on the runtime — so widening it to the store predicate would admit a
+ * cohort to a page whose every query answers all-false.
+ *
+ * ⚠️ SCOPE: this gates the PAGE. The `Installs` TAB inside it stays on
+ * `features.appBlocks` alone, because that tab's content (slot subscriptions /
+ * per-model installs) is what the slot flag governs — a tab's predicate is its
+ * content's own gate, restated. See `pages/apps/activity.tsx`.
+ *
+ * Neither flag is `toggleable: true` in `feature-flags.service.ts`, so
+ * `computeUserFeatureFlagsOverlay` never emits them and the client value cannot move
+ * between the SSR gate and the first client paint — which is what lets one predicate
+ * serve both without a hydration hazard.
+ *
+ * Fails CLOSED: absent / null features, or an empty object, → `false`.
+ */
+export function canAccessAppsActivity(features: AppsActivityFeatureFlags): boolean {
+  return !!features?.appBlocks || !!features?.appBlocksPages;
 }
 
 /**


### PR DESCRIPTION
Renames `/apps/installed` to `/apps/activity`, widens the page past the model-slot flag, defaults it to the activity feed, moves `Build` to the end of the sub-nav, and makes the activity table readable.

The page stopped being an installs surface some time ago — it hosts four tabs, three of which are not installs. This makes the route say so, and makes the gate honest about who has activity.

## What changed, per acceptance criterion

**1 — Route + label.** `src/pages/apps/installed.tsx` → `src/pages/apps/activity.tsx`, with a `statusCode: 301` redirect in `next.config.mjs` (not `permanent: true` — Next maps that to 308, which preserves the request method; these are GET-only pages whose inbound links are bookmarks). The page component is **moved, not stubbed**: a stub whose only job is to redirect reads as a live route, and `appsPageWidths`' fs-walk would then demand a width classification for a page that never renders. Same shape as the `/apps/build` consolidation. Sub-nav row now reads **Activity**. Every in-repo link is repointed and the prose swept.

**2 — Page gate widens to `appBlocks || appBlocksPages`.** Extracted as `resolveActivityPageAccess` (pure, node-importable — the `resolveAppsPageAccess` / `resolveBuildPageAccess` pattern) over a new shared `canAccessAppsActivity`. `appBlocks` is the model-**slot** flag; someone who has only ever run a full-page app (`/apps/run/<slug>`, gated on `appBlocksPages`) has generations, scope-gated API calls and Buzz spends recorded against them and **no slot install at all**. Refusing them a page called "Activity" was the dishonest half of the rename. The page body re-checks with the same predicate, so the SSR gate and the client gate cannot drift.

Verified before relying on it: `appBlocksPages` exists in `feature-flags.service.ts` (`availability: ['mod']`, fliptKey `app-blocks-pages-enabled`) and is **not** `toggleable`, so `computeUserFeatureFlagsOverlay` cannot move it between the server render and the first client paint — which is what lets one predicate serve an SSR-resolved gate and a client re-check.

**3 — Installs tab narrows to `features.appBlocks`.** The tab's content is slot subscriptions and per-model installs, which is exactly what that flag governs. Non-vacuous only because of (2). The **panel** is gated with the tab, not just the tab: a `Tabs.Panel` whose `value` has no tab is unreachable through the UI but still mounts its children on every render.

**4 — Tabs are URL-backed.** Controlled `value` + `onChange` writing `?tab=` through `router.replace(..., { shallow: true })` — no `getServerSideProps` re-run, no history entry per click. The default tab **drops** the key rather than writing `?tab=activity`. Resolution rules live in a pure `appsActivityTabs.ts` so they run in the blocking node tier: an unknown / repeated / prototype-key value falls back, and so does `?tab=subscriptions` for a viewer without the slot flag (handing that to `Tabs.value` selects a tab that is not in the list — a bar with nothing active over an empty panel).

**5 — Sub-nav order: Marketplace → Activity → Invites → Revenue → Build → Review.** `Build` led the table on the argument that it is "the front door for someone who has not built anything yet"; it is the narrowest-audience row here (`canAccessAppsBuild`), so leading with it put the smallest cohort's destination in the position that reads as what the bar is for. The stale comment is **rewritten**, not relocated. `chromeNavAlignsWithSubNav.test.ts` and `subNavRowsMatchPageGates.test.ts` are green; the chrome's two `/apps/installed` items are repointed and the platform-nav one relabelled to "App activity".

**6 — Header CTA removed.** Marketplace is a sub-nav tab. The three in-empty-state anchors stay — an empty panel with no way forward is a dead end.

**7 — `When` is relative.** The existing `DaysFromNow`, with the absolute stamp still in the tooltip (and now also in the `<time datetime>` attribute).

**8 — App name links to the store detail, GATED.** `getListingDetailHref(slug)`, gated on `hasAppsStoreAccess` read through `useOptionalFeatureFlags` so an absent provider fails **closed**. This is `AppNameCrumb`'s solution copied rather than re-derived. `/apps/store-preview/<slug>` `getServerSideProps`-gates on that predicate and answers `notFound`, and `appListings.getAppDetail` throws NOT_FOUND at scope `none` — an ungated link is a 404 affordance, the class #4668 shipped and #4685 exists to prevent.

**9 — Column ledger re-measured, not inherited.** See below.

## Test matrix — RED before, GREEN after

Every new test was run against `origin/main`'s code with the rest of this branch in place.

| file | tier | at `origin/main` | here |
|---|---|---|---|
| `resolveActivityPageAccess.test.ts` | unit (blocking) | the `appBlocksPages`-without-`appBlocks` case is red — main's gate is `if (!features?.appBlocks) return { notFound: true }` | 7/7 green |
| `appsActivityTabs.test.ts` | unit (blocking) | new module; new-feature coverage, labelled as such in the file | 12/12 green |
| `apps-activity-redirect.test.ts` | unit (blocking) | red — no rule, and `installed.tsx` still exists | 6/6 green |
| `AppActivityPanel.storeGate.browser.test.tsx` | component | **8 of 8 red** (`Cannot find element with locator: getByTestId('app-activity-app-name')` — main renders a plain `<Text>` with no testid) | 8/8 green |
| `AppActivityPage.browser.test.tsx` | component | **9 of 11 red** | 11/11 green |

The two that pass at `origin/main` are the positive-direction cases main already satisfies (`Installs` present with `appBlocks`; no tabs at all without either flag). Their red siblings are what carry the claim. The 9 reds, with their messages:

```
expected 'Installs' to be 'Recent activity'          (opens on the feed — main defaults to subscriptions)
expected 'Installs' to be 'Apps & permissions'       (?tab= selects on load — main's tabs read no query)
expected 'Installs' to be 'Recent activity'          (unknown ?tab falls back)
expected "vi.fn()" to be called 1 times, but got 0   (switching a tab rewrites the URL)
TypeError: undefined is not iterable                 (…and the default tab drops the key)
Cannot find element … Recent activity                (Installs ABSENT without appBlocks — main 404s the page)
Cannot find element … Recent activity                (…and the page still LOADS for that viewer)
expected [ 'Browse marketplace', …(3) ] to deeply equal [ 'Browse the marketplace', …(2) ]
expected true to be false                            (the removed header CTA is back)
```

## Criterion 8 — mutation check

Deleting `!canSeeStore ||` from `ActivityAppName`'s early return:

```
× 🔴 an ineligible viewer gets PLAIN TEXT, not a link
    AssertionError: an ineligible viewer must not be given an anchor:
    expected 'A' not to be 'A' // Object.is equality
× 🔴 FAILS CLOSED with no FeatureFlags provider at all
    AssertionError: expected 'A' not to be 'A' // Object.is equality

Tests  2 failed | 6 passed (8)
```

Both die on **their own** assertion, not on another test's error, and the three eligible-viewer cases stay green — which is what makes the red attributable to the gate rather than to the feature existing. Asserted as "not an anchor, no `href`" rather than as a tag literal, because Mantine's `<Text>` renders a `<p>` and pinning `'P'` would make the test about Mantine's default element; the eligible-viewer case is the positive control that keeps `not.toBe('A')` from being vacuous.

## Criterion 9 — the `appsWideLayout` EXEMPT entry, re-measured

The exemption rested on a measurement taken while `When` rendered a fixed-width `YYYY-MM-DD HH:mm` stamp, so it no longer described the table. Redone at 768 / 1200 / 1440 / 2560 on the same rich `tip` fixture, `AppsWideLayout.geometry.test.tsx` — `When | App | Action | Detail | Status`, natural layout, cell widths in px:

```
before   @768    119.67 | 177.34 | 194.36 | 179.09 |  65.53
         @1200   189.94 | 281.44 | 308.44 | 284.23 | 103.95
         @1440   228.95 | 339.27 | 371.81 | 342.63 | 125.34
         @2560   411.09 | 609.14 | 667.58 | 615.19 | 225.00

after    @768    108.39 | 180.58 | 197.91 | 182.38 |  66.75
         @1200   172.02 | 286.59 | 314.08 | 289.44 | 105.88
         @1440   207.38 | 345.47 | 378.63 | 348.91 | 127.63
         @2560   372.33 | 620.30 | 679.80 | 626.45 | 229.13

ROW HEIGHT  36.19 at all four widths, before AND after.
```

`When` gave up ~10% of its width at every viewport (38.76px at 2560) and the other four absorbed it proportionally — the table stayed at its natural distribution, it did not develop a surplus. The `no-surplus` argument is a claim about max-content sum vs container width at 768, and a narrower `When` makes that sum *smaller*, i.e. further from the case a ledger could help. **Control on the instrument:** the `before @2560` row reproduces the `natural @2560` figures already recorded in that comment, exactly.

Two measurement repairs came out of this and are worth reading:

- the geometry fixture used an absolute `createdAt`, which under `DaysFromNow` renders a string that **grows with wall-clock time** ("7 days ago" → "a year ago") and would have quietly moved the widths this file measures. Now a fixed offset from `now`.
- the `…each ONE line box` arm reads `lineCount` = `Range.getClientRects().length`, which returns one rect **per box** in the range. Once `When` became `<Text><time>…</time></Text>` the wrapper's range held two boxes and returned 2 **with nothing having wrapped**. The read drills to the `<time>`; the row-height arm staying at 36.19 across all four widths is the independent proof the cell is still one line.

## Also in here

`appsStoreAccessCallSites`' blanking-ratio bound moved 0.55 → 0.65. Measured on `origin/main` it sat at **0.5486** against a 0.55 bound — 0.0014 of headroom, so any added line of documentation (or one longer JSX string, which masks as blanks too) tripped it. It now carries a **negative control on the real file** — the historical apostrophe desync reproduced, blanking the tail — proving the bound can still fire. The `AppActivityPanel.tsx` entry was added to `STORE_GATE_SITES` with its reason.

## Gates run

- `pnpm typecheck` — **0 errors under `src/`**. 31 remain under `packages/`, all `Cannot find package 'kysely'` from a local `packages/*/node_modules` gap, identical on a clean `origin/main` worktree.
- `vitest --project unit` (full) — **34,638 passed / 30 failed**. All 30 are in `src/server/**`, `src/tests/**`, `src/test-utils/**`, none in a file this PR touches. Confirmed pre-existing: the same 6 files reproduce **23 identical failures** in a clean `origin/main` worktree sharing the same `node_modules`; the remaining 7 are a timing-sensitive watchdog test and a suite added by `e76bc60be7`, which this branch is rebased onto.
- `vitest --project component` on the 11 files in scope — **148 passed / 0 failed**.
- `vitest --project geometry` on `AppsWideLayout.geometry.test.tsx` — **34 passed / 0 failed**.
- `eslint` on the 7 added files — clean. `prettier --list-different` on the added files + the two modified files that were prettier-clean at `origin/main` — clean. The other 11 modified files are prettier-nonconforming **at `origin/main`** (measured per file via `--stdin-filepath`), and are deliberately left alone: CI treats modified files as report-only precisely so a 3-line change does not become a 200-line reformat.

## ⚠️ Superseded below

The two bullets that used to close this PR ("`blocks.*` untouched" and "the Activity row's
predicate is still `s.hasInstalls`") are **no longer true** — see the follow-up section.
They are named rather than deleted because they were the recorded justification, and the
audit found the justification itself was wrong.

---

# Audit follow-ups (commit `5107853cba`)

The operator approved a scope expansion into `blocks.*` for this. What the audit found:

🔴 **The justification for criterion 2 was false, and the real defect was elsewhere.**
Widening the page gate to `appBlocks || appBlocksPages` was argued from "someone who ran a
full-page app has activity and no slot install, so they were refused". They were not:
`src/pages/apps/run/[slug]/[[...path]].tsx:89` requires **BOTH** flags, so a page-app
runner always held `appBlocks` and the old page gate never refused them. The page gate is
kept as-is (operator's call). The **actual** defect was the sub-nav row — `hasInstalls` is
`dbRead.blockUserSubscription.findFirst(...) !== null`, and full-page apps are stateless by
design (`/apps/run`'s Decision 2: *"no `block_user_subscriptions` row, no migration"*), so a
viewer with both flags who runs page apps has activity and **no Activity tab**.

## What changed

| # | Item | Status |
|---|---|---|
| 1 | `getNavSummary` reports page-app activity (`hasActivity`) | done |
| 2 | Activity row keys on `s.hasInstalls \|\| s.hasActivity` | done |
| 3 | Empty-state `/apps` anchors gated on `hasAppsStoreAccess` (both sites) | done |
| 4 | `ActivityAppName` never links a listing that does not exist — fixed **in the service** | done |
| 5 | `subNavRowsMatchPageGates` pins the Activity row; header claim corrected | done |
| 6 | Two stale comment claims corrected | done |
| 7 | Double tooltip removed; `live` passed | done |
| 8 | Run-frame drawer: link **suppressed**, not left | done (decided, below) |

### 1. The `hasActivity` predicate, and why it matches the feed

```ts
hasActivity: buzzActivity !== null || scopeActivity !== null
```

built from two bounded probes added to the existing `Promise.all`:

```ts
dbRead.blockBuzzAttribution.findFirst({ where: { userId: user.id }, select: { id: true } }),
dbRead.blockScopeInvocation.findFirst({
  where: {
    userId: user.id,
    OR: [{ appBlockId: { not: null } }, { syntheticAppId: { not: null } }],
  },
  select: { id: true },
}),
```

These are **the two tables the feed itself walks** — `listMyAppActivity` reads
`block_buzz_attribution` on the SPENDER's `userId`
(`user-app-surface.service.ts:222`), `listMyScopeInvocations` reads
`block_scope_invocations` on the same column (`:392`). The scope probe copies the feed's
own `WHERE`, **external-OAuth exclusion included**: the global feed keeps `app-block` and
synthetic dev-tunnel rows and drops external-OAuth rows (both columns null). Without that
term an external-OAuth-only viewer would be handed an Activity tab whose feed says "No
activity yet" — the mirror of the defect being fixed. `getNavSummary`'s all-false
short-circuit shape gains the key too.

### 4. The slug fix is server-side

`user-app-surface.service.ts:261` and `:450` emitted
`appSlug: r.appBlock?.blockId ?? r.appBlockId`. Those two columns are not
interchangeable: `AppBlock.blockId` is the slug `AppListing.slug` mirrors
(`app-listing-mapper.ts` writes `slug: ab.blockId`); `appBlockId` is the **foreign key**.
So an unresolved join produced `/apps/store-preview/<pk>` — a guaranteed 404, offered
exactly on the rows where the app is least resolvable. That join really does come back
null: a pre-approval App-Dev-Tunnel spend writes `appBlockId: null` + `syntheticAppId`.

Both sites now emit `null`, the item types are `string | null`, `ActivityAppName` renders
plain text when absent, and the slug badge beside it is dropped rather than printing the
primary key. `appName` keeps its `?? r.appBlockId` tail on purpose — a display string with
no navigational meaning. **No per-row client fetch was added.**

A pre-existing test asserted the OLD behaviour
(`expect(result.items[0].appSlug).toBe('apb_x')`) and went red on the fix — that is the
change's own red→green, in the inverse direction. It is rewritten with the reason the old
expectation was the defect written down.

### 8. The drawer decision (item 8)

`AppPermissionsActivityDrawer` mounts the shared panel **over a running full-page app**, so
the new app-name link would top-level-navigate the user out of it — from a panel they
opened to read, with no warning and no route back to their in-app state. The column is also
redundant there (every row is the same app).

**Decision: suppress the link in per-app drill-down mode.** `ActivityAppName` gains
`linkable`, and the panel passes `linkable={!appBlockId}` — reusing the existing
"plain text" branch rather than adding a second rendering of the column. Not
`target="_blank"`: a second mechanism for one column is how the two come to disagree.
Written down on both components and pinned by a test in
`AppPermissionsActivityDrawer.browser.test.tsx` (the seam), with a positive control showing
the same viewer + same row DOES get a link on the whole-account feed.

## Red→green matrix

Every behavioural change was watched to fail without it.

| Change | Red without it | Green with it |
|---|---|---|
| `hasActivity` on the row | `subNavRowsMatchPageGates` › *Activity is visible exactly when…* + *the page ADMITS the cohort…* fail; `AppsSubNav.browser` › *Activity shows for hasActivity with NO installs* fails | unit 10/10, component 48/48 |
| empty-state anchor gate | `AppActivityPage.browser` › *a page-apps-only viewer gets NO marketplace anchor…* and `AppActivityPanel.storeGate` › *a page-apps-only viewer gets NO marketplace link* + *FAILS CLOSED…* fail (3) | 30/30 across the two files |
| `appSlug` → null | pre-existing `user-app-surface.orchestration` › *falls back to appBlockId…* went RED on the fix (it pinned the defect) | rewritten + 2 new cases; file green |
| drawer `linkable` | drawer › *the App name is PLAIN TEXT in the drawer…* and panel › *appBlockId set ⇒ plain text…* fail (2) | 25/25 |
| tooltip removal | see the mutation note below | 17/17 |

## Mutation checks (exact messages)

**A — delete the `hasActivity` term** (`visible: (s) => s.hasInstalls`):

```
subNavRowsMatchPageGates › Activity is visible exactly when the viewer has installs OR activity
AssertionError: hasInstalls=false hasActivity=true (others=false store=false author=false):
the Activity TAB is hidden. …: expected false to be true
```

and, in the browser tier, `AppsSubNav.browser.test.tsx:225` —
`await expect.element(tab('Activity')).toBeInTheDocument()` → `Matcher did not succeed in
time`, **1 failed / 47 passed**. The `Activity shows when hasInstalls` case stays green, so
the red is attributable to this term.

**B — delete the `canSeeStore &&` guard from both empty states**: 3 tests fail on their own
assertions, 27 stay green:

```
AppActivityPage › a page-apps-only viewer gets NO marketplace anchor anywhere on the page
AssertionError: a link into a `notFound` was offered to a viewer with no store access:
expected [ 'Browse the marketplace', …(1) ] to deeply equal []

AppActivityPanel.storeGate › a page-apps-only viewer gets NO marketplace link
AssertionError: a link into a `notFound` was rendered for a store-less viewer:
expected <a …(6)></a> to have a length of +0 but got 1
```

**C — drop `linkable={!appBlockId}`**: 2 fail, 23 pass —
`AssertionError: the drawer must not offer a link that navigates out of the running app:
expected 'A' not to be 'A'`.

🔴 **D — re-add the `<Tooltip>`: the first version of that guard SURVIVED (17/17 green).**
A **closed** Mantine `Tooltip` adds no attribute and no element, so wrapped and unwrapped
markup are byte-identical in the DOM — the structural guard (counting `[title]` nodes and
`aria-describedby`) could not see the hazard it claimed to cover. It is rewritten as a real
hover: `.hover()` the cell, poll for `[role="tooltip"]`. Under the re-added wrapper it now
fails —
`AssertionError: a second tooltip was re-added over DaysFromNow… expected [ Array(1) ] to
deeply equal []` — and passes with the wrapper gone.

## Gate results (counts, not exit codes)

- `pnpm typecheck` — **0 type errors**, and the instrument was negative-controlled: removing
  `hasActivity` from one typed fixture produced `1 type error(s)` / exit 2
  (`TS2741: Property 'hasActivity' is missing … but required in type 'AppsNavSummary'`).
- `vitest --project unit` (**full tier**) — **38,894 passed / 1 failed / 33 skipped** across
  1,689 files. The one failure is `src/server/__tests__/eventloop-watchdog.capture.test.ts`,
  a timing test unrelated to this diff. Controlled by alternating runs against a clean
  `HEAD` worktree: base run 1 **2 failed**, mine run 1 **1 failed**, base run 2 **9/9
  passed**, mine run 2 **9/9 passed** — flaky at base as well as here.
- `vitest --project unit` scoped to `components/Apps`, `components/AppBlocks`,
  `server/routers/__tests__`, `server/services/blocks/__tests__` — **348 files / 7,585
  passed / 0 failed**.
- `vitest --project component` on every browser test under `components/Apps` +
  `components/AppBlocks` — **127 files / 1,783 passed / 0 failed**.
- `vitest --project geometry` on `AppsWideLayout.geometry.test.tsx` — **34 passed / 0
  failed**.
- `prettier` — the 3 files this commit newly made non-conforming were written; the other 5
  touched files were **already** non-conforming at this branch's HEAD (measured two ways:
  `--stdin-filepath` on `git show HEAD:<file>`, and `--list-different` on a clean
  `git worktree` of HEAD — both name the same 5). CI treats modified files as report-only.
- `eslint` on all 18 changed files — **16 errors, 3 warnings, all pre-existing** (JSX
  apostrophes, empty arrow functions, the drawer test's pre-existing wholesale `~/utils/trpc`
  mock, `blocks.router.ts:5347/8135`, `user-app-surface.service.ts:16`). Every reported line
  is outside this commit's hunks — one that *was* inside (`onClose={() => {}}` in a new test)
  was changed to `vi.fn()` so this commit adds none.

## Fixtures updated (all green)

`AppsSubNav.{browser,hydration,ssrHydration,storeGate}.browser.test.tsx`,
`AppsBuildBody.browser.test.tsx`, `AppActivityPage.browser.test.tsx`,
`blocks.router.getNavSummary.test.ts`, `subNavRowsMatchPageGates.test.ts`. Also
`appsStoreAccessCallSites.test.ts` — the ledger **grew** by `pages/apps/activity.tsx`, with
a carve-out explaining why a runtime-gated page can still hold a store-gated link.

## Still not done / not verified

- **The page gate stays `appBlocks || appBlocksPages`** — operator's call, not re-litigated.
- **A residual narrowness survives, deliberately.** Both summary flags come from
  `getNavSummary`, whose `enabled` and whose server middleware gate on `appBlocks`, while the
  page admits `appBlocks || appBlocksPages`. A viewer holding `appBlocksPages` **without**
  `appBlocks` still gets an all-false summary and no tab. That is the safe direction of the
  #3899 / #4668 class (an unreachable page, never a tab into a 404); closing it means moving
  the procedure's own gate, which widens every flag on the summary. Recorded on the row.
- **`live` on `DaysFromNow` is not pinned by a test.** Asserting it would need fake timers
  against dayjs; the change is a one-word prop and the stale-relative-string behaviour it
  fixes is not covered.
- **No live/manual verification.** Everything above is tests, typecheck and lint on this
  machine — the click path on a real `/apps/activity` for a page-apps-only viewer has not
  been exercised.
- The two added `getNavSummary` probes are asserted to be `findFirst` + `select: { id }` +
  user-scoped, but their **cost against production data has not been measured**.

## Base sync (`fef6336dd5`)

`origin/main` was merged into this branch — **no force-push, no rewrite, and none of this
PR's files are touched by main's side** (`git diff HEAD^1 HEAD -- <this PR's paths>` is
empty). It was needed because CI was red on a failure this branch does not contain:

`Unit tests (2)` failed on `no-direct-shared-module-mock` naming
`src/server/routers/__tests__/article.router.scan-status-authz.test.ts` — a file that **does
not exist on this branch**. GitHub's `refs/pull/4699/merge` was pinned at base `02ad4701ad`,
the commit immediately *before* #4709 (`2a19acf8ef`, "use the canonical db mock in the
scan-status authz test") fixed exactly that file. Verified rather than inferred:
`git merge-base --is-ancestor 2a19acf8ef refs/pull/4699/merge` → **NO**, and that ref's copy
of the file still carries the `vi.mock('~/server/db/client', …)` the guard rejects. Re-running
the job reused the same stale merge ref and failed identically; only moving the head
recomputes it.

Re-gated on the MERGED tree afterwards: `pnpm typecheck` **0 errors**; `vitest --project unit`
over `components/Apps`, `components/AppBlocks`, `server/routers/__tests__`,
`server/services/blocks/__tests__` **plus the guard test itself** — **350 files / 7,593 passed
/ 0 failed**; the 9 in-scope browser files — **156 passed / 0 failed**. PR checks now read
**18 pass / 0 fail** (1 `skipping`, a main-pushes-only job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
