### PR TITLE
test(articles): use the canonical db mock in the scan-status authz test

### DIFF
--- a/src/server/routers/__tests__/article.router.scan-status-authz.test.ts
+++ b/src/server/routers/__tests__/article.router.scan-status-authz.test.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
 import type * as ArticleService from '~/server/services/article.service';
 import type * as FeatureFlagsService from '~/server/services/feature-flags.service';
 
@@ -14,20 +15,17 @@ import type * as FeatureFlagsService from '~/server/services/feature-flags.servi
  * article page, which is exactly why a server-side gap here stayed invisible.
  */
 
-const { mockGetArticleScanStatus, mockFindUnique } = vi.hoisted(() => ({
+const { mockGetArticleScanStatus } = vi.hoisted(() => ({
   mockGetArticleScanStatus: vi.fn(),
-  mockFindUnique: vi.fn(),
 }));
+
+// `isOwnerOrModerator` resolves the article's owner itself; this is the row it reads. It uses
+// `dbRead` only, so the previous fixture's `dbWrite` alias was never exercised.
+const mockFindUnique = dbMock.dbRead.article.findUnique;
 
 vi.mock('~/server/services/article.service', async (importOriginal) => ({
   ...(await importOriginal<typeof ArticleService>()),
   getArticleScanStatus: mockGetArticleScanStatus,
-}));
-
-// `isOwnerOrModerator` resolves the article's owner itself; this is the row it reads.
-vi.mock('~/server/db/client', () => ({
-  dbRead: { article: { findUnique: mockFindUnique } },
-  dbWrite: { article: { findUnique: mockFindUnique } },
 }));
 
 // The procedure sits behind `isFlagProtected('articleImageScanning')`. Left off, every


### PR DESCRIPTION
## Problem

`Unit tests (2)` has been red on `main` since 1d8ad23785 (#4696 — "scope getScanStatus to the article's author"), and therefore red on every PR branched from it:

```
FAIL  src/server/services/__tests__/no-direct-shared-module-mock.test.ts
  > adds no new direct mock of a module that has a canonical mock
AssertionError: These files mock a module that has a canonical mock.
+   "src/server/routers/__tests__/article.router.scan-status-authz.test.ts"
```

Confirmed on `main` itself at `02ad4701ad`, not only on PR branches.

The new test mocks `~/server/db/client` directly. That is one of the three specifiers in `CANONICAL_SPECIFIERS`, and the guard is a ratchet — under `isolate: false` a single per-file `vi.mock` of a shared specifier freezes that file's mock shape into every later file in the same worker.

## Fix

Point the fixture at the canonical `dbMock` and drop the direct `vi.mock`. The rest of the file is untouched — the local `mockFindUnique` const keeps its name, so no assertion or body changes.

`node scripts/test-perf/codemod-shared-mocks.mjs --write` refuses this one:

```
1 candidate files | 0 convertible | 1 with refusals
   1  local "mockFindUnique" aliases dbMock.dbRead.article.findUnique and dbMock.dbWrite.article.findUnique — needs a human
```

That is the documented aliasing case: `dbRead` and `dbWrite` are distinct objects under the canonical mock, so the file has to name the client it actually exercises. `isOwnerOrModerator` in `article.router.ts:49` reads the owner through `dbRead.article.findUnique` and nothing in the path writes, so the alias resolves to `dbRead`. The `dbWrite` half was never exercised.

## Tests

```
pnpm exec vitest run --project 'unit*' \
  src/server/routers/__tests__/article.router.scan-status-authz.test.ts \
  src/server/services/__tests__/no-direct-shared-module-mock.test.ts

PASS (8) FAIL (0)
```

All five authorization cases still run, including the positive control that the author gets through — a mock that silently stopped resolving would take that one down first.

The allowlist is deliberately **not** touched: it only ever shrinks, and this file was never on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpwdksmyFtgSRAUcVfBFZr
