### PR TITLE
fix(search-index): drain deletes before pulls so a restored document survives

### DIFF
--- a/src/server/search-index/__tests__/base-index-queue-order.test.ts
+++ b/src/server/search-index/__tests__/base-index-queue-order.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetQueue, mockCleanup, mockSetLastUpdate } = vi.hoisted(() => ({
+  mockGetQueue: vi.fn(),
+  mockCleanup: vi.fn(),
+  mockSetLastUpdate: vi.fn(),
+}));
+
+vi.mock('~/server/search-index/SearchIndexUpdate', () => ({
+  SearchIndexUpdate: { getQueue: mockGetQueue, queueUpdate: vi.fn(), clearQueue: vi.fn() },
+}));
+vi.mock('~/server/meilisearch/util', () => ({
+  onSearchIndexDocumentsCleanup: mockCleanup,
+  getOrCreateIndex: vi.fn(async () => ({})),
+  swapIndex: vi.fn(),
+}));
+vi.mock('~/server/jobs/job', () => ({
+  getJobDate: async () => [new Date(0), mockSetLastUpdate] as const,
+}));
+
+import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+
+const QUEUED_ID = 42;
+
+// Ordered log of the two things whose relative order is the whole subject here: the
+// Meilisearch delete, and the upsert the pull path produces for the same id.
+let calls: string[] = [];
+
+// `qualifies` stands in for the index's own WHERE, which every real pullData applies —
+// that is what makes delete-then-pull safe rather than merely a different guess.
+const buildProcessor = ({ qualifies }: { qualifies: boolean }) => ({
+  indexName: 'test_index',
+  setup: async () => undefined,
+  prepareBatches: async () => ({ batchSize: 100, startId: 1, endId: 0, updateIds: [] }),
+  pullData: async (_ctx: unknown, batch: { type: string; ids?: number[] }) => {
+    calls.push(`pull:${batch.ids?.join(',') ?? 'range'}`);
+    return qualifies ? [{ id: QUEUED_ID }] : null;
+  },
+  transformData: async (data: unknown) => data,
+  pushData: async (_ctx: unknown, data: { id: number }[]) => {
+    calls.push(`push:${data.map((d) => d.id).join(',')}`);
+  },
+  workerCount: 1,
+  client: {} as never,
+});
+
+const stubQueues = ({ updates, deletes }: { updates: number[]; deletes: number[] }) => {
+  mockGetQueue.mockImplementation(async (_index: string, action: SearchIndexUpdateQueueAction) => ({
+    content: action === SearchIndexUpdateQueueAction.Delete ? deletes : updates,
+    commit: async () => undefined,
+  }));
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  calls = [];
+  mockCleanup.mockImplementation(async ({ ids }: { ids: number[] }) => {
+    calls.push(`delete:${ids.join(',')}`);
+  });
+});
+
+// The Update and Delete queues are disjoint Redis sets with no timestamps, so an id in
+// both carries no record of which action came last. Whichever side the drain resolves
+// second wins. Resolving it as delete-then-pull hands the decision to the database.
+describe('search index :: doubly-queued id', () => {
+  it('rebuilds a restored document instead of deleting it, in update()', async () => {
+    stubQueues({ updates: [QUEUED_ID], deletes: [QUEUED_ID] });
+    const index = createSearchIndexUpdateProcessor(buildProcessor({ qualifies: true }));
+
+    await index.update({} as never);
+
+    expect(calls).toEqual([`delete:${QUEUED_ID}`, `pull:${QUEUED_ID}`, `push:${QUEUED_ID}`]);
+  });
+
+  it('leaves the document deleted when the row no longer qualifies', async () => {
+    stubQueues({ updates: [QUEUED_ID], deletes: [QUEUED_ID] });
+    const index = createSearchIndexUpdateProcessor(buildProcessor({ qualifies: false }));
+
+    await index.update({} as never);
+
+    expect(calls).toEqual([`delete:${QUEUED_ID}`, `pull:${QUEUED_ID}`]);
+    expect(calls.some((c) => c.startsWith('push'))).toBe(false);
+  });
+
+  it('rebuilds a restored document instead of deleting it, in processQueues()', async () => {
+    stubQueues({ updates: [QUEUED_ID], deletes: [QUEUED_ID] });
+    const index = createSearchIndexUpdateProcessor(buildProcessor({ qualifies: true }));
+
+    await index.processQueues({ processUpdates: true, processDeletes: true }, {} as never);
+
+    expect(calls).toEqual([`delete:${QUEUED_ID}`, `pull:${QUEUED_ID}`, `push:${QUEUED_ID}`]);
+  });
+});
+
+describe('search index :: single-action ids are unaffected', () => {
+  it('still deletes an id queued only for deletion', async () => {
+    stubQueues({ updates: [], deletes: [QUEUED_ID] });
+    const index = createSearchIndexUpdateProcessor(buildProcessor({ qualifies: false }));
+
+    await index.update({} as never);
+
+    expect(calls).toEqual([`delete:${QUEUED_ID}`]);
+  });
+
+  it('still upserts an id queued only for update', async () => {
+    stubQueues({ updates: [QUEUED_ID], deletes: [] });
+    const index = createSearchIndexUpdateProcessor(buildProcessor({ qualifies: true }));
+
+    await index.update({} as never);
+
+    expect(mockCleanup).not.toHaveBeenCalled();
+    expect(calls).toEqual([`pull:${QUEUED_ID}`, `push:${QUEUED_ID}`]);
+  });
+});

