### PR TITLE
docs(clickhouse): sections 3 and 4 are applied — say so in the file

### DIFF
--- a/src/server/clickhouse/migrations/2026-09-07-reaction-report-enum-widening.sql
+++ b/src/server/clickhouse/migrations/2026-09-07-reaction-report-enum-widening.sql
@@ -2,12 +2,17 @@
 --
 -- Apply this MANUALLY. We do not auto-run DDL (same policy as the Postgres migrations).
 --
--- 🔴 THIS FILE IS PART "ALREADY APPLIED", PART "STILL TO APPLY". Read the section headers.
--- Sections 1, 2 and 5 were applied by hand — 1 and 2 on 2026-09-07, 5 on 2026-09-08 — and are
+-- 🔴 EVERY SECTION IN THIS FILE IS NOW APPLIED. It is a history record, not a work list:
+-- sections 1 and 2 on 2026-09-07, section 5 on 2026-09-08T04:04:14Z, and the coupled
+-- 3+4 pair on 2026-09-08T18:08:24Z/:25Z. Re-applying any of them is a no-op. They are
 -- recorded here so the history exists in the repo and so the drift guard can see the
--- definitions. Sections 3 and 4 have NOT been applied. The sections are numbered in the order
--- they were WRITTEN, not the order they were applied, so the numbering is not a running order:
--- each section header carries its own status and that is the only thing to trust here.
+-- definitions. The sections are numbered in the order they were WRITTEN, not the order they
+-- were applied, so the numbering is not a running order: each section header carries its own
+-- status and that is the only thing to trust here.
+--
+-- 🔴 "APPLIED" IS NOT "SAFE TO EDIT". The ordering constraint in section 3 and the
+-- whole-statement warning in section 4 govern any REVERT just as they governed the apply,
+-- and a revert of one half alone is the corruption this file exists to prevent.
 --
 -- WHY THIS FILE EXISTS AT ALL. The enum-drift guard in this directory's sibling test only
 -- ever covered `actions.type`. Every other enum column the tracker writes was unchecked,
@@ -88,7 +93,17 @@ ALTER TABLE default.reports
 
 
 -- =====================================================================================
--- 3. reactions.type — ⚠️ NOT YET APPLIED. Adds 'Post_Create' = 17, 'Post_Delete' = 18.
+-- 3. reactions.type — ✅ APPLIED TO PRODUCTION 2026-09-08T18:08:24Z, with section 4 at
+--    18:08:25Z — one second later — and the tracker pods replaced at 18:09:09Z and
+--    18:09:32Z. Adds 'Post_Create' = 17, 'Post_Delete' = 18.
+--
+--    The POST-APPLY gap query below returned 0: no post reaction landed between the two
+--    statements, so no owner score was decremented and none needs repair.
+--
+--    Recorded here for history; re-applying it is a no-op. 🔴 The warning below is NOT
+--    historical trivia — it still governs any REVERT, and it is the reason this section
+--    cannot be reverted on its own. See the rollback bundle and, in particular, its
+--    ORDER, at <talos-infra>/claudedocs/clickhouse-enum-widening-2026-09-07/rollback-reaction-type.sql
 --
 -- 🔴🔴 SECTIONS 3 AND 4 ARE ONE OPERATION. APPLY BOTH, IN THIS ORDER, IN ONE SITTING.
 --
@@ -143,7 +158,15 @@ ALTER TABLE default.reactions
 
 
 -- =====================================================================================
--- 4. reactions_owner_scores_mv — ⚠️ NOT YET APPLIED. THE OTHER HALF OF SECTION 3.
+-- 4. reactions_owner_scores_mv — ✅ APPLIED TO PRODUCTION 2026-09-08T18:08:25Z.
+--    THE OTHER HALF OF SECTION 3.
+--
+--    Verified by diffing the WHOLE statement against the pre-image recorded below, not by
+--    reading the IN list: removing the single added 'Post_Create' from the live post-image
+--    reproduces that pre-image character-for-character once whitespace is collapsed. The
+--    multiIf arms, the 2024-04-27 cutoff, the FROM and the GROUP BY are provably unchanged.
+--
+--    Recorded here for history; re-applying it is a no-op.
 --
 --    Adds 'Post_Create' to the +1 list. Everything not in this list scores -1, which is
 --    why this cannot lag behind section 3 by even one deploy.

--- a/src/server/clickhouse/migrations/2026-09-07-reaction-report-enum-widening.sql
+++ b/src/server/clickhouse/migrations/2026-09-07-reaction-report-enum-widening.sql
@@ -102,8 +102,19 @@ ALTER TABLE default.reports
 --
 --    Recorded here for history; re-applying it is a no-op. 🔴 The warning below is NOT
 --    historical trivia — it still governs any REVERT, and it is the reason this section
