### PR TITLE
fix(models): unblock model edit when meta is JSON null

### DIFF
--- a/src/components/Resource/Forms/ModelUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelUpsertForm.tsx
@@ -47,7 +47,7 @@ import {
 } from '~/libs/form';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { TagSort } from '~/server/common/enums';
-import type { ModelUpsertInput } from '~/server/schema/model.schema';
+import type { ModelMeta, ModelUpsertInput } from '~/server/schema/model.schema';
 import { modelUpsertSchema } from '~/server/schema/model.schema';
 import { getSanitizedStringSchema } from '~/server/schema/utils.schema';
 import type { ModelType } from '~/shared/utils/prisma/enums';
@@ -154,6 +154,7 @@ export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId 
   // form before `model` arrived.
   const initialModel = useRef(model).current;
   const { grandfatheredType, initialType, replacedType } = resolveModelTypeDefaults(initialModel);
+  const initialMeta = model?.meta as ModelMeta | null | undefined;
   const defaultValues: ModelUpsertSchema = {
     ...model,
     name: model?.name ?? '',
@@ -177,6 +178,14 @@ export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId 
     category: model?.tagsOnModels?.find((tag) => !!tag.isCategory)?.id ?? defaultCategory,
     attestation: !!model?.id,
     availability: model?.availability ?? Availability.Public,
+    // A model whose `meta` is null predates the metric-privacy feature. Left null, RHF's `get`
+    // returns null (not the default) for every `meta.*` path and the three switches submit null.
+    meta: {
+      ...(initialMeta ?? {}),
+      hideBuzz: initialMeta?.hideBuzz ?? false,
+      hideDownloads: initialMeta?.hideDownloads ?? false,
+      hideGenerations: initialMeta?.hideGenerations ?? false,
+    },
   };
 
   const form = useForm({ schema, mode: 'onChange', defaultValues, shouldUnregister: false });