--- a/src/server/search-index/base.search-index.ts
+++ b/src/server/search-index/base.search-index.ts
@@ -315,8 +315,9 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
       }
 
       // Deletes FIRST, as `updateSync` already does. The two queues are disjoint sets with no
-      // timestamps, so an id in both records no order and the drain decides it. Pulling second
-      // lets `pullData`'s own WHERE arbitrate; pulling first rebuilt the doc then deleted it.
+      // timestamps, so an id queued in both carries no record of which action came last, and the
+      // drain order alone decides the outcome. Pulling second lets `pullData`'s own WHERE
+      // arbitrate; pulling first rebuilt the document and then deleted it.
       if (queuedDeletes.content.length > 0 && !partial) {
         await onSearchIndexDocumentsCleanup({
           indexName,

--- a/src/server/search-index/base.search-index.ts
+++ b/src/server/search-index/base.search-index.ts
@@ -314,6 +314,17 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
         });
       }
 
+      // Deletes FIRST, as `updateSync` already does. The two queues are disjoint sets with no
+      // timestamps, so an id in both records no order and the drain decides it. Pulling second
+      // lets `pullData`'s own WHERE arbitrate; pulling first rebuilt the doc then deleted it.
+      if (queuedDeletes.content.length > 0 && !partial) {
+        await onSearchIndexDocumentsCleanup({
+          indexName,
+          ids: queuedDeletes.content,
+          client: processor.client,
+        });
+      }
+
       const workers = Array.from({ length: workerCount }).map(() => {
         return getTaskQueueWorker(
           queue,
@@ -323,14 +334,6 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
       });
 
       await Promise.all(workers);
-
-      if (queuedDeletes.content.length > 0 && !partial) {
-        await onSearchIndexDocumentsCleanup({
-          indexName,
-          ids: queuedDeletes.content,
-          client: processor.client,
-        });
-      }
 
       // Commit queues:
       await queuedUpdates.commit();
@@ -476,6 +479,27 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
         logger,
       };
 
+      // Deletes before updates, for the reason spelled out in `update()` above: when both
+      // flags are set an id can sit in both queues, and pulling first would rebuild the
+      // document only for the cleanup to remove it.
+      if (opts.processDeletes) {
+        const queuedDeletes = await SearchIndexUpdate.getQueue(
+          indexName,
+          SearchIndexUpdateQueueAction.Delete,
+          partial ? true : false // readOnly
+        );
+
+        if (queuedDeletes.content.length > 0 && !partial) {
+          await onSearchIndexDocumentsCleanup({
+            indexName,
+            ids: queuedDeletes.content,
+            client: processor.client,
+          });
+        }
+
+        await queuedDeletes.commit();
+      }
+
       if (opts.processUpdates) {
         const queuedUpdates = await SearchIndexUpdate.getQueue(
           indexName,
@@ -515,25 +539,6 @@ export function createSearchIndexUpdateProcessor(processor: SearchIndexProcessor
 
         await Promise.all(workers);
         await queuedUpdates.commit();
-      }
-
-      if (opts.processDeletes) {
-        const queuedDeletes = await SearchIndexUpdate.getQueue(
-          indexName,
-          SearchIndexUpdateQueueAction.Delete,
-          partial ? true : false // readOnly
-        );
-
-        if (queuedDeletes.content.length > 0 && !partial) {
-          await onSearchIndexDocumentsCleanup({
-            indexName,
-            ids: queuedDeletes.content,
-            client: processor.client,
-          });
-        }
-
-        // Commit queues:
-        await queuedDeletes.commit();
       }
     },
   };


