### PR TITLE
fix(search-index): surface updateSync task failures instead of reporting success

### DIFF
--- a/src/__tests__/pages/api/mod/update-index.test.ts
+++ b/src/__tests__/pages/api/mod/update-index.test.ts
@@ -42,7 +42,8 @@ vi.mock('~/server/jobs/job', () => ({
   inJobContext: (_res: NextApiResponse, fn: (jobContext: unknown) => Promise<void>) => fn({}),
 }));
 
-// The real index objects open a Meilisearch client and hit the database at module load.
+// Replaced with spies because which of these objects the handler reaches for is the thing under
+// test; the real ones would talk to Meilisearch and the database once called.
 vi.mock('~/server/search-index', () => indexMocks);
 
 import {

--- a/src/__tests__/pages/api/mod/update-index.test.ts
+++ b/src/__tests__/pages/api/mod/update-index.test.ts
@@ -1,10 +1,37 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { updateSync, processQueues } = vi.hoisted(() => ({
-  updateSync: vi.fn(),
-  processQueues: vi.fn().mockResolvedValue(undefined),
-}));
+/**
+ * One mock per export, each with its OWN spies. Sharing a single object across all nine made the
+ * lookup table in the handler unobservable: any index could be mapped to any other and every
+ * assertion still passed.
+ */
+const { indexMocks } = vi.hoisted(() => {
+  const exportNames = [
+    'modelsSearchIndex',
+    'usersSearchIndex',
+    'imagesSearchIndex',
+    'articlesSearchIndex',
+    'imagesMetricsSearchIndex',
+    'collectionsSearchIndex',
+    'bountiesSearchIndex',
+    'toolsSearchIndex',
+    'comicsSearchIndex',
+  ] as const;
+
+  type ExportName = (typeof exportNames)[number];
+  const mocks = {} as Record<
+    ExportName,
+    { updateSync: ReturnType<typeof vi.fn>; processQueues: ReturnType<typeof vi.fn> }
+  >;
+  for (const name of exportNames) {
+    mocks[name] = { updateSync: vi.fn(), processQueues: vi.fn() };
+  }
+  return { indexMocks: mocks };
+});
+
+type IndexExportName = keyof typeof indexMocks;
+const indexExportNames = Object.keys(indexMocks) as IndexExportName[];
 
 // ModEndpoint wraps the handler in mod-auth; the handler itself is what is under test.
 vi.mock('~/server/utils/endpoint-helpers', () => ({
@@ -16,23 +43,40 @@ vi.mock('~/server/jobs/job', () => ({
 }));
 
 // The real index objects open a Meilisearch client and hit the database at module load.
-vi.mock('~/server/search-index', () => {
-  const index = { updateSync, processQueues };
-  return {
-    modelsSearchIndex: index,
-    usersSearchIndex: index,
-    imagesSearchIndex: index,
-    articlesSearchIndex: index,
-    imagesMetricsSearchIndex: index,
-    collectionsSearchIndex: index,
-    bountiesSearchIndex: index,
-    toolsSearchIndex: index,
-    comicsSearchIndex: index,
-  };
-});
+vi.mock('~/server/search-index', () => indexMocks);
 
-import { COLLECTIONS_SEARCH_INDEX } from '~/server/common/constants';
+import {
+  ARTICLES_SEARCH_INDEX,
+  BOUNTIES_SEARCH_INDEX,
+  COLLECTIONS_SEARCH_INDEX,
+  COMICS_SEARCH_INDEX,
+  IMAGES_SEARCH_INDEX,
+  METRICS_IMAGES_SEARCH_INDEX,
+  MODELS_SEARCH_INDEX,
+  TOOLS_SEARCH_INDEX,
+  USERS_SEARCH_INDEX,
+} from '~/server/common/constants';
 import handler from '~/pages/api/mod/update-index';
+
+/**
+ * The routing this file pins: every `index` query value and the module export that must handle
+ * it. Written out by hand rather than derived from the handler, so a copy-paste slip in the
+ * handler's lookup table disagrees with it instead of being mirrored by it.
+ */
+const expectedRouting: Array<{ index: string; exportName: IndexExportName }> = [
+  { index: MODELS_SEARCH_INDEX, exportName: 'modelsSearchIndex' },
+  { index: USERS_SEARCH_INDEX, exportName: 'usersSearchIndex' },
+  { index: IMAGES_SEARCH_INDEX, exportName: 'imagesSearchIndex' },
+  { index: ARTICLES_SEARCH_INDEX, exportName: 'articlesSearchIndex' },
+  { index: METRICS_IMAGES_SEARCH_INDEX, exportName: 'imagesMetricsSearchIndex' },
+  { index: COLLECTIONS_SEARCH_INDEX, exportName: 'collectionsSearchIndex' },
+  { index: BOUNTIES_SEARCH_INDEX, exportName: 'bountiesSearchIndex' },
+  { index: TOOLS_SEARCH_INDEX, exportName: 'toolsSearchIndex' },
+  { index: COMICS_SEARCH_INDEX, exportName: 'comicsSearchIndex' },
+];
+
+const updateSync = indexMocks.collectionsSearchIndex.updateSync;
+const processQueues = indexMocks.collectionsSearchIndex.processQueues;
 
 const runRequest = async (query: Record<string, string>) => {
   const req = {
@@ -60,7 +104,15 @@ const runRequest = async (query: Record<string, string>) => {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  processQueues.mockResolvedValue(undefined);
+  for (const name of indexExportNames) {
+    indexMocks[name].processQueues.mockResolvedValue(undefined);
+    indexMocks[name].updateSync.mockResolvedValue({
+      indexName: name,
+      totalTasks: 1,
+      failedTasks: 0,
+      failedIds: 0,
+    });
+  }
 });
 
 describe('/api/mod/update-index', () => {
@@ -119,6 +171,36 @@ describe('/api/mod/update-index', () => {
       { id: 7, action: 'Update' },
       { id: 8, action: 'Update' },
     ]);
+  });
+
+  describe.each(expectedRouting)('index routing :: $index', ({ index, exportName }) => {
+    it(`sends updateSync to ${exportName} and to no other index`, async () => {
+      await runRequest({ index, updateIds: '7,8' });
+
+      expect(
+        indexMocks[exportName].updateSync,
+        `index "${index}" should have been routed to ${exportName}`
+      ).toHaveBeenCalledTimes(1);
+
+      const misrouted = indexExportNames.filter(
+        (name) => name !== exportName && indexMocks[name].updateSync.mock.calls.length > 0
+      );
+      expect(misrouted, `index "${index}" was ALSO routed to: ${misrouted.join(', ')}`).toEqual([]);
+    });
+
+    it(`sends processQueues to ${exportName} and to no other index`, async () => {
+      await runRequest({ index, processQueues: 'update' });
+
+      expect(
+        indexMocks[exportName].processQueues,
+        `index "${index}" should have been routed to ${exportName}`
+      ).toHaveBeenCalledTimes(1);
+
+      const misrouted = indexExportNames.filter(
+        (name) => name !== exportName && indexMocks[name].processQueues.mock.calls.length > 0
+      );
+      expect(misrouted, `index "${index}" was ALSO routed to: ${misrouted.join(', ')}`).toEqual([]);
+    });
   });
 
   it('still returns 200 for a processQueues run, which reports no sync result', async () => {

--- a/src/__tests__/pages/api/mod/update-index.test.ts
+++ b/src/__tests__/pages/api/mod/update-index.test.ts
@@ -1,0 +1,135 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { updateSync, processQueues } = vi.hoisted(() => ({
+  updateSync: vi.fn(),
+  processQueues: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ModEndpoint wraps the handler in mod-auth; the handler itself is what is under test.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  ModEndpoint: (handler: (req: NextApiRequest, res: NextApiResponse) => unknown) => handler,
+}));
+
+vi.mock('~/server/jobs/job', () => ({
+  inJobContext: (_res: NextApiResponse, fn: (jobContext: unknown) => Promise<void>) => fn({}),
+}));
+
+// The real index objects open a Meilisearch client and hit the database at module load.
+vi.mock('~/server/search-index', () => {
+  const index = { updateSync, processQueues };
+  return {
+    modelsSearchIndex: index,
+    usersSearchIndex: index,
+    imagesSearchIndex: index,
+    articlesSearchIndex: index,
+    imagesMetricsSearchIndex: index,
+    collectionsSearchIndex: index,
+    bountiesSearchIndex: index,
+    toolsSearchIndex: index,
+    comicsSearchIndex: index,
+  };
+});
+
+import { COLLECTIONS_SEARCH_INDEX } from '~/server/common/constants';
+import handler from '~/pages/api/mod/update-index';
+
+const runRequest = async (query: Record<string, string>) => {
+  const req = {
+    method: 'GET',
+    query,
+    headers: { host: 'localhost:3000' },
+  } as unknown as NextApiRequest;
+
+  const send = vi.fn().mockReturnThis();
+  const status = vi.fn().mockReturnThis();
+  const res = {
+    status,
+    send,
+    json: vi.fn().mockReturnThis(),
+    on: vi.fn(),
+  } as unknown as NextApiResponse;
+
+  await handler(req, res);
+
+  return {
+    status: status.mock.calls[0]?.[0] as number | undefined,
+    body: send.mock.calls[0]?.[0] as Record<string, unknown> | undefined,
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  processQueues.mockResolvedValue(undefined);
+});
+
+describe('/api/mod/update-index', () => {
+  it('does NOT return 200 ok when a batch failed to index', async () => {
+    updateSync.mockResolvedValue({
+      indexName: COLLECTIONS_SEARCH_INDEX,
+      totalTasks: 5,
+      failedTasks: 4,
+      failedIds: 1200,
+    });
+
+    const { status, body } = await runRequest({
+      index: COLLECTIONS_SEARCH_INDEX,
+      updateIds: '1,2,3',
+    });
+
+    expect(status).not.toBe(200);
+    expect(status).toBeGreaterThanOrEqual(400);
+    expect(body).toMatchObject({
+      status: 'error',
+      index: COLLECTIONS_SEARCH_INDEX,
+      failedTasks: 4,
+      failedIds: 1200,
+    });
+  });
+
+  it('keeps the success response unchanged when every batch succeeded', async () => {
+    updateSync.mockResolvedValue({
+      indexName: COLLECTIONS_SEARCH_INDEX,
+      totalTasks: 5,
+      failedTasks: 0,
+      failedIds: 0,
+    });
+
+    const { status, body } = await runRequest({
+      index: COLLECTIONS_SEARCH_INDEX,
+      updateIds: '1,2,3',
+    });
+
+    expect(status).toBe(200);
+    expect(body).toEqual({ status: 'ok' });
+  });
+
+  it('routes the requested index to updateSync with the requested ids', async () => {
+    updateSync.mockResolvedValue({
+      indexName: COLLECTIONS_SEARCH_INDEX,
+      totalTasks: 1,
+      failedTasks: 0,
+      failedIds: 0,
+    });
+
+    await runRequest({ index: COLLECTIONS_SEARCH_INDEX, updateIds: '7,8' });
+
+    expect(updateSync).toHaveBeenCalledTimes(1);
+    expect(updateSync.mock.calls[0][0]).toEqual([
+      { id: 7, action: 'Update' },
+      { id: 8, action: 'Update' },
+    ]);
+  });
+
+  it('still returns 200 for a processQueues run, which reports no sync result', async () => {
+    const { status, body } = await runRequest({
+      index: COLLECTIONS_SEARCH_INDEX,
+      processQueues: 'update',
+    });
+
+    expect(processQueues).toHaveBeenCalledTimes(1);
+    expect(updateSync).not.toHaveBeenCalled();
+    expect(status).toBe(200);
+    expect(body).toEqual({ status: 'ok' });
+  });
+});

--- a/src/pages/api/mod/update-index.ts
+++ b/src/pages/api/mod/update-index.ts
@@ -24,8 +24,21 @@ import {
   toolsSearchIndex,
   comicsSearchIndex,
 } from '~/server/search-index';
+import type { SearchIndexUpdateSyncResult } from '~/server/search-index/base.search-index';
 import { ModEndpoint } from '~/server/utils/endpoint-helpers';
 import { commaDelimitedEnumArray, commaDelimitedNumberArray } from '~/utils/zod-helpers';
+
+const searchIndexes = {
+  [MODELS_SEARCH_INDEX]: modelsSearchIndex,
+  [USERS_SEARCH_INDEX]: usersSearchIndex,
+  [IMAGES_SEARCH_INDEX]: imagesSearchIndex,
+  [ARTICLES_SEARCH_INDEX]: articlesSearchIndex,
+  [METRICS_IMAGES_SEARCH_INDEX]: imagesMetricsSearchIndex,
+  [COLLECTIONS_SEARCH_INDEX]: collectionsSearchIndex,
+  [BOUNTIES_SEARCH_INDEX]: bountiesSearchIndex,
+  [TOOLS_SEARCH_INDEX]: toolsSearchIndex,
+  [COMICS_SEARCH_INDEX]: comicsSearchIndex,
+};
 
 export const schema = z.object({
   updateIds: commaDelimitedNumberArray().optional(),
@@ -41,7 +54,7 @@ export const schema = z.object({
     BOUNTIES_SEARCH_INDEX,
     TOOLS_SEARCH_INDEX,
     COMICS_SEARCH_INDEX,
-  ]),
+  ] as const satisfies ReadonlyArray<keyof typeof searchIndexes>),
 });
 export default ModEndpoint(async function updateIndexSync(
   req: NextApiRequest,
@@ -59,6 +72,8 @@ export default ModEndpoint(async function updateIndexSync(
       throw new Error('No ids provided');
     }
 
+    let syncResult: SearchIndexUpdateSyncResult | undefined;
+
     await inJobContext(res, async (jobContext) => {
       const processQueuesOpts =
         (input.processQueues?.length ?? 0) > 0
@@ -68,74 +83,30 @@ export default ModEndpoint(async function updateIndexSync(
             }
           : undefined;
 
-      switch (input.index) {
-        case USERS_SEARCH_INDEX:
-          if (processQueuesOpts) {
-            await usersSearchIndex.processQueues(processQueuesOpts, jobContext);
-          } else {
-            await usersSearchIndex.updateSync(data, jobContext);
-          }
-          break;
-        case MODELS_SEARCH_INDEX:
-          if (processQueuesOpts) {
-            await modelsSearchIndex.processQueues(processQueuesOpts, jobContext);
-          } else {
-            await modelsSearchIndex.updateSync(data, jobContext);
-          }
-          break;
-        case IMAGES_SEARCH_INDEX:
-          if (processQueuesOpts) {
-            await imagesSearchIndex.processQueues(processQueuesOpts, jobContext);
-          } else {
-            await imagesSearchIndex.updateSync(data, jobContext);
-          }
-          break;
-        case ARTICLES_SEARCH_INDEX:
-          if (processQueuesOpts) {
-            await articlesSearchIndex.processQueues(processQueuesOpts, jobContext);
-          } else {
-            await articlesSearchIndex.updateSync(data, jobContext);
-          }
-          break;
-        case METRICS_IMAGES_SEARCH_INDEX:
-          if (processQueuesOpts) {
-            await imagesMetricsSearchIndex.processQueues(processQueuesOpts, jobContext);
-          } else {
-            await imagesMetricsSearchIndex.updateSync(data, jobContext);
-          }
-          break;
-        case COLLECTIONS_SEARCH_INDEX:
-          if (processQueuesOpts) {
-            await collectionsSearchIndex.processQueues(processQueuesOpts, jobContext);
-          } else {
-            await collectionsSearchIndex.updateSync(data, jobContext);
-          }
-          break;
-        case BOUNTIES_SEARCH_INDEX:
-          if (processQueuesOpts) {
-            await bountiesSearchIndex.processQueues(processQueuesOpts, jobContext);
-          } else {
-            await bountiesSearchIndex.updateSync(data, jobContext);
-          }
-          break;
-        case TOOLS_SEARCH_INDEX:
-          if (processQueuesOpts) {
-            await toolsSearchIndex.processQueues(processQueuesOpts, jobContext);
-          } else {
-            await toolsSearchIndex.updateSync(data, jobContext);
-          }
-          break;
-        case COMICS_SEARCH_INDEX:
-          if (processQueuesOpts) {
-            await comicsSearchIndex.processQueues(processQueuesOpts, jobContext);
-          } else {
-            await comicsSearchIndex.updateSync(data, jobContext);
-          }
-          break;
-        default:
-          break;
+      // `input.index` is constrained to the keys of `searchIndexes` by the zod enum above, which
+      // is itself checked against those keys — so this lookup cannot miss.
+      const searchIndex = searchIndexes[input.index];
+
+      if (processQueuesOpts) {
+        await searchIndex.processQueues(processQueuesOpts, jobContext);
+      } else {
+        syncResult = await searchIndex.updateSync(data, jobContext);
       }
     });
+
+    // A batch that exhausted its retries indexed nothing. Returning 200 here is what made a
+    // failed backfill indistinguishable from a successful one for the caller.
+    if (syncResult && syncResult.failedTasks > 0) {
+      res.status(500).send({
+        status: 'error',
+        index: syncResult.indexName,
+        failedTasks: syncResult.failedTasks,
+        totalTasks: syncResult.totalTasks,
+        failedIds: syncResult.failedIds,
+        error: `${syncResult.failedIds} ids in ${syncResult.failedTasks} of ${syncResult.totalTasks} batches failed to index`,
+      });
+      return;
+    }
 
     res.status(200).send({ status: 'ok' });
   } catch (error: unknown) {

--- a/src/server/search-index/__tests__/update-sync-failure-reporting.test.ts
+++ b/src/server/search-index/__tests__/update-sync-failure-reporting.test.ts
@@ -186,8 +186,11 @@ describe('updateSync :: per-index chunk size', () => {
   // The non-finite cases are what pin `Number.isFinite` rather than a `typeof x === 'number'`
   // test: `NaN`, `Infinity` and `-Infinity` are all of type `number`, so the declared type does
   // not exclude them, and `Math.max(1, Math.floor(NaN))` is `NaN` — the same empty-chunk silent
-  // success the clamp exists to remove. (`-Infinity` is the weakest of the three: a `typeof`
-  // mutant clamps it to 1, so only the exact-size assertion below separates it from the floor.)
+  // success the clamp exists to remove. (`Infinity` is the weakest of the three: under a `typeof`
+  // mutant `Math.max(1, Math.floor(Infinity))` is `Infinity`, and `chunk(60, Infinity)` is one
+  // batch of 60 — byte-identical to the default-sized batch this row expects — so the exact-size
+  // assertion below is the only thing that separates them. `-Infinity` clamps to 1 under the same
+  // mutant, giving 60 batches instead of 1, so the batch-count assertions catch it too.)
 
   // 60 ids at one id per batch is 60 batches of 1; 60 ids at the default (which is larger than
   // 60) is a single batch of 60.

--- a/src/server/search-index/__tests__/update-sync-failure-reporting.test.ts
+++ b/src/server/search-index/__tests__/update-sync-failure-reporting.test.ts
@@ -177,27 +177,66 @@ describe('updateSync :: per-index chunk size', () => {
     expect(pulledIdCounts(pullData)).toEqual([ITEM_COUNT]);
   });
 
-  // `chunk(xs, 0)` and `chunk(xs, -1)` both return [] in lodash, so an unclamped chunk size would
-  // queue zero tasks and return `{ totalTasks: 0, failedTasks: 0 }` — a clean result for a run
-  // that indexed nothing.
+  // `chunk(xs, 0)`, `chunk(xs, -1)` and `chunk(xs, NaN)` all return [] in lodash, so an unguarded
+  // chunk size would queue zero tasks and return `{ totalTasks: 0, failedTasks: 0 }` — a clean
+  // result for a run that indexed nothing. The two arms of the guard produce different sizes and
+  // are pinned separately: a non-positive but finite value is CLAMPED to the one-id floor, while a
+  // non-finite one FALLS BACK to the default.
+  //
+  // The non-finite cases are what pin `Number.isFinite` rather than a `typeof x === 'number'`
+  // test: `NaN`, `Infinity` and `-Infinity` are all of type `number`, so the declared type does
+  // not exclude them, and `Math.max(1, Math.floor(NaN))` is `NaN` — the same empty-chunk silent
+  // success the clamp exists to remove. (`-Infinity` is the weakest of the three: a `typeof`
+  // mutant clamps it to 1, so only the exact-size assertion below separates it from the floor.)
+
+  // 60 ids at one id per batch is 60 batches of 1; 60 ids at the default (which is larger than
+  // 60) is a single batch of 60.
+  const CLAMPED_TO_FLOOR = Array.from({ length: ITEM_COUNT }, () => 1);
+  const ONE_DEFAULT_SIZED_BATCH = [ITEM_COUNT];
+
   it.each([
-    { configured: 0, label: 'zero' },
-    { configured: -5, label: 'negative' },
+    { configured: 0, label: 'zero', expectedChunkSize: 1, expectedBatchSizes: CLAMPED_TO_FLOOR },
+    {
+      configured: -5,
+      label: 'negative',
+      expectedChunkSize: 1,
+      expectedBatchSizes: CLAMPED_TO_FLOOR,
+    },
+    {
+      configured: NaN,
+      label: 'NaN',
+      expectedChunkSize: DEFAULT_UPDATE_SYNC_CHUNK_SIZE,
+      expectedBatchSizes: ONE_DEFAULT_SIZED_BATCH,
+    },
+    {
+      configured: Infinity,
+      label: 'Infinity',
+      expectedChunkSize: DEFAULT_UPDATE_SYNC_CHUNK_SIZE,
+      expectedBatchSizes: ONE_DEFAULT_SIZED_BATCH,
+    },
+    {
+      configured: -Infinity,
+      label: 'negative Infinity',
+      expectedChunkSize: DEFAULT_UPDATE_SYNC_CHUNK_SIZE,
+      expectedBatchSizes: ONE_DEFAULT_SIZED_BATCH,
+    },
   ])(
     'still indexes every item when the chunk size is $label',
-    async ({ configured }) => {
+    async ({ configured, expectedChunkSize, expectedBatchSizes }) => {
       const pullData = vi.fn(async (_ctx, batch) => (batch.type === 'update' ? batch.ids : []));
       const pushData = vi.fn().mockResolvedValue(undefined);
       const index = buildIndex({ pullData, pushData, updateSyncChunkSize: configured });
 
       const result = await index.updateSync(updateItems(ITEM_COUNT));
 
-      expect(index.updateSyncChunkSize).toBeGreaterThanOrEqual(1);
-      // One id per batch is the floor, so 60 items produce 60 tasks — the point is that it is not 0.
-      expect(result.totalTasks).toBe(ITEM_COUNT);
+      // An exact size, not `toBeGreaterThanOrEqual(1)`: that weaker form cannot tell the clamped
+      // floor from the default from `Infinity`, all three of which satisfy it.
+      expect(index.updateSyncChunkSize).toBe(expectedChunkSize);
+      // The point common to every case is that this is not 0.
+      expect(result.totalTasks).toBe(expectedBatchSizes.length);
       expect(result.failedTasks).toBe(0);
-      expect(pushData).toHaveBeenCalledTimes(ITEM_COUNT);
-      expect(pulledIdCounts(pullData)).toEqual(Array.from({ length: ITEM_COUNT }, () => 1));
+      expect(pushData).toHaveBeenCalledTimes(expectedBatchSizes.length);
+      expect(pulledIdCounts(pullData)).toEqual(expectedBatchSizes);
     },
     30_000
   );

--- a/src/server/search-index/__tests__/update-sync-failure-reporting.test.ts
+++ b/src/server/search-index/__tests__/update-sync-failure-reporting.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as MeiliUtil from '~/server/meilisearch/util';
+
+// Partial: only the cleanup helper would reach a real Meilisearch instance from `updateSync`.
+vi.mock('~/server/meilisearch/util', async (importOriginal) => ({
+  ...(await importOriginal<typeof MeiliUtil>()),
+  onSearchIndexDocumentsCleanup: vi.fn(),
+}));
+
+const { createSearchIndexUpdateProcessor, DEFAULT_UPDATE_SYNC_CHUNK_SIZE } = await import(
+  '~/server/search-index/base.search-index'
+);
+const { collectionsSearchIndex } = await import('~/server/search-index/collections.search-index');
+
+type Processor = Parameters<typeof createSearchIndexUpdateProcessor>[0];
+
+const buildIndex = (overrides: Partial<Processor> = {}) =>
+  createSearchIndexUpdateProcessor({
+    indexName: 'test_index',
+    setup: async () => undefined,
+    prepareBatches: async () => ({ batchSize: 100, startId: 0, endId: 0 }),
+    pullData: async (_ctx, batch) => (batch.type === 'update' ? batch.ids : []),
+    transformData: async (data: unknown) => data,
+    pushData: async () => undefined,
+    ...overrides,
+  });
+
+const updateItems = (count: number) => Array.from({ length: count }, (_, i) => ({ id: i + 1 }));
+
+/** What a Prisma statement-timeout surfaces as inside `pullData`. */
+const statementTimeout = () =>
+  Object.assign(new Error('canceling statement due to statement timeout'), { code: 'P2010' });
+
+beforeEach(() => {
+  // processSearchIndexTask logs every caught error; keep the run readable.
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  vi.spyOn(console, 'log').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('updateSync :: failure reporting', () => {
+  it('reports the failed batch when the pull step throws, instead of resolving silently', async () => {
+    const pullData = vi.fn().mockRejectedValue(statementTimeout());
+    const index = buildIndex({ pullData, updateSyncChunkSize: 300 });
+
+    const result = await index.updateSync(updateItems(3));
+
+    expect(result).toEqual({
+      indexName: 'test_index',
+      totalTasks: 1,
+      failedTasks: 1,
+      failedIds: 3,
+    });
+    // 1 attempt + the 3 retries the queue promises. Before the retry slot was held open across
+    // the backoff, every worker exited during the first retry's sleep and the task was dropped
+    // after a single attempt with nothing recorded as failed.
+    expect(pullData).toHaveBeenCalledTimes(4);
+  }, 30_000);
+
+  it('attributes a failure at the push step back to the ids that were never written', async () => {
+    // The push task no longer carries the id list, so this pins that the id count survives the
+    // pull -> transform -> push handoff.
+    const pushData = vi.fn().mockRejectedValue(new Error('meilisearch rejected the batch'));
+    const index = buildIndex({ pushData, updateSyncChunkSize: 300 });
+
+    const result = await index.updateSync(updateItems(7));
+
+    expect(result.failedTasks).toBe(1);
+    expect(result.failedIds).toBe(7);
+  }, 30_000);
+
+  it('reports zero failures when every batch succeeds', async () => {
+    const pushData = vi.fn().mockResolvedValue(undefined);
+    const index = buildIndex({ pushData, updateSyncChunkSize: 300 });
+
+    const result = await index.updateSync(updateItems(7));
+
+    expect(result).toEqual({
+      indexName: 'test_index',
+      totalTasks: 1,
+      failedTasks: 0,
+      failedIds: 0,
+    });
+    expect(pushData).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an all-zero result for an empty item list', async () => {
+    const index = buildIndex();
+    await expect(index.updateSync([])).resolves.toEqual({
+      indexName: 'test_index',
+      totalTasks: 0,
+      failedTasks: 0,
+      failedIds: 0,
+    });
+  });
+});
+
+describe('updateSync :: per-index chunk size', () => {
+  // 60 is deliberately NOT a multiple of 25 — a batching off-by-one would show up as a
+  // different final batch size rather than the same count.
+  const ITEM_COUNT = 60;
+
+  const pulledIdCounts = (pullData: ReturnType<typeof vi.fn>) =>
+    pullData.mock.calls.map(([, batch]) => (batch.type === 'update' ? batch.ids.length : 0));
+
+  it('splits into batches of the configured size', async () => {
+    const pullData = vi.fn(async (_ctx, batch) => (batch.type === 'update' ? batch.ids : []));
+    const index = buildIndex({ pullData, updateSyncChunkSize: 25 });
+
+    const result = await index.updateSync(updateItems(ITEM_COUNT));
+
+    expect(result.totalTasks).toBe(3);
+    expect(pulledIdCounts(pullData).sort((a, b) => b - a)).toEqual([25, 25, 10]);
+  });
+
+  it('falls back to the default chunk size when a processor sets none', async () => {
+    const pullData = vi.fn(async (_ctx, batch) => (batch.type === 'update' ? batch.ids : []));
+    const index = buildIndex({ pullData });
+
+    const result = await index.updateSync(updateItems(ITEM_COUNT));
+
+    expect(index.updateSyncChunkSize).toBe(DEFAULT_UPDATE_SYNC_CHUNK_SIZE);
+    // 60 ids fit in a single default-sized batch, so the same input produces ONE task here and
+    // three above — the chunk size is what moved.
+    expect(result.totalTasks).toBe(1);
+    expect(pulledIdCounts(pullData)).toEqual([ITEM_COUNT]);
+  });
+
+  it('keeps the collections index well below the default', () => {
+    // The batch that timed out in production was 300 ids; the default is 500.
+    expect(collectionsSearchIndex.updateSyncChunkSize).toBeLessThan(DEFAULT_UPDATE_SYNC_CHUNK_SIZE);
+    expect(collectionsSearchIndex.updateSyncChunkSize).toBe(25);
+  });
+});

--- a/src/server/search-index/__tests__/update-sync-failure-reporting.test.ts
+++ b/src/server/search-index/__tests__/update-sync-failure-reporting.test.ts
@@ -72,6 +72,54 @@ describe('updateSync :: failure reporting', () => {
     expect(result.failedIds).toBe(7);
   }, 30_000);
 
+  it('counts only the ids of the batches that failed, not every id in the run', async () => {
+    // Deliberately pairwise-distinct, and distinct from every constant the assertions name:
+    // 30 items / chunk 8 => 4 batches sized 8, 8, 8, 6. Failing the FIRST and the LAST gives
+    // failedTasks 2 and failedIds 14 — a number that is not the item count (30), not the batch
+    // count (4), not the chunk size (8), and not `failedTasks * chunkSize` (16). Every "close
+    // enough" way of deriving it lands on a different value.
+    const ITEM_COUNT = 30;
+    const CHUNK_SIZE = 8;
+    const FIRST_ID_OF_FAILING_HEAD_BATCH = 1;
+    const FIRST_ID_OF_FAILING_TAIL_BATCH = 25;
+
+    const pushed: number[] = [];
+    const pullData = vi.fn(async (_ctx, batch) => {
+      if (batch.type !== 'update') return [];
+      const ids = batch.ids as number[];
+      if (
+        ids.includes(FIRST_ID_OF_FAILING_HEAD_BATCH) ||
+        ids.includes(FIRST_ID_OF_FAILING_TAIL_BATCH)
+      ) {
+        throw statementTimeout();
+      }
+      return ids;
+    });
+    const pushData = vi.fn(async (_ctx: unknown, data: number[]) => {
+      pushed.push(...data);
+    });
+
+    const index = buildIndex({ pullData, pushData, updateSyncChunkSize: CHUNK_SIZE });
+
+    const result = await index.updateSync(updateItems(ITEM_COUNT));
+
+    expect(result).toEqual({
+      indexName: 'test_index',
+      totalTasks: 4,
+      failedTasks: 2,
+      failedIds: 14,
+    });
+    // A partial failure, not a total one: strictly fewer than every batch, and strictly fewer
+    // than every id.
+    expect(result.failedTasks).toBeLessThan(result.totalTasks);
+    expect(result.failedIds).toBeLessThan(ITEM_COUNT);
+    // The batches that did not fail were still written — 16 ids, the complement of the 14.
+    expect(pushData).toHaveBeenCalledTimes(2);
+    expect(pushed.sort((a, b) => a - b)).toEqual([
+      9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+    ]);
+  }, 30_000);
+
   it('reports zero failures when every batch succeeds', async () => {
     const pushData = vi.fn().mockResolvedValue(undefined);
     const index = buildIndex({ pushData, updateSyncChunkSize: 300 });
@@ -127,6 +175,43 @@ describe('updateSync :: per-index chunk size', () => {
     // three above — the chunk size is what moved.
     expect(result.totalTasks).toBe(1);
     expect(pulledIdCounts(pullData)).toEqual([ITEM_COUNT]);
+  });
+
+  // `chunk(xs, 0)` and `chunk(xs, -1)` both return [] in lodash, so an unclamped chunk size would
+  // queue zero tasks and return `{ totalTasks: 0, failedTasks: 0 }` — a clean result for a run
+  // that indexed nothing.
+  it.each([
+    { configured: 0, label: 'zero' },
+    { configured: -5, label: 'negative' },
+  ])(
+    'still indexes every item when the chunk size is $label',
+    async ({ configured }) => {
+      const pullData = vi.fn(async (_ctx, batch) => (batch.type === 'update' ? batch.ids : []));
+      const pushData = vi.fn().mockResolvedValue(undefined);
+      const index = buildIndex({ pullData, pushData, updateSyncChunkSize: configured });
+
+      const result = await index.updateSync(updateItems(ITEM_COUNT));
+
+      expect(index.updateSyncChunkSize).toBeGreaterThanOrEqual(1);
+      // One id per batch is the floor, so 60 items produce 60 tasks — the point is that it is not 0.
+      expect(result.totalTasks).toBe(ITEM_COUNT);
+      expect(result.failedTasks).toBe(0);
+      expect(pushData).toHaveBeenCalledTimes(ITEM_COUNT);
+      expect(pulledIdCounts(pullData)).toEqual(Array.from({ length: ITEM_COUNT }, () => 1));
+    },
+    30_000
+  );
+
+  it('rounds a fractional chunk size down to a whole number of ids', async () => {
+    const pullData = vi.fn(async (_ctx, batch) => (batch.type === 'update' ? batch.ids : []));
+    const index = buildIndex({ pullData, updateSyncChunkSize: 7.9 });
+
+    expect(index.updateSyncChunkSize).toBe(7);
+
+    const result = await index.updateSync(updateItems(ITEM_COUNT));
+    // 60 / 7 => 8 full batches of 7 plus a final 4.
+    expect(result.totalTasks).toBe(9);
+    expect(pulledIdCounts(pullData).sort((a, b) => b - a)).toEqual([7, 7, 7, 7, 7, 7, 7, 7, 4]);
   });
 
   it('keeps the collections index well below the default', () => {

--- a/src/server/search-index/base.search-index.ts
+++ b/src/server/search-index/base.search-index.ts
@@ -207,10 +207,14 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
     updateSyncChunkSize: configuredUpdateSyncChunkSize = DEFAULT_UPDATE_SYNC_CHUNK_SIZE,
   } = processor;
 
-  // `chunk(xs, 0)` and `chunk(xs, -1)` both return `[]`, so a processor configured with a
-  // non-positive chunk size would queue zero tasks, write nothing to the index, and still report
-  // `totalTasks: 0, failedTasks: 0` — the silent success this reporting exists to remove. Clamp to
-  // at least one id per batch, and fall back to the default for a non-numeric value.
+  // `chunk(xs, 0)`, `chunk(xs, -1)` and `chunk(xs, NaN)` all return `[]`, so a processor
+  // configured that way would queue zero tasks, write nothing to the index, and still report
+  // `totalTasks: 0, failedTasks: 0` — the silent success this reporting exists to remove. Clamp a
+  // finite value to at least one id per batch; fall back to the default for a NON-FINITE one.
+  // `NaN`, `Infinity` and `-Infinity` are all of type `number`, so the declared type does not
+  // exclude them and a value derived from config or an env var can reach here. Note that this
+  // changes what `Infinity` does: it used to reach `chunk` and yield a single batch of everything,
+  // and now yields default-sized batches instead.
   const updateSyncChunkSize = Number.isFinite(configuredUpdateSyncChunkSize)
     ? Math.max(1, Math.floor(configuredUpdateSyncChunkSize))
     : DEFAULT_UPDATE_SYNC_CHUNK_SIZE;

--- a/src/server/search-index/base.search-index.ts
+++ b/src/server/search-index/base.search-index.ts
@@ -25,6 +25,8 @@ import { getTaskQueueWorker, TaskQueue } from '~/server/search-index/utils/taskQ
 import { createLogger } from '~/utils/logging';
 
 const DEFAULT_UPDATE_INTERVAL = 30 * 1000;
+/** Ids per `updateSync` batch when a processor does not set `updateSyncChunkSize`. */
+export const DEFAULT_UPDATE_SYNC_CHUNK_SIZE = 500;
 const logger = createLogger(`search-index-processor`);
 
 export type SearchIndexContext = {
@@ -65,6 +67,12 @@ type SearchIndexProcessor = {
   primaryKey?: string;
   updateInterval?: number;
   workerCount?: number;
+  /**
+   * Ids per batch for `updateSync`. Each batch becomes one `pullData` call, so this is the knob
+   * that decides whether that query fits inside the database statement timeout. Defaults to
+   * `DEFAULT_UPDATE_SYNC_CHUNK_SIZE`.
+   */
+  updateSyncChunkSize?: number;
   pullSteps?: number;
   client?: MeiliSearch | null;
   jobName?: string;
@@ -127,6 +135,7 @@ const processSearchIndexTask = async (
           type: 'transform',
           index: task.index,
           total: task.total,
+          idCount: task.idCount,
           data: pulledData,
         } as TransformTask;
       }
@@ -141,6 +150,7 @@ const processSearchIndexTask = async (
         type: 'push',
         index: task.index,
         total: task.total,
+        idCount: task.idCount,
         data: transformedData,
       } as PushTask;
     } else if (type === 'push') {
@@ -171,6 +181,17 @@ const processSearchIndexTask = async (
 
 export type SearchIndexTaskResult = Awaited<ReturnType<typeof processSearchIndexTask>>;
 
+/**
+ * Outcome of an `updateSync` run. `failedTasks > 0` means those batches were dropped after
+ * exhausting their retries and `failedIds` documents were never written to the index.
+ */
+export type SearchIndexUpdateSyncResult = {
+  indexName: string;
+  totalTasks: number;
+  failedTasks: number;
+  failedIds: number;
+};
+
 export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor) {
   const {
     indexName,
@@ -183,10 +204,13 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
     jobName,
     partial,
     queues,
+    updateSyncChunkSize = DEFAULT_UPDATE_SYNC_CHUNK_SIZE,
   } = processor;
 
   return {
     indexName,
+    /** Exposed so callers/tests can see the batch size `updateSync` will actually use. */
+    updateSyncChunkSize,
     async getData(ids: number[]) {
       const ctx = {
         db: dbWrite,
@@ -405,9 +429,9 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
     async updateSync(
       items: Array<{ id: number; action?: SearchIndexUpdateQueueAction }>,
       jobContext?: JobContext
-    ) {
+    ): Promise<SearchIndexUpdateSyncResult> {
       if (!items.length) {
-        return;
+        return { indexName, totalTasks: 0, failedTasks: 0, failedIds: 0 };
       }
 
       // TODO index.update shouldnt run
@@ -417,7 +441,8 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
         `createSearchIndexUpdateProcessor :: updateSync :: ${indexName} :: Called with ${items.length} items`
       );
       const queue = new TaskQueue('pull', maxQueueSize);
-      const batches = chunk(items, 500);
+      const batches = chunk(items, updateSyncChunkSize);
+      let totalTasks = 0;
 
       for (const batch of batches) {
         const updateIds = batch
@@ -440,9 +465,11 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
             type: 'pull',
             mode: 'targeted',
             ids: updateIds,
+            idCount: updateIds.length,
             steps: processor.pullSteps,
             currentStep: 0,
           });
+          totalTasks++;
         }
       }
 
@@ -460,6 +487,24 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
       });
 
       await Promise.all(workers);
+
+      // A task that exhausted its retries wrote nothing to the index. Report that instead of
+      // resolving as though everything landed — the caller cannot otherwise tell a total failure
+      // from a total success.
+      const result: SearchIndexUpdateSyncResult = {
+        indexName,
+        totalTasks,
+        failedTasks: queue.failedTasks.length,
+        failedIds: queue.failedIdCount,
+      };
+
+      if (result.failedTasks > 0) {
+        console.error(
+          `createSearchIndexUpdateProcessor :: updateSync :: ${indexName} :: ${result.failedTasks} of ${result.totalTasks} batches failed (${result.failedIds} ids not indexed)`
+        );
+      }
+
+      return result;
     },
     async queueUpdate(items: Array<{ id: number; action?: SearchIndexUpdateQueueAction }>) {
       await SearchIndexUpdate.queueUpdate({ indexName, items });

--- a/src/server/search-index/base.search-index.ts
+++ b/src/server/search-index/base.search-index.ts
@@ -204,8 +204,16 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
     jobName,
     partial,
     queues,
-    updateSyncChunkSize = DEFAULT_UPDATE_SYNC_CHUNK_SIZE,
+    updateSyncChunkSize: configuredUpdateSyncChunkSize = DEFAULT_UPDATE_SYNC_CHUNK_SIZE,
   } = processor;
+
+  // `chunk(xs, 0)` and `chunk(xs, -1)` both return `[]`, so a processor configured with a
+  // non-positive chunk size would queue zero tasks, write nothing to the index, and still report
+  // `totalTasks: 0, failedTasks: 0` — the silent success this reporting exists to remove. Clamp to
+  // at least one id per batch, and fall back to the default for a non-numeric value.
+  const updateSyncChunkSize = Number.isFinite(configuredUpdateSyncChunkSize)
+    ? Math.max(1, Math.floor(configuredUpdateSyncChunkSize))
+    : DEFAULT_UPDATE_SYNC_CHUNK_SIZE;
 
   return {
     indexName,

--- a/src/server/search-index/base.search-index.ts
+++ b/src/server/search-index/base.search-index.ts
@@ -68,9 +68,11 @@ type SearchIndexProcessor = {
   updateInterval?: number;
   workerCount?: number;
   /**
-   * Ids per batch for `updateSync`. Each batch becomes one `pullData` call, so this is the knob
-   * that decides whether that query fits inside the database statement timeout. Defaults to
-   * `DEFAULT_UPDATE_SYNC_CHUNK_SIZE`.
+   * Ids per batch for `updateSync`. Each batch becomes one targeted pull task, so this is the
+   * knob that bounds the id list a `pullData` query is handed, and therefore whether that query
+   * fits inside the database statement timeout. Note that it bounds the id list per call, not the
+   * number of calls: a processor that also sets `pullSteps` runs the same batch of ids through
+   * `pullData` once per step. Defaults to `DEFAULT_UPDATE_SYNC_CHUNK_SIZE`.
    */
   updateSyncChunkSize?: number;
   pullSteps?: number;
@@ -207,14 +209,15 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
     updateSyncChunkSize: configuredUpdateSyncChunkSize = DEFAULT_UPDATE_SYNC_CHUNK_SIZE,
   } = processor;
 
-  // `chunk(xs, 0)`, `chunk(xs, -1)` and `chunk(xs, NaN)` all return `[]`, so a processor
-  // configured that way would queue zero tasks, write nothing to the index, and still report
-  // `totalTasks: 0, failedTasks: 0` — the silent success this reporting exists to remove. Clamp a
-  // finite value to at least one id per batch; fall back to the default for a NON-FINITE one.
-  // `NaN`, `Infinity` and `-Infinity` are all of type `number`, so the declared type does not
-  // exclude them and a value derived from config or an env var can reach here. Note that this
-  // changes what `Infinity` does: it used to reach `chunk` and yield a single batch of everything,
-  // and now yields default-sized batches instead.
+  // `chunk(xs, 0)`, `chunk(xs, -1)`, `chunk(xs, NaN)` and `chunk(xs, -Infinity)` all return `[]`
+  // (lodash-es 4.17.21; `Infinity` is the one non-finite size that does not — it returns a single
+  // batch of everything). A processor configured with any of the empty-returning values would
+  // queue zero tasks, write nothing to the index, and still report `totalTasks: 0,
+  // failedTasks: 0` — the silent success this reporting exists to remove. Clamp a finite value to
+  // at least one id per batch; fall back to the default for a NON-FINITE one. `NaN`, `Infinity`
+  // and `-Infinity` are all of type `number`, so the declared type does not exclude them.
+  // Defensive only: no caller passes one today — `collections.search-index.ts` is the sole
+  // processor that configures this field at all, at 25.
   const updateSyncChunkSize = Number.isFinite(configuredUpdateSyncChunkSize)
     ? Math.max(1, Math.floor(configuredUpdateSyncChunkSize))
     : DEFAULT_UPDATE_SYNC_CHUNK_SIZE;

--- a/src/server/search-index/collections.search-index.ts
+++ b/src/server/search-index/collections.search-index.ts
@@ -475,6 +475,11 @@ export const collectionsSearchIndex = createSearchIndexUpdateProcessor({
       endId,
     };
   },
+  // Measured against production data: a 25-id targeted pull runs in ~0.18s, but the planner flips
+  // around 50 ids and a 50-id pull already costs ~1.4s — about the same as 300 ids. Under load
+  // those larger batches have hit the ~10s statement timeout and lost the whole batch, so keep the
+  // sync batch on the fast side of that flip rather than near the default of 500.
+  updateSyncChunkSize: 25,
   pullData,
   transformData,
   pushData,

--- a/src/server/search-index/utils/__tests__/taskQueue.test.ts
+++ b/src/server/search-index/utils/__tests__/taskQueue.test.ts
@@ -4,17 +4,27 @@ import { TaskQueue } from '~/server/search-index/utils/taskQueue';
 
 /**
  * Walks a retained value and reports whether `needle` is reachable from it by object identity.
- * A `JSON.stringify` check alone can only see a payload that happens to serialise; this sees a
- * held reference regardless of shape.
+ * A `JSON.stringify` check alone can only see a payload that happens to serialise.
+ *
+ * Follows own enumerable properties (which covers array elements) plus the entries of a `Set` and
+ * both the keys and the values of a `Map`. Those two branches are load-bearing rather than
+ * defensive: `Object.values` returns `[]` for a `Set` and for a `Map` because their entries live
+ * in internal slots, and `TaskQueue.processing` is a `Set<Task>` — exactly where a task would be
+ * held. It does NOT follow prototype properties (class getters among them), closures, or
+ * WeakMap/WeakSet entries, so a `false` is "not reachable by this walk", not a proof of
+ * unreachability.
  */
 const holdsReference = (value: unknown, needle: object, seen = new Set<unknown>()): boolean => {
   if (value === needle) return true;
   if (value === null || typeof value !== 'object') return false;
   if (seen.has(value)) return false;
   seen.add(value);
-  return Object.values(value as Record<string, unknown>).some((child) =>
-    holdsReference(child, needle, seen)
-  );
+
+  const children: unknown[] = Object.values(value as Record<string, unknown>);
+  if (value instanceof Set) children.push(...value);
+  if (value instanceof Map) children.push(...value.keys(), ...value.values());
+
+  return children.some((child) => holdsReference(child, needle, seen));
 };
 
 /** Marks a task as in-flight the way `getTask` would, so `failTask` sees consistent stats. */
@@ -24,11 +34,44 @@ const startProcessing = (queue: TaskQueue, task: Task) => {
   queue.updateTaskStatus(task, 'processing');
 };
 
+/**
+ * The retention specs below are only as good as the walk they are built on: a walker that reports
+ * `false` for every container it cannot traverse would pass them while seeing nothing. These are
+ * its positive controls — each shape must be found — plus the negative one.
+ */
+describe('holdsReference :: the walk the retention specs depend on', () => {
+  const needle = { marker: 'NEEDLE' };
+
+  it.each([
+    { label: 'a plain object property', value: { held: needle } },
+    { label: 'an array element', value: [1, needle, 3] },
+    { label: 'a nested object', value: { a: { b: [{ c: needle }] } } },
+    { label: 'a Set entry', value: new Set([{ data: needle }]) },
+    { label: 'a Map value', value: new Map([['k', { data: needle }]]) },
+    { label: 'a Map key', value: new Map([[needle, 'v']]) },
+    { label: 'a Set inside an object', value: { processing: new Set([needle]) } },
+  ])('finds a reference held as $label', ({ value }) => {
+    expect(holdsReference(value, needle)).toBe(true);
+  });
+
+  it('reports false when the needle is genuinely absent', () => {
+    expect(holdsReference({ a: [1, 2], b: new Set([{ marker: 'OTHER' }]) }, needle)).toBe(false);
+  });
+
+  it('terminates on a cyclic graph rather than recursing forever', () => {
+    const cyclic: Record<string, unknown> = { self: null, held: new Set([needle]) };
+    cyclic.self = cyclic;
+    expect(holdsReference(cyclic, needle)).toBe(true);
+    expect(holdsReference({ self: cyclic }, { marker: 'ABSENT' })).toBe(false);
+  });
+});
+
 describe('TaskQueue :: what a permanently-failed task retains', () => {
   it("does not retain a failed push task's document payload", async () => {
     const queue = new TaskQueue('pull');
     // Stand-in for a transformed batch. Production sizes this at the processor's document batch
-    // size, which is five figures for the images index — the reason retaining it matters.
+    // size, which is 100,000 documents for the images index (`images.search-index.ts`, and the
+    // same for `metrics-images`) — the reason retaining it matters.
     const documents = Array.from({ length: 64 }, (_, i) => ({
       id: i + 1,
       blob: 'PAYLOAD_SENTINEL_DO_NOT_RETAIN',
@@ -46,9 +89,17 @@ describe('TaskQueue :: what a permanently-failed task retains', () => {
     expect(queue.failedTasks).toHaveLength(1);
     const [record] = queue.failedTasks;
 
+    // Queue-wide, not record-wide: the claim in `failTask` is that NOTHING on the queue still
+    // reaches the payload once it returns. Asserting only against `failedTasks` leaves a second
+    // structure holding the whole task (a retained `processing` entry, a diagnostics/audit array)
+    // green, which is the regression this guard exists to catch.
     expect(
-      holdsReference(record, documents),
-      'the retained failure record still holds a reference to the pushed documents'
+      holdsReference(queue, documents),
+      'the queue still reaches the pushed documents after failTask returned'
+    ).toBe(false);
+    expect(
+      holdsReference(queue, task),
+      'the queue still reaches the failed task object itself after failTask returned'
     ).toBe(false);
     expect(
       JSON.stringify(record),
@@ -79,8 +130,12 @@ describe('TaskQueue :: what a permanently-failed task retains', () => {
 
     const [record] = queue.failedTasks;
     expect(
-      holdsReference(record, intermediate),
-      'the retained failure record still holds a reference to the intermediate pull data'
+      holdsReference(queue, intermediate),
+      'the queue still reaches the intermediate pull data after failTask returned'
+    ).toBe(false);
+    expect(
+      holdsReference(queue, task),
+      'the queue still reaches the failed pull task itself after failTask returned'
     ).toBe(false);
     expect(JSON.stringify(record)).not.toContain('ROW_SENTINEL_');
     expect(record).toEqual({ type: 'pull', idCount: 3, retries: 0 });
@@ -92,9 +147,11 @@ describe('TaskQueue :: what a permanently-failed task retains', () => {
     // from the sum.
     const idCounts = [7, 13, 40];
     const payloads = idCounts.map((n) => ({ marker: `BATCH_SENTINEL_${n}` }));
+    const tasks: PushTask[] = [];
 
     for (const [i, idCount] of idCounts.entries()) {
       const task: PushTask = { type: 'push', data: payloads[i], idCount, maxRetries: 0 };
+      tasks.push(task);
       startProcessing(queue, task);
       await queue.failTask(task);
     }
@@ -102,7 +159,16 @@ describe('TaskQueue :: what a permanently-failed task retains', () => {
     expect(queue.failedTasks).toHaveLength(3);
     expect(queue.failedIdCount).toBe(60);
     for (const payload of payloads) {
-      expect(holdsReference(queue.failedTasks, payload)).toBe(false);
+      expect(
+        holdsReference(queue, payload),
+        `the queue still reaches ${payload.marker} after failTask returned`
+      ).toBe(false);
+    }
+    for (const task of tasks) {
+      expect(
+        holdsReference(queue, task),
+        `the queue still reaches the failed ${task.type} task itself after failTask returned`
+      ).toBe(false);
     }
     expect(JSON.stringify(queue.failedTasks)).not.toContain('BATCH_SENTINEL_');
   });

--- a/src/server/search-index/utils/__tests__/taskQueue.test.ts
+++ b/src/server/search-index/utils/__tests__/taskQueue.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import type { PullTask, PushTask, Task } from '~/server/search-index/utils/taskQueue';
+import { TaskQueue } from '~/server/search-index/utils/taskQueue';
+
+/**
+ * Walks a retained value and reports whether `needle` is reachable from it by object identity.
+ * A `JSON.stringify` check alone can only see a payload that happens to serialise; this sees a
+ * held reference regardless of shape.
+ */
+const holdsReference = (value: unknown, needle: object, seen = new Set<unknown>()): boolean => {
+  if (value === needle) return true;
+  if (value === null || typeof value !== 'object') return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  return Object.values(value as Record<string, unknown>).some((child) =>
+    holdsReference(child, needle, seen)
+  );
+};
+
+/** Marks a task as in-flight the way `getTask` would, so `failTask` sees consistent stats. */
+const startProcessing = (queue: TaskQueue, task: Task) => {
+  queue.processing.add(task);
+  queue.stats.queued++;
+  queue.updateTaskStatus(task, 'processing');
+};
+
+describe('TaskQueue :: what a permanently-failed task retains', () => {
+  it("does not retain a failed push task's document payload", async () => {
+    const queue = new TaskQueue('pull');
+    // Stand-in for a transformed batch. Production sizes this at the processor's document batch
+    // size, which is five figures for the images index — the reason retaining it matters.
+    const documents = Array.from({ length: 64 }, (_, i) => ({
+      id: i + 1,
+      blob: 'PAYLOAD_SENTINEL_DO_NOT_RETAIN',
+    }));
+    const task: PushTask = {
+      type: 'push',
+      data: documents,
+      idCount: 64,
+      maxRetries: 0,
+    };
+
+    startProcessing(queue, task);
+    await queue.failTask(task);
+
+    expect(queue.failedTasks).toHaveLength(1);
+    const [record] = queue.failedTasks;
+
+    expect(
+      holdsReference(record, documents),
+      'the retained failure record still holds a reference to the pushed documents'
+    ).toBe(false);
+    expect(
+      JSON.stringify(record),
+      'the retained failure record still serialises the document payload'
+    ).not.toContain('PAYLOAD_SENTINEL_DO_NOT_RETAIN');
+
+    // The number the caller actually reports on survives the summarising.
+    expect(record).toEqual({ type: 'push', idCount: 64, retries: 0 });
+    expect(queue.failedIdCount).toBe(64);
+  });
+
+  it("does not retain a failed multi-step pull task's intermediate data", async () => {
+    const queue = new TaskQueue('pull');
+    const intermediate = { rows: Array.from({ length: 32 }, (_, i) => `ROW_SENTINEL_${i}`) };
+    const task: PullTask = {
+      type: 'pull',
+      mode: 'targeted',
+      ids: [11, 22, 33],
+      idCount: 3,
+      steps: 2,
+      currentStep: 1,
+      currentData: intermediate,
+      maxRetries: 0,
+    };
+
+    startProcessing(queue, task);
+    await queue.failTask(task);
+
+    const [record] = queue.failedTasks;
+    expect(
+      holdsReference(record, intermediate),
+      'the retained failure record still holds a reference to the intermediate pull data'
+    ).toBe(false);
+    expect(JSON.stringify(record)).not.toContain('ROW_SENTINEL_');
+    expect(record).toEqual({ type: 'pull', idCount: 3, retries: 0 });
+  });
+
+  it('sums the ids of several failed tasks without keeping any of their payloads', async () => {
+    const queue = new TaskQueue('pull');
+    // Pairwise-distinct id counts: a mutant returning any single one, or the task count, differs
+    // from the sum.
+    const idCounts = [7, 13, 40];
+    const payloads = idCounts.map((n) => ({ marker: `BATCH_SENTINEL_${n}` }));
+
+    for (const [i, idCount] of idCounts.entries()) {
+      const task: PushTask = { type: 'push', data: payloads[i], idCount, maxRetries: 0 };
+      startProcessing(queue, task);
+      await queue.failTask(task);
+    }
+
+    expect(queue.failedTasks).toHaveLength(3);
+    expect(queue.failedIdCount).toBe(60);
+    for (const payload of payloads) {
+      expect(holdsReference(queue.failedTasks, payload)).toBe(false);
+    }
+    expect(JSON.stringify(queue.failedTasks)).not.toContain('BATCH_SENTINEL_');
+  });
+
+  it('still retries up to maxRetries before recording a failure', async () => {
+    const queue = new TaskQueue('pull');
+    const task: PushTask = { type: 'push', data: { marker: 'x' }, idCount: 5, maxRetries: 1 };
+
+    startProcessing(queue, task);
+    // First failure requeues rather than recording — `retrying` keeps it visible to the workers.
+    await queue.failTask(task);
+    expect(queue.failedTasks).toHaveLength(0);
+    expect(queue.queues.push).toHaveLength(1);
+
+    const requeued = queue.queues.push[0];
+    startProcessing(queue, requeued);
+    await queue.failTask(requeued);
+
+    expect(queue.failedTasks).toEqual([{ type: 'push', idCount: 5, retries: 1 }]);
+    expect(queue.failedIdCount).toBe(5);
+  }, 15_000);
+});

--- a/src/server/search-index/utils/taskQueue.ts
+++ b/src/server/search-index/utils/taskQueue.ts
@@ -239,9 +239,19 @@ export const getTaskQueueWorker = (
       const result = await processor(task);
 
       if (result === 'error') {
-        // Awaited so a rejection from failTask is not dropped on the floor. It is not what keeps
-        // the retry alive — `retrying` does that — but the two are redundant, not alternatives;
-        // see the comment on the retry branch in `failTask`.
+        // Awaited so the re-queue completes before this worker re-evaluates `isQueueEmpty()`.
+        // That is redundant with `retrying`, not an alternative to it: measured, either
+        // mechanism ALONE keeps the retry alive, and only with neither do all the workers
+        // resolve before the task is added back. See the retry branch in `failTask`.
+        //
+        // 🔴 It does NOT stop a rejection from `failTask` being dropped. This worker is a
+        // `new Promise(async (resolve) => …)`, and a throw inside an async executor rejects
+        // the executor's own unobserved promise, never the outer one — so the rejection is
+        // unhandled with or without this `await`. What the `await` changes is that the worker
+        // then never settles, hanging the `Promise.all(workers)` in `updateSync` instead of
+        // returning. `failTask` cannot realistically throw today (`processSearchIndexTask`
+        // catches everything), so this is a latent shape, not a live bug — but do not read
+        // the `await` as error handling.
         await queue.failTask(task);
       } else {
         queue.completeTask(task);

--- a/src/server/search-index/utils/taskQueue.ts
+++ b/src/server/search-index/utils/taskQueue.ts
@@ -12,6 +12,12 @@ type BaseTask = {
   index?: number;
   total?: number;
   start?: number;
+  /**
+   * How many source ids this task is responsible for. Carried through the pull -> transform ->
+   * push chain (the derived tasks no longer hold the id list) so that a task which ends up
+   * failing can be attributed back to a number of documents that were never indexed.
+   */
+  idCount?: number;
 };
 
 export type PullTask = BaseTask &
@@ -54,6 +60,13 @@ export class TaskQueue {
   processing: Set<Task>;
   stats: Record<TaskStatus, number>;
   maxQueueSize: number;
+  /** Tasks that exhausted their retries. Kept so a caller can report what was NOT indexed. */
+  failedTasks: Task[];
+  /**
+   * Tasks that are between "failed" and "back on a queue" — see `failTask`. Counted by
+   * `isQueueEmpty` so the workers cannot all exit during the retry backoff.
+   */
+  retrying: number;
 
   constructor(queueEntry: Task['type'] = 'pull', maxQueueSize = MAX_QUEUE_SIZE_DEFAULT) {
     this.queues = {
@@ -71,6 +84,8 @@ export class TaskQueue {
       failed: 0,
     };
     this.maxQueueSize = maxQueueSize;
+    this.failedTasks = [];
+    this.retrying = 0;
   }
 
   get data() {
@@ -79,6 +94,11 @@ export class TaskQueue {
       processing: this.processing,
       stats: this.stats,
     };
+  }
+
+  /** Number of source ids belonging to tasks that permanently failed. */
+  get failedIdCount(): number {
+    return this.failedTasks.reduce((acc, task) => acc + (task.idCount ?? 0), 0);
   }
 
   async waitForQueueCapacity(queue: Task[]): Promise<void> {
@@ -138,20 +158,29 @@ export class TaskQueue {
     task.retries = task.retries ?? 0;
 
     if (task.retries < task.maxRetries) {
-      // Requeue it:
-      await sleep(RETRY_TIMEOUT);
-      task.retries++;
-      this.addTask(task);
+      // Requeue it. The task is no longer processing and not yet queued, so it is invisible to
+      // isQueueEmpty() for the whole backoff — without `retrying` every worker can decide the
+      // queue is empty and resolve before the retry is ever added back.
+      this.stats.processing--;
+      this.retrying++;
+      try {
+        await sleep(RETRY_TIMEOUT);
+        task.retries++;
+        await this.addTask(task);
+      } finally {
+        this.retrying--;
+      }
       return;
     }
 
+    this.failedTasks.push(task);
     this.updateTaskStatus(task, 'failed');
   }
 
   isQueueEmpty(): boolean {
     const queueSize = Object.values(this.queues).reduce((acc, queue) => acc + queue.length, 0);
     const processingSize = this.processing.size;
-    const totalSize = queueSize + processingSize;
+    const totalSize = queueSize + processingSize + this.retrying;
     return totalSize === 0;
   }
 }
@@ -174,7 +203,9 @@ export const getTaskQueueWorker = (
       const result = await processor(task);
 
       if (result === 'error') {
-        queue.failTask(task);
+        // Awaited: failTask holds the task's retry slot open, and dropping the promise on the
+        // floor also drops any error it raises.
+        await queue.failTask(task);
       } else {
         queue.completeTask(task);
         if (result !== 'done') {

--- a/src/server/search-index/utils/taskQueue.ts
+++ b/src/server/search-index/utils/taskQueue.ts
@@ -58,13 +58,18 @@ type TaskStatus = 'queued' | 'processing' | 'completed' | 'failed';
  * up to a processor's document batch size) and any multi-step pull task carries `currentData`.
  * Holding the task object would keep those payloads alive for the whole life of the queue —
  * which, on a degraded backend where many batches fail, is a large amount of memory retained for
- * the sake of a number. Only the fields a caller actually reports on are kept.
+ * the sake of a number. `idCount` is the only field any production consumer reads (via
+ * `failedIdCount`); `type` and `retries` are kept for diagnostics and are so far read only by the
+ * specs.
  */
 export type FailedTaskRecord = {
   type: Task['type'];
   /** Source ids this task was responsible for; none of them reached the index. */
   idCount: number;
-  /** Attempts made before giving up. */
+  /**
+   * Retries the task had already made when it gave up — it was attempted `retries + 1` times.
+   * A task with `maxRetries: 0` is attempted once and records 0.
+   */
   retries: number;
 };
 
@@ -193,8 +198,9 @@ export class TaskQueue {
       return;
     }
 
-    // Summarise rather than retain: the task (and its `data`/`currentData` payload) becomes
-    // garbage as soon as this returns.
+    // Summarise rather than retain: once this returns, no structure on the queue reaches the task
+    // or its `data`/`currentData` payload. (Pinned queue-wide, not just for `failedTasks`, by the
+    // reachability walk in `src/server/search-index/utils/__tests__/taskQueue.test.ts`.)
     this.failedTasks.push({
       type: task.type,
       idCount: task.idCount ?? 0,

--- a/src/server/search-index/utils/taskQueue.ts
+++ b/src/server/search-index/utils/taskQueue.ts
@@ -249,9 +249,9 @@ export const getTaskQueueWorker = (
         // the executor's own unobserved promise, never the outer one — so the rejection is
         // unhandled with or without this `await`. What the `await` changes is that the worker
         // then never settles, hanging the `Promise.all(workers)` in `updateSync` instead of
-        // returning. `failTask` cannot realistically throw today (`processSearchIndexTask`
-        // catches everything), so this is a latent shape, not a live bug — but do not read
-        // the `await` as error handling.
+        // returning. Nothing in `failTask`'s own body throws today — it mutates queue state,
+        // sleeps, and calls `addTask` — so this is a latent shape, not a live bug. But do not
+        // read the `await` as error handling.
         await queue.failTask(task);
       } else {
         queue.completeTask(task);

--- a/src/server/search-index/utils/taskQueue.ts
+++ b/src/server/search-index/utils/taskQueue.ts
@@ -51,6 +51,23 @@ export type OnCompleteTask = BaseTask & {
 
 type TaskStatus = 'queued' | 'processing' | 'completed' | 'failed';
 
+/**
+ * What is retained about a task that exhausted its retries.
+ *
+ * Deliberately NOT the `Task` itself: a push task carries `data` (an entire transformed batch,
+ * up to a processor's document batch size) and any multi-step pull task carries `currentData`.
+ * Holding the task object would keep those payloads alive for the whole life of the queue —
+ * which, on a degraded backend where many batches fail, is a large amount of memory retained for
+ * the sake of a number. Only the fields a caller actually reports on are kept.
+ */
+export type FailedTaskRecord = {
+  type: Task['type'];
+  /** Source ids this task was responsible for; none of them reached the index. */
+  idCount: number;
+  /** Attempts made before giving up. */
+  retries: number;
+};
+
 const MAX_QUEUE_SIZE_DEFAULT = 50;
 const RETRY_TIMEOUT = 1000;
 
@@ -60,8 +77,11 @@ export class TaskQueue {
   processing: Set<Task>;
   stats: Record<TaskStatus, number>;
   maxQueueSize: number;
-  /** Tasks that exhausted their retries. Kept so a caller can report what was NOT indexed. */
-  failedTasks: Task[];
+  /**
+   * Summaries of the tasks that exhausted their retries, kept so a caller can report what was NOT
+   * indexed. Summaries rather than tasks — see `FailedTaskRecord`.
+   */
+  failedTasks: FailedTaskRecord[];
   /**
    * Tasks that are between "failed" and "back on a queue" — see `failTask`. Counted by
    * `isQueueEmpty` so the workers cannot all exit during the retry backoff.
@@ -98,7 +118,7 @@ export class TaskQueue {
 
   /** Number of source ids belonging to tasks that permanently failed. */
   get failedIdCount(): number {
-    return this.failedTasks.reduce((acc, task) => acc + (task.idCount ?? 0), 0);
+    return this.failedTasks.reduce((acc, record) => acc + record.idCount, 0);
   }
 
   async waitForQueueCapacity(queue: Task[]): Promise<void> {
@@ -173,7 +193,13 @@ export class TaskQueue {
       return;
     }
 
-    this.failedTasks.push(task);
+    // Summarise rather than retain: the task (and its `data`/`currentData` payload) becomes
+    // garbage as soon as this returns.
+    this.failedTasks.push({
+      type: task.type,
+      idCount: task.idCount ?? 0,
+      retries: task.retries,
+    });
     this.updateTaskStatus(task, 'failed');
   }
 

--- a/src/server/search-index/utils/taskQueue.ts
+++ b/src/server/search-index/utils/taskQueue.ts
@@ -183,9 +183,11 @@ export class TaskQueue {
     task.retries = task.retries ?? 0;
 
     if (task.retries < task.maxRetries) {
-      // Requeue it. The task is no longer processing and not yet queued, so it is invisible to
-      // isQueueEmpty() for the whole backoff — without `retrying` every worker can decide the
-      // queue is empty and resolve before the retry is ever added back.
+      // Requeue it. The task is no longer processing and not yet queued, so `retrying` is what
+      // keeps it visible to isQueueEmpty() across the backoff. It is redundant with the `await`
+      // in getTaskQueueWorker rather than an alternative to it: measured, either mechanism on its
+      // own keeps the retry alive, and only with neither do the workers all decide the queue is
+      // empty and resolve before the retry is added back.
       this.stats.processing--;
       this.retrying++;
       try {
@@ -198,9 +200,11 @@ export class TaskQueue {
       return;
     }
 
-    // Summarise rather than retain: once this returns, no structure on the queue reaches the task
-    // or its `data`/`currentData` payload. (Pinned queue-wide, not just for `failedTasks`, by the
-    // reachability walk in `src/server/search-index/utils/__tests__/taskQueue.test.ts`.)
+    // Summarise rather than retain. On this path only — the task has given up, the retry branch
+    // above having already returned with it back on `queues[type]` — no structure on the queue
+    // reaches the task or its `data`/`currentData` payload once this returns. (Pinned queue-wide,
+    // not just for `failedTasks`, by the reachability walk in
+    // `src/server/search-index/utils/__tests__/taskQueue.test.ts`.)
     this.failedTasks.push({
       type: task.type,
       idCount: task.idCount ?? 0,
@@ -235,8 +239,9 @@ export const getTaskQueueWorker = (
       const result = await processor(task);
 
       if (result === 'error') {
-        // Awaited: failTask holds the task's retry slot open, and dropping the promise on the
-        // floor also drops any error it raises.
+        // Awaited so a rejection from failTask is not dropped on the floor. It is not what keeps
+        // the retry alive — `retrying` does that — but the two are redundant, not alternatives;
+        // see the comment on the retry branch in `failTask`.
         await queue.failTask(task);
       } else {
         queue.completeTask(task);


### PR DESCRIPTION
## The problem

A production backfill submitted through `GET /api/mod/update-index` reported success while ~97% of the work failed on a database statement timeout. Every call returned HTTP 200 `{"status":"ok"}`; in reality only one of the five batches indexed anything, and ~1,200 of ~1,239 documents were never written. Nothing in the response, the status code, or the caller's view distinguished that from a clean run.

The silence is layered, and every layer has to be crossed for the caller to see anything:

- `processSearchIndexTask` catches the exception, logs it, and returns the string `'error'`.
- `updateSync` runs its workers with `await Promise.all(workers)` and then returns `undefined` unconditionally — it never asks whether any task ended in `'error'`.
- The endpoint awaits `updateSync(...)` and unconditionally sends `200 {"status":"ok"}`.

## What this changes

**1. `updateSync` reports its outcome.** It now resolves to `{ indexName, totalTasks, failedTasks, failedIds }` instead of `undefined`. This builds on what the queue already does rather than adding a parallel mechanism: `getTaskQueueWorker` already routes an `'error'` result to `TaskQueue.failTask`, which already counts a permanently-failed task; the queue now also keeps the failed tasks so the caller can be told *how much* was lost, not just that something was. Existing callers (`refresh-auction-cache`, `handle-auctions`, `reindex-recent-scheduled-images`) ignore the return value and are unaffected.

Two supporting fixes in `TaskQueue`, both of which the count depends on to be truthful:

- **`failTask` could drop a retry entirely.** It removed the task from `processing` and *then* awaited the retry backoff. During that window `isQueueEmpty()` returned true, so with a single in-flight task every worker exited before the task was re-queued — the retry never ran, and because `stats.failed` is only incremented once retries are exhausted, nothing was ever recorded as failed. This is exactly the shape of the production incident: one batch per call, one failure, zero retries, zero failures recorded. A `retrying` counter now keeps the task visible to `isQueueEmpty()` across the backoff, and the worker awaits `failTask` rather than dropping its promise.
- **A failure after the pull step lost its id count.** The transform and push tasks no longer carry the id list, so tasks now carry an `idCount` through the `pull -> transform -> push` handoff and a failure at any step can still be attributed to a number of documents.

**2. The endpoint reports it.** If any batch failed, the response is a non-2xx carrying the index name and the failed batch/id counts:

```json
{ "status": "error", "index": "collections_v3", "failedTasks": 4, "totalTasks": 5,
  "failedIds": 1200, "error": "1200 ids in 4 of 5 batches failed to index" }
```

The all-succeeded response is byte-for-byte what it was (`200 {"status":"ok"}`), so existing callers see no change on the happy path, and a `processQueues` run — which produces no sync result — is also unchanged. The nine-arm `switch` became a lookup keyed by the same zod enum (checked against the lookup's keys with `satisfies`, so the two cannot drift), which is what lets the result be captured in one place instead of nine.

**3. The sync chunk size is per-index.** `updateSync` hardcoded `chunk(items, 500)`. It is now an optional `updateSyncChunkSize` on the processor, defaulting to 500 — so every index behaves exactly as before unless it opts in.

The collections index opts in at **25**. Measured against production data for the affected collections: a 25-id targeted pull runs in **~0.18s**, but the query planner flips around 50 ids and a 50-id pull already costs **~1.41s** — essentially the same as a 300-id pull at **~1.45s**. So the cost is not linear in batch size; what matters is staying on the fast side of that flip. Against a ~10s statement timeout that these queries demonstrably hit under normal load, 25 leaves roughly two orders of magnitude of headroom, where 300 and 500 do not.

## Adjacent, deliberately not fixed here

`processQueues` shares `processSearchIndexTask` and calls `queuedUpdates.commit()` after `await Promise.all(workers)` regardless of whether any task errored — so a failed background batch clears its queued ids as well, and those ids are not retried by a later run. That is a real second instance of the same silent-failure shape, but it is a background cron with a different blast radius and a different fix (the commit has to become conditional, and the ids of failed tasks have to be preserved rather than merely counted). Worth a reviewer knowing about; deliberately out of scope for this PR.

## Tests

`src/server/search-index/__tests__/update-sync-failure-reporting.test.ts` and `src/__tests__/pages/api/mod/update-index.test.ts`.

The regression specs were run against the parent commit (`87f3073240`, with only the test files added) and watched fail — 8 failed / 3 passed:

- `reports the failed batch when the pull step throws, instead of resolving silently` — `Cannot read properties of undefined`, i.e. `updateSync` resolved to nothing. Its wall time there was **1.0s**, not the ~4s of four attempts, which is the dropped-retry bug showing up directly in the timing.
- `attributes a failure at the push step back to the ids that were never written`
- `reports zero failures when every batch succeeds`
- `returns an all-zero result for an empty item list`
- `splits into batches of the configured size` / `falls back to the default chunk size when a processor sets none` / `keeps the collections index well below the default`
- `does NOT return 200 ok when a batch failed to index` — `expected 200 not to be 200`

The 3 that passed at the parent commit are the ones that pin *unchanged* behaviour (the 200 success shape, id routing, the `processQueues` path) — invariant guards, not regression coverage.

The batching spec uses 60 ids against a chunk size of 25, deliberately not a multiple, so it asserts `[25, 25, 10]` — an off-by-one in the batching changes the final batch rather than hiding in a round number.

All 11 pass on this branch.