--- a/src/server/schema/__tests__/metric-privacy-meta.schema.test.ts
+++ b/src/server/schema/__tests__/metric-privacy-meta.schema.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { modelUpsertSchema } from '~/server/schema/model.schema';
+import { modelVersionUpsertSchema2 } from '~/server/schema/model-version.schema';
+
+// A model whose `meta` is JSON null reaches ModelUpsertForm as `meta: null`, and
+// react-hook-form's `get` resolves every `meta.*` path on it to null rather than to the
+// field's default — so the three switches submit null and the whole edit is rejected.
+// 927 published models were in that state when this was found.
+const NULL_TOGGLES = {
+  hideBuzz: null,
+  hideDownloads: null,
+  hideGenerations: null,
+} as const;
+
+const baseModelInput = {
+  id: 1,
+  name: 'A model',
+  type: 'LORA',
+  status: 'Published',
+  uploadType: 'Created',
+  description: '<p>hello</p>',
+  tagsOnModels: [],
+  availability: 'Public',
+};
+
+describe('metric-privacy meta toggles', () => {
+  it('accepts null toggles on a model', () => {
+    const result = modelUpsertSchema.safeParse({
+      ...baseModelInput,
+      meta: { commentsLocked: false, ...NULL_TOGGLES },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts null toggles on a model version', () => {
+    const result = modelVersionUpsertSchema2.safeParse({
+      modelId: 1,
+      name: 'v1',
+      baseModel: 'SD 1.5',
+      meta: NULL_TOGGLES,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('still rejects a non-boolean toggle', () => {
+    const result = modelUpsertSchema.safeParse({
+      ...baseModelInput,
+      meta: { commentsLocked: false, hideBuzz: 'yes' },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -538,9 +538,9 @@ export const modelVersionUpsertSchema2 = z.object({
   // Creator Controls: per-version metric privacy (merged into ModelVersion.meta).
   meta: z
     .object({
-      hideBuzz: z.boolean().optional(),
-      hideDownloads: z.boolean().optional(),
-      hideGenerations: z.boolean().optional(),
+      hideBuzz: z.boolean().nullish(),
+      hideDownloads: z.boolean().nullish(),
+      hideGenerations: z.boolean().nullish(),
     })
     .optional(),
 });

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -236,9 +236,9 @@ export const modelUpsertSchema = z.object({
     .looseObject({
       showcaseCollectionId: z.coerce.number().nullish(),
       commentsLocked: z.boolean().default(false),
-      hideBuzz: z.boolean().optional(),
-      hideDownloads: z.boolean().optional(),
-      hideGenerations: z.boolean().optional(),
+      hideBuzz: z.boolean().nullish(),
+      hideDownloads: z.boolean().nullish(),
+      hideGenerations: z.boolean().nullish(),
     })
     .transform((val) => val as ModelMeta | null)
     .nullish(),
@@ -358,9 +358,9 @@ export type ModelMeta = Partial<{
   minorHashAccepted: { at: string };
   // Creator Controls: hide public metrics (only while the owner has a valid
   // Creator Program membership — see server/utils/model-metric-privacy.ts).
-  hideBuzz: boolean;
-  hideDownloads: boolean;
-  hideGenerations: boolean;
+  hideBuzz: boolean | null;
+  hideDownloads: boolean | null;
+  hideGenerations: boolean | null;
 }>;
 
 export type ChangeModelModifierSchema = z.infer<typeof changeModelModifierSchema>;


### PR DESCRIPTION
Fixes [868m2qwrd](https://app.clickup.com/t/8459928/868m2qwrd).

## Problem

Editing a model fails validation on all three **Creator Controls: metric privacy** toggles with `Invalid input: expected boolean, received null`, and the form cannot be submitted. There is no creator-side workaround.

## Root cause

Not what the ticket assumed — no model stores `hideBuzz: null`. Verified on prod:

```
meta ? 'hideBuzz'                   =   691 models
meta->'hideBuzz' = 'null'::jsonb    =     0 models
```

The null is manufactured on the client. The trigger is `Model.meta` itself being **JSON `null`** — which is not SQL NULL, so `meta IS NULL` matches nothing while `meta = 'null'::jsonb` matches **1,518 models, 927 of them Published across 566 creators**.

1. `getModelHandler` returns `meta: model.meta ? filterModelMetaForClient(...) : null` (`model.controller.ts:541`), so the client receives `meta: null`.
2. `ModelUpsertForm` builds `defaultValues` as `{ ...model }` with no `meta` default, so `_formValues.meta === null`.
3. Each `InputSwitch name="meta.hideBuzz"` registers, and RHF's `updateValidAndValue` resolves the default via `get(_formValues, 'meta.hideBuzz')`. RHF's `get` **short-circuits on a null intermediate and returns that null rather than falling through to the supplied default**, and `set` then writes it back into the form values.

Confirmed against the real library:

```
meta = null                                 => {"showcaseCollectionId":null,"hideBuzz":null,"hideDownloads":null,"hideGenerations":null}
meta = {}                                   => {}                                    (fine)
meta = {commentsLocked:false, imageNsfwLevel:8} => unchanged                          (fine)
```

4. `z.boolean().optional()` accepts `undefined` but rejects `null`, so all three fields error and the submit is blocked.

`ModelVersionUpsertForm` is unaffected because it already builds `meta: { hideBuzz: … ?? false, … }`, so its `meta` is never null.

## Fix

- **`ModelUpsertForm.tsx`** — `defaultValues.meta` is now always an object, with the three toggles defaulted to `false` and every other `meta` key preserved. This stops the null from forming at all.
- **`model.schema.ts` / `model-version.schema.ts`** — the three fields are `.nullish()` instead of `.optional()`, as a backstop for any other route to a null. `ModelMeta`'s field types are widened to `boolean | null` to match. The read path already coerces with `!!`, so a stored null is inert.

## Tests

New `src/server/schema/__tests__/metric-privacy-meta.schema.test.ts` covers null toggles on both the model and the model-version schema, plus a negative case that a non-boolean is still rejected.

Checked how it fails, not just that it passes: reverting the schema change makes it fail with `expected false to be true` in under a second, rather than passing silently.

```
pnpm exec vitest run --project 'unit*' \
  src/server/schema/__tests__/metric-privacy-meta.schema.test.ts \
  src/server/__tests__/model-metric-privacy.test.ts \
  src/server/utils/__tests__/minor-flag-meta.test.ts \
  src/server/routers/__tests__/model.router.cache-key.test.ts \
  src/server/services/__tests__/model-locked-properties.service.test.ts \
  src/server/services/__tests__/model-moderation.upsert-wiring.test.ts \
  src/shared/constants/__tests__/model-type.constants.test.ts

PASS (105) FAIL (0)
```

LSP diagnostics are clean on all four touched files.

## Notes

No migration and no backfill. The affected rows need no repair — the fix is entirely in how the form seeds and how the schema parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpwdksmyFtgSRAUcVfBFZr
