### PR TITLE
fix(search): stop a Meilisearch task wait timing out into a silent success

### DIFF
--- a/src/server/meilisearch/__tests__/get-or-create-index.test.ts
+++ b/src/server/meilisearch/__tests__/get-or-create-index.test.ts
@@ -1,0 +1,89 @@
+import { MeiliSearchTimeOutError } from 'meilisearch';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Index creation is a QUEUED Meilisearch task, so waiting on it is waiting for queue position rather
+ * than for work. `getOrCreateIndex` used to call `client.waitForTask` bare, which takes the client
+ * default of 5s and never retries — so a `search-index-sync-*-reset` fired while the queue had a
+ * backlog threw MeiliSearchTimeOutError about four minutes in and built nothing, while the creation
+ * task sat enqueued and made the dead job look like a running one.
+ *
+ * These pin that a creation wait survives a timeout instead of ending the job. They do NOT claim the
+ * reset is immune to a long backlog: the retry budget is finite (~75s) and one images batch on prod
+ * has taken 51 minutes. A quiet queue is still a precondition.
+ */
+
+vi.mock('~/server/meilisearch/client', () => ({ searchClient: null, metricsSearchClient: null }));
+import { getOrCreateIndex } from '~/server/meilisearch/util';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
+
+const notFound = Object.assign(new Error('index_not_found'), { code: 'index_not_found' });
+
+function fakeClient({ timeouts }: { timeouts: number }) {
+  let remaining = timeouts;
+  const index = { uid: 'test_index', update: vi.fn() };
+  return {
+    created: false,
+    getIndex: vi.fn(function (this: any) {
+      // Not found until createIndex has run — the branch under test.
+      return this.created ? Promise.resolve(index) : Promise.reject(notFound);
+    }),
+    createIndex: vi.fn(function (this: any) {
+      this.created = true;
+      return Promise.resolve({ taskUid: 42 });
+    }),
+    waitForTasks: vi.fn(() => {
+      if (remaining-- > 0) return Promise.reject(new MeiliSearchTimeOutError(''));
+      return Promise.resolve([{ uid: 42, status: 'succeeded' }]);
+    }),
+    // Deliberately absent: waitForTask. The old implementation called it, so a revert fails here by
+    // name rather than by a vague timeout.
+  } as any;
+}
+
+// Fake timers are what keep a REVERT fast. getOrCreateIndex is wrapped in withRetries(fn, 3, 60000),
+// so anything that throws out of it sleeps 3 x 60s of real time — a revert took over 2 minutes per
+// test before this, which reads as a wedged runner rather than a failure. Do not drop them.
+async function createIndexWith(client: any) {
+  const pending = getOrCreateIndex('test_index', { primaryKey: 'id' }, client);
+  pending.catch(() => undefined);
+  await vi.runAllTimersAsync();
+  return pending;
+}
+
+describe('getOrCreateIndex — creation waits for a queued task', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('returns the index when the creation task resolves immediately', async () => {
+    const client = fakeClient({ timeouts: 0 });
+    const index = await createIndexWith(client);
+
+    expect(index).toBeTruthy();
+    expect(client.createIndex).toHaveBeenCalledTimes(1);
+    expect(client.waitForTasks).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives a timed-out wait and retries rather than failing the job', async () => {
+    // Two timeouts then success. Under the old bare `waitForTask` there was no second attempt at all.
+    const client = fakeClient({ timeouts: 2 });
+    const index = await createIndexWith(client);
+
+    expect(index).toBeTruthy();
+    expect(client.waitForTasks).toHaveBeenCalledTimes(3);
+  });
+
+  // Do not relax this to toHaveBeenCalled(): the first wait uses the caller's client either way, so
+  // only the exact count can see the retry dropping it. Dropped, the retry hits a null searchClient,
+  // returns [] as if the tasks succeeded, and this reads 1.
+  it('forwards the caller-supplied client on RETRY, not only on the first attempt', async () => {
+    const client = fakeClient({ timeouts: 1 });
+    await createIndexWith(client);
+
+    expect(client.waitForTasks).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/server/meilisearch/util.ts
+++ b/src/server/meilisearch/util.ts
@@ -48,7 +48,12 @@ const getOrCreateIndex = async (
         if (meiliSearchError.code === 'index_not_found') {
           console.error('getOrCreateIndex :: Error :: Index not found. Attempting to create it...');
           const createdIndexTask = await client.createIndex(indexName, options);
-          await client.waitForTask(createdIndexTask.taskUid);
+          // Index creation is a QUEUED task, so this waits for queue position, not for work. A bare
+          // waitForTask takes the client default of 5s and never retries, so a reset fired against a
+          // backlog threw MeiliSearchTimeOutError and built nothing while the creation task sat
+          // enqueued, making the dead job read as running. The escalating retry budget (~75s) covers
+          // ordinary queue depth only — a quiet queue is still a precondition for a reset.
+          await waitForTasksWithRetries([createdIndexTask.taskUid], undefined, client);
           return await client.getIndex(indexName);
         } else {
           console.error('getOrCreateIndex :: Error :: ', e);
@@ -170,7 +175,10 @@ const waitForTasksWithRetries = async (
     return tasks;
   } catch (e) {
     if (e instanceof MeiliSearchTimeOutError) {
-      return waitForTasksWithRetries(taskUids, remainingRetries - 1);
+      // `client` MUST be forwarded. Without it the retry falls back to the module-level searchClient,
+      // which is a different instance than the metrics processors pass and is null when SEARCH_HOST
+      // is unset — where the guard above returns an EMPTY array as if the tasks had succeeded.
+      return waitForTasksWithRetries(taskUids, remainingRetries - 1, client);
     }
 
     throw e;


### PR DESCRIPTION
Two defects in `src/server/meilisearch/util.ts`. They are in one PR because separating them is unsafe — see the last section.

## 1. A task-wait timeout became a silent success (the wider blast radius)

`waitForTasksWithRetries` did not forward its `client` when it recursed:

```ts
return waitForTasksWithRetries(taskUids, remainingRetries - 1);   // client dropped
```

Every retry therefore fell back to the module-level `searchClient` — a **different instance** from the one the metrics processors pass, and `null` whenever `SEARCH_HOST` is unset, where the `if (!client) return []` guard at the top returns an **empty array as if the tasks had succeeded**. A timeout turns into a success with no error anywhere.

## 2. An index reset died on any backlog, and looked alive while dead

`getOrCreateIndex` awaited index creation with a bare `client.waitForTask`, which takes the client default of **5s** and never retries. Index creation is a *queued* Meilisearch task, so that wait is for queue position, not for work. A `search-index-sync-*-reset` fired while the queue had a backlog threw `MeiliSearchTimeOutError` and built nothing — while the creation task **stayed enqueued**, so the dead job read as a running one. That cost two hours of misdiagnosis today.

It now uses the escalating retry budget (5s, 10s, … ≈75s total).

**This does not make a reset immune to a long backlog, and is not meant to.** One `images_v6` batch on this instance has taken 51 minutes; nothing in-process should wait that long. A quiet queue remains a precondition for a reset.

## Why they ship together

Before this change **nothing in the repo passed a client to `waitForTasksWithRetries`** — its only call sites are inside `util.ts`, and the pre-change one called `client.waitForTask` directly. Defect 1 was latent.

Fixing the wait is what makes it reachable: the search-index processors pass their own client to `getOrCreateIndex` (`base.search-index.ts:355`; the metrics indexes pass `metricsSearchClient`), and that client is now forwarded into the helper. Fixing #2 without #1 would have **introduced** the silent success rather than exposed one.

## Tests

`src/server/meilisearch/__tests__/get-or-create-index.test.ts`, 3 tests. Both defects have a measured revert:

| revert | result |
|---|---|
| drop `client` from the retry call | `Tests 2 failed \| 1 passed (3)` — `expected "vi.fn()" to be called 3 times, but got 1 times` — 1.36s |
| restore the bare `client.waitForTask` | `Tests 3 failed (3)` — `expected "vi.fn()" to be called 1 times, but got 0 times` — 1.37s |

Two notes for whoever edits these next, both also written into the file:

- The client-forwarding test asserts an **exact** call count. `toHaveBeenCalled()` cannot fail here — the first attempt uses the caller's client whether or not the retry forwards it. The original draft of this test asserted that and was vacuous.
- The tests use **fake timers** deliberately. `getOrCreateIndex` is wrapped in `withRetries(fn, 3, 60000)`, so anything thrown out of it sleeps 3×60s of *real* time; before the fake timers a revert took over two minutes per test and read as a wedged runner rather than a failure.

## Verification

- `pnpm run typecheck` — 0 type errors
- `pnpm exec eslint` on both touched files — 0 errors (6 pre-existing-style `any`/unused-mock-import warnings)
- Full unit suite — see comment below
- Nothing here writes to Meilisearch. Search on prod flapped three times this afternoon; a separate stability gate covers the live steps, and this PR is not one of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7ZW9caRhbAUDQGTXxGwgn