### PR DESCRIPTION
Closes the ordering half of [868m29b1p](https://app.clickup.com/t/868m29b1p).

## The problem

`SearchIndexUpdate.queueUpdate` writes **one Redis set per action** — `<index>:Update` and `<index>:Delete` (`SearchIndexUpdate.ts:11-15`). They are disjoint, with no dedup and no timestamps, so an id sitting in both records nothing about which action came last. Drain order alone decides the outcome, and the three drains did not agree:

| Path | Order | Winner |
|---|---|---|
| `update()` — the cron | workers, then cleanup | **Delete** |
| `processQueues()` — admin `/api/mod/update-index` | updates, then deletes | **Delete** |
| `updateSync()` | cleanup, then targeted pulls | **Update** |

So a delete-then-restore inside one sync window rebuilt the document and then deleted it. Nothing re-enqueues it afterwards: the restoring write is raw SQL, so `Image.updatedAt` never moves and `prepareBatches`' delta scan (`WHERE "updatedAt" > lastUpdate`) can't re-derive it.

## The fix

Delete first, pull second — the order `updateSync()` already used.

That hands the decision to the database rather than to queue order. `pullData` re-applies the index's own `WHERE`, so an entity that still doesn't qualify yields no row and stays deleted, while one that was genuinely restored is rebuilt. Meilisearch processes tasks FIFO per index, so *enqueue* order is what decides the final state.

Pure statement reordering — no behaviour outside the ordering changes.

**Deliberately not** fixed by removing an id from the opposite queue on enqueue: a stale `Update` arriving after a legitimate `Delete` would cancel the delete and strand the document in the index forever. Keeping both operations and letting `pullData` arbitrate is the safe direction.

## Scope note — read before assuming this was on fire

The ticket cited image `140906473` as a production instance. **It isn't one**, and the ticket's "natural experiment" argument doesn't hold either:

- `metrics_images_v1` has **no qualification `WHERE`** (`metrics-images.search-index.ts:332-337`) — it indexes every image with a `postId` and filters at query time, while `images_v6` filters at index time. A `200` there says nothing about whether a document qualifies for `images_v6`.
- That image's post is a **standalone scheduled post** published 2026-08-30, and its block/unblock fell in *different* cron windows. It's the subject of a separate PR.

An independent 90-day cohort — 210 approved image appeals, resolved >2d ago, all satisfying every one of the 10 `imageWhere` predicates — came back **209 present, 1 absent**, and that 1 was the misattributed image. So: **the race is real in the code, with zero confirmed production instances.**

Incidence can't be measured from the database. Unblock deletes the `JobQueue` `BlockedImageDelete` row (0 of 210 survive), so block time is gone, and appeals nearly always straddle the daily boundary anyway — which biases that sample against the same-window case this bug needs.

Fixing it anyway because it's a few lines, it removes an inconsistency between three drains that should agree, and the hazard grows with every reversible `Delete` enqueue added later.

## Tests

`src/server/search-index/__tests__/base-index-queue-order.test.ts` — 5 tests driving a fake processor through `update()` and `processQueues()`.

**Revert check:** reverting the reorder fails 3 of them with the bug spelled out —

```
AssertionError: expected [ 'pull:42', 'push:42', 'delete:42' ]
                to deeply equal [ 'delete:42', 'pull:42', 'push:42' ]
```

The two single-action tests (id queued for delete only / update only) stay green on revert. They're the no-regression controls, not race detectors.

## Verification

- `vitest --project 'unit*' src/server/search-index/__tests__/` → 24 passed
- `pnpm run typecheck` → 0 errors

⚠️ Unrelated pre-existing red on `main`: `no-direct-shared-module-mock` fails on `src/server/routers/__tests__/article.router.scan-status-authz.test.ts` (direct `~/server/db/client` mock, not allowlisted), from `1d8ad23785`. Untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iC4y1ZyjNX9EUAgV9tXav
