### PR TITLE
fix(search): reindex standalone scheduled posts when they actually go live

### DIFF
--- a/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
+++ b/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
@@ -7,6 +7,8 @@ const {
   mockSetLastRun,
   mockProcessEngagement,
   mockCreateNotification,
+  mockQueueImageSearchIndexUpdate,
+  mockRefreshImageVideoCounts,
   jobDate,
 } = vi.hoisted(() => ({
   mockApply: vi.fn(),
@@ -14,6 +16,8 @@ const {
   mockSetLastRun: vi.fn(),
   mockProcessEngagement: vi.fn(),
   mockCreateNotification: vi.fn(),
+  mockQueueImageSearchIndexUpdate: vi.fn(),
+  mockRefreshImageVideoCounts: vi.fn(),
   jobDate: { lastRun: new Date(0) },
 }));
 
@@ -27,9 +31,11 @@ vi.mock('~/server/rewards/active/firstDailyPost.reward', () => ({
 vi.mock('~/server/events', () => ({ eventEngine: { processEngagement: mockProcessEngagement } }));
 vi.mock('~/server/redis/caches', () => ({
   dataForModelsCache: { refresh: vi.fn() },
-  userImageVideoCountCaches: { refresh: vi.fn() },
+  userImageVideoCountCaches: { refresh: mockRefreshImageVideoCounts },
 }));
-vi.mock('~/server/services/image.service', () => ({ queueImageSearchIndexUpdate: vi.fn() }));
+vi.mock('~/server/services/image.service', () => ({
+  queueImageSearchIndexUpdate: mockQueueImageSearchIndexUpdate,
+}));
 vi.mock('~/server/search-index', () => ({ modelsSearchIndex: { queueUpdate: vi.fn() } }));
 vi.mock('~/server/services/model-version.service', () => ({
   bustMvCache: vi.fn(),
@@ -47,6 +53,7 @@ vi.mock('~/server/jobs/job', () => ({
 }));
 
 import { processScheduledPublishing } from '~/server/jobs/process-scheduled-publishing';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { loggingMock } from '~/__tests__/mocks/logging.mock';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 const mockLogToAxiom = loggingMock.logToAxiom;
@@ -199,6 +206,51 @@ describe('processScheduledPublishing :: first daily post reward', () => {
     expect(mockLogToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'warning', message: expect.stringContaining('row limit') })
     );
+  });
+});
+
+describe('processScheduledPublishing :: search index reindex', () => {
+  // A standalone scheduled post goes live when the clock passes publishedAt, with no
+  // write anywhere. images_v6 gates on `p."publishedAt" <= NOW()` at pull time, so the
+  // enqueue updatePost fired at schedule time was rejected as future-dated, and
+  // Image.updatedAt never moves afterwards for the delta scan to re-derive it. If this
+  // sweep skips them the image is absent from site search permanently.
+  it('reindexes standalone scheduled posts on the day they go live', async () => {
+    stubReads({ newlyLive: [{ id: 2, userId: 20 }] });
+    mockDbWrite.image.findMany.mockResolvedValue([{ id: 900 }]);
+    await runJob();
+    expect(mockQueueImageSearchIndexUpdate).toHaveBeenCalledWith({
+      ids: [900],
+      action: SearchIndexUpdateQueueAction.Update,
+    });
+  });
+
+  it('reindexes both publish paths in one pass, deduped', async () => {
+    stubReads({ scheduled: [{ id: 1, userId: 10 }], newlyLive: [{ id: 2, userId: 20 }] });
+    mockDbWrite.image.findMany.mockResolvedValue([{ id: 901 }]);
+    await runJob();
+    expect(mockDbWrite.image.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { postId: { in: [1, 2] } } })
+    );
+    expect(mockQueueImageSearchIndexUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not enqueue when the published posts carry no images', async () => {
+    stubReads({ newlyLive: [{ id: 2, userId: 20 }] });
+    await runJob();
+    expect(mockQueueImageSearchIndexUpdate).not.toHaveBeenCalled();
+  });
+
+  // The count refresh compensates for this job publishing via raw SQL instead of
+  // updatePost, so it belongs to the posts this job actually flips. The sweep half was
+  // published by something else, which already refreshed. Widening it to `publishedPosts`
+  // would refresh up to REWARD_SWEEP_LIMIT users every minute.
+  it('keeps the count refresh to the posts this job flips', async () => {
+    stubReads({ newlyLive: [{ id: 2, userId: 20 }] });
+    mockDbWrite.image.findMany.mockResolvedValue([{ id: 902 }]);
+    await runJob();
+    expect(mockQueueImageSearchIndexUpdate).toHaveBeenCalled();
+    expect(mockRefreshImageVideoCounts).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/jobs/__tests__/reindex-recent-scheduled-images.test.ts
+++ b/src/server/jobs/__tests__/reindex-recent-scheduled-images.test.ts
@@ -1,0 +1,88 @@
+import type { NextApiRequest } from 'next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSearchSync, mockMetricsSync } = vi.hoisted(() => ({
+  mockSearchSync: vi.fn(),
+  mockMetricsSync: vi.fn(),
+}));
+
+vi.mock('~/server/search-index', () => ({
+  imagesSearchIndex: { updateSync: mockSearchSync },
+  imagesMetricsSearchIndex: { updateSync: mockMetricsSync },
+}));
+vi.mock('~/server/jobs/job', () => ({
+  createJob: (_n: string, _c: string, fn: unknown) => fn,
+  UNRUNNABLE_JOB_CRON: '0 0 31 2 *',
+}));
+
+import { reindexRecentScheduledImages } from '~/server/jobs/reindex-recent-scheduled-images';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const mockDbRead = dbMock.dbRead;
+
+type JobResult = { reindexed: number; lastId: number; done: boolean };
+const runJob = (query: Record<string, string> = {}) =>
+  (reindexRecentScheduledImages as unknown as (ctx: { req?: NextApiRequest }) => Promise<JobResult>)(
+    { req: { query } as unknown as NextApiRequest }
+  );
+
+const rows = (...ids: number[]) => ids.map((id) => ({ id }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDbRead.$queryRaw.mockResolvedValue(rows(1, 2));
+});
+
+describe('reindexRecentScheduledImages', () => {
+  // images_v6 is the half that was never covered: the metrics index takes every image and
+  // filters at query time, so a stale doc is merely mis-sorted there, while images_v6
+  // rejects a future-dated post outright and the image is absent from site search.
+  it('syncs both image indexes by default', async () => {
+    await runJob();
+    const data = rows(1, 2).map(({ id }) => ({ id, action: SearchIndexUpdateQueueAction.Update }));
+    expect(mockSearchSync).toHaveBeenCalledWith(data, expect.anything());
+    expect(mockMetricsSync).toHaveBeenCalledWith(data, expect.anything());
+  });
+
+  it('syncs only the index named in `indexes`', async () => {
+    await runJob({ indexes: 'search' });
+    expect(mockSearchSync).toHaveBeenCalled();
+    expect(mockMetricsSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown index rather than silently syncing both', async () => {
+    await expect(runJob({ indexes: 'bogus' })).rejects.toThrow();
+    expect(mockSearchSync).not.toHaveBeenCalled();
+    expect(mockMetricsSync).not.toHaveBeenCalled();
+  });
+
+  // The backfill spans far more images than one invocation should carry, so the operator
+  // pages through it. A cursor that didn't advance would re-walk the head forever.
+  it('reports the last id so the next run can resume past it', async () => {
+    mockDbRead.$queryRaw.mockResolvedValue(rows(10, 20, 30));
+    const result = await runJob({ limit: '3' });
+    expect(result).toEqual({ reindexed: 3, lastId: 30, done: false });
+  });
+
+  it('reports done when the page comes back short', async () => {
+    mockDbRead.$queryRaw.mockResolvedValue(rows(10));
+    const result = await runJob({ limit: '3' });
+    expect(result).toEqual({ reindexed: 1, lastId: 10, done: true });
+  });
+
+  it('passes the cursor and limit into the query', async () => {
+    await runJob({ afterId: '500', limit: '250' });
+    const args = mockDbRead.$queryRaw.mock.calls[0] as unknown[];
+    expect(args).toContain(500);
+    expect(args).toContain(250);
+  });
+
+  it('syncs nothing and stops when the page is empty', async () => {
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+    const result = await runJob();
+    expect(mockSearchSync).not.toHaveBeenCalled();
+    expect(mockMetricsSync).not.toHaveBeenCalled();
+    expect(result).toEqual({ reindexed: 0, lastId: 0, done: true });
+  });
+});

--- a/src/server/jobs/__tests__/reindex-recent-scheduled-images.test.ts
+++ b/src/server/jobs/__tests__/reindex-recent-scheduled-images.test.ts
@@ -23,9 +23,9 @@ const mockDbRead = dbMock.dbRead;
 
 type JobResult = { reindexed: number; lastId: number; done: boolean };
 const runJob = (query: Record<string, string> = {}) =>
-  (reindexRecentScheduledImages as unknown as (ctx: { req?: NextApiRequest }) => Promise<JobResult>)(
-    { req: { query } as unknown as NextApiRequest }
-  );
+  (
+    reindexRecentScheduledImages as unknown as (ctx: { req?: NextApiRequest }) => Promise<JobResult>
+  )({ req: { query } as unknown as NextApiRequest });
 
 const rows = (...ids: number[]) => ids.map((id) => ({ id }));
 

--- a/src/server/jobs/process-scheduled-publishing.ts
+++ b/src/server/jobs/process-scheduled-publishing.ts
@@ -357,11 +357,12 @@ export const processScheduledPublishing = createJob(
       );
     }
 
-    // Reindex the just-published posts' images so the metrics_images feed picks
-    // up their new sort position (GREATEST(publishedAt, scannedAt, createdAt)).
-    if (scheduledPosts.length) {
+    // Both halves, not just the posts this job flips: a standalone scheduled post goes live
+    // by the clock with no write, and images_v6 rejects a future-dated post at pull time —
+    // so the enqueue from schedule time never landed and this sweep is its only hook.
+    if (publishedPosts.length) {
       const images = await dbWrite.image.findMany({
-        where: { postId: { in: scheduledPosts.map((p) => p.id) } },
+        where: { postId: { in: publishedPosts.map((p) => p.id) } },
         select: { id: true },
       });
       if (images.length) {
@@ -370,6 +371,9 @@ export const processScheduledPublishing = createJob(
           action: SearchIndexUpdateQueueAction.Update,
         });
       }
+    }
+
+    if (scheduledPosts.length) {
       // This job publishes via raw SQL rather than updatePost, so it owns the
       // count refresh for the posts it flips.
       await userImageVideoCountCaches.refresh(uniq(scheduledPosts.map((p) => p.userId)));

--- a/src/server/jobs/reindex-recent-scheduled-images.ts
+++ b/src/server/jobs/reindex-recent-scheduled-images.ts
@@ -1,37 +1,61 @@
+import { z } from 'zod';
 import { dbRead } from '~/server/db/client';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
-import { imagesMetricsSearchIndex } from '~/server/search-index';
+import { imagesMetricsSearchIndex, imagesSearchIndex } from '~/server/search-index';
+import { commaDelimitedEnumArray } from '~/utils/zod-helpers';
 import { createJob, UNRUNNABLE_JOB_CRON } from './job';
 
-// Manual / one-off backfill. Re-syncs the metrics_images_v1 index for images
-// of scheduled/rescheduled posts whose feed sort position got frozen at the
-// original scheduled time (or never indexed at all) because the reschedule
-// never propagated to the index — see https://app.clickup.com/t/868k68g0z
-// (and the earlier modelVersion-only case https://app.clickup.com/t/868jc90r3).
+// Manual / one-off backfill. Re-syncs the image indexes for scheduled/rescheduled
+// posts whose documents got frozen at the original scheduled time, or were never
+// indexed at all — see https://app.clickup.com/t/868k68g0z (and the earlier
+// modelVersion-only case https://app.clickup.com/t/868jc90r3).
 //
-// Targets posts still scheduled in the future (publishedAt > now) — the
-// actively-broken "vanish entirely / surface at the wrong time" cases — plus
-// posts published within a short recent window. Covers standalone posts too,
-// not just ModelVersion-linked ones.
+// The two indexes are broken in different ways, which is why both are synced here:
+//   - metrics_images_v1 takes every image and filters at query time, so a stale doc
+//     carries the wrong sort position (GREATEST(publishedAt, scannedAt, createdAt)).
+//   - images_v6 gates on `p."publishedAt" <= NOW()` at pull time, so a document
+//     enqueued while the post was still future-dated was rejected outright and the
+//     image is simply absent from site search.
+//
+// Targets posts still scheduled in the future (publishedAt > now) — the actively-broken
+// "vanish entirely / surface at the wrong time" cases — plus posts published within the
+// lookback window. Covers standalone posts too, not just ModelVersion-linked ones.
 //
 // Trigger via: /api/webhooks/run-jobs?run=reindex-recent-scheduled-images
+//   &days=<lookback>   how far back to reach (default 3)
+//   &limit=<n>         images per run (default 25000)
+//   &afterId=<imageId> resume cursor; the run logs the last id it processed
+//   &indexes=search,metrics   which indexes to sync (default both)
 
-const DAYS_LOOKBACK = 3;
+const DEFAULT_DAYS_LOOKBACK = 3;
+const DEFAULT_LIMIT = 25000;
+
+const schema = z.object({
+  days: z.coerce.number().int().positive().default(DEFAULT_DAYS_LOOKBACK),
+  limit: z.coerce.number().int().positive().max(100000).default(DEFAULT_LIMIT),
+  afterId: z.coerce.number().int().nonnegative().default(0),
+  indexes: commaDelimitedEnumArray(['search', 'metrics']).default(['search', 'metrics']),
+});
 
 export const reindexRecentScheduledImages = createJob(
   'reindex-recent-scheduled-images',
   UNRUNNABLE_JOB_CRON,
   async (jobContext) => {
-    const since = new Date(Date.now() - DAYS_LOOKBACK * 24 * 60 * 60 * 1000);
+    const { days, limit, afterId, indexes } = schema.parse(jobContext.req?.query ?? {});
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 
-    // Future-scheduled posts are inherently at-risk. For recently-published
-    // posts we only reindex "scheduled-like" ones (publishedAt well after
-    // createdAt) to skip the large volume of instant publishes that index fine.
+    // Future-scheduled posts are inherently at-risk. For already-published posts we only
+    // reindex "scheduled-like" ones (publishedAt well after createdAt) to skip the large
+    // volume of instant publishes that index fine.
+    //
+    // Ordered and cursored by image id so a backfill spanning more than one run resumes
+    // where it stopped rather than re-walking the head of the range.
     const images = await dbRead.$queryRaw<{ id: number }[]>`
       SELECT i.id
       FROM "Image" i
       JOIN "Post" p ON p.id = i."postId"
       WHERE p."publishedAt" IS NOT NULL
+        AND i.id > ${afterId}
         AND (
           p."publishedAt" > now()
           OR (
@@ -39,17 +63,19 @@ export const reindexRecentScheduledImages = createJob(
             AND p."publishedAt" > p."createdAt" + interval '15 minutes'
           )
         )
+      ORDER BY i.id
+      LIMIT ${limit}
     `;
 
     if (!images.length) {
       console.log('reindex-recent-scheduled-images :: no images to reindex');
-      return;
+      return { reindexed: 0, lastId: afterId, done: true };
     }
 
+    const lastId = images[images.length - 1].id;
     console.log(
-      `reindex-recent-scheduled-images :: reindexing ${
-        images.length
-      } images since ${since.toISOString()}`
+      `reindex-recent-scheduled-images :: reindexing ${images.length} images since ${since.toISOString()}`,
+      { indexes, afterId, lastId }
     );
 
     const data = images.map(({ id }) => ({
@@ -57,6 +83,14 @@ export const reindexRecentScheduledImages = createJob(
       action: SearchIndexUpdateQueueAction.Update,
     }));
 
-    await imagesMetricsSearchIndex.updateSync(data, jobContext);
+    if (indexes.includes('metrics')) {
+      await imagesMetricsSearchIndex.updateSync(data, jobContext);
+    }
+    if (indexes.includes('search')) {
+      await imagesSearchIndex.updateSync(data, jobContext);
+    }
+
+    // `done` lets the operator stop without guessing: a short page is the last one.
+    return { reindexed: images.length, lastId, done: images.length < limit };
   }
 );

--- a/src/server/jobs/reindex-recent-scheduled-images.ts
+++ b/src/server/jobs/reindex-recent-scheduled-images.ts
@@ -74,7 +74,9 @@ export const reindexRecentScheduledImages = createJob(
 
     const lastId = images[images.length - 1].id;
     console.log(
-      `reindex-recent-scheduled-images :: reindexing ${images.length} images since ${since.toISOString()}`,
+      `reindex-recent-scheduled-images :: reindexing ${
+        images.length
+      } images since ${since.toISOString()}`,
       { indexes, afterId, lastId }
     );
 


### PR DESCRIPTION
Standalone scheduled posts are largely **absent from site search**. Found while verifying [868m29b1p](https://app.clickup.com/t/868m29b1p); it's a different bug from the one that ticket describes.

## The problem

A standalone scheduled post has no status to flip. It goes live when the clock passes `publishedAt` — no write happens anywhere, feeds simply stop filtering it out (`process-scheduled-publishing.ts:90-96` says exactly this).

`updatePost` **does** enqueue a search-index update whenever `publishedAt` is written (`post.service.ts:988-994`). But that fires at *schedule* time, and `images_v6` gates on `p."publishedAt" <= NOW()` at pull time (`images.search-index.ts:143`). So:

1. Creator schedules → enqueue fires → daily sync drains it while the post is still future-dated → **row rejected, nothing upserted**.
2. The scheduled moment arrives → no write → nothing to hang a second enqueue on.
3. `Image.updatedAt` never moved, so `prepareBatches`' delta scan can't re-derive it either.

The image never enters `images_v6`. `metrics_images_v1` escaped only because it has **no qualification `WHERE` at all** (`metrics-images.search-index.ts:332-337`) — it takes every image with a `postId` and filters at query time.

## Measured

`images_v6` document probes, 200-image samples. Every image satisfies all 10 `imageWhere` predicates, published 2–30 days ago, `modelVersionId IS NULL`:

| Cohort | Present |
|---|---|
| instant publish (`publishedAt <= createdAt + 1h`) — **control** | **200 / 200** |
| scheduled (`publishedAt > createdAt + 1h`) | 61 / 200 — **139 missing (70%)** |
| scheduled + passive (`Post.updatedAt < publishedAt`) | 29 / 200 — **171 missing (86%)** |

**340,277** qualifying images sit in that population for the last 30 days alone.

The instant-publish control is what rules out "`images_v6` is just incomplete": same predicates, same window, same probe, 100% present.

## The fix

`process-scheduled-publishing` already computes the right set one screen above the reindex:

```js
const publishedPosts = uniqBy([...scheduledPosts, ...newlyLivePosts], 'id');
```

…and already uses it for `eventEngine.processEngagement`. The reindex block read `scheduledPosts` — only the ModelVersion-linked half. Point it at the union.

**No new job and no new cron.** This sweep runs `*/1` and is the only publish-time hook a passively-published post gets.

The count-cache refresh is deliberately **not** widened. It compensates for this job publishing via raw SQL instead of `updatePost`, so it belongs to the posts this job actually flips; widening it to `publishedPosts` would refresh up to `REWARD_SWEEP_LIMIT` (5000) users' caches every minute. There's a test pinning that split.

### Backfill

`reindex-recent-scheduled-images` was the existing manual patch for this family (`868k68g0z`) but only ever touched the **metrics** index. It now syncs `imagesSearchIndex` too, and takes `days` / `limit` / `afterId` / `indexes` so the backlog can be paged:

```
/api/webhooks/run-jobs?run=reindex-recent-scheduled-images&days=30&limit=25000&afterId=<lastId>
```

It returns `{ reindexed, lastId, done }` so the operator knows when to stop rather than guessing. Still `UNRUNNABLE_JOB_CRON` — manual only.

**This needs a human to run it after merge**; the code fix only stops new posts from being lost.

## Known gaps left open

Two pre-existing limits of the sweep now also bound reindexing, both already documented in the file:

- `LIMIT 5000` per minute — over-limit minutes drop the remainder. Already logs an Axiom warning (`:320`).
- The window never reaches past the start of the UTC day, so a job outage spanning midnight permanently skips what published before it.

The manual reindex job is the recovery path for both. I did not add a standing reconciler cron — happy to if you'd rather have one.

## Tests

- 4 added to `process-scheduled-publishing.rewards.test.ts` — reindex covers the passive half, both halves dedupe into one call, no enqueue when there are no images, and the count-refresh scoping.
- 7 new in `reindex-recent-scheduled-images.test.ts` — index selection, unknown-index rejection, cursor paging, `done` flag, empty page.

**Revert check:** reverting `publishedPosts` → `scheduledPosts` fails 3 of the 4. Mutating out the `imagesSearchIndex.updateSync` call fails 2 of the 7.

## Verification

- `vitest --project 'unit*'` over both suites → 25 passed
- `pnpm run typecheck` → 0 errors

One bug caught in review of my own code, noting it since it's a repo-wide trap: zod 4's `.default()` on a `.transform().pipe()` returns the default **unparsed**, so `indexes` would have been the string `'search,metrics'` rather than an array — and `String.prototype.includes` would have made it look like it worked. Typecheck passes either way. Now uses the repo's `commaDelimitedEnumArray`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iC4y1ZyjNX9EUAgV9tXav