---    cannot be reverted on its own. See the rollback bundle and, in particular, its
---    ORDER, at <talos-infra>/claudedocs/clickhouse-enum-widening-2026-09-07/rollback-reaction-type.sql
+--    cannot be reverted on its own.
+--
+-- 🔴 REVERT ORDER, IF IT EVER COMES TO THAT: narrow the COLUMN first, then the view —
+--    the REVERSE of the apply order. The hazard shape in both directions is "wide column
+--    + narrow view", so narrowing the view first opens exactly the window section 3 warns
+--    about, whereas once 'Post_Create' is not a member of the column no row can carry it
+--    and the view's surplus IN-list element is inert. The objection to column-first —
+--    that the view would then compare an Enum8 against a literal the enum no longer
+--    contains and throw, breaking every INSERT into reactions — was measured and is
+--    FALSE: an unknown element in an IN list evaluates to 0, no error. (Verified with a
+--    positive control, because a 0 from a query failing shut would look identical.)
+--    Precondition either way: require 0 rows carrying 'Post_Create'/'Post_Delete', since
+--    narrowing an enum that already carries a value makes those rows unreadable.
 --
 -- 🔴🔴 SECTIONS 3 AND 4 ARE ONE OPERATION. APPLY BOTH, IN THIS ORDER, IN ONE SITTING.
 --


### PR DESCRIPTION
## What

`2026-09-07-reaction-report-enum-widening.sql` still labels sections 3 and 4 `⚠️ NOT YET APPLIED`, and its header still splits the file into "already applied" and "still to apply". Both were applied to production yesterday. This corrects the status lines.

**Comment-only.** Every changed line begins with `--`; no DDL is touched, and the verbatim `POST-APPLY:` tracker-restart marker the drift guard pins is unchanged.

## The apply this records

| | instant (UTC) |
|---|---|
| §3 `reactions.type` += `Post_Create`=17, `Post_Delete`=18 | `2026-09-08T18:08:24Z` |
| §4 `reactions_owner_scores_mv` MODIFY QUERY, `Post_Create` into the +1 list | `2026-09-08T18:08:25Z` |
| tracker pods replaced (serializers re-read the schema) | `18:09:09Z`, `18:09:32Z` |

Applied behind a guard that re-read the live pre-state at the moment of acting and aborted unless `reactions.type` had exactly its 16 known arms with no `Post_*` and the MV matched the committed pre-image. Statements were extracted from `origin/main`, not from a working tree.

**The gap query returned 0** — no post reaction landed in the one-second window between the two statements, so nothing was scored −1 and no owner's all-time score needs repair. That zero is load-bearing rather than decorative: the same instrument returned a healthy five-figure row count for the preceding hour, so the table was actively ingesting and a 0 is a real 0 rather than a broken query.

`system.mutations … is_done=0` = 0 on both — metadata-only, so no rewrite of this table.

## Why this is not just tidying

The two sections that ARE applied each carry a dated `✅ APPLIED` line. Leaving these two on `⚠️ NOT YET APPLIED` does not read as a stale comment — it reads as *outstanding work*, in the one file someone opens before touching this table.

Two things are deliberately **kept** rather than trimmed as historical now that the apply is done:

- **The ordering warnings now say they govern a REVERT.** Reverting one half alone is the same sign-inversion corruption arrived at from the other direction — a `Post_Create` row against a narrowed view scores −1, permanently, because a materialized view does not backfill. These paragraphs are live constraints, not a record of a past decision.
- **Section 4 records *how* it was verified:** the whole statement was diffed against the recorded pre-image, not spot-checked for `'Post_Create'` in the IN list. Stripping the single added element from the live post-image reproduces the pre-image character-for-character. A spot-check of the IN list passes over a swapped `multiIf` sign or a moved `2024-04-27` cutoff, either of which silently rewrites every user's all-time reaction score.

## Not claimed here

**The positive control has not passed.** No `Post_*` row has been observed yet, and a zero there is ambiguous by construction — equally consistent with "nobody reacted to a post yet". What *is* measured is that the tracker's dead-letter counter now has **no series at all** on either restarted pod, where the previous pods carried a nonzero `reactions` count. That is not a silent zero: the tracker's records-received and records-inserted counters are present for both, so they are being scraped and the absence is real.

## Test

```
npx vitest run --project unit src/server/clickhouse/
→ Test Files 7 passed (7) · Tests 68 passed (68)
```

Count read, not assumed — this repo's vacuous green is a suite that collects 0 tests. The diff touches no test file, so 68 is also the base count at `origin/main`.

## Rollback

The revert order is now stated inline in section 3 (the second commit moved it there, out of a cross-repo pointer): narrow the **column first**, then the view — the reverse of the apply order, because "wide column + narrow view" is the sign-inversion shape from either direction. Full rollback text lives with the rest of this arc's operational records.
