### PR TITLE
feat(search): hide paid models from model search, behind a flag

### DIFF
--- a/src/components/Search/__tests__/hide-paid-search-filter-negation.test.ts
+++ b/src/components/Search/__tests__/hide-paid-search-filter-negation.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync, readdirSync, statSync } from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
-import { HIDE_PAID_MODELS_FILTER } from '~/components/Search/paid-model-search-filter';
+import {
+  HIDE_PAID_MODELS_FILTER,
+  paidModelsSearchFilterClause,
+} from '~/components/Search/paid-model-search-filter';
 import { joinFilterClauses } from '~/components/Search/search-filters';
 import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
 import { filterableAttributesByIndex } from '~/server/search-index/filterable-attributes';
@@ -25,7 +28,7 @@ import { filterableAttributesByIndex } from '~/server/search-index/filterable-at
 const repoRoot = path.resolve(__dirname, '../../../..');
 const CALL_SITE = 'src/pages/search/models.tsx';
 
-// This file states the forbidden spelling in order to forbid it, so it is the one exemption.
+// This file states the forbidden spellings in order to forbid them, so it is the one exemption.
 // Exactly one, asserted below: widening this list is the edit that must be visible in a diff.
 const ALLOWLIST = [
   'src/components/Search/__tests__/hide-paid-search-filter-negation.test.ts',
@@ -33,14 +36,14 @@ const ALLOWLIST = [
 
 describe('hide-paid search filter', () => {
   it('is a negation, not an equality on false', () => {
-    expect(HIDE_PAID_MODELS_FILTER).toMatch(/^NOT\s/);
-    expect(HIDE_PAID_MODELS_FILTER).toContain('hasActivePaidAccess');
-    expect(HIDE_PAID_MODELS_FILTER).not.toContain('false');
+    // The exact string is the load-bearing assertion, not the shape checks around it: `NOT
+    // hasActivePaidAccess EXISTS` would satisfy every property below and hide the wrong documents.
+    expect(HIDE_PAID_MODELS_FILTER).toBe('NOT hasActivePaidAccess = true');
   });
 
   it('survives the parenthesising every clause gets before it reaches Meilisearch', () => {
-    // joinFilterClauses wraps each clause in `(...)`. A clause that is only valid unwrapped would
-    // fail as a 400 at runtime and never in a unit test that looked at the constant alone.
+    // joinFilterClauses wraps each clause in `(...)`. A clause only valid unwrapped would fail as a
+    // 400 at runtime and never in a unit test that looked at the constant alone.
     expect(joinFilterClauses([HIDE_PAID_MODELS_FILTER])).toBe('(NOT hasActivePaidAccess = true)');
   });
 
@@ -48,6 +51,23 @@ describe('hide-paid search filter', () => {
     // Without this the whole models search answers 400 invalid_search_filter the moment anyone
     // ticks the box — not just the paid filter, the entire result set.
     expect(filterableAttributesByIndex[MODELS_SEARCH_INDEX]).toContain('hasActivePaidAccess');
+  });
+});
+
+describe('paidModelsSearchFilterClause', () => {
+  it('applies the clause only when the flag is on AND the box is ticked', () => {
+    expect(paidModelsSearchFilterClause(true, true)).toBe(HIDE_PAID_MODELS_FILTER);
+  });
+
+  it('emits nothing when the feature flag is off, whatever the box says', () => {
+    // Dropping the flag from the gate would ship the filter to everyone before the index settings
+    // and the backfill land, which breaks the entire models search rather than just this filter.
+    expect(paidModelsSearchFilterClause(false, true)).toBeNull();
+  });
+
+  it('emits nothing when the box is unticked — paid models are shown by DEFAULT', () => {
+    // A default of `true` would silently remove paid models from everyone's search.
+    expect(paidModelsSearchFilterClause(true, false)).toBeNull();
   });
 });
 
@@ -61,27 +81,42 @@ function walk(dir: string, out: string[] = []) {
   return out;
 }
 
-describe('no equality-on-false spelling anywhere', () => {
-  it('src/ never writes `hasActivePaidAccess = false`', () => {
+// Each alternative is a spelling that is valid Meilisearch and matches only documents that HAVE the
+// attribute. `= false` is the obvious one; `!= true` reads as the opposite but excludes absent
+// documents the same way, and the attribute may be quoted.
+const FORBIDDEN = /"?hasActivePaidAccess"?\s*(=\s*false|!=\s*true)/;
+
+describe('no equality-on-present-only spelling anywhere', () => {
+  it('src/ never writes hasActivePaidAccess as an equality that skips absent documents', () => {
     const offenders = walk(path.join(repoRoot, 'src'))
-      .filter((file) => /hasActivePaidAccess\s*=\s*false/.test(readFileSync(file, 'utf8')))
+      .filter((file) => FORBIDDEN.test(readFileSync(file, 'utf8')))
       .map((file) => path.relative(repoRoot, file).split(path.sep).join('/'))
       .filter((file) => !ALLOWLIST.includes(file as (typeof ALLOWLIST)[number]));
 
     expect(ALLOWLIST).toHaveLength(1);
-
     expect(
       offenders,
       'Use a NOT clause. An equality does not match documents that lack the attribute.'
     ).toEqual([]);
   });
 
-  it('the call site uses the shared constant rather than an inline string', () => {
-    // The constant carries the reasoning. Inlining the string is how the reasoning gets lost and
-    // the next edit reaches for `= false`.
+  it('the call site actually WIRES the clause in, not merely imports it', () => {
+    // `toContain('HIDE_PAID_MODELS_FILTER')` was satisfied by the import line alone, so deleting the
+    // clause from the filters array left every suite green while the checkbox did nothing. Pin the
+    // call, which the import cannot satisfy.
     const source = readFileSync(path.join(repoRoot, CALL_SITE), 'utf8');
 
-    expect(source).toContain('HIDE_PAID_MODELS_FILTER');
-    expect(source).not.toContain("'NOT hasActivePaidAccess");
+    expect(source).toContain(
+      'paidModelsSearchFilterClause(features.paidModelSearchFilter, hidePaid)'
+    );
+    expect(source).not.toMatch(/['"`]NOT hasActivePaidAccess/);
+  });
+
+  it('shows paid models by DEFAULT — the box starts unticked', () => {
+    // The helper test covers "unticked emits nothing", but nothing read the initial value, so
+    // useState(true) — every user's model search silently losing paid models — was invisible.
+    const source = readFileSync(path.join(repoRoot, CALL_SITE), 'utf8');
+
+    expect(source).toContain('const [hidePaid, setHidePaid] = useState(false)');
   });
 });

--- a/src/components/Search/__tests__/hide-paid-search-filter-negation.test.ts
+++ b/src/components/Search/__tests__/hide-paid-search-filter-negation.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync, readdirSync, statSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { HIDE_PAID_MODELS_FILTER } from '~/components/Search/paid-model-search-filter';
+import { joinFilterClauses } from '~/components/Search/search-filters';
+import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
+import { filterableAttributesByIndex } from '~/server/search-index/filterable-attributes';
+
+/**
+ * These pin one decision, not the code around it: the "hide paid models" clause is a NEGATION and
+ * must never become an equality on `false`.
+ *
+ * To whoever is about to simplify this to `hasActivePaidAccess = false` because it reads better —
+ * that is the bug this ticket exists to prevent, and it fails silently rather than loudly. Only
+ * GATED models carry `hasActivePaidAccess`; ~700K documents simply do not have the attribute, and
+ * the card treats absent as false. In Meilisearch an equality matches only documents that HAVE the
+ * attribute, while a negation also matches documents that lack it. So `= false` would hide almost
+ * the entire index and "hide paid" would return nearly nothing.
+ *
+ * Measured on the live index against `cannotPromote`, which is sparse the same way:
+ * `EXISTS` 1,853 · `= true` 1,115 · `NOT = true` >=100,000. That last number is the proof — if a
+ * negation skipped absent documents it could not have exceeded 1,853 - 1,115 = 738.
+ */
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+const CALL_SITE = 'src/pages/search/models.tsx';
+
+// This file states the forbidden spelling in order to forbid it, so it is the one exemption.
+// Exactly one, asserted below: widening this list is the edit that must be visible in a diff.
+const ALLOWLIST = [
+  'src/components/Search/__tests__/hide-paid-search-filter-negation.test.ts',
+] as const;
+
+describe('hide-paid search filter', () => {
+  it('is a negation, not an equality on false', () => {
+    expect(HIDE_PAID_MODELS_FILTER).toMatch(/^NOT\s/);
+    expect(HIDE_PAID_MODELS_FILTER).toContain('hasActivePaidAccess');
+    expect(HIDE_PAID_MODELS_FILTER).not.toContain('false');
+  });
+
+  it('survives the parenthesising every clause gets before it reaches Meilisearch', () => {
+    // joinFilterClauses wraps each clause in `(...)`. A clause that is only valid unwrapped would
+    // fail as a 400 at runtime and never in a unit test that looked at the constant alone.
+    expect(joinFilterClauses([HIDE_PAID_MODELS_FILTER])).toBe('(NOT hasActivePaidAccess = true)');
+  });
+
+  it('filters on an attribute the models index declares filterable', () => {
+    // Without this the whole models search answers 400 invalid_search_filter the moment anyone
+    // ticks the box — not just the paid filter, the entire result set.
+    expect(filterableAttributesByIndex[MODELS_SEARCH_INDEX]).toContain('hasActivePaidAccess');
+  });
+});
+
+function walk(dir: string, out: string[] = []) {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry.startsWith('.')) continue;
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+describe('no equality-on-false spelling anywhere', () => {
+  it('src/ never writes `hasActivePaidAccess = false`', () => {
+    const offenders = walk(path.join(repoRoot, 'src'))
+      .filter((file) => /hasActivePaidAccess\s*=\s*false/.test(readFileSync(file, 'utf8')))
+      .map((file) => path.relative(repoRoot, file).split(path.sep).join('/'))
+      .filter((file) => !ALLOWLIST.includes(file as (typeof ALLOWLIST)[number]));
+
+    expect(ALLOWLIST).toHaveLength(1);
+
+    expect(
+      offenders,
+      'Use a NOT clause. An equality does not match documents that lack the attribute.'
+    ).toEqual([]);
+  });
+
+  it('the call site uses the shared constant rather than an inline string', () => {
+    // The constant carries the reasoning. Inlining the string is how the reasoning gets lost and
+    // the next edit reaches for `= false`.
+    const source = readFileSync(path.join(repoRoot, CALL_SITE), 'utf8');
+
+    expect(source).toContain('HIDE_PAID_MODELS_FILTER');
+    expect(source).not.toContain("'NOT hasActivePaidAccess");
+  });
+});

--- a/src/components/Search/paid-model-search-filter.ts
+++ b/src/components/Search/paid-model-search-filter.ts
@@ -9,5 +9,21 @@
  * Measured on the live index against `cannotPromote`, which has the same sparse shape:
  * `cannotPromote EXISTS` 1,853 · `cannotPromote = true` 1,115 · `NOT cannotPromote = true` >=100,000.
  * If negation skipped absent documents that last number could not have exceeded 738.
+ *
+ * `poi != true` and `minor != true` two lines above the call site say the same thing a different
+ * way and are equally correct. This spelling is kept because it is the one the numbers above were
+ * measured with.
  */
 export const HIDE_PAID_MODELS_FILTER = 'NOT hasActivePaidAccess = true';
+
+/**
+ * Returns the clause when it should apply, and `null` when it should not — `null` because
+ * `buildBrowsingLevelFilters` drops undefined-ish entries and Meilisearch rejects a bare `()`.
+ *
+ * A function rather than an inline ternary at the call site so the flag gate and the default are
+ * testable: both were previously unreachable from any test, and deleting the whole clause from the
+ * page left every suite green.
+ */
+export function paidModelsSearchFilterClause(enabled: boolean, hidePaid: boolean) {
+  return enabled && hidePaid ? HIDE_PAID_MODELS_FILTER : null;
+}

--- a/src/components/Search/paid-model-search-filter.ts
+++ b/src/components/Search/paid-model-search-filter.ts
@@ -1,0 +1,13 @@
+/**
+ * The "hide paid models" clause for the models search index.
+ *
+ * 🔴 `NOT <attr> = true`, never `<attr> = false`. A negation matches documents that LACK the
+ * attribute; an equality does not. Only GATED models are backfilled with `hasActivePaidAccess`, so
+ * `= false` would hide every model whose document has not been rewritten since the field shipped —
+ * which is nearly all of them, and the failure would look like "hide paid returns almost nothing".
+ *
+ * Measured on the live index against `cannotPromote`, which has the same sparse shape:
+ * `cannotPromote EXISTS` 1,853 · `cannotPromote = true` 1,115 · `NOT cannotPromote = true` >=100,000.
+ * If negation skipped absent documents that last number could not have exceeded 738.
+ */
+export const HIDE_PAID_MODELS_FILTER = 'NOT hasActivePaidAccess = true';

--- a/src/pages/api/admin/temp/apply-models-index-filterable-attributes.ts
+++ b/src/pages/api/admin/temp/apply-models-index-filterable-attributes.ts
@@ -17,25 +17,49 @@ import { booleanString } from '~/utils/zod-helpers';
  *
  * 🔴 Meilisearch reindexes the filterable fields across every document in the index when this list
  * changes. The cost on this index has never been measured, and one `images_v6` batch on this
- * instance has taken 51 minutes. Treat it as a maintenance operation with an owner watching, not as
- * a deploy step: check the queue is quiet first, and poll the returned task uid.
+ * instance has taken 51 minutes. Treat it as a maintenance operation with an owner watching.
+ *
+ * Two refusals, because `updateFilterableAttributes` REPLACES the list rather than merging into it:
+ *
+ * - Anything live on the index but missing from the code list would be DELETED by the write. Drift
+ *   is not directional and the repo cannot see which way it has gone, so a non-empty `extra`
+ *   refuses unless `allowRemove=true`. Removing a filterable attribute makes every query using it
+ *   answer `invalid_search_filter`, and undoing it costs a second full reindex.
+ * - The write returns as soon as the task is ENQUEUED, while `getFilterableAttributes` reports what
+ *   is APPLIED. In between, a second call sees the same `missing` and enqueues a second full
+ *   reindex. There is no method guard on `WebhookEndpoint`, so a browser reload is enough. A
+ *   pending settings task therefore refuses unless `force=true`.
  *
  * Usage:
  *   POST /api/admin/temp/apply-models-index-filterable-attributes?token=$WEBHOOK_TOKEN
  *     &dryRun=false
  *
  * Params (query):
- *   dryRun - default true. Report the current list and what would be added, write nothing.
+ *   dryRun     - default true. Report the current list and what would change, write nothing.
+ *   allowRemove - default false. Permit a write that removes attributes the live index has.
+ *   force      - default false. Permit a write while a settings task is already enqueued.
  */
 
 const schema = z.object({
   dryRun: booleanString().default(true),
+  allowRemove: booleanString().default(false),
+  force: booleanString().default(false),
 });
+
+async function pendingSettingsTaskUids(index: {
+  getTasks: (q: { statuses: string[]; types: string[] }) => Promise<{ results: { uid: number }[] }>;
+}) {
+  const tasks = await index.getTasks({
+    statuses: ['enqueued', 'processing'],
+    types: ['settingsUpdate'],
+  });
+  return tasks.results.map((t) => t.uid);
+}
 
 export default WebhookEndpoint(async (req, res) => {
   const parsed = schema.safeParse(req.query);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
-  const { dryRun } = parsed.data;
+  const { dryRun, allowRemove, force } = parsed.data;
 
   if (!searchClient) return res.status(503).json({ error: 'search client not configured' });
 
@@ -47,13 +71,30 @@ export default WebhookEndpoint(async (req, res) => {
 
   const missing = desired.filter((a) => !current.includes(a));
   const extra = current.filter((a) => !desired.includes(a as never));
+  const pending = await pendingSettingsTaskUids(index as never);
 
   if (dryRun) {
-    return res.status(200).json({ dryRun: true, current, desired, missing, extra });
+    return res.status(200).json({ dryRun: true, current, desired, missing, extra, pending });
   }
 
   if (!missing.length && !extra.length) {
     return res.status(200).json({ dryRun: false, unchanged: true, current });
+  }
+
+  if (extra.length && !allowRemove) {
+    return res.status(409).json({
+      error: 'refusing to remove filterable attributes',
+      extra,
+      hint: 'pass allowRemove=true only if you intend the live index to lose these',
+    });
+  }
+
+  if (pending.length && !force) {
+    return res.status(409).json({
+      error: 'a settings task is already enqueued on this index',
+      pending,
+      hint: 'wait for it to apply, then re-read; pass force=true only to enqueue a second reindex',
+    });
   }
 
   const task = await index.updateFilterableAttributes(desired);

--- a/src/pages/api/admin/temp/apply-models-index-filterable-attributes.ts
+++ b/src/pages/api/admin/temp/apply-models-index-filterable-attributes.ts
@@ -1,0 +1,70 @@
+import * as z from 'zod';
+import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
+import { searchClient } from '~/server/meilisearch/client';
+import { modelsFilterableAttributes } from '~/server/search-index/filterable-attributes';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { booleanString } from '~/utils/zod-helpers';
+
+/**
+ * Apply `modelsFilterableAttributes` to the LIVE models index.
+ *
+ * Hidden admin route. Guarded by WEBHOOK_TOKEN via `?token=` query param.
+ *
+ * Why this exists: nothing else can apply the list without a full rebuild. Each index's
+ * `onIndexSetup` is the only in-repo writer of these settings, and it runs in exactly one place —
+ * `reset()` in base.search-index.ts — against the `_NEW` swap index. So adding an attribute to the
+ * list is INERT on the live index until either a reset rebuilds all ~705K documents, or this runs.
+ *
+ * 🔴 Meilisearch reindexes the filterable fields across every document in the index when this list
+ * changes. The cost on this index has never been measured, and one `images_v6` batch on this
+ * instance has taken 51 minutes. Treat it as a maintenance operation with an owner watching, not as
+ * a deploy step: check the queue is quiet first, and poll the returned task uid.
+ *
+ * Usage:
+ *   POST /api/admin/temp/apply-models-index-filterable-attributes?token=$WEBHOOK_TOKEN
+ *     &dryRun=false
+ *
+ * Params (query):
+ *   dryRun - default true. Report the current list and what would be added, write nothing.
+ */
+
+const schema = z.object({
+  dryRun: booleanString().default(true),
+});
+
+export default WebhookEndpoint(async (req, res) => {
+  const parsed = schema.safeParse(req.query);
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+  const { dryRun } = parsed.data;
+
+  if (!searchClient) return res.status(503).json({ error: 'search client not configured' });
+
+  // `index()` is a local handle — unlike getOrCreateIndex it cannot create an index as a side
+  // effect of a typo in the name.
+  const index = searchClient.index(MODELS_SEARCH_INDEX);
+  const current = (await index.getFilterableAttributes()) ?? [];
+  const desired = [...modelsFilterableAttributes];
+
+  const missing = desired.filter((a) => !current.includes(a));
+  const extra = current.filter((a) => !desired.includes(a as never));
+
+  if (dryRun) {
+    return res.status(200).json({ dryRun: true, current, desired, missing, extra });
+  }
+
+  if (!missing.length && !extra.length) {
+    return res.status(200).json({ dryRun: false, unchanged: true, current });
+  }
+
+  const task = await index.updateFilterableAttributes(desired);
+
+  return res.status(200).json({
+    dryRun: false,
+    unchanged: false,
+    added: missing,
+    removed: extra,
+    // Poll this. The call returns as soon as the task is ENQUEUED, which on a busy instance is a
+    // long way from applied.
+    taskUid: task.taskUid,
+  });
+});

--- a/src/pages/api/admin/temp/apply-models-index-filterable-attributes.ts
+++ b/src/pages/api/admin/temp/apply-models-index-filterable-attributes.ts
@@ -46,14 +46,24 @@ const schema = z.object({
   force: booleanString().default(false),
 });
 
+// Returns null when the tasks API could not be reached or refused. That is deliberately distinct
+// from an empty array: an empty array means "checked, nothing pending", null means "do not know",
+// and the write path treats not-knowing as a refusal. Swallowing the difference would turn a
+// permissions or availability problem into a green light for a full-index reindex.
+//
+// The SDK scopes this to the index handle (it sends indexUids=<uid>), so it does not scan globally.
 async function pendingSettingsTaskUids(index: {
   getTasks: (q: { statuses: string[]; types: string[] }) => Promise<{ results: { uid: number }[] }>;
 }) {
-  const tasks = await index.getTasks({
-    statuses: ['enqueued', 'processing'],
-    types: ['settingsUpdate'],
-  });
-  return tasks.results.map((t) => t.uid);
+  try {
+    const tasks = await index.getTasks({
+      statuses: ['enqueued', 'processing'],
+      types: ['settingsUpdate'],
+    });
+    return tasks.results.map((t) => t.uid);
+  } catch {
+    return null;
+  }
 }
 
 export default WebhookEndpoint(async (req, res) => {
@@ -74,6 +84,8 @@ export default WebhookEndpoint(async (req, res) => {
   const pending = await pendingSettingsTaskUids(index as never);
 
   if (dryRun) {
+    // Reports `pending: null` rather than failing when the tasks API is unreachable, so the read-only
+    // path still answers the question it is for — what would change — even if the write could not run.
     return res.status(200).json({ dryRun: true, current, desired, missing, extra, pending });
   }
 
@@ -89,7 +101,14 @@ export default WebhookEndpoint(async (req, res) => {
     });
   }
 
-  if (pending.length && !force) {
+  if (pending === null && !force) {
+    return res.status(409).json({
+      error: 'could not determine whether a settings task is already pending',
+      hint: 'the tasks API was unreachable or refused; SEARCH_API_KEY may lack tasks.get. Pass force=true only if you have checked by hand',
+    });
+  }
+
+  if (pending?.length && !force) {
     return res.status(409).json({
       error: 'a settings task is already enqueued on this index',
       pending,

--- a/src/pages/api/admin/temp/queue-paid-models-reindex.ts
+++ b/src/pages/api/admin/temp/queue-paid-models-reindex.ts
@@ -1,0 +1,84 @@
+import * as z from 'zod';
+import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { queryGatedModelIds } from '~/server/services/paid-access.service';
+import { SearchIndexUpdate } from '~/server/search-index/SearchIndexUpdate';
+import { modelsSearchIndex } from '~/server/search-index';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { booleanString } from '~/utils/zod-helpers';
+
+/**
+ * Queue every model with a live paid-access gate for a models-index rewrite.
+ *
+ * Hidden admin route. Guarded by WEBHOOK_TOKEN via `?token=` query param.
+ *
+ * Purpose: `hasActivePaidAccess` was added to the models search document, and the deployed indexer
+ * writes it — but only for documents it has rewritten since. Existing documents predate the field.
+ * Only GATED models need queueing: the card and the search filter both treat an absent attribute as
+ * false, so the ~700K ungated documents are already correct and rewriting them would be waste.
+ *
+ * Usage:
+ *   POST /api/admin/temp/queue-paid-models-reindex?token=$WEBHOOK_TOKEN&dryRun=false
+ *
+ * Params (query):
+ *   dryRun    - default true. Report the id count and the current queue depth, queue nothing.
+ *   chunkSize - default 1000. Ids per queueUpdate call.
+ *
+ * Response reports `queueDepthBefore` and `queueDepthAfter` as READ BACK from the queue, not as
+ * inferred from the call returning. `addToQueue` fails open on a degraded sysRedis — it parks the
+ * ids in Postgres and returns false — and neither `SearchIndexUpdate.queueUpdate` nor
+ * `modelsSearchIndex.queueUpdate` propagates that boolean. So "the call returned" is not evidence
+ * the ids landed; the delta between the two depths is.
+ */
+
+const schema = z.object({
+  dryRun: booleanString().default(true),
+  chunkSize: z.coerce.number().min(1).max(10000).default(1000),
+});
+
+const QUEUE_ACTION = SearchIndexUpdateQueueAction.Update;
+
+async function readQueuedIds() {
+  // readOnly: does NOT append a new bucket or retire the current ones, so calling this cannot
+  // consume work the */15 sync is about to pick up.
+  const queue = await SearchIndexUpdate.getQueue(MODELS_SEARCH_INDEX, QUEUE_ACTION, true);
+  return queue.content;
+}
+
+export default WebhookEndpoint(async (req, res) => {
+  const parsed = schema.safeParse(req.query);
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+  const { dryRun, chunkSize } = parsed.data;
+
+  const modelIds = await queryGatedModelIds();
+  const before = await readQueuedIds();
+
+  if (dryRun) {
+    return res.status(200).json({
+      dryRun: true,
+      gatedModelCount: modelIds.length,
+      queueDepthBefore: before.length,
+      alreadyQueued: modelIds.filter((id) => before.includes(id)).length,
+    });
+  }
+
+  for (let i = 0; i < modelIds.length; i += chunkSize) {
+    const chunk = modelIds.slice(i, i + chunkSize);
+    await modelsSearchIndex.queueUpdate(chunk.map((id) => ({ id, action: QUEUE_ACTION })));
+  }
+
+  const after = await readQueuedIds();
+  const afterSet = new Set(after);
+  const landed = modelIds.filter((id) => afterSet.has(id)).length;
+
+  return res.status(200).json({
+    dryRun: false,
+    gatedModelCount: modelIds.length,
+    queueDepthBefore: before.length,
+    queueDepthAfter: after.length,
+    // The number that decides whether this worked. `landed < gatedModelCount` means sysRedis
+    // dropped ids; they are parked in KeyValue under `search-index-queue-fallback:` and the
+    // `search-index-queue-drain` job replays them. Re-run rather than assuming.
+    landed,
+  });
+});

--- a/src/pages/api/admin/temp/queue-paid-models-reindex.ts
+++ b/src/pages/api/admin/temp/queue-paid-models-reindex.ts
@@ -17,6 +17,16 @@ import { booleanString } from '~/utils/zod-helpers';
  * Only GATED models need queueing: the card and the search filter both treat an absent attribute as
  * false, so the ~700K ungated documents are already correct and rewriting them would be waste.
  *
+ * 🔴 `alreadyQueued` is only meaningful IMMEDIATELY after an enqueue. The 15-minute sync checks
+ * this queue out destructively, so any later reading is near zero whatever happened — and a near
+ * zero reads naturally as "nothing is queued, safe to write again", which may be the opposite of
+ * the truth.
+ *
+ * History: the one-off backfill this was written for was performed on 2026-09-08 through
+ * /api/internal/search-index-update, because this endpoint was not yet deployed. This is not
+ * therefore spent — the gated set moves with the wall clock, since `endsAt` is in the predicate —
+ * but it is a reconciler rather than a pending step.
+ *
  * Usage:
  *   POST /api/admin/temp/queue-paid-models-reindex?token=$WEBHOOK_TOKEN&dryRun=false
  *

--- a/src/pages/api/admin/temp/queue-paid-models-reindex.ts
+++ b/src/pages/api/admin/temp/queue-paid-models-reindex.ts
@@ -28,7 +28,12 @@ import { booleanString } from '~/utils/zod-helpers';
  * inferred from the call returning. `addToQueue` fails open on a degraded sysRedis — it parks the
  * ids in Postgres and returns false — and neither `SearchIndexUpdate.queueUpdate` nor
  * `modelsSearchIndex.queueUpdate` propagates that boolean. So "the call returned" is not evidence
- * the ids landed; the delta between the two depths is.
+ * the ids landed.
+ *
+ * `landed` is one-directional evidence. Equal to `gatedModelCount` it proves the ids are queued.
+ * BELOW it, the ids may have been dropped OR the 15-minute search-index sync may have checked the
+ * queue out destructively between the enqueue and the read — a low count is a reason to re-run,
+ * not a diagnosis. Re-running is harmless; the enqueue is idempotent.
  */
 
 const schema = z.object({
@@ -40,7 +45,7 @@ const QUEUE_ACTION = SearchIndexUpdateQueueAction.Update;
 
 async function readQueuedIds() {
   // readOnly: does NOT append a new bucket or retire the current ones, so calling this cannot
-  // consume work the */15 sync is about to pick up.
+  // consume work the 15-minute sync is about to pick up.
   const queue = await SearchIndexUpdate.getQueue(MODELS_SEARCH_INDEX, QUEUE_ACTION, true);
   return queue.content;
 }
@@ -52,13 +57,16 @@ export default WebhookEndpoint(async (req, res) => {
 
   const modelIds = await queryGatedModelIds();
   const before = await readQueuedIds();
+  // Set, not Array.includes: this queue reaches ~211K ids on a large fan-out, and scanning it once
+  // per gated model is enough to wedge the handler.
+  const beforeSet = new Set(before);
 
   if (dryRun) {
     return res.status(200).json({
       dryRun: true,
       gatedModelCount: modelIds.length,
       queueDepthBefore: before.length,
-      alreadyQueued: modelIds.filter((id) => before.includes(id)).length,
+      alreadyQueued: modelIds.filter((id) => beforeSet.has(id)).length,
     });
   }
 
@@ -76,9 +84,8 @@ export default WebhookEndpoint(async (req, res) => {
     gatedModelCount: modelIds.length,
     queueDepthBefore: before.length,
     queueDepthAfter: after.length,
-    // The number that decides whether this worked. `landed < gatedModelCount` means sysRedis
-    // dropped ids; they are parked in KeyValue under `search-index-queue-fallback:` and the
-    // `search-index-queue-drain` job replays them. Re-run rather than assuming.
+    // `landed === gatedModelCount` is proof the ids are queued. A lower number is ambiguous — see
+    // the note at the top of this file — and the response to it is to re-run.
     landed,
   });
 });

--- a/src/pages/search/models.tsx
+++ b/src/pages/search/models.tsx
@@ -26,7 +26,7 @@ import { MasonryGrid } from '~/components/MasonryColumns/MasonryGrid';
 import { NoContent } from '~/components/NoContent/NoContent';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
-import { HIDE_PAID_MODELS_FILTER } from '~/components/Search/paid-model-search-filter';
+import { paidModelsSearchFilterClause } from '~/components/Search/paid-model-search-filter';
 import { Availability } from '~/shared/utils/prisma/enums';
 import { useBrowsingSettingsAddons } from '~/providers/BrowsingSettingsAddonsProvider';
 import { isDefined } from '~/utils/type-guards';
@@ -60,7 +60,7 @@ const RenderFilters = () => {
     `availability != ${Availability.Private}${
       currentUser?.id ? ` OR user.id = ${currentUser.id}` : ''
     }`,
-    features.paidModelSearchFilter && hidePaid ? HIDE_PAID_MODELS_FILTER : null,
+    paidModelsSearchFilterClause(features.paidModelSearchFilter, hidePaid),
     `NOT (nsfwLevel IN [${nsfwBrowsingLevelsArray.join(
       ', '
     )}] AND version.baseModel IN [${nsfwRestrictedBaseModels

--- a/src/pages/search/models.tsx
+++ b/src/pages/search/models.tsx
@@ -1,4 +1,4 @@
-import { Stack, Center, Loader, Title, Text, ThemeIcon } from '@mantine/core';
+import { Stack, Center, Loader, Title, Text, ThemeIcon, Checkbox } from '@mantine/core';
 import { useInstantSearch } from 'react-instantsearch';
 
 import {
@@ -9,7 +9,7 @@ import {
   SearchableMultiSelectRefinementList,
   SortBy,
 } from '~/components/Search/CustomSearchComponents';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { ModelCard } from '~/components/Cards/ModelCard';
 import { ModelCardContextProvider, useModelSaleBadges } from '~/components/Cards/ModelCardContext';
 import { SearchHeader } from '~/components/Search/SearchHeader';
@@ -25,6 +25,8 @@ import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApp
 import { MasonryGrid } from '~/components/MasonryColumns/MasonryGrid';
 import { NoContent } from '~/components/NoContent/NoContent';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { HIDE_PAID_MODELS_FILTER } from '~/components/Search/paid-model-search-filter';
 import { Availability } from '~/shared/utils/prisma/enums';
 import { useBrowsingSettingsAddons } from '~/providers/BrowsingSettingsAddonsProvider';
 import { isDefined } from '~/utils/type-guards';
@@ -45,6 +47,8 @@ export default function ModelsSearch() {
 const RenderFilters = () => {
   const currentUser = useCurrentUser();
   const browsingSettingsAddons = useBrowsingSettingsAddons();
+  const features = useFeatureFlags();
+  const [hidePaid, setHidePaid] = useState(false);
 
   const filters = [
     browsingSettingsAddons.settings.disablePoi
@@ -56,6 +60,7 @@ const RenderFilters = () => {
     `availability != ${Availability.Private}${
       currentUser?.id ? ` OR user.id = ${currentUser.id}` : ''
     }`,
+    features.paidModelSearchFilter && hidePaid ? HIDE_PAID_MODELS_FILTER : null,
     `NOT (nsfwLevel IN [${nsfwBrowsingLevelsArray.join(
       ', '
     )}] AND version.baseModel IN [${nsfwRestrictedBaseModels
@@ -112,6 +117,13 @@ const RenderFilters = () => {
         operator="and"
         searchable
       />
+      {features.paidModelSearchFilter && (
+        <Checkbox
+          label="Hide paid models"
+          checked={hidePaid}
+          onChange={(event) => setHidePaid(event.currentTarget.checked)}
+        />
+      )}
       <ClearRefinements />
     </>
   );

--- a/src/server/__tests__/apply-models-index-filterable-attributes-endpoint.test.ts
+++ b/src/server/__tests__/apply-models-index-filterable-attributes-endpoint.test.ts
@@ -1,17 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '~/__tests__/mocks/logging.mock';
 import '~/__tests__/mocks/db.mock';
+import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
 import { modelsFilterableAttributes } from '~/server/search-index/filterable-attributes';
 
 /**
  * This endpoint is the only in-repo way to apply `modelsFilterableAttributes` to the LIVE models
  * index without a full rebuild, and Meilisearch reindexes the filterable fields across every
- * document when the list changes — an unmeasured cost on ~705K documents.
+ * document when the list changes — unmeasured on ~705K documents.
  *
- * So what is pinned here is that it is INERT unless someone explicitly asks for the write, and that
- * the write it makes is the whole desired list. `updateFilterableAttributes` REPLACES rather than
- * merges, so writing anything narrower silently strips the rest of the index's filterable
- * attributes and every models search then answers 400 invalid_search_filter.
+ * Two properties are pinned: it is INERT unless someone explicitly asks for the write, and the
+ * write it makes is the whole desired list ON THE MODELS INDEX. `updateFilterableAttributes`
+ * REPLACES rather than merges, so writing anything narrower — or writing to the wrong index —
+ * silently strips that index's filterable attributes and every search on it then answers
+ * 400 invalid_search_filter.
  */
 
 const { env, getFilterableAttributes, updateFilterableAttributes, getTasks, index } = vi.hoisted(
@@ -72,16 +74,34 @@ describe('apply-models-index-filterable-attributes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getFilterableAttributes.mockResolvedValue(['id', 'nsfwLevel']);
+    getTasks.mockReset();
     getTasks.mockResolvedValue({ results: [] });
   });
 
   it('rejects a call with the wrong token, and writes nothing', async () => {
-    // Deleting the WebhookEndpoint wrapper makes this route world-callable, and every other test
-    // here passes a valid token, so nothing else can see it.
     const { statusCode } = await call({ dryRun: 'false' }, 'wrong');
 
     expect(statusCode).toBe(401);
     expect(updateFilterableAttributes).not.toHaveBeenCalled();
+  });
+
+  it('targets the MODELS index', async () => {
+    // Retargeting this at another index passes every other assertion in this file while wiping that
+    // index's filterable attributes in production.
+    await call({});
+
+    expect(index).toHaveBeenCalledWith(MODELS_SEARCH_INDEX);
+  });
+
+  it('asks only for PENDING SETTINGS tasks when deciding whether one is in flight', async () => {
+    // Point this at another type or drop 'processing' and the double-reindex guard silently stops
+    // guarding, while the 409 test below keeps passing on its canned result.
+    await call({});
+
+    expect(getTasks.mock.calls[0][0]).toEqual({
+      statuses: ['enqueued', 'processing'],
+      types: ['settingsUpdate'],
+    });
   });
 
   it('writes NOTHING by default', async () => {
@@ -92,9 +112,28 @@ describe('apply-models-index-filterable-attributes', () => {
     expect(updateFilterableAttributes).not.toHaveBeenCalled();
   });
 
+  it('still answers the dry run when the tasks API is unreachable', async () => {
+    // A key without tasks.get would otherwise take out the read-only path too. null means "did not
+    // determine", which is distinct from [] meaning "checked, nothing pending".
+    getTasks.mockRejectedValue(new Error('403 forbidden'));
+
+    const { statusCode, payload } = await call({});
+
+    expect(statusCode).toBe(200);
+    expect(payload.pending).toBeNull();
+    expect(updateFilterableAttributes).not.toHaveBeenCalled();
+  });
+
+  it('REFUSES the write when it cannot tell whether a settings task is pending', async () => {
+    getTasks.mockRejectedValue(new Error('403 forbidden'));
+
+    const { statusCode } = await call({ dryRun: 'false' });
+
+    expect(statusCode).toBe(409);
+    expect(updateFilterableAttributes).not.toHaveBeenCalled();
+  });
+
   it('writes the WHOLE desired list, because the call replaces rather than merges', async () => {
-    // toContain would pass on `updateFilterableAttributes(missing)`, which reads like the obvious
-    // edit and strips every other filterable attribute from the live index.
     const { payload } = await call({ dryRun: 'false' });
 
     expect(updateFilterableAttributes).toHaveBeenCalledTimes(1);
@@ -123,12 +162,15 @@ describe('apply-models-index-filterable-attributes', () => {
     expect(updateFilterableAttributes).not.toHaveBeenCalled();
   });
 
-  it('permits the removal only when allowRemove is passed', async () => {
+  it('permits the removal only with allowRemove, and actually removes', async () => {
+    // Asserting only that a write happened let `[...desired, ...extra]` pass — which reports
+    // `removed` while removing nothing, so an operator re-runs forever.
     getFilterableAttributes.mockResolvedValue(['id', 'somethingElse']);
 
-    await call({ dryRun: 'false', allowRemove: 'true' });
+    const { payload } = await call({ dryRun: 'false', allowRemove: 'true' });
 
-    expect(updateFilterableAttributes).toHaveBeenCalledTimes(1);
+    expect(updateFilterableAttributes.mock.calls[0][0]).toEqual([...modelsFilterableAttributes]);
+    expect(payload.removed).toEqual(['somethingElse']);
   });
 
   it('REFUSES a second write while a settings task is still enqueued', async () => {
@@ -144,11 +186,17 @@ describe('apply-models-index-filterable-attributes', () => {
     expect(updateFilterableAttributes).not.toHaveBeenCalled();
   });
 
-  it('permits it only when force is passed', async () => {
+  it('permits it only with force, and still writes the whole list', async () => {
+    // Production shape: the live index has everything except the one new attribute, so `added` is
+    // exactly that attribute rather than the 20 the default fixture is missing.
+    getFilterableAttributes.mockResolvedValue(
+      modelsFilterableAttributes.filter((a) => a !== 'hasActivePaidAccess')
+    );
     getTasks.mockResolvedValue({ results: [{ uid: 7 }] });
 
-    await call({ dryRun: 'false', force: 'true' });
+    const { payload } = await call({ dryRun: 'false', force: 'true' });
 
-    expect(updateFilterableAttributes).toHaveBeenCalledTimes(1);
+    expect(updateFilterableAttributes.mock.calls[0][0]).toEqual([...modelsFilterableAttributes]);
+    expect(payload.added).toEqual(['hasActivePaidAccess']);
   });
 });

--- a/src/server/__tests__/apply-models-index-filterable-attributes-endpoint.test.ts
+++ b/src/server/__tests__/apply-models-index-filterable-attributes-endpoint.test.ts
@@ -1,31 +1,38 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '~/__tests__/mocks/logging.mock';
 import '~/__tests__/mocks/db.mock';
+import { modelsFilterableAttributes } from '~/server/search-index/filterable-attributes';
 
 /**
  * This endpoint is the only in-repo way to apply `modelsFilterableAttributes` to the LIVE models
  * index without a full rebuild, and Meilisearch reindexes the filterable fields across every
  * document when the list changes — an unmeasured cost on ~705K documents.
  *
- * So the property that matters is that it is INERT unless someone explicitly asks for the write.
- * `dryRun` defaults to true; these fail if that default is ever flipped or the guard removed.
+ * So what is pinned here is that it is INERT unless someone explicitly asks for the write, and that
+ * the write it makes is the whole desired list. `updateFilterableAttributes` REPLACES rather than
+ * merges, so writing anything narrower silently strips the rest of the index's filterable
+ * attributes and every models search then answers 400 invalid_search_filter.
  */
 
-const { env, getFilterableAttributes, updateFilterableAttributes, index } = vi.hoisted(() => {
-  const getFilterableAttributes = vi.fn(async () => ['id', 'nsfwLevel'] as string[]);
-  const updateFilterableAttributes = vi.fn(async () => ({ taskUid: 99 }));
-  return {
-    env: {
-      WEBHOOK_TOKEN: 'test-token',
-      LOGGING: '',
-      NEXTAUTH_URL: 'https://example.test',
-      TRPC_ORIGINS: [] as string[],
-    },
-    getFilterableAttributes,
-    updateFilterableAttributes,
-    index: vi.fn(() => ({ getFilterableAttributes, updateFilterableAttributes })),
-  };
-});
+const { env, getFilterableAttributes, updateFilterableAttributes, getTasks, index } = vi.hoisted(
+  () => {
+    const getFilterableAttributes = vi.fn(async () => ['id', 'nsfwLevel'] as string[]);
+    const updateFilterableAttributes = vi.fn(async () => ({ taskUid: 99 }));
+    const getTasks = vi.fn(async () => ({ results: [] as { uid: number }[] }));
+    return {
+      env: {
+        WEBHOOK_TOKEN: 'test-token',
+        LOGGING: '',
+        NEXTAUTH_URL: 'https://example.test',
+        TRPC_ORIGINS: [] as string[],
+      },
+      getFilterableAttributes,
+      updateFilterableAttributes,
+      getTasks,
+      index: vi.fn(() => ({ getFilterableAttributes, updateFilterableAttributes, getTasks })),
+    };
+  }
+);
 
 vi.mock('~/env/server', () => ({ env }));
 vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
@@ -38,49 +45,110 @@ vi.mock('~/server/meilisearch/client', () => ({
 const handler = (await import('~/pages/api/admin/temp/apply-models-index-filterable-attributes'))
   .default;
 
-function call(query: Record<string, string>) {
-  const req = { method: 'POST', query: { token: 'test-token', ...query }, headers: {} } as never;
+function call(query: Record<string, string>, token = 'test-token') {
+  const req = { method: 'POST', query: { token, ...query }, headers: {} } as never;
+  let statusCode = 0;
   let payload: Record<string, unknown> | undefined;
   const res = {
-    status: () => res,
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
     json(data: Record<string, unknown>) {
       payload = data;
       return res;
     },
+    send: () => res,
     setHeader: () => res,
     end: () => res,
   };
-  return handler(req, res as never).then(() => payload as Record<string, unknown>);
+  return handler(req, res as never).then(() => ({
+    statusCode,
+    payload: payload as Record<string, unknown>,
+  }));
 }
 
 describe('apply-models-index-filterable-attributes', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getFilterableAttributes.mockResolvedValue(['id', 'nsfwLevel']);
+    getTasks.mockResolvedValue({ results: [] });
+  });
+
+  it('rejects a call with the wrong token, and writes nothing', async () => {
+    // Deleting the WebhookEndpoint wrapper makes this route world-callable, and every other test
+    // here passes a valid token, so nothing else can see it.
+    const { statusCode } = await call({ dryRun: 'false' }, 'wrong');
+
+    expect(statusCode).toBe(401);
+    expect(updateFilterableAttributes).not.toHaveBeenCalled();
+  });
 
   it('writes NOTHING by default', async () => {
-    const payload = await call({});
+    const { payload } = await call({});
 
     expect(payload.dryRun).toBe(true);
     expect(payload.missing).toContain('hasActivePaidAccess');
     expect(updateFilterableAttributes).not.toHaveBeenCalled();
   });
 
-  it('writes only when dryRun is explicitly false, and returns the task to poll', async () => {
-    const payload = await call({ dryRun: 'false' });
+  it('writes the WHOLE desired list, because the call replaces rather than merges', async () => {
+    // toContain would pass on `updateFilterableAttributes(missing)`, which reads like the obvious
+    // edit and strips every other filterable attribute from the live index.
+    const { payload } = await call({ dryRun: 'false' });
 
     expect(updateFilterableAttributes).toHaveBeenCalledTimes(1);
-    expect(updateFilterableAttributes.mock.calls[0][0]).toContain('hasActivePaidAccess');
+    expect(updateFilterableAttributes.mock.calls[0][0]).toEqual([...modelsFilterableAttributes]);
     expect(payload.taskUid).toBe(99);
   });
 
   it('does not write when the live list already matches', async () => {
-    const { modelsFilterableAttributes } = await import(
-      '~/server/search-index/filterable-attributes'
-    );
-    getFilterableAttributes.mockResolvedValueOnce([...modelsFilterableAttributes]);
+    getFilterableAttributes.mockResolvedValue([...modelsFilterableAttributes]);
 
-    const payload = await call({ dryRun: 'false' });
+    const { payload } = await call({ dryRun: 'false' });
 
     expect(payload.unchanged).toBe(true);
     expect(updateFilterableAttributes).not.toHaveBeenCalled();
+  });
+
+  it('REFUSES a write that would remove an attribute the live index has', async () => {
+    // Drift is not directional. Removing a filterable attribute makes every query using it answer
+    // 400, and undoing that costs a second full reindex.
+    getFilterableAttributes.mockResolvedValue(['id', 'somethingElse']);
+
+    const { statusCode, payload } = await call({ dryRun: 'false' });
+
+    expect(statusCode).toBe(409);
+    expect(payload.extra).toEqual(['somethingElse']);
+    expect(updateFilterableAttributes).not.toHaveBeenCalled();
+  });
+
+  it('permits the removal only when allowRemove is passed', async () => {
+    getFilterableAttributes.mockResolvedValue(['id', 'somethingElse']);
+
+    await call({ dryRun: 'false', allowRemove: 'true' });
+
+    expect(updateFilterableAttributes).toHaveBeenCalledTimes(1);
+  });
+
+  it('REFUSES a second write while a settings task is still enqueued', async () => {
+    // getFilterableAttributes reports what is APPLIED, so during the enqueue-to-applied window a
+    // second call sees the same `missing` and would enqueue a second full reindex. There is no
+    // method guard on the route, so a browser reload is enough to do it.
+    getTasks.mockResolvedValue({ results: [{ uid: 7 }] });
+
+    const { statusCode, payload } = await call({ dryRun: 'false' });
+
+    expect(statusCode).toBe(409);
+    expect(payload.pending).toEqual([7]);
+    expect(updateFilterableAttributes).not.toHaveBeenCalled();
+  });
+
+  it('permits it only when force is passed', async () => {
+    getTasks.mockResolvedValue({ results: [{ uid: 7 }] });
+
+    await call({ dryRun: 'false', force: 'true' });
+
+    expect(updateFilterableAttributes).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/__tests__/apply-models-index-filterable-attributes-endpoint.test.ts
+++ b/src/server/__tests__/apply-models-index-filterable-attributes-endpoint.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '~/__tests__/mocks/logging.mock';
+import '~/__tests__/mocks/db.mock';
+
+/**
+ * This endpoint is the only in-repo way to apply `modelsFilterableAttributes` to the LIVE models
+ * index without a full rebuild, and Meilisearch reindexes the filterable fields across every
+ * document when the list changes — an unmeasured cost on ~705K documents.
+ *
+ * So the property that matters is that it is INERT unless someone explicitly asks for the write.
+ * `dryRun` defaults to true; these fail if that default is ever flipped or the guard removed.
+ */
+
+const { env, getFilterableAttributes, updateFilterableAttributes, index } = vi.hoisted(() => {
+  const getFilterableAttributes = vi.fn(async () => ['id', 'nsfwLevel'] as string[]);
+  const updateFilterableAttributes = vi.fn(async () => ({ taskUid: 99 }));
+  return {
+    env: {
+      WEBHOOK_TOKEN: 'test-token',
+      LOGGING: '',
+      NEXTAUTH_URL: 'https://example.test',
+      TRPC_ORIGINS: [] as string[],
+    },
+    getFilterableAttributes,
+    updateFilterableAttributes,
+    index: vi.fn(() => ({ getFilterableAttributes, updateFilterableAttributes })),
+  };
+});
+
+vi.mock('~/env/server', () => ({ env }));
+vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
+vi.mock('~/server/meilisearch/client', () => ({
+  searchClient: { index },
+  metricsSearchClient: null,
+}));
+
+const handler = (await import('~/pages/api/admin/temp/apply-models-index-filterable-attributes'))
+  .default;
+
+function call(query: Record<string, string>) {
+  const req = { method: 'POST', query: { token: 'test-token', ...query }, headers: {} } as never;
+  let payload: Record<string, unknown> | undefined;
+  const res = {
+    status: () => res,
+    json(data: Record<string, unknown>) {
+      payload = data;
+      return res;
+    },
+    setHeader: () => res,
+    end: () => res,
+  };
+  return handler(req, res as never).then(() => payload as Record<string, unknown>);
+}
+
+describe('apply-models-index-filterable-attributes', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('writes NOTHING by default', async () => {
+    const payload = await call({});
+
+    expect(payload.dryRun).toBe(true);
+    expect(payload.missing).toContain('hasActivePaidAccess');
+    expect(updateFilterableAttributes).not.toHaveBeenCalled();
+  });
+
+  it('writes only when dryRun is explicitly false, and returns the task to poll', async () => {
+    const payload = await call({ dryRun: 'false' });
+
+    expect(updateFilterableAttributes).toHaveBeenCalledTimes(1);
+    expect(updateFilterableAttributes.mock.calls[0][0]).toContain('hasActivePaidAccess');
+    expect(payload.taskUid).toBe(99);
+  });
+
+  it('does not write when the live list already matches', async () => {
+    const { modelsFilterableAttributes } = await import(
+      '~/server/search-index/filterable-attributes'
+    );
+    getFilterableAttributes.mockResolvedValueOnce([...modelsFilterableAttributes]);
+
+    const payload = await call({ dryRun: 'false' });
+
+    expect(payload.unchanged).toBe(true);
+    expect(updateFilterableAttributes).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/__tests__/queue-paid-models-reindex-endpoint.test.ts
+++ b/src/server/__tests__/queue-paid-models-reindex-endpoint.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '~/__tests__/mocks/logging.mock';
+import '~/__tests__/mocks/db.mock';
+
+/**
+ * The endpoint exists because `addToQueue` FAILS OPEN: on a degraded sysRedis it parks the ids in
+ * Postgres and returns false, and neither `SearchIndexUpdate.queueUpdate` nor
+ * `modelsSearchIndex.queueUpdate` propagates that boolean. So "the call resolved" is not evidence
+ * the ids are queued.
+ *
+ * What is pinned here is that the response's `landed` count comes from READING THE QUEUE BACK, not
+ * from the call returning — the last test drives exactly the fail-open shape and expects landed 0
+ * while the call resolves normally.
+ */
+
+const { env, queryGatedModelIds, queueUpdate, getQueue } = vi.hoisted(() => ({
+  env: {
+    WEBHOOK_TOKEN: 'test-token',
+    LOGGING: '',
+    NEXTAUTH_URL: 'https://example.test',
+    TRPC_ORIGINS: [] as string[],
+  },
+  queryGatedModelIds: vi.fn(async () => [1, 2, 3]),
+  queueUpdate: vi.fn(async () => undefined),
+  getQueue: vi.fn(async () => ({ content: [] as number[], commit: async () => undefined })),
+}));
+
+vi.mock('~/env/server', () => ({ env }));
+vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
+vi.mock('~/server/services/paid-access.service', () => ({ queryGatedModelIds }));
+vi.mock('~/server/search-index', () => ({ modelsSearchIndex: { queueUpdate } }));
+vi.mock('~/server/search-index/SearchIndexUpdate', () => ({ SearchIndexUpdate: { getQueue } }));
+
+const handler = (await import('~/pages/api/admin/temp/queue-paid-models-reindex')).default;
+
+function call(query: Record<string, string>) {
+  const req = { method: 'POST', query: { token: 'test-token', ...query }, headers: {} } as never;
+  let statusCode = 0;
+  let payload: Record<string, unknown> | undefined;
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(data: Record<string, unknown>) {
+      payload = data;
+      return res;
+    },
+    setHeader: () => res,
+    end: () => res,
+  };
+  return handler(req, res as never).then(() => ({
+    statusCode,
+    payload: payload as Record<string, unknown>,
+  }));
+}
+
+describe('queue-paid-models-reindex', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryGatedModelIds.mockResolvedValue([1, 2, 3]);
+    getQueue.mockResolvedValue({ content: [], commit: async () => undefined });
+  });
+
+  it('defaults to a dry run and queues nothing', async () => {
+    const { statusCode, payload } = await call({});
+
+    expect(statusCode).toBe(200);
+    expect(payload.dryRun).toBe(true);
+    expect(payload.gatedModelCount).toBe(3);
+    expect(queueUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reads the gated ids UNCACHED, so a stale cached set cannot decide the backfill', async () => {
+    // `getGatedModelIds` is the cached entry point and carries a live TTL; a reindex must see the
+    // set as it is now. Swap the call and this mock is never reached.
+    await call({});
+
+    expect(queryGatedModelIds).toHaveBeenCalledTimes(1);
+  });
+
+  it('queues every gated id as an Update when dryRun=false', async () => {
+    getQueue
+      .mockResolvedValueOnce({ content: [], commit: async () => undefined })
+      .mockResolvedValueOnce({ content: [1, 2, 3], commit: async () => undefined });
+
+    const { payload } = await call({ dryRun: 'false' });
+
+    const queued = queueUpdate.mock.calls.flatMap((c) => c[0] as { id: number; action: string }[]);
+    expect(queued.map((x) => x.id)).toEqual([1, 2, 3]);
+    expect(new Set(queued.map((x) => x.action))).toEqual(new Set(['Update']));
+    expect(payload.landed).toBe(3);
+  });
+
+  it('reports landed 0 when the enqueue silently dropped every id', async () => {
+    // The fail-open shape: queueUpdate resolves, and the queue is still empty afterwards. A handler
+    // that inferred success from the call returning would report 3 here.
+    getQueue.mockResolvedValue({ content: [], commit: async () => undefined });
+
+    const { payload } = await call({ dryRun: 'false' });
+
+    expect(queueUpdate).toHaveBeenCalled();
+    expect(payload.gatedModelCount).toBe(3);
+    expect(payload.landed).toBe(0);
+  });
+});

--- a/src/server/__tests__/queue-paid-models-reindex-endpoint.test.ts
+++ b/src/server/__tests__/queue-paid-models-reindex-endpoint.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '~/__tests__/mocks/logging.mock';
 import '~/__tests__/mocks/db.mock';
+import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
 
 /**
  * The endpoint exists because `addToQueue` FAILS OPEN: on a degraded sysRedis it parks the ids in
@@ -8,9 +9,10 @@ import '~/__tests__/mocks/db.mock';
  * `modelsSearchIndex.queueUpdate` propagates that boolean. So "the call resolved" is not evidence
  * the ids are queued.
  *
- * What is pinned here is that the response's `landed` count comes from READING THE QUEUE BACK, not
- * from the call returning — the last test drives exactly the fail-open shape and expects landed 0
- * while the call resolves normally.
+ * What is pinned here is that `landed` comes from READING THE QUEUE BACK. The two fixtures below
+ * deliberately make queue depth and our-ids-landed DIFFERENT numbers — when they were equal, a
+ * handler returning `after.length` passed both the landed-3 and the landed-0 case and the pair only
+ * looked like a control.
  */
 
 const { env, queryGatedModelIds, queueUpdate, getQueue } = vi.hoisted(() => ({
@@ -34,8 +36,10 @@ vi.mock('~/server/search-index/SearchIndexUpdate', () => ({ SearchIndexUpdate: {
 
 const handler = (await import('~/pages/api/admin/temp/queue-paid-models-reindex')).default;
 
-function call(query: Record<string, string>) {
-  const req = { method: 'POST', query: { token: 'test-token', ...query }, headers: {} } as never;
+const queued = (q: { content: number[] }) => ({ ...q, commit: async () => undefined });
+
+function call(query: Record<string, string>, token = 'test-token') {
+  const req = { method: 'POST', query: { token, ...query }, headers: {} } as never;
   let statusCode = 0;
   let payload: Record<string, unknown> | undefined;
   const res = {
@@ -47,6 +51,7 @@ function call(query: Record<string, string>) {
       payload = data;
       return res;
     },
+    send: () => res,
     setHeader: () => res,
     end: () => res,
   };
@@ -59,16 +64,44 @@ function call(query: Record<string, string>) {
 describe('queue-paid-models-reindex', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // reset, not clear: clearAllMocks leaves a queued mockResolvedValueOnce behind, and a leaked
+    // once-value surfaces as a failure in the NEXT test, which misattributes the cause.
+    getQueue.mockReset();
     queryGatedModelIds.mockResolvedValue([1, 2, 3]);
-    getQueue.mockResolvedValue({ content: [], commit: async () => undefined });
+    getQueue.mockResolvedValue(queued({ content: [] }));
+  });
+
+  it('rejects a call with the wrong token, and queues nothing', async () => {
+    // Deleting the WebhookEndpoint wrapper leaves this route world-callable, and every other test
+    // here passes a valid token, so nothing else can see it.
+    const { statusCode } = await call({}, 'wrong');
+
+    expect(statusCode).toBe(401);
+    expect(queryGatedModelIds).not.toHaveBeenCalled();
+    expect(queueUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reads the models Update queue NON-destructively', async () => {
+    // The third argument is readOnly. Passed as false — or omitted, since the real signature
+    // defaults it to false — this endpoint checks the queue out destructively and consumes the
+    // pending work the 15-minute sync was about to take, on every call including the dry run.
+    await call({});
+
+    expect(getQueue.mock.calls[0]).toEqual([MODELS_SEARCH_INDEX, 'Update', true]);
   });
 
   it('defaults to a dry run and queues nothing', async () => {
+    getQueue.mockResolvedValue(queued({ content: [2, 777] }));
+
     const { statusCode, payload } = await call({});
 
     expect(statusCode).toBe(200);
     expect(payload.dryRun).toBe(true);
     expect(payload.gatedModelCount).toBe(3);
+    expect(payload.queueDepthBefore).toBe(2);
+    // Of ours, only id 2 is already queued — 777 belongs to another producer. A negation slip here
+    // reports 2 and tells an operator the work is already done.
+    expect(payload.alreadyQueued).toBe(1);
     expect(queueUpdate).not.toHaveBeenCalled();
   });
 
@@ -82,45 +115,36 @@ describe('queue-paid-models-reindex', () => {
 
   it('queues every gated id as an Update when dryRun=false', async () => {
     getQueue
-      .mockResolvedValueOnce({ content: [], commit: async () => undefined })
-      .mockResolvedValueOnce({ content: [1, 2, 3], commit: async () => undefined });
+      .mockResolvedValueOnce(queued({ content: [] }))
+      .mockResolvedValueOnce(queued({ content: [1, 2, 3] }));
 
     const { payload } = await call({ dryRun: 'false' });
 
-    const queued = queueUpdate.mock.calls.flatMap((c) => c[0] as { id: number; action: string }[]);
-    expect(queued.map((x) => x.id)).toEqual([1, 2, 3]);
-    expect(new Set(queued.map((x) => x.action))).toEqual(new Set(['Update']));
+    const items = queueUpdate.mock.calls.flatMap((c) => c[0] as { id: number; action: string }[]);
+    expect(items.map((x) => x.id)).toEqual([1, 2, 3]);
+    expect(new Set(items.map((x) => x.action))).toEqual(new Set(['Update']));
     expect(payload.landed).toBe(3);
   });
 
-  it('rejects a call with the wrong token, and queues nothing', async () => {
-    // Deleting the WebhookEndpoint wrapper leaves both routes world-callable, and every other test
-    // here passes a valid token, so nothing else can see it.
-    const req = { method: 'POST', query: { token: 'wrong' }, headers: {} } as never;
-    let statusCode = 0;
-    const res = {
-      status(code: number) {
-        statusCode = code;
-        return res;
-      },
-      json: () => res,
-      send: () => res,
-      setHeader: () => res,
-      end: () => res,
-    };
-    await handler(req, res as never);
+  it('counts OUR ids as landed, not the queue depth', async () => {
+    // The queue also holds a foreign id, so landed (3) and queueDepthAfter (4) disagree. With the
+    // two equal, `landed = after.length` passed every case here.
+    getQueue
+      .mockResolvedValueOnce(queued({ content: [] }))
+      .mockResolvedValueOnce(queued({ content: [1, 2, 3, 999] }));
 
-    expect(statusCode).toBe(401);
-    expect(queryGatedModelIds).not.toHaveBeenCalled();
-    expect(queueUpdate).not.toHaveBeenCalled();
+    const { payload } = await call({ dryRun: 'false' });
+
+    expect(payload.landed).toBe(3);
+    expect(payload.queueDepthAfter).toBe(4);
   });
 
   it('chunks by chunkSize rather than queueing only the first chunk', async () => {
     // slice(i, chunkSize) instead of slice(i, i + chunkSize) — the standard slice-arguments slip —
     // is invisible at the default chunk size, because three ids fit in one iteration.
     getQueue
-      .mockResolvedValueOnce({ content: [], commit: async () => undefined })
-      .mockResolvedValueOnce({ content: [1, 2, 3], commit: async () => undefined });
+      .mockResolvedValueOnce(queued({ content: [] }))
+      .mockResolvedValueOnce(queued({ content: [1, 2, 3] }));
 
     await call({ dryRun: 'false', chunkSize: '2' });
 
@@ -131,7 +155,7 @@ describe('queue-paid-models-reindex', () => {
   it('reports landed 0 when the enqueue silently dropped every id', async () => {
     // The fail-open shape: queueUpdate resolves, and the queue is still empty afterwards. A handler
     // that inferred success from the call returning would report 3 here.
-    getQueue.mockResolvedValue({ content: [], commit: async () => undefined });
+    getQueue.mockResolvedValue(queued({ content: [] }));
 
     const { payload } = await call({ dryRun: 'false' });
 

--- a/src/server/__tests__/queue-paid-models-reindex-endpoint.test.ts
+++ b/src/server/__tests__/queue-paid-models-reindex-endpoint.test.ts
@@ -93,6 +93,41 @@ describe('queue-paid-models-reindex', () => {
     expect(payload.landed).toBe(3);
   });
 
+  it('rejects a call with the wrong token, and queues nothing', async () => {
+    // Deleting the WebhookEndpoint wrapper leaves both routes world-callable, and every other test
+    // here passes a valid token, so nothing else can see it.
+    const req = { method: 'POST', query: { token: 'wrong' }, headers: {} } as never;
+    let statusCode = 0;
+    const res = {
+      status(code: number) {
+        statusCode = code;
+        return res;
+      },
+      json: () => res,
+      send: () => res,
+      setHeader: () => res,
+      end: () => res,
+    };
+    await handler(req, res as never);
+
+    expect(statusCode).toBe(401);
+    expect(queryGatedModelIds).not.toHaveBeenCalled();
+    expect(queueUpdate).not.toHaveBeenCalled();
+  });
+
+  it('chunks by chunkSize rather than queueing only the first chunk', async () => {
+    // slice(i, chunkSize) instead of slice(i, i + chunkSize) — the standard slice-arguments slip —
+    // is invisible at the default chunk size, because three ids fit in one iteration.
+    getQueue
+      .mockResolvedValueOnce({ content: [], commit: async () => undefined })
+      .mockResolvedValueOnce({ content: [1, 2, 3], commit: async () => undefined });
+
+    await call({ dryRun: 'false', chunkSize: '2' });
+
+    const batches = queueUpdate.mock.calls.map((c) => (c[0] as { id: number }[]).map((x) => x.id));
+    expect(batches).toEqual([[1, 2], [3]]);
+  });
+
   it('reports landed 0 when the enqueue silently dropped every id', async () => {
     // The fail-open shape: queueUpdate resolves, and the queue is still empty afterwards. A handler
     // that inferred success from the call returning would report 3 here.

--- a/src/server/search-index/filterable-attributes.ts
+++ b/src/server/search-index/filterable-attributes.ts
@@ -69,6 +69,7 @@ export const modelsFilterableAttributes = [
   'cannotPromote',
   'poi',
   'minor',
+  'hasActivePaidAccess',
 ];
 
 export const toolsFilterableAttributes = ['id', 'type', 'company'];

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -183,6 +183,10 @@ const featureFlags = createFeatureFlags({
   // with `enabled: false` and no rollout hides the bar for everyone, moderators included.
   // Until that flag exists, evaluation returns null and static evaluation keeps it on.
   feedTagBar: { availability: ['public'], fliptKey: 'feed-tag-bar' },
+  // `availability: []` is the Flipt-down fallback, and off is the right one here: the search
+  // refinement is useless until the gated documents carry `hasActivePaidAccess`, which is a backfill
+  // and an index-settings change, not a deploy.
+  paidModelSearchFilter: { availability: [], fliptKey: 'paid-model-search-filter' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },


### PR DESCRIPTION
Closes the search half of ClickUp `868m1r2u7`. The card badge (#4678) and the feed `Hide Paid` filter (#4690) already shipped; this adds the same choice to `/search/models`, behind a Flipt flag that is off.

"Paid" here means a **gated** model — a live `PaidAccess` row — which is Justin's ruling, not the ~31K licensing-fee models. ~3,181 models on prod as of tonight.

## Do not enable the flag before the index settings have APPLIED

Measured against live prod Meilisearch, not reasoned about:

```
baseline site filter                            200, 21,140 hits, processingTimeMs 23
baseline + AND NOT hasActivePaidAccess = true   400 Attribute hasActivePaidAccess is not filterable
```

Turning `paid-model-search-filter` on before `updateFilterableAttributes` has applied makes **every models search 400 for anyone who ticks the box** — not just the paid results, the whole result set. Bounded and self-healing (the clause is only sent when the box is ticked, and the state is per-session), but loud.

The only load-bearing constraint is that **both the settings change and the backfill precede the flag**. Flag before the settings is the 400 above; flag before the backfill hides nothing at all, which reads as "the feature doesn't work". Between themselves the order does not matter much, and in production the backfill went first — see below.

## The polarity is the whole feature

The clause is `NOT hasActivePaidAccess = true`, **never** an equality.

Only GATED models carry the attribute. Around 700K model documents do not have it — the deployed indexer writes it, but existing documents predate the field, and the card reads `!!data.hasActivePaidAccess` so absent means false. In Meilisearch an **equality matches only documents that HAVE the attribute**, while a **negation also matches documents that lack it**. `= false` would hide nearly the whole index and "hide paid" would silently return almost nothing — precisely the failure this ticket exists to prevent. `!= true` reads as the opposite but excludes absent documents the same way; both spellings are forbidden by a guard named for the decision.

Measured on the live index against `cannotPromote`, which is sparse the same way:

| filter | hits |
|---|---|
| `cannotPromote EXISTS` | 1,853 |
| `cannotPromote = true` | 1,115 |
| `NOT cannotPromote = true` | at least 100,000 |

If a negation skipped absent documents, that last number could not have exceeded 1,853 minus 1,115 = 738.

## Two admin endpoints, both inert by default

**`queue-paid-models-reindex`** queues the gated model ids for a document rewrite. Only gated documents need it.

It reports `landed` by **reading the queue back**, not by the enqueue returning: `addToQueue` fails open — on a degraded sysRedis it parks the ids in Postgres and returns `false` — and neither wrapper propagates that boolean. `landed === gatedModelCount` proves the ids are queued. A lower number is **ambiguous**, because the 15-minute sync may have checked the queue out destructively in between; it means re-run, not diagnose.

**`apply-models-index-filterable-attributes`** applies the filterable list to the live index.

It exists because the step "add the attribute to `modelsFilterableAttributes`" had no mechanism behind it. Each index's `onIndexSetup` is the only in-repo caller of `updateFilterableAttributes`, and it runs in exactly one place — `reset()` in `base.search-index.ts` — against the `_NEW` **swap** index. Adding an attribute to the list is **inert on the live index** until a full ~705K-document rebuild, or this.

The call **replaces** the list rather than merging, so it refuses two ways:

- a write that would **remove** an attribute the live index has refuses without `allowRemove`. Drift is not directional, and removing a filterable attribute makes every query using it answer 400. A point-in-time read at 19:16Z showed live 21 attributes against 22 desired, added `hasActivePaidAccess`, removed none — but that is true of one read, not of run time, which is what the refusal is for.
- a write while a settings task is **already enqueued** refuses without `force`. The call returns on *enqueue* while `getFilterableAttributes` reports *applied*, and `WebhookEndpoint` has no method guard, so a browser reload would otherwise fire a second full reindex.

It uses `searchClient.index(name)` rather than `getOrCreateIndex`, so a typo is an error rather than a new empty index.

**The environment it would land in**, measured on prod at 19:16Z: `models_v9` holds **705,068 documents**; task 1742909 was received 16:40:21Z and did not start until **17:27:19Z**, a 46m58s queue wait; **522 enqueued, 5 processing, 563 failed** globally; the newest *succeeded* `models_v9` task was 16:40Z, so the models index had landed nothing for about 2h40m. The duration of the settings task itself remains unmeasured — nobody has run one. All point-in-time: re-read before running rather than quoting these forward.

Neither endpoint is reachable from a startup hook, a cron, a setup path, or a test against a live client, and `dryRun` defaults to `true` on both.

**`apply-models-index-filterable-attributes` has never been run, in either mode.**

**The backfill, however, is already done** — and not by the endpoint in this PR, which is not deployed. On **2026-09-08 at 19:46Z** I queued the 3,180 gated model ids through `/api/internal/search-index-update`, which is already on `main` and shipped in 5.1.80. Four POSTs of ≤1000 ids, all 200. The 15-minute sync drained the queue at 19:46:12–19:46:14 and Meilisearch enqueued four `documentAdditionOrUpdate` tasks.

⚠️ **Do not re-run the backfill after merging.** The rollout below reflects what is actually left.

## Rollout

~~1. backfill the gated documents~~ — **DONE 2026-09-08 19:46Z**, via `/api/internal/search-index-update`, 3,180 ids. Four Meilisearch tasks enqueued; at the time of writing they had not yet started.

Remaining:

1. confirm the four `documentAdditionOrUpdate` tasks reached `succeeded`, and that sampled gated documents now carry `hasActivePaidAccess`
2. merge, deploy
3. `apply-models-index-filterable-attributes?dryRun=false`, poll the returned `taskUid` until **applied** (not merely enqueued)
4. read `getFilterableAttributes` back and see the attribute
5. merge `civitai/flipt-state` #83, then turn `paid-model-search-filter` on

`queue-paid-models-reindex` is **not** a pending step. It stays because the set of gated models changes with the wall clock — `endsAt` is in the predicate — so this is a reconciler rather than a one-shot, and because it is the only thing that reads the queue back. Nine other `admin/temp` endpoints queue search-index updates and every one of them reports success from the call returning, which `addToQueue`'s fail-open makes worthless. Run it `dryRun=true` after deploy if you want a second reading on tonight's backfill — but note `alreadyQueued` is computed against a queue the sync drains destructively, so it reads near zero more than a tick after any enqueue regardless of what happened.

Steps 2 and 4 are held behind a search-stability gate: prod Meilisearch has flapped repeatedly today, most recently an ECONNRESET/408 episode from 19:33:28Z to 19:37:33Z, confirmed by an external 503 in the same minute.

## Tests, with the revert measured for each

| mutation | result |
|---|---|
| clause to `hasActivePaidAccess = false` | 3 failed, 19 passed (22) |
| clause to `hasActivePaidAccess != true` (present-only) | 3 failed, 19 passed (22) |
| flag gate dropped from the helper | 1 failed |
| checkbox default flipped to ticked | 1 failed |
| clause deleted from the filters array | 1 failed |
| `hasActivePaidAccess` removed from the filterable list | 2 failed |
| apply writes only the missing attrs, not the whole list | 1 failed |
| apply's removal refusal deleted | 1 failed |
| apply's pending-task refusal deleted | 1 failed |
| `dryRun` default flipped, either endpoint | 1 failed each |
| `WebhookEndpoint` wrapper removed, either endpoint | 1 failed each |
| `slice(i, chunkSize)` slip in the chunking loop | 1 failed |
| `landed` inferred from the call, not the read-back | `expected 3 to be +0` |
| queue endpoint switched to the cached `getGatedModelIds` | 5 failed |

Seventeen mutations, all red. One was **green** on the first pass — flipping the checkbox default to ticked, which would have silently removed paid models from everyone's search — and is now pinned.

## Verification

- `pnpm run typecheck` — 0 type errors
- `pnpm exec eslint` on every touched file — 0 errors
- Full unit suite — see comment below

## Known and deliberate

`hidePaid` is component-local state, so it is absent from the URL and `ClearRefinements` does not clear it, where the feed's equivalent is URL-persisted. The half a user actually notices is **browser-back**: every other control in that sidebar is restored from the URL on a back-navigation into search, and this one resets to unticked, so the paid models reappear. The same-named control therefore behaves two ways — linkable and clearable on `/models`, neither on `/search/models`. Raised by two reviewers; left as-is for this PR because moving it into InstantSearch's `uiState` is a separate change to the search routing layer, and `ToggleRefinement` cannot express this filter — it would force the equality-on-`false` bug above.

**Staleness, stated for the record.** Within the search page the card and the filter read the *same* document attribute, so they cannot disagree — a stale document is stale in both directions at once, and the "card says Paid but Hide Paid left it on screen" divergence this ticket exists to close cannot occur there. What remains is cross-surface: search can lag the model page and the feed by the index-sync latency, which is normally ~1 minute for the expiry job plus up to 15 for the sync, but is in practice bounded by the Meilisearch backlog — measured at 46m58s of queue wait today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7ZW9caRhbAUDQGTXxGwgn
