### PR TITLE
chore(csam): drop a stale record id from a code comment

### DIFF
--- a/src/server/services/csam.service-new.ts
+++ b/src/server/services/csam.service-new.ts
@@ -1220,8 +1220,8 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
   const { userId } = data;
   if (!userId) {
     // An internal report (userId === -1 is stored as NULL) has no user-scoped content to
-    // archive, and archiveBaseReportData bails on it too. Returning silently left report 236
-    // re-selected by getCsamsToArchive every hour since 2024. Stamp a terminal state, but
+    // archive, and archiveBaseReportData bails on it too. Returning silently left such a
+    // report re-selected by getCsamsToArchive every hour since 2024. Stamp a terminal state, but
     // record that nothing was stored — archivedAt alone would read as evidence-complete.
     await dbWrite.csamReport.update({
       where: { id: data.id },


### PR DESCRIPTION
Comment-only change in `archiveCsamDataForReport`.

The comment explains why an internal report (no user-scoped content) kept being re-selected by `getCsamsToArchive` every hour — that explanation stands on its own. It also named one specific record, which adds nothing to it. This repository is public, so the id comes out.

No behaviour change; the surrounding logic and the rest of the comment are untouched.
