### PR TITLE
Make the rewards-abuse exclusivity test exact, not approximate

### DIFF
--- a/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
+++ b/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
@@ -166,7 +166,12 @@ describe('rewards-abuse-prevention — detection shape', () => {
 
     const sql = sqlOf();
     expect(sql).toContain('ip_user_count = user_count');
-    expect(sql).toContain("uniqIf(be.toUserId, startsWith(be.type, 'encouragement:'))");
+    expect(sql).toContain("uniqExactIf(be.toUserId, startsWith(be.type, 'encouragement:'))");
+    // Exact on BOTH sides: the having-clause compares them for equality, and an equality
+    // between two HyperLogLog estimates flips on the boundary the test lives on.
+    expect(sql).toContain('uniqExact(be.toUserId) as ip_user_count');
+    expect(sql).not.toMatch(/uniqIf\(/);
+    expect(sql).not.toMatch(/uniq\(be\.toUserId\) as ip_user_count/);
     // The type filter has to leave the WHERE, or the users it hides are the ones
     // exclusivity exists to count.
     expect(sql).not.toContain('AND startsWith');

--- a/src/server/jobs/rewards-abuse-prevention.ts
+++ b/src/server/jobs/rewards-abuse-prevention.ts
@@ -53,8 +53,7 @@ export const rewardsAbusePrevention = createJob(
     //
     // Exact, not `uniq`: the having-clause compares these two counts for EQUALITY, and an
     // equality between two HyperLogLog estimates is unstable on exactly the boundary the test
-    // lives on. Measured on one day's data, the approximate form returned 130 IPs and then 48
-    // minutes apart; the exact form returned 48 three times.
+    // lives on.
     const exclusivity = abuseLimits.require_exclusive_ip
       ? {
           where: '',

--- a/src/server/jobs/rewards-abuse-prevention.ts
+++ b/src/server/jobs/rewards-abuse-prevention.ts
@@ -50,10 +50,15 @@ export const rewardsAbusePrevention = createJob(
 
     // Exclusivity has to count the users the type filter would have hidden, which costs a
     // whole-day scan — so it moves the filter out of the WHERE only when it is switched on.
+    //
+    // Exact, not `uniq`: the having-clause compares these two counts for EQUALITY, and an
+    // equality between two HyperLogLog estimates is unstable on exactly the boundary the test
+    // lives on. Measured on one day's data, the approximate form returned 130 IPs and then 48
+    // minutes apart; the exact form returned 48 three times.
     const exclusivity = abuseLimits.require_exclusive_ip
       ? {
           where: '',
-          select: `uniqIf(be.toUserId, ${matched}) as user_count, uniq(be.toUserId) as ip_user_count, sumIf(awardAmount, ${matched}) as awarded`,
+          select: `uniqExactIf(be.toUserId, ${matched}) as user_count, uniqExact(be.toUserId) as ip_user_count, sumIf(awardAmount, ${matched}) as awarded`,
           having: 'AND ip_user_count = user_count',
         }
       : {


### PR DESCRIPTION
One line, plus the test that pins it. **Blocks enabling `require_exclusive_ip`** — the guard it fixes is not safe to switch on before this lands.

Ticket: [868m2zub6](https://app.clickup.com/t/868m2zub6). Found while writing down what a first dry run *should* produce, before running one.

## The bug

The exclusivity check compares two HyperLogLog estimates for **equality**:

```
uniqIf(be.toUserId, <matched>) as user_count,
uniq(be.toUserId)              as ip_user_count,
HAVING ... AND ip_user_count = user_count
```

An equality between two approximations is unstable on exactly the boundary the test lives on.

## The measurement

Same predicate, same production data, minutes apart:

| aggregates | run 1 | run 2 | run 3 |
|---|---|---|---|
| `uniq` / `uniqIf` (current) | **130 IPs** | **48 IPs** | — |
| `uniqExact` / `uniqExactIf` | 48 | 48 | 48 |

The exact form is stable across the same interval. A rolling one-day window explains drift of a few, not 130 → 48.

## Why it matters more than the size of the diff

This is the guard that separates a farm from a carrier range, and `require_exclusive_ip` exists precisely so such ranges are not swept into a job that disables accounts unattended. Hanging that on a comparison whose answer changes between runs is the wrong foundation, regardless of how often it happens to be right.

*(Correcting a figure I used earlier: I had cited 5,663 users on the busiest IP. That is a **monthly** rollup from the reactions table, and this job's window is one day. The worst **daily** per-IP cardinality in `buzzEvents` is **515**, across 36,934 IPs — measured. The argument is unchanged; the number I attached to it was the wrong one.)*

## Blast radius today: none

The branch is only reachable through `require_exclusive_ip`, and `rewards:abuse-limits` is unset in sysRedis, so the deployed job never takes it. This is a fix ahead of a switch being thrown, not a live incident.

## What is deliberately NOT changed

The non-exclusive branch keeps `uniq`. Its count feeds threshold comparisons (`user_count > N`) rather than an equality, so approximation there is far less consequential — and changing it would move what the **currently enforcing** detection flags. That is a live behaviour change, which this PR is not. It predates this line of work and stays as it is.

## Review

All five lanes ran over this diff. Findings taken:

- **intent** — the comment originally pinned the measured numbers. Dropped in `ed9d66ae53`: the mechanism is timeless, the figures are a snapshot nothing re-measures, and this repo has been bitten three times by exactly that. They stay in the commit message, here, and on the ticket, where they are dated.
- **reuse** — no duplication, and it confirmed this change brings the job in line with `src/pages/api/admin/reaction-abuse.ts`, which already uses `uniqExact`/`uniqExactIf` throughout for the same kind of IP clustering. It also found no other place in `src/server/` comparing two approximate aggregates for equality.
- **correctness** — clean. Confirmed the branch is unreachable today and that `uniqExact` introduces no NULL/empty or overflow difference for an integer column.
- **perf** — measured rather than reasoned, and it improved the argument: `array_agg(distinct be.toUserId)` is already in this query (unchanged by the diff — it is how the job knows whom to disable), and it already forces exact per-IP materialisation. So `uniqExact` rides on state the query was already paying for. Measured delta: **read_rows and read_bytes identical**, memory 211 → 220 MB (2-6%), sub-400 ms, once nightly. It also rejected `uniqCombined`: its exact/approximate crossover is 2^17 per group, three orders of magnitude above anything observed, so it would behave as exact everywhere while being less legible at the call site.
- **tests** — see below.

## Test

The exclusivity SQL assertion now pins `uniqExactIf` and `uniqExact(be.toUserId) as ip_user_count`, and negatively asserts that neither approximate form comes back.

**Revert control:** with the job file restored to what is deployed on `origin/main`, that test fails — `expected … to contain 'uniqExactIf(be.toUserId, startsWith(…'` — and the other 23 stay green. So it fails for the reason it names, not because everything reddens.

The test lane went further than that control, on the thing I was least sure of. The negative assertions are `/uniqIf\(/` and `/uniq\(be\.toUserId\) as ip_user_count/` with no word boundary, so the question was whether `uniqIf(` matches *inside* `uniqExactIf(` and makes the assertion vacuous. It does not — the characters between `uniq` and `If(` are `Exact`, so the substring is not contiguous — and that was confirmed by direct regex probe rather than by reading.

It also mutated **each half of the fix separately** — reverting one aggregate at a time — and both halves fail, each caught by two independent assertions. So no single assertion is doing all the work.

24 tests in the file, typecheck clean, ESLint at the two `no-explicit-any` warnings that predate this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbTHWSRzK8asgVTBLP3UiP
