### PR TITLE
feat(generation): rework the form-graph header and the resource picker

### DIFF
--- a/docs/features/generator-header-redesign.md
+++ b/docs/features/generator-header-redesign.md
@@ -1,0 +1,102 @@
+# Generator header redesign — form-graph lane only
+
+Implements the ["Above the Prompt"](https://claude.ai/code/artifact/01a73589-85d1-4e87-bdc2-b389579d1294)
+proposal, scoped to the **form-graph** generation forms. `GenerationFormV2` (the data-graph lane) and
+every other `ResourceSelectModal` consumer keep today's behaviour.
+
+## Why this scope is safe
+
+`GenerationTabs` mounts `FormGraphGenerator` when `formGraphGenerator` is on and `GenerationFormV2`
+otherwise. That flag is `availability: ['mod']`, so the redesigned header ships to moderators only
+until it is widened — the rollout gate already exists and needs nothing new.
+
+## The seam
+
+Three kinds of code are involved, and they get different treatment:
+
+| Layer | Files | Treatment |
+|---|---|---|
+| Shell / header | `src/components/form-graph/generation/BaseGenerationForm.tsx` | Already form-graph-local. Edit freely. |
+| Header inputs | `generation_v2/inputs/WorkflowInput`, `BaseModelInput` | **Fork** into `form-graph/generation/inputs/`. Shared with the v2 lane; the redesign changes their contract, not their styling. |
+| Picker internals | `ImageGeneration/GenerationForm/ResourceSelect*` | **Extend additively.** Shared with App Blocks, Challenge, Apps settings, wildcards, `Resource/Files`. New props default to today's behaviour. |
+
+The picker internals are the expensive half to rebuild and the ones the proposal explicitly wants to
+keep (catalog query, cards, filters, infinite list). Forking them would double the surface that has to
+stay correct; forking the two header inputs costs ~1.7k lines of divergence that dies when the v2 lane
+does.
+
+## Decisions taken (the artifact's three open questions)
+
+1. **Version is a step after the pick.** Picking a model takes its latest version immediately; version
+   becomes a field under the model row, rendered only when more than one exists. `VersionGroupSelector`
+   in `form-graph/generation/form-helpers.tsx` is already form-graph-local and already renders under the
+   model row — it stays, and the in-card segmented control stops being the mechanism. This absorbs the
+   hierarchical case rather than leaving it parallel.
+2. **The rail replaces the pill.** `BaseModelInput` comes out of the header entirely in the form-graph
+   lane. Keeping both would put one axis in two places, which is the problem this started from.
+3. **Input switching costs a click.** The mode strip folds into the workflow picker as a filter. No
+   telemetry gate first — the lane is mod-only, so the click cost is observable directly by the people
+   who can undo it.
+
+## Phases
+
+All four are implemented. Ordering below is the order they landed, not a remaining plan.
+
+### 01 — Fold the mode strip into the workflow picker
+- New `form-graph/generation/inputs/WorkflowPicker.tsx`: every workflow listed once, input type
+  (`from text` / `from image` / `from video`) shown per row, with an All / From-text / From-image
+  filter across the top.
+- `BaseGenerationForm.tsx`: drop the `ButtonGroupInput` mode strip and its `getWorkflowModes()` call.
+- `getWorkflowModes` stays exported (the v2 lane still uses it); only the form-graph call site goes.
+
+### 02 — Teach the picker its role
+- `ResourceSelectProvider` gains `role?: 'checkpoint' | 'resource'` (default `undefined` = today).
+- In `resource` mode: per-card compatibility badging against the current checkpoint's ecosystem,
+  multi-select, and a footer tray that stages a batch. **Per-item strength is NOT edited in the tray**
+  — the form's own resource list already owns strength, and a second control for one value is the
+  duplication this redesign removes.
+- The `resource` role also gets a left rail of the picker's own resource types, promoted out of the
+  filters dropdown. Not in the original proposal; added so both roles read the same way.
+- The modal's LAYOUT changed for **every** consumer, not only the roled ones: the header band spans
+  the full width, rail beside catalog, footer spans, width 1200 → 1500, and the grid fills its pane
+  instead of centring fixed-width columns. Behaviour without a `role` is unchanged; the shared chrome
+  is not.
+
+### 03 — Catalog or roster
+- `ResourceHitList` branches on catalog size. Hosted providers (Kling, Veo, Sora, ACE, Hunyuan3D)
+  render a version roster instead of a search grid; search, sort and filters hide rather than sitting
+  dead. **No price column** — `TransformedModel` carries no cost data, so "N per second" is deferred
+  rather than faked.
+
+### 04 — The rail and the consequence footer
+- Ecosystem selection moves into the picker as a left rail with search, replacing `BaseModelInput` in
+  the form-graph header. **No output-type scope control in the rail** — `BaseModelListContent` already
+  carries its compatible/recent/all tabs, and two scope controls is the duplication being removed.
+- The footer counts the resources a switch will actually drop, by real compatibility check, while the
+  choice is still cancellable — `ResourceAlerts` information, moved before the commit.
+- These two ship together: the point of moving the control is making the switching cost visible at the
+  moment of switching.
+- Mobile splits the panes into two screens and opens on the **catalog**, not the ecosystem list.
+- Cards get no "picked" check overlay and no Early Access badge; the mode strip's `modeLabel` copy
+  ("Text to Image") stops rendering in this lane — the picker shows the workflow `label` plus a
+  per-row input line instead.
+
+## How the rail reaches the catalog
+
+The shared modal gained two slots — `rail` and `footer` — typed as components, not nodes, so they
+render inside `ResourceSelectProvider` and can call `setOptionsOverride`. The modal itself contains
+no ecosystem concept; `openCheckpointPicker` in the form-graph lane fills both slots.
+
+Selecting in the rail is a **pending** choice: it re-aims the catalog at that family via
+`getResourceSelectOptions(ecosystemKey, types)` (pure, keyed by ecosystem, so no store write is
+needed to preview a family) and the footer counts what a commit would drop. It commits when you press
+Use, or when you pick a checkpoint — the latter writes the ecosystem first so the model write is the
+one that survives reconciliation.
+
+Pending state lives in `checkpoint-picker.store.ts` because the rail and footer render into two
+different slots and have no common ancestor to hold it.
+
+## Not in scope
+
+The v2 lane, App Blocks' checkpoint/resource pickers, the Challenge multi-select, wildcard sets, and
+`Resource/Files`. Everything below the prompt (Compose, Output, Tuning) is untouched.

--- a/docs/form-graph-rhf-migration.md
+++ b/docs/form-graph-rhf-migration.md
@@ -1,0 +1,142 @@
+# react-hook-form → form-graph: where switching pays, and what a full migration retires
+
+Status: discussion (2026-09-08). Question being answered: would our react-hook-form usage
+be simplified by moving forms onto form-graph — and does anything short of a full
+migration actually retire the `Input*` boilerplate layer?
+
+## Current state, measured
+
+54 form components run on the house wrapper (`~/libs/form`: `useForm` + `Form` +
+`withController` + ~35 stamped `Input*` exports). Only 2 files in the app own a form on
+raw react-hook-form; RHF is not spread across the app, it is spread across
+`src/libs/form`. The form-graph lane (generation) is fully disjoint — no file imports
+from both.
+
+By character:
+
+| Bucket | Count | Examples |
+| --- | --- | --- |
+| Static CRUD — schema + submit, zero watch/setValue | ~24 | the `createReportForm` family (9 forms from one factory), account modals, schedule modals |
+| Mildly dynamic — 1–2 watches gating a section, reset-on-data | ~24 | ArticleUpsertForm, CollectionEditModal, UserProfileEditModal |
+| Value-dependent shape — the field set/validation/defaults change with the form's own values | **6** | see below |
+
+The complexity is **depth, not sprawl**: app-wide there are 74 `watch`/`useWatch`
+occurrences, 98 `setValue`, and 22 `setError` outside the lib — and the six
+value-dependent forms account for most of them.
+
+The six, worst first (signals = watch + setValue + useEffect + setError + reset):
+
+1. `src/components/Resource/Forms/ModelVersionUpsertForm.tsx` — 2,055 lines, 46 signals.
+   `usageControl`/`availability` cascade nulls five monetization fields; two competing
+   effects reconcile `licensingSourceVersionId`; four separate comments document which
+   hidden values must survive unmount and which must be hand-cleared.
+2. `src/components/Challenge/ChallengeUpsertForm.tsx` — 1,365 lines, 26 signals.
+   `prizeMode` switches the prize fields between three shapes (a discriminated union);
+   11 hand-rolled `setError` calls exist because the house `useForm` casts the schema to
+   `ZodObject` to read `.shape`, which forbids `.refine()` (comment at line 85). Its
+   `CategoryWeights` child is the app's only field array.
+3. `src/components/Resource/Forms/ModelUpsertForm.tsx` — 907 lines, 23 signals. The
+   `nsfw`/`poi`/`sfwOnly`/`minor` four-way interlock is spread across five `setValue`
+   sites; a self-watching subscription builds `lockedProperties` from touched fields.
+4. `src/components/Bounty/BountyUpsertForm.tsx` — 906 lines, 16 signals. `type`
+   switches the whole `details` sub-object shape — and `useFormStorage` persists that
+   branching shape to localStorage, so a draft saved on one branch restores against
+   another.
+5. `src/components/CosmeticShop/CosmeticShopItemUpsertForm.tsx` — 696 lines; cosmetic
+   type rewrites the item's field set.
+6. `src/components/Generation/PromptEnhance/EnhanceTab.tsx` — 520 lines; RHF used as a
+   state bag (watch + setValue on unregistered fields). Weakest case — zustand would
+   also fit.
+
+**The loudest single signal**: the house `useForm` defaults `shouldUnregister: true`
+(with a literal `// TODO - do we need this?`), and **30 call sites individually override
+it back to `false`** — several with comments explaining which hidden values must
+survive. The whole codebase votes, one file at a time, for "a field leaving the DOM
+keeps its value." That is form-graph's core model (intent persists; visible state
+derives), which RHF makes a global boolean plus hand-managed exceptions.
+
+## The `Input*` layer: what it actually is, and what each option retires
+
+The layer is two things fused:
+
+1. **~20 presentational wrappers** (`TextInputWrapper`, `NumberInputWrapper`,
+   `SelectWrapper`, `NumberSlider`, upload components, …) — Mantine adaptation. These
+   are controlled components with `value`/`onChange`/`error` props and know nothing
+   about RHF. **They survive any migration, full or partial.** No form library removes
+   the need to adapt Mantine.
+2. **The binding**: `withController(Component)` stamped 35 times, plus per-component
+   mapper hacks. This is where the debt lives:
+   - the ref-forwarding check compares against `Symbol('react.forward_ref')` — a fresh
+     symbol, so it is always false and **refs are never forwarded** (latent bug);
+   - a `resetCount` counter threaded to every input as a `reset` prop, because RHF's
+     reset doesn't notify non-field UI;
+   - the `InputNumber` mapper reads `form.getValues()` to defeat `useController`'s
+     defaultValue resurrection;
+   - `any`-typed props, `@ts-ignore`, error-shape special-casing.
+
+Under form-graph the binding becomes either direct `Controller`/`createTypedController`
+render props (what the generation form does) or a ~30-line typed `withField(Component)`
+factory giving the same `<InputText name=… />` call-site ergonomics. So a full
+migration does **not** reduce 35 stamped exports to zero — it reduces them to one small,
+properly typed factory with no mapper hacks, no reset prop, and no resurrection
+workarounds.
+
+The boilerplate that genuinely disappears is different, and bigger:
+
+- **Call-site config duplication.** Today `min`/`max`/`step`/options live in the JSX at
+  every call site AND (sometimes disagreeing) in the zod schema. In form-graph they
+  live once, in the field def, and reach the component through `meta` — the same def
+  the server validates with. The JSX shrinks to name + label + presentation.
+- **The `useForm` hook itself** — the `looseObject` cast (which is what forbids
+  `.refine()` and forces Challenge's 11 hand-rolled `setError`s), the
+  `shouldUnregister` battle, `resetCount`.
+- **`Form.tsx` submit plumbing** — replaced by `store.validate()` + `focusFirstError`.
+- **`useFormStorage`** — replaced by `persistedStorage`, which is per-branch safe
+  (scoped intent) where the localStorage envelope is not.
+- **The per-form effect soup** — the watch/setValue cascades in the six forms above
+  become resolver branches, `.effect` rules, `correct` policies, and computeds. The
+  `lockedProperties` self-watch becomes `dirtyFields()`.
+- Dead code found along the way: `src/libs/form/components/FieldArray.tsx` is
+  unexported with zero users.
+
+## Recommendation
+
+**Partial first, full as the eventual end-state — but let the partial pay for itself
+before committing to the tail.**
+
+1. **Now, regardless of any migration** (small, benefits all 54 forms):
+   - fix the always-false ref-forward check in `withController`;
+   - flip the house `shouldUnregister` default to `false` (30/54 already override it;
+     audit the remainder against the documented resurrection trap first).
+2. **Port the value-dependent six**, one at a time, after the training-form rewrite
+   (the agreed next form-graph consumer). Oracle-first, same as the generation port:
+   freeze the current submit payload as golden fixtures, differential-test until
+   byte-equal. Suggested first: **ChallengeUpsertForm** — the clearest categorical win
+   (a shape union RHF cannot express, plus the app's only field array → `list()`) at
+   two-thirds the size of ModelVersionUpsertForm.
+3. **Then decide on the tail.** Once the six are ported, `src/libs/form` serves only
+   static/mild forms. The remaining ~48 migrate mechanically (a typed `withField`
+   factory keeps call sites nearly identical), which is when the RHF dependency and the
+   `withController` layer can actually be deleted — the payoff the partial migration
+   alone never delivers. Whether that mechanical pass is worth its regression surface
+   is best judged after the six, when the per-form cost is known instead of estimated.
+   The `createReportForm` factory (9 forms from one schema+render spec) would port as
+   one unit, not nine.
+
+What stays no matter what: the presentational wrappers, the upload components, rich
+text — and submission orchestration (mutations, notifications), which is app code under
+either library.
+
+## Costs and risks, honestly
+
+- Each of the six ports is real work — they are the app's hairiest forms, which is both
+  why they pay and why they bite. The generation port's method (fixtures + differential
+  oracle) is what made that tractable; budget for it per form.
+- form-graph is pre-1.0 and we own it. The generation form in production plus its
+  12k-case differential suite is the stability gate; breaking changes go through us.
+- Two forms in the six carry localStorage drafts (`useFormStorage`); the port must
+  migrate or deliberately drop existing drafts (the generation port's
+  `migrate-v1-storage.ts` is the precedent for migrating).
+- A half-migrated app has two form idioms for however long the tail survives. The
+  mitigation is that the lanes are already cleanly disjoint today, and the boundary
+  (value-dependent vs static) is legible enough to state in a review comment.

--- a/packages/civitai-shared/src/basemodel.constants.ts
+++ b/packages/civitai-shared/src/basemodel.constants.ts
@@ -3117,7 +3117,6 @@ export const baseModelRecords: BaseModelRecord[] = [
     type: 'image',
     ecosystemId: ECO.Qwen,
     licenseId: 13,
-    experimental: true,
   },
   {
     id: BM.Qwen2,

--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceHitList.tsx
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceHitList.tsx
@@ -1,9 +1,12 @@
 import { Button, Center, Loader, Stack, Text, ThemeIcon, Title } from '@mantine/core';
 import { IconCloudOff } from '@tabler/icons-react';
 import clsx from 'clsx';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import cardClasses from '~/components/Cards/Cards.module.css';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
+import { useResizeObserver } from '~/hooks/useResizeObserver';
+import { useDebouncer } from '~/utils/debouncer';
 import { useResourceSelectContext } from '~/components/ImageGeneration/GenerationForm/ResourceSelectProvider';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { MasonryColumnsVirtual } from '~/components/MasonryColumns/MasonryColumnsVirtual';
@@ -15,8 +18,63 @@ import { skipBaseModelForOwnTabs } from '~/components/ImageGeneration/Generation
 import { useResourceSelectInfinite } from './useResourceSelectInfinite';
 import { isDefined } from '~/utils/type-guards';
 
+const GRID_GAP = 16;
+/** Below this a column stops being worth showing, so the count drops instead. */
+const MIN_COLUMN_WIDTH = 240;
+const MAX_COLUMN_COUNT = 4;
+
+/**
+ * The catalog grid, sized to FILL its pane.
+ *
+ * `MasonryProvider` holds `columnWidth` fixed and centres whatever it can fit,
+ * which is right for the page feeds — they sit in an open page and the leftover
+ * becomes margin. In a modal pane that leftover reads as broken padding: at
+ * three columns of 278px it is ~150px of dead space. So the column width is
+ * derived from the measured pane instead — the count comes from a minimum
+ * width, and the columns then divide the space exactly.
+ */
+function FillingMasonryGrid({ children }: { children: React.ReactNode }) {
+  const [width, setWidth] = useState(0);
+  // Debounced to match MasonryProvider's own 100ms observer. `columnWidth`
+  // arrives there as a prop and bypasses that debounce, so an undebounced
+  // update here re-lays the grid once per animation frame for the length of a
+  // window drag — and the two observers settling at different times briefly
+  // disagree about the column count.
+  const debounce = useDebouncer(100);
+  const ref = useResizeObserver<HTMLDivElement>((entry) => {
+    const next = entry.contentRect.width;
+    debounce(() => setWidth(next));
+  });
+
+  // Measure before paint, as MasonryProvider does. Without this the first paint
+  // lays every result into a single MIN_COLUMN_WIDTH column and then relayouts.
+  useIsomorphicLayoutEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const style = getComputedStyle(node);
+    const paddingX = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+    setWidth(node.clientWidth - paddingX);
+  }, []);
+
+  const [columnCount, columnWidth] = useMemo(() => {
+    if (!width) return [1, MIN_COLUMN_WIDTH];
+    const fits = Math.floor((width + GRID_GAP) / (MIN_COLUMN_WIDTH + GRID_GAP));
+    const count = Math.min(Math.max(fits, 1), MAX_COLUMN_COUNT);
+    return [count, Math.floor((width - (count - 1) * GRID_GAP) / count)];
+  }, [width]);
+
+  return (
+    <div ref={ref}>
+      <MasonryProvider columnWidth={columnWidth} maxColumnCount={columnCount} gap={GRID_GAP}>
+        {children}
+      </MasonryProvider>
+    </div>
+  );
+}
+
 export function ResourceHitList({ query }: { query: string }) {
-  const { canGenerate, resources, selectSource, excludedIds, tab } = useResourceSelectContext();
+  const { canGenerate, resources, selectSource, excludedIds, tab, optionsOverride } =
+    useResourceSelectContext();
 
   const { data: featured } = trpc.model.getFeaturedModels.useQuery(undefined, {
     enabled: tab === 'featured',
@@ -30,6 +88,7 @@ export function ResourceHitList({ query }: { query: string }) {
     fetchNextPage,
     hasNextPage,
     isError,
+    isPlaceholderData,
     refetch,
   } = useResourceSelectInfinite({ query });
 
@@ -199,8 +258,23 @@ export function ResourceHitList({ query }: { query: string }) {
   // Exclude podium items from the main grid
   const restItems = tab === 'featured' ? filtered.filter((m) => !topItemIds.has(m.id)) : filtered;
 
+  /**
+   * `keepPreviousData` holds the last catalog on screen while a new one loads.
+   * That is right when only the query changed, and wrong once a rail can re-aim
+   * the OPTIONS: the rows on screen then belong to a family the form is no
+   * longer pointed at, and clicking one commits a model the graph substitutes
+   * away. Inert for every consumer that never sets an override.
+   */
+  const showingOtherEcosystem = isPlaceholderData && !!optionsOverride;
+
   return (
-    <div className="flex flex-col gap-3 p-3">
+    <div
+      className={clsx(
+        'flex flex-col gap-3 p-3',
+        showingOtherEcosystem && 'pointer-events-none opacity-50'
+      )}
+      aria-busy={showingOtherEcosystem}
+    >
       {hiddenCount > 0 && (
         <Text c="dimmed">{hiddenCount} models have been hidden due to your settings.</Text>
       )}
@@ -227,7 +301,7 @@ export function ResourceHitList({ query }: { query: string }) {
         </div>
       )}
 
-      <MasonryProvider columnWidth={278} maxColumnCount={4}>
+      <FillingMasonryGrid>
         <MasonryColumnsVirtual
           data={restItems}
           render={renderCard}
@@ -235,7 +309,7 @@ export function ResourceHitList({ query }: { query: string }) {
           adjustHeight={({ height }) => height + 82}
           itemId={(x) => x.id}
         />
-      </MasonryProvider>
+      </FillingMasonryGrid>
 
       {items.length > 0 && hasNextPage && (
         <InViewLoader loadFn={fetchNextPage} loadCondition={!isFetchingNextPage}>

--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceSelectCard.tsx
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceSelectCard.tsx
@@ -9,7 +9,7 @@ import {
   useComputedColorScheme,
   useMantineTheme,
 } from '@mantine/core';
-import { IconBrush, IconDownload, IconLock } from '@tabler/icons-react';
+import { IconBrush, IconCheck, IconDownload, IconLock, IconPlus } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useState } from 'react';
 import { BidModelButton } from '~/components/Auction/BidModelButton';
@@ -20,6 +20,7 @@ import type { Props as DescriptionTableProps } from '~/components/DescriptionTab
 import { DescriptionTable } from '~/components/DescriptionTable/DescriptionTable';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { IconBadge } from '~/components/IconBadge/IconBadge';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { useResourceSelectContext } from '~/components/ImageGeneration/GenerationForm/ResourceSelectProvider';
 import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
 import { MediaHash } from '~/components/ImageHash/ImageHash';
@@ -47,6 +48,7 @@ import { getDisplayName, getModelUrl } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
 import { isDefined } from '~/utils/type-guards';
 import type { ResourceSelectSource } from '../resource-select.types';
+import { getResourceCompatibility } from '~/components/generation_v2/inputs/ResourceItemContent';
 import { TopRightIcons } from './TopRightIcons';
 
 const IMAGE_CARD_WIDTH = 450;
@@ -60,7 +62,17 @@ export function ResourceSelectCard({
   height?: number;
   selectSource?: ResourceSelectSource;
 }) {
-  const { onSelect } = useResourceSelectContext();
+  const {
+    onSelect,
+    role,
+    multiSelect,
+    isStaged,
+    addStaged,
+    removeStaged,
+    resources,
+    staged,
+    limit,
+  } = useResourceSelectContext();
   const currentUser = useCurrentUser();
   const [loading, setLoading] = useState(false);
 
@@ -74,7 +86,12 @@ export function ResourceSelectCard({
   const selectedVersion = versions[_selectedIndex];
   const [flipped, setFlipped] = useState(false);
 
-  const handleSelect = async () => {
+  /**
+   * `take` commits the resource and closes the picker; `stage` adds it to the
+   * batch and leaves the picker open. Same fetch either way — only the
+   * destination differs.
+   */
+  const handleSelect = async (mode: 'take' | 'stage' = 'take') => {
     const version = selectedVersion;
     if (!version) return;
     const { id } = version;
@@ -94,11 +111,21 @@ export function ResourceSelectCard({
         return;
       }
       const previewImage = resource.image ?? image;
+      // `atLimit` was computed at render; two fast clicks near the cap both pass
+      // it and the second would be dropped by `addStaged` in silence. Every
+      // other rejection on this card says something, so this one does too.
+      if (mode === 'stage' && limit !== undefined && staged.length >= limit) {
+        showErrorNotification({
+          error: new Error(`You can add ${limit} more ${limit === 1 ? 'resource' : 'resources'}`),
+        });
+        return;
+      }
+      const commit = mode === 'stage' ? addStaged : onSelect;
       if (selectSource !== 'generation') {
-        onSelect({ ...resource, image: previewImage });
+        commit({ ...resource, image: previewImage });
       } else {
         if (resource?.canGenerate || resource?.substitute?.canGenerate)
-          onSelect({ ...resource, image: previewImage });
+          commit({ ...resource, image: previewImage });
         else
           showErrorNotification({
             error: new Error('This model is no longer available for generation'),
@@ -107,6 +134,20 @@ export function ResourceSelectCard({
     });
     setLoading(false);
   };
+
+  // Compatibility of the shown version against the form's current ecosystem —
+  // the same predicate the form's own resource list badges with.
+  const compatibility =
+    role === 'resource'
+      ? getResourceCompatibility(selectedVersion?.baseModel, data.type, { resources })
+      : 'full';
+  const incompatible = compatibility === null;
+  const isAdded = multiSelect && selectedVersion ? isStaged(selectedVersion.id) : false;
+  const atLimit = multiSelect && limit !== undefined && staged.length >= limit && !isAdded;
+  // Batch mode starts the moment something is staged. Until then the main
+  // button is the one-click path it has always been; once a batch exists,
+  // committing a single resource behind the user's back would discard it.
+  const batching = multiSelect && staged.length > 0;
 
   // Read favorite state straight from the bookmarked-models query so the
   // toggle's optimistic cache update drives the button — single source of truth,
@@ -270,36 +311,99 @@ export function ResourceSelectCard({
             ))}
 
           <div className="flex flex-col gap-2 p-3 text-black dark:text-white">
-            <Text size="sm" fw={700} lineClamp={1} lh={1} data-testid="resource-select-name">
+            <Text
+              component={Link}
+              href={getModelUrl({
+                modelId: data.id,
+                modelName: data.name,
+                modelVersionId: selectedVersion.id,
+              })}
+              target="_blank"
+              onClick={(e: React.MouseEvent) => e.stopPropagation()}
+              size="sm"
+              fw={700}
+              lh={1}
+              data-testid="resource-select-name"
+              // `self-start` so the link's hit area is the name, not the full
+              // width of the card — the parent is a flex column, where the
+              // default `align-items: stretch` would fill the cross axis.
+              className="max-w-full self-start truncate hover:underline"
+            >
               {data.name}
             </Text>
-            <div className="flex justify-between gap-2">
-              <Select
-                className="flex-1"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                }}
-                readOnly={versions.length <= 1}
-                value={_selectedIndex?.toString()}
-                data={versions.map((version, index) => ({
-                  label: version.name,
-                  value: index.toString(),
-                }))}
-                onChange={(index) => setSelectedIndex(Number(index ?? 0))}
-                styles={{
-                  input: { cursor: versions.length <= 1 ? 'auto !important' : undefined },
-                }}
-              />
+            <div className="flex items-center justify-between gap-2">
+              {/* In `checkpoint` role the version is a field under the model row,
+                  not part of the pick — see the header comment on
+                  ResourceSelectRole. */}
+              {role !== 'checkpoint' && (
+                <Select
+                  className="flex-1"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  readOnly={versions.length <= 1}
+                  value={_selectedIndex?.toString()}
+                  data={versions.map((version, index) => ({
+                    label: version.name,
+                    value: index.toString(),
+                  }))}
+                  onChange={(index) => setSelectedIndex(Number(index ?? 0))}
+                  styles={{
+                    input: { cursor: versions.length <= 1 ? 'auto !important' : undefined },
+                  }}
+                />
+              )}
+              {compatibility === 'partial' && (
+                <Badge color="yellow" variant="light" size="sm">
+                  Partial support
+                </Badge>
+              )}
+              {incompatible && (
+                <Badge color="red" variant="light" size="sm">
+                  Incompatible
+                </Badge>
+              )}
+              {/* The batch control, separate from the primary action: adding one
+                  resource stays a single click, and building a set is opt-in
+                  rather than the toll everyone pays. */}
+              {multiSelect && !incompatible && (
+                <Tooltip
+                  label={isAdded ? 'Remove from selection' : 'Add to selection'}
+                  position="top"
+                  withArrow
+                >
+                  <LegacyActionIcon
+                    aria-label={isAdded ? 'Remove from selection' : 'Add to selection'}
+                    aria-pressed={isAdded}
+                    variant={isAdded ? 'filled' : 'default'}
+                    disabled={atLimit}
+                    onClick={(e: React.MouseEvent) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      // Un-staging needs no round trip — the resource is in hand.
+                      if (isAdded && selectedVersion) removeStaged(selectedVersion.id);
+                      else handleSelect('stage');
+                    }}
+                  >
+                    {isAdded ? <IconCheck size={16} /> : <IconPlus size={16} />}
+                  </LegacyActionIcon>
+                </Tooltip>
+              )}
               <Button
+                className={role === 'checkpoint' ? 'flex-1' : undefined}
                 loading={loading}
+                disabled={incompatible || (batching && atLimit)}
+                variant={isAdded ? 'light' : 'filled'}
                 onClick={(e: React.MouseEvent) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  handleSelect();
+                  if (!batching) return void handleSelect('take');
+                  if (isAdded && selectedVersion) removeStaged(selectedVersion.id);
+                  else handleSelect('stage');
                 }}
               >
-                Select
+                {batching ? (isAdded ? 'Added' : 'Add') : 'Select'}
               </Button>
             </div>
           </div>

--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceSelectModalContent.tsx
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceSelectModalContent.tsx
@@ -1,6 +1,14 @@
-import { Box, CloseButton, SegmentedControl, Text, TextInput } from '@mantine/core';
+import { Badge, Button, CloseButton, Text, TextInput, UnstyledButton } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
-import { IconSearch, IconSettings } from '@tabler/icons-react';
+import clsx from 'clsx';
+import {
+  IconBox,
+  IconDatabase,
+  IconLink,
+  IconSearch,
+  IconSettings,
+  IconStack2,
+} from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import { GenerationSettingsPopover } from '~/components/Generation/GenerationSettings';
 import {
@@ -8,6 +16,7 @@ import {
   ResourceSelectSort,
 } from '~/components/ImageGeneration/GenerationForm/ResourceSelectFilters';
 import { useResourceSelectContext } from '~/components/ImageGeneration/GenerationForm/ResourceSelectProvider';
+import { ScrollArea } from '~/components/ScrollArea/ScrollArea';
 import {
   resourceSelectTabs,
   type Tabs,
@@ -19,8 +28,30 @@ import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { CategoryTagFilters } from './CategoryTagFilters';
 import { ResourceHitList } from './ResourceHitList';
 
-export function ResourceSelectModalContent() {
-  const { title, onClose, selectSource, tab, setTab } = useResourceSelectContext();
+/** Each role says what it is and what it is judged against. */
+const ROLE_COPY = {
+  checkpoint: {
+    title: 'Select checkpoint',
+    subtitle: 'The base model everything else is judged against',
+  },
+  resource: {
+    title: 'Add resources',
+    subtitle: 'LoRAs, embeddings and VAEs layered on your checkpoint',
+  },
+} as const;
+
+export function ResourceSelectModalContent({ Rail }: { Rail?: React.ComponentType }) {
+  const {
+    title,
+    onClose,
+    selectSource,
+    tab,
+    setTab,
+    footer: Footer,
+    role,
+    resources,
+    catalogNotice,
+  } = useResourceSelectContext();
   const dialog = useDialogContext();
   const currentUser = useCurrentUser();
   const features = useFeatureFlags();
@@ -53,47 +84,230 @@ export function ResourceSelectModalContent() {
   }
 
   return (
-    <>
-      <div className="sticky top-0 z-30 flex flex-col gap-3 bg-gray-0 p-3 dark:bg-dark-7">
-        <div className="flex flex-wrap items-center justify-between gap-4 @sm:gap-10">
-          <Text>{title}</Text>
-          <TextInput
-            value={search}
-            onChange={(e) => setSearch(e.currentTarget.value)}
-            leftSection={<IconSearch size={18} />}
-            placeholder="Search models"
-            className="order-last w-full grow @sm:order-none @sm:w-auto"
-            autoFocus
-          />
-          <CloseButton onClick={handleClose} />
+    // Three bands, as the design draws them: the header spans the whole modal,
+    // the rail and the catalog sit side by side beneath it, and the footer spans
+    // the whole modal again. Only the catalog scrolls — the rail scrolls itself.
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-none items-center gap-2.5 border-b border-gray-3 p-3 dark:border-dark-4">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-gray-2 text-gray-6 dark:bg-dark-5 dark:text-dark-2">
+          {role === 'resource' ? <IconStack2 size={19} /> : <IconBox size={19} />}
+        </span>
+        <div className="min-w-0 flex-1">
+          <Text fw={600} className="leading-tight">
+            {role ? ROLE_COPY[role].title : title}
+          </Text>
+          {role && (
+            <Text size="xs" c="dimmed" className="leading-tight">
+              {ROLE_COPY[role].subtitle}
+            </Text>
+          )}
         </div>
+        {/* What the catalog is scoped to — a filtered list otherwise reads as
+            models being missing. Stated once, here, rather than beside the
+            search box where it competes with the controls. */}
+        {role && (
+          <span className="hidden shrink-0 items-center gap-1.5 text-xs text-gray-6 md:flex dark:text-dark-2">
+            {role === 'resource' ? (
+              <>
+                <IconLink size={13} />
+                Compatible with your checkpoint
+              </>
+            ) : (
+              <>
+                <IconDatabase size={13} />
+                {[...new Set(resources.flatMap((r) => r.baseModels))].slice(0, 3).join(', ')}{' '}
+                checkpoints
+              </>
+            )}
+          </span>
+        )}
+        <CloseButton onClick={handleClose} />
+      </div>
 
-        <div className="flex flex-col gap-3 @sm:flex-row @sm:flex-nowrap @sm:items-center @sm:justify-between @sm:gap-10">
-          <SegmentedControl
-            value={tab}
-            onChange={(v) => setTab(v as Tabs)}
-            data={allowedTabs.map((v) => ({
-              value: v,
-              label: (
-                <Box className={v === 'featured' ? 'text-yellow-7' : ''}>{v.toUpperCase()}</Box>
-              ),
-            }))}
-            className="w-full shrink-0 @sm:w-auto"
-          />
-          <CategoryTagFilters />
-          <div className="flex shrink-0 flex-row items-center justify-end gap-3">
-            {tab !== 'featured' && <ResourceSelectSort />}
-            <ResourceSelectFiltersDropdown />
-            <GenerationSettingsPopover>
-              <LegacyActionIcon>
-                <IconSettings />
-              </LegacyActionIcon>
-            </GenerationSettingsPopover>
+      <div className="flex min-h-0 flex-1">
+        {/* Viewport breakpoint, not `@md`: Mantine's Modal sets no containerType
+            (only Drawer does), so container-query variants never resolve here
+            and the rail would stay hidden. */}
+        {Rail && (
+          <div className="hidden w-56 shrink-0 border-r border-gray-3 md:flex dark:border-dark-4">
+            <Rail />
           </div>
+        )}
+
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="flex flex-none flex-col gap-2.5 p-3">
+            <div className={clsx('flex flex-wrap items-center gap-2', !!catalogNotice && 'hidden')}>
+              <CatalogTabs tabs={allowedTabs} value={tab} onChange={setTab} />
+              {tab !== 'featured' && <ResourceSelectSort />}
+              <ResourceSelectFiltersDropdown />
+              <GenerationSettingsPopover>
+                <LegacyActionIcon>
+                  <IconSettings />
+                </LegacyActionIcon>
+              </GenerationSettingsPopover>
+              <TextInput
+                value={search}
+                onChange={(e) => setSearch(e.currentTarget.value)}
+                leftSection={<IconSearch size={16} />}
+                placeholder="Search models"
+                size="xs"
+                className="w-full min-w-40 flex-1 sm:w-auto"
+                autoFocus
+              />
+            </div>
+
+            <CategoryTagFilters />
+
+            <MobileRailStep Rail={Rail} />
+          </div>
+
+          {/* `overflow-y-scroll`, not `auto`: the gutter is reserved whether or
+              not the catalog overflows. At the threshold — a result set just
+              tall enough to need a scrollbar — `auto` toggles it on and off,
+              which changes the pane width, which re-flows the grid, which
+              changes the height again. */}
+          <ScrollArea
+            id="resource-select-modal"
+            scrollRestore={{ key: 'resource-select-modal', enabled: false }}
+            className="flex-1 overflow-y-scroll"
+          >
+            {catalogNotice ? (
+              <div className="p-3">{catalogNotice}</div>
+            ) : (
+              <ResourceHitList key={tab} query={debouncedSearch} />
+            )}
+          </ScrollArea>
         </div>
       </div>
 
-      <ResourceHitList key={tab} query={debouncedSearch} />
-    </>
+      <div className="flex-none">
+        <StagedTray />
+        {Footer && (
+          <div className="border-t border-gray-3 dark:border-dark-4">
+            <Footer />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The catalog tabs as a compact segmented group — small caps in one bordered
+ * track, sized to its labels. Mantine's SegmentedControl stretched to the row
+ * and pushed the sort and filter controls onto a line of their own.
+ */
+function CatalogTabs({
+  tabs,
+  value,
+  onChange,
+}: {
+  tabs: Tabs[];
+  value: Tabs;
+  onChange: (tab: Tabs) => void;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Catalog tab"
+      className="flex shrink-0 gap-0.5 rounded-lg border border-gray-3 bg-gray-1 p-0.5 dark:border-dark-4 dark:bg-dark-6"
+    >
+      {tabs.map((t) => (
+        <UnstyledButton
+          key={t}
+          aria-pressed={t === value}
+          onClick={() => onChange(t)}
+          className={clsx(
+            'rounded-md px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider',
+            t === value
+              ? 'bg-white text-dark-9 shadow-sm dark:bg-dark-4 dark:text-white'
+              : 'text-gray-6 hover:text-gray-9 dark:text-dark-2 dark:hover:text-gray-3',
+            t === 'featured' && t !== value && 'text-yellow-7 dark:text-yellow-5'
+          )}
+        >
+          {t}
+        </UnstyledButton>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The rail's mobile half. A 224px column beside a catalog does not fit in
+ * 390px, so below @md the rail collapses to this bar and the picker opens on
+ * the CATALOG: swapping within a family is the common move and stays one tap,
+ * while changing family — rarer, and destructive — sits one level up.
+ */
+function MobileRailStep({ Rail }: { Rail?: React.ComponentType }) {
+  const [opened, setOpened] = useState(false);
+  if (!Rail) return null;
+
+  return (
+    <div className="md:hidden">
+      {opened ? (
+        <div className="rounded-lg border border-gray-3 dark:border-dark-4">
+          <div className="flex items-center gap-2 border-b border-gray-3 p-2 dark:border-dark-4">
+            <Button variant="subtle" size="compact-sm" onClick={() => setOpened(false)}>
+              Back
+            </Button>
+            <Text size="sm" fw={600}>
+              Change model family
+            </Text>
+          </div>
+          <div className="max-h-80 overflow-y-auto">
+            <Rail />
+          </div>
+        </div>
+      ) : (
+        <Button variant="default" fullWidth onClick={() => setOpened(true)}>
+          Change model family
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Multi-select's commit bar. Strength is deliberately NOT editable here — the
+ * form's own resource list already owns it, and a second control for one value
+ * is the duplication this picker is being reshaped to remove.
+ */
+function StagedTray() {
+  const { multiSelect, staged, removeStaged, commitStaged, limit } = useResourceSelectContext();
+  const dialog = useDialogContext();
+  // Only once a batch exists. Standing permanently at the foot of the picker, it
+  // implied everyone had to use it — which is what made adding one resource
+  // cost two clicks.
+  if (!multiSelect || !staged.length) return null;
+
+  return (
+    <div className="flex items-center gap-3 border-t border-gray-3 bg-gray-0 p-3 dark:border-dark-4 dark:bg-dark-7">
+      <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto">
+        {staged.map((resource) => (
+          <Badge
+            key={resource.id}
+            variant="light"
+            size="lg"
+            className="shrink-0"
+            rightSection={
+              <CloseButton
+                size="xs"
+                onClick={() => removeStaged(resource.id)}
+                aria-label="Remove"
+              />
+            }
+          >
+            {resource.model.name}
+          </Badge>
+        ))}
+      </div>
+      <Button variant="default" onClick={dialog.onClose} className="shrink-0">
+        Cancel
+      </Button>
+      <Button onClick={commitStaged} className="shrink-0">
+        Add {staged.length} {staged.length === 1 ? 'resource' : 'resources'}
+        {limit !== undefined ? ` (${limit} free)` : ''}
+      </Button>
+    </div>
   );
 }

--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceTypeRail.tsx
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceTypeRail.tsx
@@ -1,0 +1,96 @@
+import { Text, UnstyledButton } from '@mantine/core';
+import { useMemo } from 'react';
+import { IconLayersIntersect } from '@tabler/icons-react';
+import clsx from 'clsx';
+import { useResourceSelectContext } from '~/components/ImageGeneration/GenerationForm/ResourceSelectProvider';
+import { sortByModelTypes } from '~/utils/array-helpers';
+import { getDisplayName } from '~/utils/string-helpers';
+import type { ModelType } from '~/shared/utils/prisma/enums';
+
+/**
+ * The rail in the `resource` role: the picker's own resource types, promoted
+ * out of the filters dropdown so the axis you actually switch on is visible.
+ *
+ * Its counterpart in the `checkpoint` role is the ecosystem rail, which the
+ * form-graph lane passes in — this one needs nothing from the caller, since the
+ * allowed types are already in the picker's options.
+ */
+export function ResourceTypeRail() {
+  const { resources, filters, setFilters, role } = useResourceSelectContext();
+  // Deduped and ordered the way the filters dropdown does it — options can carry
+  // the same `type` twice with different base models, which would otherwise put
+  // duplicate rows here under a duplicate React key.
+  const types = useMemo(
+    () =>
+      sortByModelTypes(
+        [...new Set(resources.map((r) => r.type as ModelType))].map((modelType) => ({ modelType }))
+      ),
+    [resources]
+  );
+  if (role !== 'resource' || types.length < 2) return null;
+
+  const selected = filters.types;
+
+  return (
+    <div className="flex min-h-0 w-full flex-col gap-1 overflow-y-auto p-2">
+      <Text size="xs" c="dimmed" tt="uppercase" fw={600} className="px-1 pb-1">
+        Resource type
+      </Text>
+
+      {types.map(({ modelType }) => {
+        const type = modelType as ModelType;
+        const isSelected = selected.includes(type);
+        return (
+          <UnstyledButton
+            key={type}
+            aria-pressed={isSelected}
+            onClick={() =>
+              setFilters((current) => ({
+                ...current,
+                // A rail selection is a jump, not an accumulation: picking a type
+                // shows that type, picking it again clears back to everything.
+                types: isSelected ? [] : [type],
+              }))
+            }
+            className={clsx(
+              'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm',
+              isSelected
+                ? 'bg-blue-0 font-semibold dark:bg-blue-9/20'
+                : 'hover:bg-gray-1 dark:hover:bg-dark-5'
+            )}
+          >
+            <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-gray-2 dark:bg-dark-5">
+              <IconLayersIntersect size={13} />
+            </span>
+            <span className="min-w-0 flex-1 truncate">{getDisplayName(type)}</span>
+          </UnstyledButton>
+        );
+      })}
+
+      <LockedToCheckpointNote />
+    </div>
+  );
+}
+
+/**
+ * Says out loud why the catalog is narrower than the site's — the picker is
+ * filtered to what loads on the current checkpoint, which otherwise reads as
+ * missing models.
+ */
+function LockedToCheckpointNote() {
+  const { resources } = useResourceSelectContext();
+  const baseModels = [...new Set(resources.flatMap((r) => r.baseModels))];
+  if (!baseModels.length) return null;
+
+  return (
+    <div className="mt-3 rounded-lg border border-gray-3 p-2 dark:border-dark-4">
+      <Text size="xs" fw={600} className="mb-1">
+        Locked to your checkpoint
+      </Text>
+      <Text size="xs" c="dimmed" className="leading-snug">
+        Showing resources that load on {baseModels.slice(0, 3).join(', ')}
+        {baseModels.length > 3 ? ` +${baseModels.length - 3} more` : ''}.
+      </Text>
+    </div>
+  );
+}

--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/index.tsx
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/index.tsx
@@ -2,11 +2,14 @@ import { Modal } from '@mantine/core';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import type { ResourceSelectModalProps } from '~/components/ImageGeneration/GenerationForm/ResourceSelectProvider';
 import { ResourceSelectProvider } from '~/components/ImageGeneration/GenerationForm/ResourceSelectProvider';
-import { ScrollArea } from '~/components/ScrollArea/ScrollArea';
 import { ResourceSelectModalContent } from './ResourceSelectModalContent';
+import { ResourceTypeRail } from './ResourceTypeRail';
 
 export default function ResourceSelectModal(props: ResourceSelectModalProps) {
   const dialog = useDialogContext();
+  // The resource role brings its own rail; the checkpoint role's comes from the
+  // caller, because only the form-graph form knows about ecosystems.
+  const Rail = props.rail ?? (props.role === 'resource' ? ResourceTypeRail : undefined);
 
   function handleClose() {
     dialog.onClose();
@@ -17,7 +20,7 @@ export default function ResourceSelectModal(props: ResourceSelectModalProps) {
     <Modal
       {...dialog}
       onClose={handleClose}
-      size={1200}
+      size={1500}
       withCloseButton={false}
       padding={0}
       styles={{
@@ -25,17 +28,9 @@ export default function ResourceSelectModal(props: ResourceSelectModalProps) {
         body: { flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' },
       }}
     >
-      {/* Unique key + disabled: without an explicit key this falls back to the
-          page-path key and restore() would apply the underlying page's scroll
-          offset to the modal on open. A private key has no recorded position. */}
-      <ScrollArea
-        id="resource-select-modal"
-        scrollRestore={{ key: 'resource-select-modal', enabled: false }}
-      >
-        <ResourceSelectProvider {...props}>
-          <ResourceSelectModalContent />
-        </ResourceSelectProvider>
-      </ScrollArea>
+      <ResourceSelectProvider {...props}>
+        <ResourceSelectModalContent Rail={Rail} />
+      </ResourceSelectProvider>
     </Modal>
   );
 }

--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectProvider.tsx
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useMemo, useState } from 'react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import type {
   ResourceFilter,
@@ -13,18 +13,67 @@ import type { GenerationResource } from '~/shared/types/generation.types';
 
 const defaultTab: Tabs = 'all';
 
+/**
+ * Which of the picker's jobs this instance is doing. Left undefined the modal
+ * behaves exactly as it always has — every consumer outside the form-graph
+ * generation form passes nothing.
+ *
+ * `checkpoint` drops the per-card version dropdown: the version is a field under
+ * the model row in the form, not part of the pick.
+ * `resource` judges each card against the checkpoint's ecosystem and, when the
+ * caller supplies `onSelectMultiple`, collects several picks before committing.
+ */
+export type ResourceSelectRole = 'checkpoint' | 'resource';
+
 export type ResourceSelectModalProps = {
   title?: React.ReactNode;
   onSelect: (value: GenerationResource) => void;
   onClose?: () => void;
   options?: ResourceSelectOptions;
   selectSource?: ResourceSelectSource;
+  role?: ResourceSelectRole;
+  /** Enables multi-select. Called once with everything picked. */
+  onSelectMultiple?: (values: GenerationResource[]) => void;
+  /** Cap on a multi-select batch — the form's remaining slots. */
+  limit?: number;
+  /**
+   * Slots. The modal knows nothing about what goes in them — the form-graph
+   * generation form fills them with an ecosystem rail and a consequence footer,
+   * which is why neither concept appears in this file.
+   *
+   * Components, not nodes: they render INSIDE the provider, so a rail can aim
+   * the catalog at a pending ecosystem via `setOptionsOverride`.
+   */
+  rail?: React.ComponentType;
+  footer?: React.ComponentType;
 };
 
-type ResourceSelectState = Omit<ResourceSelectModalProps, 'options' | 'selectSource'> & {
+type ResourceSelectState = Omit<
+  ResourceSelectModalProps,
+  'options' | 'selectSource' | 'onSelectMultiple'
+> & {
   selectSource: ResourceSelectSource;
   canGenerate?: boolean;
   excludedIds: number[];
+  /**
+   * Lets a rail re-aim the catalog at an ecosystem the user is considering but
+   * has not committed to. Null restores the options the modal was opened with.
+   */
+  optionsOverride: ResourceSelectOptions | null;
+  setOptionsOverride: (options: ResourceSelectOptions | null) => void;
+  /**
+   * Set by a rail when the catalog must not be browsed — the family pins its
+   * checkpoint, so anything picked here would be substituted back. Rendered in
+   * place of the results.
+   */
+  catalogNotice: React.ReactNode | null;
+  setCatalogNotice: (notice: React.ReactNode | null) => void;
+  multiSelect: boolean;
+  staged: GenerationResource[];
+  addStaged: (value: GenerationResource) => void;
+  removeStaged: (id: number) => void;
+  isStaged: (id: number) => boolean;
+  commitStaged: () => void;
   resources: DeepRequired<ResourceSelectOptions>['resources'];
   tab: Tabs;
   setTab: React.Dispatch<React.SetStateAction<Tabs>>;
@@ -75,22 +124,30 @@ export function ResourceSelectProvider({
   });
   const [sort, setSort] = useState<ResourceSort>('relevance');
   const [categoryTag, setCategoryTag] = useState<string | undefined>();
-  const resources = (props.options?.resources ?? []).map(
-    ({ type, baseModels = [], partialSupport = [] }) => ({
-      type,
-      // if generation, check toggle
-      // if modelVersion or addResource, always include all
-      // otherwise (training, auction, etc.), only include baseModels
-      baseModels:
-        props.selectSource === 'generation'
-          ? generation?.advancedMode
+  const [optionsOverride, setOptionsOverride] = useState<ResourceSelectOptions | null>(null);
+  const [catalogNotice, setCatalogNotice] = useState<React.ReactNode | null>(null);
+  const activeOptions = optionsOverride ?? props.options;
+  // Memoised because staging a resource now re-renders this provider, and a new
+  // `resources` identity invalidates the hit list's `filterVersions` callback —
+  // which re-filters every loaded model and re-lays out the whole grid.
+  const resources = useMemo(
+    () =>
+      (activeOptions?.resources ?? []).map(({ type, baseModels = [], partialSupport = [] }) => ({
+        type,
+        // if generation, check toggle
+        // if modelVersion or addResource, always include all
+        // otherwise (training, auction, etc.), only include baseModels
+        baseModels:
+          props.selectSource === 'generation'
+            ? generation?.advancedMode
+              ? [...baseModels, ...partialSupport]
+              : baseModels
+            : props.selectSource === 'modelVersion' || props.selectSource === 'addResource'
             ? [...baseModels, ...partialSupport]
-            : baseModels
-          : props.selectSource === 'modelVersion' || props.selectSource === 'addResource'
-          ? [...baseModels, ...partialSupport]
-          : baseModels,
-      partialSupport,
-    })
+            : baseModels,
+        partialSupport,
+      })),
+    [activeOptions, props.selectSource, generation?.advancedMode]
   );
   const resourceTypes = resources.map((x) => x.type);
   const types =
@@ -104,8 +161,33 @@ export function ResourceSelectProvider({
       ? filters.baseModels.filter((baseModel) => resourceBaseModels.includes(baseModel))
       : filters.baseModels;
 
+  // Same reason as `resources`: a fresh array each render re-runs the hit
+  // list's version filter over every loaded model.
+  const excludedIds = useMemo(() => activeOptions?.excludeIds ?? [], [activeOptions]);
+
   function handleSelect(value: GenerationResource) {
     props.onSelect(value);
+    dialog.onClose();
+  }
+
+  const multiSelect = !!props.onSelectMultiple;
+  const [staged, setStaged] = useState<GenerationResource[]>([]);
+
+  function addStaged(value: GenerationResource) {
+    setStaged((current) => {
+      if (current.some((x) => x.id === value.id)) return current;
+      if (props.limit !== undefined && current.length >= props.limit) return current;
+      return [...current, value];
+    });
+  }
+
+  function removeStaged(id: number) {
+    setStaged((current) => current.filter((x) => x.id !== id));
+  }
+
+  function commitStaged() {
+    if (!staged.length) return;
+    props.onSelectMultiple?.(staged);
     dialog.onClose();
   }
 
@@ -114,8 +196,8 @@ export function ResourceSelectProvider({
       value={{
         ...props,
         selectSource,
-        canGenerate: props.options?.canGenerate,
-        excludedIds: props.options?.excludeIds ?? [],
+        canGenerate: activeOptions?.canGenerate,
+        excludedIds,
         resources,
         tab,
         setTab,
@@ -129,6 +211,16 @@ export function ResourceSelectProvider({
         categoryTag,
         setCategoryTag,
         onSelect: handleSelect,
+        optionsOverride,
+        setOptionsOverride,
+        catalogNotice,
+        setCatalogNotice,
+        multiSelect,
+        staged,
+        addStaged,
+        removeStaged,
+        isStaged: (id: number) => staged.some((x) => x.id === id),
+        commitStaged,
       }}
     >
       {children}

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -21,7 +21,7 @@ import {
 } from '@mantine/core';
 import { IconAlertTriangle, IconInfoCircle } from '@tabler/icons-react';
 import { getQueryKey } from '@trpc/react-query';
-import { isEqual, uniq } from 'lodash-es';
+import { uniq } from 'lodash-es';
 import { useRouter } from 'next/router';
 import React, { useEffect, useRef, useState } from 'react';
 import * as z from 'zod';
@@ -66,7 +66,6 @@ import { generationResourceSchema } from '~/server/schema/generation.schema';
 import type {
   ModelVersionMeta,
   ModelVersionPaidAccessDto,
-  ModelVersionPaidAccessInputSchema,
   ModelVersionUpsertInput,
   RecommendedSettingsSchema,
 } from '~/server/schema/model-version.schema';
@@ -83,8 +82,6 @@ import {
   PRICING_SLOT_EXPLAINER,
   DEFAULT_FEE_IMAGES,
   MONETIZATION_RIGHTS_AFFIRMATION_STATEMENT,
-  acceptsBlueBuzz,
-  buildModelVersionTerms,
   feeMaxFor,
   hasCurrentRightsAffirmation,
   paidAccessCharges,
@@ -94,7 +91,6 @@ import {
   pricingAllowanceState,
   ratioToFee,
   resolveCapTier,
-  separateGenerationPriceMissing,
   seedFeeRatio,
 } from '@civitai/buzz';
 import type { ModelUpsertInput } from '~/server/schema/model.schema';
@@ -122,73 +118,13 @@ import {
 } from '~/components/Resource/Forms/model-version-monetization-defaults';
 import { monetizationDefaultsStore } from '~/store/model-version-monetization-defaults.store';
 
-// Wrap the terms in the permanent/timed gate shape (or null for an off/invalid gate).
-function toGate(
-  config: FormPaidAccessConfig,
-  terms: ModelVersionTerms
-): ModelVersionPaidAccessInputSchema | null {
-  if (config.permanent) return { permanent: true, terms };
-  const timeframeDays = config.timeframe ?? 0;
-  if (timeframeDays <= 0) return null;
-  return { permanent: false, timeframeDays, terms };
-}
-
-function toPaidAccessInput(
-  config: FormPaidAccessConfig | null | undefined,
-  usageControl: ModelUsageControl | undefined
-): ModelVersionPaidAccessInputSchema | null {
-  if (!config || config.accessPrice == null) return null;
-  // Only downloadable or on-site-generation versions can be gated; other usage controls (internal /
-  // external API) can't set paid access at all.
-  if (
-    usageControl &&
-    usageControl !== ModelUsageControl.Download &&
-    usageControl !== ModelUsageControl.Generation
-  )
-    return null;
-  const terms = buildModelVersionTerms({
-    accessPrice: config.accessPrice,
-    generationPrice: config.generationPrice,
-    freePreviewGenerations: config.freePreviewGenerations,
-    genOnly: usageControl === ModelUsageControl.Generation,
-    freeGeneration: config.freeGeneration,
-    acceptsBlueBuzz: config.acceptsBlueBuzz,
-  });
-  return toGate(config, terms);
-}
-
-type GenerationMode = 'bundled' | 'separate' | 'free';
-const generationModeOf = (config: FormPaidAccessConfig | null | undefined): GenerationMode =>
-  config?.freeGeneration ? 'free' : config?.generationPrice != null ? 'separate' : 'bundled';
-
-function toDonationGoalInput(config: FormPaidAccessConfig | null | undefined) {
-  // A donation goal only makes sense for a timed gate (it ends the window early); permanent never ends.
-  if (config?.permanent || !config?.donationGoalEnabled || !config.donationGoal) return null;
-  return { amount: config.donationGoal };
-}
-
-function toFormPaidAccessConfig(
-  paidAccess: { timeframeDays: number | null; terms: ModelVersionTerms } | null | undefined,
-  donationGoal: { goalAmount: number } | null | undefined
-): FormPaidAccessConfig | null {
-  if (!paidAccess) return null;
-  const terms = paidAccess.terms ?? {};
-  const paidGen = terms.generation && !('free' in terms.generation) ? terms.generation : undefined;
-  return {
-    // No timeframeDays on the row => a permanent (never-expiring) gate.
-    permanent: paidAccess.timeframeDays == null,
-    timeframe: paidAccess.timeframeDays ?? EARLY_ACCESS_CONFIG.timeframeValues[0],
-    // "Price for access" is the download price when downloadable; for a gen-only version (no download
-    // tier) it's the generation price. The separate generation-only tier only exists with a download bundle.
-    accessPrice: terms.download?.price ?? paidGen?.price,
-    generationPrice: terms.download ? paidGen?.price : undefined,
-    freeGeneration: !!terms.generation && `free` in terms.generation,
-    acceptsBlueBuzz: acceptsBlueBuzz(terms),
-    freePreviewGenerations: paidGen?.trialLimit ?? DEFAULT_GENERATION_TRIAL_LIMIT,
-    donationGoalEnabled: !!donationGoal,
-    donationGoal: donationGoal?.goalAmount,
-  };
-}
+import {
+  type GenerationMode,
+  decideModelVersionSubmit,
+  generationModeOf,
+  toFormPaidAccessConfig,
+  toPaidAccessInput,
+} from '~/components/Resource/Forms/model-version-submit';
 
 const schema = modelVersionUpsertSchema2
   .omit({ paidAccess: true, donationGoal: true })
@@ -687,99 +623,40 @@ export function ModelVersionUpsertForm({
     recommendedResources: rawRecommendedResources,
     ...data
   }: Schema) => {
-    // Validate NSFW + restricted base model combination
-    if (
-      model?.nsfw &&
-      data.baseModel &&
-      nsfwRestrictedBaseModels.includes(data.baseModel as BaseModel)
-    ) {
-      showErrorNotification({
-        error: new Error(
-          `NSFW models cannot use base models with license restrictions. The base model "${
-            data.baseModel
-          }" is restricted for NSFW content. Restricted base models: ${nsfwRestrictedBaseModels.join(
-            ', '
-          )}`
-        ),
-        title: 'Base Model License Restriction',
-      });
-      return;
-    }
+    const schemaResult = querySchema.safeParse(router.query);
+    const decision = decideModelVersionSubmit(
+      { ...data, recommendedResources: rawRecommendedResources },
+      {
+        modelId: model?.id,
+        modelNsfw: !!model?.nsfw,
+        gateSuppressed,
+        monetizationBlocked,
+        showClipSkip,
+        genMode,
+        requiresRightsAffirmation,
+        isDirty,
+        versionId: version?.id,
+        storedPaidAccessConfig: toFormPaidAccessConfig(version?.paidAccess, version?.donationGoal),
+        templateId: schemaResult.success ? schemaResult.data.templateId : undefined,
+        bountyId: schemaResult.success ? schemaResult.data.bountyId : undefined,
+      }
+    );
 
-    const gatedConfig = gateSuppressed ? null : data.paidAccessConfig;
-    // Keyed to the gate the submit actually sends, not to the config: a usage control that can't be gated
-    // leaves the pricing controls unmounted with their values intact, and refusing over a price nobody can
-    // see (for a gate that would be dropped anyway) is a save the creator has no way to unblock.
-    const submittedGate = toPaidAccessInput(gatedConfig, data.usageControl);
-
-    // A generation grant with no price of its own is charged at the DOWNLOAD price (see `generationPrice`),
-    // so an empty box under "a cheaper generation-only price" bills the full access price while the screen
-    // says cheaper. Nothing downstream can tell that apart from a deliberate "same as access price", so the
-    // refusal has to happen here, where the creator's choice still exists.
-    if (
-      genMode === 'separate' &&
-      submittedGate &&
-      data.usageControl !== ModelUsageControl.Generation &&
-      separateGenerationPriceMissing(data.paidAccessConfig?.generationPrice)
-    ) {
-      const message = 'Enter a generation-only price, or choose "Same as the access price"';
-      form.setError('paidAccessConfig.generationPrice', { message });
-      showErrorNotification({ error: new Error(message), title: 'Generation price required' });
-      return;
-    }
-
-    if (requiresRightsAffirmation && !data.rightsAffirmed) {
-      const message = 'You must confirm you hold the rights to monetize this model';
-      form.setError('rightsAffirmed', { message });
-      // The checkbox can be well below the fold, and this also blocks wizard step navigation — an
-      // inline-only error reads as the button doing nothing.
-      showErrorNotification({ error: new Error(message), title: 'Confirmation required' });
+    if (decision.kind === 'refuse') {
+      // The offending control can be well below the fold, and a refusal also blocks wizard step
+      // navigation — an inline-only error reads as the button doing nothing, so both surface.
+      if (decision.field) form.setError(decision.field, { message: decision.message });
+      showErrorNotification({ error: new Error(decision.message), title: decision.title });
       return;
     }
 
     if (data.baseModel) setLastUsedBaseModel(data.baseModel);
 
-    const schemaResult = querySchema.safeParse(router.query);
-    const templateId = schemaResult.success ? schemaResult.data.templateId : undefined;
-    const bountyId = schemaResult.success ? schemaResult.data.bountyId : undefined;
-
-    if (
-      isDirty ||
-      !version?.id ||
-      templateId ||
-      bountyId ||
-      !isEqual(
-        data.paidAccessConfig,
-        toFormPaidAccessConfig(version?.paidAccess, version?.donationGoal)
-      )
-    ) {
-      const recommendedResources =
-        rawRecommendedResources?.map(({ id, strength }) => ({
-          resourceId: id,
-          settings: { strength },
-        })) ?? [];
-
-      const result = await upsertVersionMutation.mutateAsync({
-        ...data,
-        // Don't persist a stale clip skip for base models that don't use it.
-        clipSkip: showClipSkip ? data.clipSkip ?? null : null,
-        epochs: data.epochs ?? null,
-        steps: data.steps ?? null,
-        modelId: model?.id ?? -1,
-        // A POI model earns nothing: the fee editor is unmounted for one, so its stored value would
-        // otherwise ride along untouched behind a section that shows no controls at all.
-        licensingFee: submittedFee,
-        paidAccess: submittedGate,
-        // Keyed to the gate that is actually sent: a goal ends a timed window early, so writing one for a
-        // version whose gate was just rejected leaves a goal against nothing to end.
-        donationGoal: submittedGate ? toDonationGoalInput(gatedConfig) : null,
-        trainedWords: skipTrainedWords ? [] : trainedWords,
-        baseModelType: data.baseModelType,
-        monetization: monetizationBlocked ? null : data.monetization,
-        recommendedResources,
-        templateId,
-        bountyId,
-      });
+    if (decision.kind === 'submit') {
+      const { payload, submittedFee, submittedGate, gatedConfig } = decision;
+      const result = await upsertVersionMutation.mutateAsync(
+        payload as Parameters<typeof upsertVersionMutation.mutateAsync>[0]
+      );
 
       // Remembered only once the server has taken it, so what comes back next time is a configuration
       // that already cleared the eligibility floor, the fee ceiling and the affirmation — and read off

--- a/src/components/Resource/Forms/__tests__/model-version-submit.test.ts
+++ b/src/components/Resource/Forms/__tests__/model-version-submit.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from 'vitest';
+import { ModelUsageControl } from '~/shared/utils/prisma/enums';
+import {
+  decideModelVersionSubmit,
+  type ModelVersionSubmitContext,
+  type ModelVersionSubmitData,
+} from '~/components/Resource/Forms/model-version-submit';
+
+/**
+ * Golden fixtures over the pure submit decision — the oracle the form-graph
+ * port of ModelVersionUpsertForm will be differentially tested against. These
+ * pin CURRENT behavior (money-path transforms included), captured 2026-09-08
+ * from the extracted handler; they are parity pins, not endorsements.
+ */
+
+const baseData = (): ModelVersionSubmitData => ({
+  id: 10,
+  name: 'v1.0',
+  modelId: 5,
+  baseModel: 'SDXL 1.0',
+  usageControl: ModelUsageControl.Download,
+  trainedWords: ['cat'],
+  skipTrainedWords: false,
+  epochs: undefined,
+  steps: undefined,
+  clipSkip: 2,
+  licensingFee: 0,
+  monetization: null,
+  baseModelType: null,
+  paidAccessConfig: null,
+  rightsAffirmed: false,
+  recommendedResources: [],
+  requireAuth: true,
+  useMonetization: false,
+});
+
+const baseCtx = (): ModelVersionSubmitContext => ({
+  modelId: 5,
+  modelNsfw: false,
+  gateSuppressed: false,
+  monetizationBlocked: false,
+  showClipSkip: true,
+  genMode: 'bundled',
+  requiresRightsAffirmation: false,
+  isDirty: true,
+  versionId: 10,
+  storedPaidAccessConfig: null,
+  templateId: undefined,
+  bountyId: undefined,
+});
+
+const timedGate = (over: Record<string, unknown> = {}) => ({
+  permanent: false,
+  timeframe: 3,
+  accessPrice: 5000,
+  generationPrice: undefined,
+  freeGeneration: false,
+  acceptsBlueBuzz: false,
+  freePreviewGenerations: 10,
+  donationGoalEnabled: false,
+  donationGoal: undefined,
+  ...over,
+});
+
+const decide = (
+  data: Partial<ModelVersionSubmitData> = {},
+  ctx: Partial<ModelVersionSubmitContext> = {}
+) => decideModelVersionSubmit({ ...baseData(), ...data }, { ...baseCtx(), ...ctx });
+
+const submitOf = (d: ReturnType<typeof decide>) => {
+  if (d.kind !== 'submit') throw new Error(`expected submit, got ${d.kind}`);
+  return d;
+};
+
+describe('decideModelVersionSubmit: payload shape', () => {
+  it('minimal no-charge submit (full payload pin)', () => {
+    expect(decide()).toEqual({
+      kind: 'submit',
+      submittedFee: 0,
+      submittedGate: null,
+      gatedConfig: null,
+      payload: {
+        id: 10,
+        name: 'v1.0',
+        modelId: 5,
+        baseModel: 'SDXL 1.0',
+        usageControl: 'Download',
+        trainedWords: ['cat'],
+        skipTrainedWords: false,
+        epochs: null,
+        steps: null,
+        clipSkip: 2,
+        licensingFee: 0,
+        monetization: null,
+        baseModelType: null,
+        paidAccessConfig: null,
+        rightsAffirmed: false,
+        requireAuth: true,
+        useMonetization: false,
+        paidAccess: null,
+        donationGoal: null,
+        recommendedResources: [],
+        templateId: undefined,
+        bountyId: undefined,
+      },
+    });
+  });
+
+  it('skipTrainedWords sends an empty word list', () => {
+    const d = submitOf(decide({ skipTrainedWords: true }));
+    expect(d.payload.trainedWords).toEqual([]);
+    expect(d.payload.skipTrainedWords).toBe(true);
+  });
+
+  it('a hidden clip skip is nulled, not persisted stale', () => {
+    const d = submitOf(decide({}, { showClipSkip: false }));
+    expect(d.payload.clipSkip).toBeNull();
+  });
+
+  it('recommendedResources rename: {id, strength} -> {resourceId, settings.strength}', () => {
+    const d = submitOf(
+      decide({
+        recommendedResources: [
+          { id: 111, strength: 0.8, model: { id: 1 } },
+          { id: 222, strength: null, model: { id: 2 } },
+        ],
+      })
+    );
+    expect(d.payload.recommendedResources).toEqual([
+      { resourceId: 111, settings: { strength: 0.8 } },
+      { resourceId: 222, settings: { strength: null } },
+    ]);
+  });
+});
+
+describe('decideModelVersionSubmit: paid access gate', () => {
+  it('timed gate with a separate generation price (full payload pin)', () => {
+    const d = submitOf(
+      decide({ paidAccessConfig: timedGate({ generationPrice: 500 }) }, { genMode: 'separate' })
+    );
+    expect(d.submittedGate).toEqual({
+      permanent: false,
+      timeframeDays: 3,
+      terms: { download: { price: 5000 }, generation: { price: 500, trialLimit: 10 } },
+    });
+    expect(d.payload.paidAccess).toEqual(d.submittedGate);
+    expect(d.payload.donationGoal).toBeNull();
+  });
+
+  it('bundled: no generation tier price, trial limit rides on the grant', () => {
+    const d = submitOf(decide({ paidAccessConfig: timedGate() }));
+    expect(d.submittedGate).toEqual({
+      permanent: false,
+      timeframeDays: 3,
+      terms: { download: { price: 5000 }, generation: { trialLimit: 10 } },
+    });
+  });
+
+  it('free generation grant', () => {
+    const d = submitOf(
+      decide({ paidAccessConfig: timedGate({ freeGeneration: true }) }, { genMode: 'free' })
+    );
+    expect(d.submittedGate).toEqual({
+      permanent: false,
+      timeframeDays: 3,
+      terms: { download: { price: 5000 }, generation: { free: true } },
+    });
+  });
+
+  it('generation-only usage control prices the generation tier, no download tier', () => {
+    const d = submitOf(
+      decide({ usageControl: ModelUsageControl.Generation, paidAccessConfig: timedGate() })
+    );
+    expect(d.submittedGate).toEqual({
+      permanent: false,
+      timeframeDays: 3,
+      terms: { generation: { price: 5000, trialLimit: 10 } },
+    });
+  });
+
+  it('a non-gateable usage control drops the gate entirely', () => {
+    const d = submitOf(
+      decide({
+        usageControl: ModelUsageControl.InternalGeneration,
+        paidAccessConfig: timedGate(),
+      })
+    );
+    expect(d.submittedGate).toBeNull();
+    expect(d.payload.paidAccess).toBeNull();
+  });
+
+  it('an UNDEFINED usage control still allows the gate (current behavior, pinned)', () => {
+    const d = submitOf(decide({ usageControl: undefined, paidAccessConfig: timedGate() }));
+    expect(d.submittedGate).not.toBeNull();
+  });
+
+  it('gate suppression drops the gate but keeps the fee; the raw config still rides in the payload', () => {
+    const d = submitOf(
+      decide({ paidAccessConfig: timedGate(), licensingFee: 100 }, { gateSuppressed: true })
+    );
+    expect(d.submittedGate).toBeNull();
+    expect(d.payload.paidAccess).toBeNull();
+    expect(d.submittedFee).toBe(100);
+    expect(d.payload.licensingFee).toBe(100);
+    // shouldUnregister:false survival — stripped by the server's input schema, not here
+    expect(d.payload.paidAccessConfig).toEqual(timedGate());
+  });
+
+  it('monetizationBlocked zeroes the fee and nulls legacy monetization (full pin)', () => {
+    const d = submitOf(
+      decide(
+        { licensingFee: 100, monetization: { type: 'legacy' } },
+        { gateSuppressed: true, monetizationBlocked: true }
+      )
+    );
+    expect(d.submittedFee).toBe(0);
+    expect(d.payload.licensingFee).toBe(0);
+    expect(d.payload.monetization).toBeNull();
+  });
+});
+
+describe('decideModelVersionSubmit: donation goal', () => {
+  it('rides only on a timed gate', () => {
+    const d = submitOf(
+      decide({
+        paidAccessConfig: timedGate({ donationGoalEnabled: true, donationGoal: 60000 }),
+      })
+    );
+    expect(d.payload.donationGoal).toEqual({ amount: 60000 });
+  });
+
+  it('a permanent gate never sends a goal, even when enabled', () => {
+    const d = submitOf(
+      decide({
+        paidAccessConfig: timedGate({
+          permanent: true,
+          donationGoalEnabled: true,
+          donationGoal: 60000,
+        }),
+      })
+    );
+    expect(d.submittedGate).toEqual({
+      permanent: true,
+      terms: { download: { price: 5000 }, generation: { trialLimit: 10 } },
+    });
+    expect(d.payload.donationGoal).toBeNull();
+  });
+});
+
+describe('decideModelVersionSubmit: refusals and skip', () => {
+  it('refuses an NSFW model on a license-restricted base model', () => {
+    const d = decide({ baseModel: 'SD 3' }, { modelNsfw: true });
+    expect(d).toMatchObject({
+      kind: 'refuse',
+      code: 'nsfw_restricted_base_model',
+      title: 'Base Model License Restriction',
+    });
+  });
+
+  it('refuses a separate generation mode with no generation price', () => {
+    expect(decide({ paidAccessConfig: timedGate() }, { genMode: 'separate' })).toEqual({
+      kind: 'refuse',
+      code: 'generation_price_missing',
+      title: 'Generation price required',
+      message: 'Enter a generation-only price, or choose "Same as the access price"',
+      field: 'paidAccessConfig.generationPrice',
+    });
+  });
+
+  it('refuses an unaffirmed charge when affirmation is required', () => {
+    expect(decide({ paidAccessConfig: timedGate() }, { requiresRightsAffirmation: true })).toEqual({
+      kind: 'refuse',
+      code: 'rights_affirmation_required',
+      title: 'Confirmation required',
+      message: 'You must confirm you hold the rights to monetize this model',
+      field: 'rightsAffirmed',
+    });
+  });
+
+  it('skips a clean save of an existing version', () => {
+    expect(decide({}, { isDirty: false })).toEqual({ kind: 'skip' });
+  });
+
+  it('a template forces the submit even when clean', () => {
+    const d = submitOf(decide({}, { isDirty: false, templateId: 77 }));
+    expect(d.payload.templateId).toBe(77);
+  });
+
+  it('a paid-access change forces the submit even when RHF says clean', () => {
+    const config = timedGate();
+    const d = decide(
+      { paidAccessConfig: config },
+      { isDirty: false, storedPaidAccessConfig: null }
+    );
+    expect(d.kind).toBe('submit');
+    expect(
+      decide({ paidAccessConfig: config }, { isDirty: false, storedPaidAccessConfig: config })
+    ).toEqual({ kind: 'skip' });
+  });
+});

--- a/src/components/Resource/Forms/model-version-submit.ts
+++ b/src/components/Resource/Forms/model-version-submit.ts
@@ -1,0 +1,246 @@
+import { isEqual } from 'lodash-es';
+import {
+  DEFAULT_GENERATION_TRIAL_LIMIT,
+  acceptsBlueBuzz,
+  buildModelVersionTerms,
+  separateGenerationPriceMissing,
+  type ModelVersionTerms,
+} from '@civitai/buzz';
+import { EARLY_ACCESS_CONFIG, nsfwRestrictedBaseModels } from '~/server/common/constants';
+import type { ModelVersionPaidAccessInputSchema } from '~/server/schema/model-version.schema';
+import type { BaseModel } from '~/shared/constants/basemodel.constants';
+import { ModelUsageControl } from '~/shared/utils/prisma/enums';
+import type { FormPaidAccessConfig } from '~/components/Resource/Forms/model-version-monetization-defaults';
+
+/**
+ * The pure half of ModelVersionUpsertForm's submit: every refusal, the
+ * dirty-check skip, and the payload construction, with no store/React/tRPC in
+ * reach. Extracted so the form-graph port can be differentially tested against
+ * it — the golden fixtures in __tests__/model-version-submit.test.ts pin the
+ * CURRENT behavior, money-path transforms included.
+ */
+
+// Wrap the terms in the permanent/timed gate shape (or null for an off/invalid gate).
+function toGate(
+  config: FormPaidAccessConfig,
+  terms: ModelVersionTerms
+): ModelVersionPaidAccessInputSchema | null {
+  if (config.permanent) return { permanent: true, terms };
+  const timeframeDays = config.timeframe ?? 0;
+  if (timeframeDays <= 0) return null;
+  return { permanent: false, timeframeDays, terms };
+}
+
+export function toPaidAccessInput(
+  config: FormPaidAccessConfig | null | undefined,
+  usageControl: ModelUsageControl | undefined
+): ModelVersionPaidAccessInputSchema | null {
+  if (!config || config.accessPrice == null) return null;
+  // Only downloadable or on-site-generation versions can be gated; other usage controls (internal /
+  // external API) can't set paid access at all.
+  if (
+    usageControl &&
+    usageControl !== ModelUsageControl.Download &&
+    usageControl !== ModelUsageControl.Generation
+  )
+    return null;
+  const terms = buildModelVersionTerms({
+    accessPrice: config.accessPrice,
+    generationPrice: config.generationPrice,
+    freePreviewGenerations: config.freePreviewGenerations,
+    genOnly: usageControl === ModelUsageControl.Generation,
+    freeGeneration: config.freeGeneration,
+    acceptsBlueBuzz: config.acceptsBlueBuzz,
+  });
+  return toGate(config, terms);
+}
+
+export type GenerationMode = 'bundled' | 'separate' | 'free';
+export const generationModeOf = (config: FormPaidAccessConfig | null | undefined): GenerationMode =>
+  config?.freeGeneration ? 'free' : config?.generationPrice != null ? 'separate' : 'bundled';
+
+export function toDonationGoalInput(config: FormPaidAccessConfig | null | undefined) {
+  // A donation goal only makes sense for a timed gate (it ends the window early); permanent never ends.
+  if (config?.permanent || !config?.donationGoalEnabled || !config.donationGoal) return null;
+  return { amount: config.donationGoal };
+}
+
+export function toFormPaidAccessConfig(
+  paidAccess: { timeframeDays: number | null; terms: ModelVersionTerms } | null | undefined,
+  donationGoal: { goalAmount: number } | null | undefined
+): FormPaidAccessConfig | null {
+  if (!paidAccess) return null;
+  const terms = paidAccess.terms ?? {};
+  const paidGen = terms.generation && !('free' in terms.generation) ? terms.generation : undefined;
+  return {
+    // No timeframeDays on the row => a permanent (never-expiring) gate.
+    permanent: paidAccess.timeframeDays == null,
+    timeframe: paidAccess.timeframeDays ?? EARLY_ACCESS_CONFIG.timeframeValues[0],
+    // "Price for access" is the download price when downloadable; for a gen-only version (no download
+    // tier) it's the generation price. The separate generation-only tier only exists with a download bundle.
+    accessPrice: terms.download?.price ?? paidGen?.price,
+    generationPrice: terms.download ? paidGen?.price : undefined,
+    freeGeneration: !!terms.generation && `free` in terms.generation,
+    acceptsBlueBuzz: acceptsBlueBuzz(terms),
+    freePreviewGenerations: paidGen?.trialLimit ?? DEFAULT_GENERATION_TRIAL_LIMIT,
+    donationGoalEnabled: !!donationGoal,
+    donationGoal: donationGoal?.goalAmount,
+  };
+}
+
+/** The fields the decision reads; the rest of the form data rides through into the payload. */
+export type ModelVersionSubmitData = {
+  baseModel?: string;
+  baseModelType?: string | null;
+  usageControl?: ModelUsageControl;
+  paidAccessConfig?: FormPaidAccessConfig | null;
+  rightsAffirmed?: boolean;
+  skipTrainedWords?: boolean;
+  trainedWords?: string[];
+  clipSkip?: number | null;
+  epochs?: number | null;
+  steps?: number | null;
+  licensingFee?: number | null;
+  monetization?: unknown;
+  recommendedResources?:
+    | ({ id: number; strength?: number | null } & Record<string, unknown>)[]
+    | null;
+} & Record<string, unknown>;
+
+export type ModelVersionSubmitContext = {
+  modelId: number | undefined;
+  modelNsfw: boolean;
+  /** private || poi || non-commercial base model — the gate is dropped at submit. */
+  gateSuppressed: boolean;
+  /** poi || non-commercial — fee zeroed and legacy monetization nulled. */
+  monetizationBlocked: boolean;
+  showClipSkip: boolean;
+  genMode: GenerationMode;
+  requiresRightsAffirmation: boolean;
+  isDirty: boolean;
+  versionId: number | undefined;
+  /** `toFormPaidAccessConfig(version.paidAccess, version.donationGoal)` — the dirty-check baseline. */
+  storedPaidAccessConfig: FormPaidAccessConfig | null;
+  templateId: number | undefined;
+  bountyId: number | undefined;
+};
+
+export type ModelVersionSubmitDecision =
+  | {
+      kind: 'refuse';
+      code:
+        | 'nsfw_restricted_base_model'
+        | 'generation_price_missing'
+        | 'rights_affirmation_required';
+      title: string;
+      message: string;
+      field?: 'paidAccessConfig.generationPrice' | 'rightsAffirmed';
+    }
+  | { kind: 'skip' }
+  | {
+      kind: 'submit';
+      payload: Record<string, unknown>;
+      submittedFee: number;
+      submittedGate: ModelVersionPaidAccessInputSchema | null;
+      gatedConfig: FormPaidAccessConfig | null | undefined;
+    };
+
+export function decideModelVersionSubmit(
+  { recommendedResources: rawRecommendedResources, ...data }: ModelVersionSubmitData,
+  ctx: ModelVersionSubmitContext
+): ModelVersionSubmitDecision {
+  if (
+    ctx.modelNsfw &&
+    data.baseModel &&
+    nsfwRestrictedBaseModels.includes(data.baseModel as BaseModel)
+  ) {
+    return {
+      kind: 'refuse',
+      code: 'nsfw_restricted_base_model',
+      title: 'Base Model License Restriction',
+      message: `NSFW models cannot use base models with license restrictions. The base model "${
+        data.baseModel
+      }" is restricted for NSFW content. Restricted base models: ${nsfwRestrictedBaseModels.join(
+        ', '
+      )}`,
+    };
+  }
+
+  const gatedConfig = ctx.gateSuppressed ? null : data.paidAccessConfig;
+  // Keyed to the gate the submit actually sends, not to the config: a usage control that can't be gated
+  // leaves the pricing controls unmounted with their values intact, and refusing over a price nobody can
+  // see (for a gate that would be dropped anyway) is a save the creator has no way to unblock.
+  const submittedGate = toPaidAccessInput(gatedConfig, data.usageControl);
+
+  // A generation grant with no price of its own is charged at the DOWNLOAD price (see `generationPrice`),
+  // so an empty box under "a cheaper generation-only price" bills the full access price while the screen
+  // says cheaper. Nothing downstream can tell that apart from a deliberate "same as access price", so the
+  // refusal has to happen here, where the creator's choice still exists.
+  if (
+    ctx.genMode === 'separate' &&
+    submittedGate &&
+    data.usageControl !== ModelUsageControl.Generation &&
+    separateGenerationPriceMissing(data.paidAccessConfig?.generationPrice)
+  ) {
+    return {
+      kind: 'refuse',
+      code: 'generation_price_missing',
+      title: 'Generation price required',
+      message: 'Enter a generation-only price, or choose "Same as the access price"',
+      field: 'paidAccessConfig.generationPrice',
+    };
+  }
+
+  if (ctx.requiresRightsAffirmation && !data.rightsAffirmed) {
+    return {
+      kind: 'refuse',
+      code: 'rights_affirmation_required',
+      title: 'Confirmation required',
+      message: 'You must confirm you hold the rights to monetize this model',
+      field: 'rightsAffirmed',
+    };
+  }
+
+  const shouldSubmit =
+    ctx.isDirty ||
+    !ctx.versionId ||
+    !!ctx.templateId ||
+    !!ctx.bountyId ||
+    !isEqual(data.paidAccessConfig, ctx.storedPaidAccessConfig);
+  if (!shouldSubmit) return { kind: 'skip' };
+
+  const submittedFee = ctx.monetizationBlocked ? 0 : data.licensingFee ?? 0;
+  const recommendedResources =
+    rawRecommendedResources?.map(({ id, strength }) => ({
+      resourceId: id,
+      settings: { strength },
+    })) ?? [];
+
+  return {
+    kind: 'submit',
+    submittedFee,
+    submittedGate,
+    gatedConfig,
+    payload: {
+      ...data,
+      // Don't persist a stale clip skip for base models that don't use it.
+      clipSkip: ctx.showClipSkip ? data.clipSkip ?? null : null,
+      epochs: data.epochs ?? null,
+      steps: data.steps ?? null,
+      modelId: ctx.modelId ?? -1,
+      // A POI model earns nothing: the fee editor is unmounted for one, so its stored value would
+      // otherwise ride along untouched behind a section that shows no controls at all.
+      licensingFee: submittedFee,
+      paidAccess: submittedGate,
+      // Keyed to the gate that is actually sent: a goal ends a timed window early, so writing one for a
+      // version whose gate was just rejected leaves a goal against nothing to end.
+      donationGoal: submittedGate ? toDonationGoalInput(gatedConfig) : null,
+      trainedWords: data.skipTrainedWords ? [] : data.trainedWords,
+      baseModelType: data.baseModelType,
+      monetization: ctx.monetizationBlocked ? null : data.monetization,
+      recommendedResources,
+      templateId: ctx.templateId,
+      bountyId: ctx.bountyId,
+    },
+  };
+}

--- a/src/components/form-graph/generation/AudioGenerationForm.tsx
+++ b/src/components/form-graph/generation/AudioGenerationForm.tsx
@@ -4,13 +4,15 @@ import { Controller } from 'form-graph/react';
 
 import { GenerationTextEditor } from '~/components/Generate/Input/GenerationTextEditor';
 import { ImageUploadMultipleInput } from '~/components/generation_v2/inputs/ImageUploadMultipleInput';
-import { ResourceSelectInput } from '~/components/generation_v2/inputs/ResourceSelectInput';
 import { SeedInput } from '~/components/generation_v2/inputs/SeedInput';
 import { SliderInput } from '~/components/generation_v2/inputs/SliderInput';
 import { SegmentedControlWrapper } from '~/libs/form/components/SegmentedControlWrapper';
 import { audioHub } from '~/shared/form-graph/generation/audio/hub.graph';
+import { generationHub } from '~/shared/form-graph/generation/hub.graph';
 
 import { ControllerLabel, VersionGroupSelector } from './form-helpers';
+import { CheckpointRow } from './inputs/CheckpointRow';
+import { openCheckpointPicker } from './inputs/openCheckpointPicker';
 
 /**
  * The AUDIO generation form — one `<Controller graph={audioHub}>` per field.
@@ -23,27 +25,44 @@ export function AudioGenerationForm() {
   return (
     <Stack gap="sm">
       <Controller
-        graph={audioHub}
-        name="model"
-        render={({ value, meta, onChange }) => (
-          <>
-            <ResourceSelectInput
-              value={value}
-              onChange={onChange}
-              label={<ControllerLabel label="Model" />}
-              buttonLabel="Select Model"
-              modalTitle="Select Model"
-              options={meta?.options}
-              allowRemove={false}
-            />
-            {meta?.versions ? (
-              <VersionGroupSelector
-                versions={meta.versions}
-                modelId={value?.id}
-                onChange={onChange}
-              />
-            ) : null}
-          </>
+        graph={generationHub}
+        name="ecosystem"
+        render={({ value: ecosystem, meta: ecosystemMeta, onChange: onEcosystemChange }) => (
+          <Controller
+            graph={audioHub}
+            name="model"
+            render={({ value, meta, onChange }) => (
+              <>
+                <CheckpointRow
+                  value={value}
+                  ecosystem={ecosystem}
+                  options={meta?.options}
+                  onOpenPicker={() =>
+                    openCheckpointPicker({
+                      options: meta?.options,
+                      onSelect: onChange,
+                      onEcosystemChange,
+                      ecosystem: {
+                        value: ecosystem,
+                        modelLocked: meta?.modelLocked,
+                        compatibleEcosystems: ecosystemMeta?.compatibleEcosystems,
+                        excludeEcosystems: ecosystemMeta?.hiddenEcosystems,
+                        ecosystemStates: ecosystemMeta?.ecosystemStates,
+                        outputType: ecosystemMeta?.mediaType,
+                      },
+                    })
+                  }
+                />
+                {meta?.versions ? (
+                  <VersionGroupSelector
+                    versions={meta.versions}
+                    modelId={value?.id}
+                    onChange={onChange}
+                  />
+                ) : null}
+              </>
+            )}
+          />
         )}
       />
       <Controller

--- a/src/components/form-graph/generation/BaseGenerationForm.tsx
+++ b/src/components/form-graph/generation/BaseGenerationForm.tsx
@@ -8,13 +8,10 @@ import {
 } from '~/components/ImageGeneration/GenerationForm/generation.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
-import { ButtonGroupInput } from '~/libs/form/components/ButtonGroupInput';
 import { VID_QUANTITY_BY_TIER } from '~/shared/constants/generation.constants';
 import { generationHub } from '~/shared/form-graph/generation/hub.graph';
 import type { GenerationCtx } from '~/shared/data-graph/generation/context';
-import { getWorkflowModes } from '~/shared/data-graph/generation/config';
 import {
-  workflowConfigByKey,
   shouldShowBackButton,
   shouldReturnAfterSubmit,
 } from '~/shared/data-graph/generation/config/workflows';
@@ -24,11 +21,7 @@ import { generationGraphPanel } from '~/store/generation-graph.store';
 
 import { GenerationLayout, GenerationFooter } from '~/components/generation_v2/GenerationLayout';
 import { PresetControl } from '~/components/generation_v2/preset/PresetControl';
-import { BaseModelInput } from '~/components/generation_v2/inputs/BaseModelInput';
-import {
-  WorkflowInput,
-  SelectedWorkflowDisplay,
-} from '~/components/generation_v2/inputs/WorkflowInput';
+import { SelectedWorkflowDisplay } from '~/components/generation_v2/inputs/WorkflowInput';
 import { MetadataExtractionPanel } from '~/components/generation_v2/inputs/MetadataExtractionPanel';
 import { MetadataExtractionFooter } from '~/components/generation_v2/FormFooter';
 import { PromptEnhancePanel } from '~/components/Generation/PromptEnhance/PromptEnhancePanel';
@@ -40,6 +33,7 @@ import {
   type PartialResourceValue,
 } from '~/components/generation_v2/inputs/resource-select.utils';
 
+import { WorkflowPicker } from './inputs/WorkflowPicker';
 import { ImageGenerationForm } from './ImageGenerationForm';
 import { VideoGenerationForm } from './VideoGenerationForm';
 import { AudioGenerationForm } from './AudioGenerationForm';
@@ -53,8 +47,7 @@ import { useOutputType, type GenerationStore } from './store';
 /**
  * The BASE generation form: the entry component. Owns the store over the
  * composed root (`generationHub`) and mirrors GenerationFormV2's shell —
- * GenerationLayout chrome, preset strip, the workflow+ecosystem selector row,
- * SelectedWorkflowDisplay with back-nav and workflow modes, the img2meta /
+ * GenerationLayout chrome, preset strip, the workflow chip, the img2meta /
  * prompt:enhance self-contained panels, and the footer slot. The per-output
  * bodies below all receive the SAME store — the graph is one form; only the
  * rendering splits.
@@ -196,35 +189,20 @@ function GenerationFormBody({ store, isMember }: { store: GenerationStore; isMem
   return (
     <GenerationLayout>
       <PresetControl />
-      {/* Workflow and ecosystem selectors — always visible, single row */}
-      <div className="flex w-full min-w-0 items-center gap-2 overflow-hidden sm:gap-4">
-        <Controller
-          graph={generationHub}
-          name="workflow"
-          render={({ value, onChange }) => (
-            <WorkflowInput
-              value={value}
-              ecosystemId={ecosystemId}
-              onChange={(graphKey) => onChange(graphKey)}
-              isMember={isMember}
-            />
-          )}
-        />
-        <Controller
-          graph={generationHub}
-          name="ecosystem"
-          render={({ value, meta, onChange }) => (
-            <BaseModelInput
-              value={value}
-              onChange={onChange}
-              compatibleEcosystems={meta?.compatibleEcosystems}
-              excludeEcosystems={meta?.hiddenEcosystems}
-              ecosystemStates={meta?.ecosystemStates}
-              outputType={meta?.mediaType}
-            />
-          )}
-        />
-      </div>
+      {/* Workflow chip — always visible; the ecosystem moved into the checkpoint picker */}
+      <Controller
+        graph={generationHub}
+        name="workflow"
+        render={({ value, onChange }) => (
+          <WorkflowPicker
+            value={value}
+            ecosystemId={ecosystemId}
+            onChange={(graphKey) => onChange(graphKey)}
+            isMember={isMember}
+            onBack={shouldShowBackButton(value) ? handleNavigationBack : undefined}
+          />
+        )}
+      />
 
       {/* img2meta: self-contained panel, no graph controllers */}
       {workflow === 'img2meta' && (
@@ -247,35 +225,6 @@ function GenerationFormBody({ store, isMember }: { store: GenerationStore; isMem
 
       {workflow !== 'img2meta' && workflow !== 'prompt:enhance' && (
         <>
-          <Controller
-            graph={generationHub}
-            name="workflow"
-            render={({ value, onChange }) => {
-              const modes = ecosystem
-                ? getWorkflowModes(
-                    value,
-                    ecosystem,
-                    (store.getSnapshot().state as { model?: { id?: number } }).model?.id
-                  )
-                : [];
-              return (
-                <div className="flex flex-col gap-1">
-                  <SelectedWorkflowDisplay
-                    workflowId={value}
-                    ecosystemId={ecosystemId}
-                    onBack={shouldShowBackButton(value) ? handleNavigationBack : undefined}
-                  />
-                  {modes.length > 0 && (
-                    <ButtonGroupInput
-                      value={workflowConfigByKey.get(value)?.variantOf ?? value}
-                      onChange={(v) => onChange(v)}
-                      data={modes}
-                    />
-                  )}
-                </div>
-              );
-            }}
-          />
           {output === 'image' ? (
             <ImageGenerationForm store={store} />
           ) : output === 'video' ? (

--- a/src/components/form-graph/generation/ImageGenerationForm.tsx
+++ b/src/components/form-graph/generation/ImageGenerationForm.tsx
@@ -29,6 +29,8 @@ import { generationHub } from '~/shared/form-graph/generation/hub.graph';
 import { imageHub } from '~/shared/form-graph/generation/image/hub.graph';
 
 import { ControllerLabel, VersionGroupSelector, useWildcardHandlers } from './form-helpers';
+import { CheckpointRow } from './inputs/CheckpointRow';
+import { openCheckpointPicker, readResources } from './inputs/openCheckpointPicker';
 import type { GenerationStore } from './store';
 
 /**
@@ -46,42 +48,58 @@ export function ImageGenerationForm({ store }: { store: GenerationStore }) {
     <Stack gap="sm">
       <div className="flex flex-col gap-1">
         <Controller
-          graph={imageHub}
-          name="model"
-          render={({ value, meta, onChange }) => {
-            const defaultModelId = meta?.defaultModelId;
-            return (
-              <>
-                <ResourceSelectInput
-                  value={value}
-                  onChange={onChange}
-                  label={
-                    <ControllerLabel
-                      label="Model"
-                      info="Models are the resources you're generating with. Using a different base model can drastically alter the style and composition of images, while adding additional resources can change the characters, concepts and objects."
+          graph={generationHub}
+          name="ecosystem"
+          render={({ value: ecosystem, meta: ecosystemMeta, onChange: onEcosystemChange }) => (
+            <Controller
+              graph={imageHub}
+              name="model"
+              render={({ value, meta, onChange }) => {
+                const defaultModelId = meta?.defaultModelId;
+                return (
+                  <>
+                    <CheckpointRow
+                      value={value}
+                      ecosystem={ecosystem}
+                      options={meta?.options}
+                      locked={meta?.modelLocked}
+                      onOpenPicker={() =>
+                        openCheckpointPicker({
+                          options: meta?.options,
+                          onSelect: onChange,
+                          onEcosystemChange,
+                          // Read at click time rather than subscribing: the
+                          // footer is the only consumer, and a subscription
+                          // would re-render this row on every strength drag.
+                          resources: readResources(store),
+                          ecosystem: {
+                            value: ecosystem,
+                            modelLocked: meta?.modelLocked,
+                            compatibleEcosystems: ecosystemMeta?.compatibleEcosystems,
+                            excludeEcosystems: ecosystemMeta?.hiddenEcosystems,
+                            ecosystemStates: ecosystemMeta?.ecosystemStates,
+                            outputType: ecosystemMeta?.mediaType,
+                          },
+                        })
+                      }
+                      onRevertToDefault={
+                        defaultModelId
+                          ? () => onChange({ id: defaultModelId, model: { type: 'Checkpoint' } })
+                          : undefined
+                      }
                     />
-                  }
-                  buttonLabel="Select Model"
-                  modalTitle="Select Model"
-                  options={meta?.options}
-                  allowRemove={false}
-                  allowSwap={!meta?.modelLocked}
-                  onRevertToDefault={
-                    defaultModelId
-                      ? () => onChange({ id: defaultModelId, model: { type: 'Checkpoint' } })
-                      : undefined
-                  }
-                />
-                {meta?.versions ? (
-                  <VersionGroupSelector
-                    versions={meta.versions}
-                    modelId={value?.id}
-                    onChange={onChange}
-                  />
-                ) : null}
-              </>
-            );
-          }}
+                    {meta?.versions ? (
+                      <VersionGroupSelector
+                        versions={meta.versions}
+                        modelId={value?.id}
+                        onChange={onChange}
+                      />
+                    ) : null}
+                  </>
+                );
+              }}
+            />
+          )}
         />
       </div>
       <Controller
@@ -96,6 +114,7 @@ export function ImageGenerationForm({ store }: { store: GenerationStore }) {
             modalTitle="Select Resources"
             options={meta?.options}
             limit={meta?.limit}
+            role="resource"
           />
         )}
       />

--- a/src/components/form-graph/generation/VideoGenerationForm.tsx
+++ b/src/components/form-graph/generation/VideoGenerationForm.tsx
@@ -7,7 +7,6 @@ import { GenerationTextEditor } from '~/components/Generate/Input/GenerationText
 import { ResourceAlerts } from '~/components/generation_v2/ResourceAlerts';
 import { AspectRatioInput } from '~/components/generation_v2/inputs/AspectRatioInput';
 import { ImageUploadMultipleInput } from '~/components/generation_v2/inputs/ImageUploadMultipleInput';
-import { ResourceSelectInput } from '~/components/generation_v2/inputs/ResourceSelectInput';
 import { ResourceSelectMultipleInput } from '~/components/generation_v2/inputs/ResourceSelectMultipleInput';
 import { SeedInput } from '~/components/generation_v2/inputs/SeedInput';
 import { SelectInput } from '~/components/generation_v2/inputs/SelectInput';
@@ -22,6 +21,8 @@ import { videoHub } from '~/shared/form-graph/generation/video/hub.graph';
 import { wanVersionDefs, wanVersionOptions } from '~/shared/form-graph/generation/video/wan.graph';
 
 import { ControllerLabel, VersionGroupSelector, useWildcardHandlers } from './form-helpers';
+import { CheckpointRow } from './inputs/CheckpointRow';
+import { openCheckpointPicker, readResources } from './inputs/openCheckpointPicker';
 import type { GenerationStore } from './store';
 
 /**
@@ -37,37 +38,55 @@ export function VideoGenerationForm({ store }: { store: GenerationStore }) {
     <Stack gap="sm">
       <div className="flex flex-col gap-1">
         <Controller
-          graph={videoHub}
-          name="model"
-          render={({ value, meta, onChange }) => {
-            const defaultModelId = meta?.defaultModelId;
-            return (
-              <>
-                <ResourceSelectInput
-                  value={value}
-                  onChange={onChange}
-                  label={<ControllerLabel label="Model" />}
-                  buttonLabel="Select Model"
-                  modalTitle="Select Model"
-                  options={meta?.options}
-                  allowRemove={false}
-                  allowSwap={!meta?.modelLocked}
-                  onRevertToDefault={
-                    defaultModelId
-                      ? () => onChange({ id: defaultModelId, model: { type: 'Checkpoint' } })
-                      : undefined
-                  }
-                />
-                {meta?.versions ? (
-                  <VersionGroupSelector
-                    versions={meta.versions}
-                    modelId={value?.id}
-                    onChange={onChange}
-                  />
-                ) : null}
-              </>
-            );
-          }}
+          graph={generationHub}
+          name="ecosystem"
+          render={({ value: ecosystem, meta: ecosystemMeta, onChange: onEcosystemChange }) => (
+            <Controller
+              graph={videoHub}
+              name="model"
+              render={({ value, meta, onChange }) => {
+                const defaultModelId = meta?.defaultModelId;
+                return (
+                  <>
+                    <CheckpointRow
+                      value={value}
+                      ecosystem={ecosystem}
+                      options={meta?.options}
+                      locked={meta?.modelLocked}
+                      onOpenPicker={() =>
+                        openCheckpointPicker({
+                          options: meta?.options,
+                          onSelect: onChange,
+                          onEcosystemChange,
+                          resources: readResources(store),
+                          ecosystem: {
+                            value: ecosystem,
+                            modelLocked: meta?.modelLocked,
+                            compatibleEcosystems: ecosystemMeta?.compatibleEcosystems,
+                            excludeEcosystems: ecosystemMeta?.hiddenEcosystems,
+                            ecosystemStates: ecosystemMeta?.ecosystemStates,
+                            outputType: ecosystemMeta?.mediaType,
+                          },
+                        })
+                      }
+                      onRevertToDefault={
+                        defaultModelId
+                          ? () => onChange({ id: defaultModelId, model: { type: 'Checkpoint' } })
+                          : undefined
+                      }
+                    />
+                    {meta?.versions ? (
+                      <VersionGroupSelector
+                        versions={meta.versions}
+                        modelId={value?.id}
+                        onChange={onChange}
+                      />
+                    ) : null}
+                  </>
+                );
+              }}
+            />
+          )}
         />
         <Controller
           graph={videoHub}
@@ -105,6 +124,7 @@ export function VideoGenerationForm({ store }: { store: GenerationStore }) {
             modalTitle="Select Resources"
             options={meta?.options}
             limit={meta?.limit}
+            role="resource"
           />
         )}
       />

--- a/src/components/form-graph/generation/inputs/CheckpointRow.tsx
+++ b/src/components/form-graph/generation/inputs/CheckpointRow.tsx
@@ -1,0 +1,140 @@
+import { Anchor, Button, Text } from '@mantine/core';
+import { IconChevronRight } from '@tabler/icons-react';
+import clsx from 'clsx';
+
+import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
+import { useResourceData } from '~/components/generation_v2/inputs/ResourceDataProvider';
+import {
+  getResourceStatus,
+  getStatusClasses,
+  isResourceDisabled,
+  shouldShowModelLink,
+} from '~/components/generation_v2/inputs/ResourceItemContent';
+import {
+  ResourceCardSkeleton,
+  type PartialResourceValue,
+} from '~/components/generation_v2/inputs/resource-select.utils';
+import type { ResourceSelectOptions } from '~/components/ImageGeneration/GenerationForm/resource-select.types';
+import { ecosystemByKey } from '~/shared/constants/basemodel.constants';
+import { getModelUrl } from '~/utils/string-helpers';
+
+/**
+ * The checkpoint as a single row: thumbnail, name, and one meta line reading
+ * `version · ecosystem`.
+ *
+ * Replaces the 52px card the header used to spend on this. Everything the card
+ * carried is still one click away in the picker.
+ */
+export function CheckpointRow({
+  value,
+  ecosystem,
+  options,
+  onOpenPicker,
+  onRevertToDefault,
+  disabled,
+  locked,
+}: {
+  value?: PartialResourceValue;
+  ecosystem?: string;
+  options?: ResourceSelectOptions;
+  onOpenPicker: () => void;
+  onRevertToDefault?: () => void;
+  disabled?: boolean;
+  /**
+   * The family pins its checkpoint — the version selector below is how you move
+   * within it. The picker still opens: with the ecosystem rail living inside it,
+   * hiding this button would strand you in the family with no way back out.
+   */
+  locked?: boolean;
+}) {
+  const { data: resource, isLoading } = useResourceData(value?.id);
+
+  if (!value) {
+    return (
+      <Button variant="light" fullWidth onClick={onOpenPicker} disabled={disabled}>
+        Select model
+      </Button>
+    );
+  }
+
+  if (!resource || isLoading) return <ResourceCardSkeleton />;
+
+  const status = getResourceStatus(resource, options);
+  const statusClasses = getStatusClasses(status);
+  const unusable = isResourceDisabled(status);
+  const ecosystemName = ecosystem ? ecosystemByKey.get(ecosystem)?.displayName : undefined;
+
+  const meta = [resource.name, ecosystemName].filter(Boolean);
+
+  const body = (
+    <>
+      {resource.image ? (
+        <EdgeMedia
+          src={resource.image.url}
+          type={resource.image.type}
+          width={64}
+          className="size-8 shrink-0 rounded-md object-cover"
+        />
+      ) : (
+        <span className="size-8 shrink-0 rounded-md bg-gray-3 dark:bg-dark-4" />
+      )}
+      <span className="min-w-0 flex-1 text-left">
+        {/* Same anchor the old model card used, via ResourceItemContent: a
+            Mantine `Anchor` so it carries the theme's link colour, sized to its
+            text so the hit area is the name and not the whole row. A private
+            model someone else owns has no page to link to. */}
+        {shouldShowModelLink(resource) ? (
+          <Anchor
+            href={getModelUrl({
+              modelId: resource.model.id,
+              modelName: resource.model.name,
+              modelVersionId: resource.id,
+            })}
+            target="_blank"
+            size="sm"
+            fw={600}
+            className="block w-fit max-w-full truncate"
+            onClick={(e: React.MouseEvent) => e.stopPropagation()}
+          >
+            {resource.model.name}
+          </Anchor>
+        ) : (
+          <Text size="sm" fw={600} className="truncate">
+            {resource.model.name}
+          </Text>
+        )}
+        <Text size="xs" c="dimmed" lineClamp={1}>
+          {meta.join(' · ')}
+        </Text>
+      </span>
+    </>
+  );
+
+  const className = clsx(
+    'flex w-full items-center gap-2.5 rounded-lg border border-gray-3 p-2 dark:border-dark-4',
+    'bg-gray-0 dark:bg-dark-6',
+    statusClasses.border,
+    statusClasses.background
+  );
+
+  return (
+    <div className={className}>
+      {body}
+      {unusable && onRevertToDefault && (
+        <Button variant="light" size="compact-xs" radius="xl" onClick={onRevertToDefault}>
+          Default
+        </Button>
+      )}
+      <Button
+        variant="subtle"
+        size="compact-sm"
+        onClick={onOpenPicker}
+        disabled={disabled}
+        rightSection={<IconChevronRight size={14} />}
+        className="shrink-0"
+      >
+        {locked ? 'Change family' : 'Change'}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/form-graph/generation/inputs/EcosystemRail.tsx
+++ b/src/components/form-graph/generation/inputs/EcosystemRail.tsx
@@ -1,0 +1,288 @@
+import { Button, Text } from '@mantine/core';
+import { IconAlertTriangle, IconInfoCircle, IconLock } from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
+
+import {
+  BaseModelListContent,
+  useBaseModelPickerState,
+} from '~/components/generation_v2/inputs/BaseModelInput';
+import { getResourceCompatibility } from '~/components/generation_v2/inputs/ResourceItemContent';
+import type { PartialResourceValue } from '~/components/generation_v2/inputs/resource-select.utils';
+import { useDialogContext } from '~/components/Dialog/DialogProvider';
+import { useResourceSelectContext } from '~/components/ImageGeneration/GenerationForm/ResourceSelectProvider';
+import { ecosystemByKey, getEcosystemDefaults } from '~/shared/constants/basemodel.constants';
+import { getResourceSelectOptions } from '~/shared/form-graph/generation/defs';
+import type { GateItemState } from '~/shared/data-graph/generation/gates';
+import type { ModelType } from '~/shared/utils/prisma/enums';
+import { useCheckpointPickerStore } from './checkpoint-picker.store';
+
+/**
+ * The ecosystem control, relocated from the form header into the checkpoint
+ * picker. Selecting here is a PENDING choice: it re-aims the catalog beside it
+ * so you can see what the family actually offers, and only commits when you
+ * pick a checkpoint or press Use — which is what makes the cost of switching
+ * visible at the moment of switching rather than after it.
+ *
+ * The list itself is `BaseModelListContent` driven by `useBaseModelPickerState`,
+ * the same pair the old header pill used.
+ */
+
+export type EcosystemRailProps = {
+  value?: string;
+  onChange: (ecosystemKey: string) => void;
+  compatibleEcosystems?: string[];
+  excludeEcosystems?: string[];
+  ecosystemStates?: GateItemState[];
+  outputType?: 'image' | 'video' | 'audio' | 'model3d';
+  /** The form's current resources, to count what a switch would drop. */
+  resources?: PartialResourceValue[];
+  /** Resource types the catalog is browsing — the pending options are built for these. */
+  resourceTypes?: ModelType[];
+  /** The graph's modelLocked for the CURRENT family — see isModelLocked. */
+  currentLocked?: boolean;
+};
+
+/**
+ * Whether a family pins its checkpoint. The graph's `correct()` substitutes any
+ * version outside such a family's own list back to its default, silently — so a
+ * catalog here would hand you a model the form then throws away.
+ *
+ * The ecosystem constants are only half the answer: `checkpointDef` resolves
+ * `opts.modelLocked ?? ecosystemDefaults?.modelLocked`, and graphs set the
+ * former per-workflow (Flux locks on `txt2img:draft`). `currentLocked` carries
+ * the graph's verdict for the family the form is on; the constants are the
+ * fallback for a family being previewed, which the graph cannot be asked about
+ * without switching to it.
+ */
+function isModelLocked(
+  ecosystemKey: string | undefined,
+  { value, currentLocked }: { value?: string; currentLocked?: boolean }
+) {
+  if (!ecosystemKey) return false;
+  if (ecosystemKey === value && currentLocked !== undefined) return currentLocked;
+  const ecosystem = ecosystemByKey.get(ecosystemKey);
+  return !!(ecosystem && getEcosystemDefaults(ecosystem.id)?.modelLocked);
+}
+
+function PinnedCheckpointNotice({ ecosystemKey }: { ecosystemKey: string }) {
+  const name = ecosystemByKey.get(ecosystemKey)?.displayName ?? ecosystemKey;
+  return (
+    <div className="rounded-lg border border-gray-3 p-4 dark:border-dark-4">
+      <div className="flex items-center gap-2">
+        <IconLock size={16} className="shrink-0 text-gray-6" />
+        <Text size="sm" fw={600}>
+          {name} pins its checkpoint
+        </Text>
+      </div>
+      <Text size="xs" c="dimmed" className="mt-1 leading-snug">
+        There is no catalog to browse here — the family ships a fixed set of weights, and which one
+        you use is chosen by the version selector under the model row. Use {name} below to switch to
+        it.
+      </Text>
+    </div>
+  );
+}
+
+/**
+ * Pending and committed ecosystem, both from the store.
+ *
+ * `value` is only the OPEN-TIME family — the modal's props are captured once,
+ * so it does not follow a commit. `committed` is what the form actually has,
+ * and is what the rail highlights and the footer describes.
+ */
+function usePendingEcosystem({
+  value,
+  currentLocked,
+  resourceTypes = ['Checkpoint'] as ModelType[],
+}: {
+  value?: string;
+  currentLocked?: boolean;
+  resourceTypes?: ModelType[];
+}) {
+  const { setOptionsOverride, setCatalogNotice } = useResourceSelectContext();
+  const pending = useCheckpointPickerStore((state) => state.pendingEcosystem);
+  const committed = useCheckpointPickerStore((state) => state.committedEcosystem) ?? value;
+  const setPending = useCheckpointPickerStore((state) => state.setPendingEcosystem);
+  // The graph's lock verdict describes the family the picker opened on; once a
+  // different one is committed the constants fallback takes over.
+  const lockedForCommitted = committed === value ? currentLocked : undefined;
+
+  function aimCatalogAt(ecosystemKey: string | undefined) {
+    setCatalogNotice(
+      ecosystemKey &&
+        isModelLocked(ecosystemKey, { value: committed, currentLocked: lockedForCommitted }) ? (
+        <PinnedCheckpointNotice ecosystemKey={ecosystemKey} />
+      ) : null
+    );
+  }
+
+  function select(ecosystemKey: string) {
+    if (ecosystemKey === committed) {
+      setPending(undefined);
+      setOptionsOverride(null);
+      aimCatalogAt(committed);
+      return;
+    }
+    setPending(ecosystemKey);
+    setOptionsOverride({
+      canGenerate: true,
+      resources: getResourceSelectOptions(ecosystemKey, resourceTypes).map((r) => ({
+        ...r,
+        partialSupport: [],
+      })),
+    });
+    aimCatalogAt(ecosystemKey);
+  }
+
+  return { pending, committed, select, aimCatalogAt };
+}
+
+export function EcosystemRail({
+  value,
+  compatibleEcosystems,
+  excludeEcosystems,
+  ecosystemStates,
+  outputType,
+  resourceTypes,
+  currentLocked,
+}: EcosystemRailProps) {
+  const [searchValue, setSearchValue] = useState('');
+  const { pending, committed, select, aimCatalogAt } = usePendingEcosystem({
+    value,
+    resourceTypes,
+    currentLocked,
+  });
+
+  // Re-runs on a commit too, so a family that pins its checkpoint shows the
+  // notice the moment it becomes the committed one — not only on open.
+  useEffect(() => {
+    aimCatalogAt(committed);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [committed]);
+
+  const picker = useBaseModelPickerState({
+    value: pending ?? committed,
+    onChange: select,
+    compatibleEcosystems,
+    excludeEcosystems,
+    ecosystemStates,
+    outputType,
+    onSelected: () => setSearchValue(''),
+  });
+
+  return (
+    <div className="flex min-h-0 w-full flex-col gap-2 overflow-y-auto p-2">
+      <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+        Ecosystem
+      </Text>
+      <BaseModelListContent
+        value={pending ?? committed}
+        recentItems={picker.recentItems}
+        groupedByFamily={picker.groupedByFamily}
+        allGroupedByFamily={picker.allGroupedByFamily}
+        onSelect={picker.handleSelect}
+        disabledStateMap={picker.disabledStateMap}
+        hasIncompatibleItems={picker.hasIncompatibleItems}
+        activeTab={picker.activeTab}
+        onTabChange={picker.handleTabChange}
+        showRecentTab={picker.showRecentTab}
+        searchValue={searchValue}
+        onSearchChange={setSearchValue}
+      />
+    </div>
+  );
+}
+
+/**
+ * The consequence footer: what switching family costs, counted against the
+ * resources actually in the form, while the choice is still cancellable.
+ */
+export function EcosystemConsequenceFooter({
+  value,
+  onChange,
+  resources = [],
+}: Pick<EcosystemRailProps, 'value' | 'onChange' | 'resources'>) {
+  // The footer only reads the keys; the catalog aiming that `resourceTypes`
+  // drives is the rail's job.
+  const { pending, committed } = usePendingEcosystem({ value });
+  const dialog = useDialogContext();
+
+  const currentName = committed
+    ? ecosystemByKey.get(committed)?.displayName ?? committed
+    : undefined;
+  const switching = !!pending && pending !== committed;
+  const pendingName = pending ? ecosystemByKey.get(pending)?.displayName ?? pending : undefined;
+
+  // Counted one resource at a time against the pending family, not guessed from
+  // the family name — a generic "some resources may be removed" is what this
+  // footer exists to replace.
+  const dropped = switching
+    ? (() => {
+        const pendingOptions = {
+          resources: getResourceSelectOptions(pending, ['LORA', 'VAE'] as ModelType[]),
+        };
+        return resources.filter((resource) => {
+          const baseModel = (resource as { baseModel?: string }).baseModel;
+          const type = (resource as { model?: { type?: string } }).model?.type;
+          if (!baseModel || !type) return false;
+          return getResourceCompatibility(baseModel, type, pendingOptions) === null;
+        }).length;
+      })()
+    : 0;
+
+  return (
+    <div className="flex items-center gap-3 p-3">
+      <div className="flex min-w-0 flex-1 items-start gap-2">
+        {!switching ? (
+          <>
+            <IconInfoCircle size={16} className="mt-0.5 shrink-0 text-gray-6" />
+            <Text size="sm" c="dimmed">
+              {currentName ? (
+                <>
+                  Currently browsing <b>{currentName}</b> — your resources and tuning carry over
+                  unchanged.
+                </>
+              ) : (
+                'Pick a checkpoint to continue.'
+              )}
+            </Text>
+          </>
+        ) : (
+          <>
+            <IconAlertTriangle size={16} className="mt-0.5 shrink-0 text-yellow-6" />
+            <Text size="sm">
+              Switching {currentName} → <b>{pendingName}</b>
+              {/* Say nothing about resources when the form holds none — a form
+                  with no resource field would otherwise read "keeps your 0
+                  resources", which is the reassuring branch stating a fact it
+                  never checked. */}
+              {resources.length > 0 &&
+                (dropped > 0 ? (
+                  <>
+                    {' '}
+                    drops <b>{dropped}</b> of your {resources.length}{' '}
+                    {resources.length === 1 ? 'resource' : 'resources'}, and
+                  </>
+                ) : (
+                  <>
+                    {' '}
+                    keeps your {resources.length}{' '}
+                    {resources.length === 1 ? 'resource' : 'resources'}, and
+                  </>
+                ))}{' '}
+              resets tuning to {pendingName} defaults.
+            </Text>
+          </>
+        )}
+      </div>
+      <Button variant="default" onClick={dialog.onClose} className="shrink-0">
+        Cancel
+      </Button>
+      {switching && (
+        <Button onClick={() => onChange(pending)} className="shrink-0">
+          Use {pendingName}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/form-graph/generation/inputs/WorkflowPicker.browser.test.tsx
+++ b/src/components/form-graph/generation/inputs/WorkflowPicker.browser.test.tsx
@@ -1,0 +1,179 @@
+import type { ReactNode } from 'react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderWithProviders } from '../../../../../test/component-setup';
+
+// =============================================================================
+// WorkflowPicker — the form-graph lane's chip + one-list workflow modal
+// =============================================================================
+//
+// The teeth are the two claims Phase 01 rests on:
+//   1. the input axis is an ATTRIBUTE and a FILTER, not a second control — so
+//      filtering to "From image" must hide `txt2img` (Create Image) and keep
+//      `img2img` (Image Variations), the two ends of the old mode strip;
+//   2. selecting a row emits the workflow GRAPH KEY the strip also set.
+//
+// A revert to the four-segment picker fails (1) on a missing filter button and
+// (2) on the emitted key, both as assertion failures rather than as a timeout.
+//
+// The mock set is inherited from `generation_v2/inputs/WorkflowInput.browser.
+// test.tsx` — see its header for why each is required (the feature-flag and
+// generation-config hooks throw outside their providers; RequireMembership and
+// SupportButton sever a static import chain into `@prisma/client` that Vite's
+// pre-scan would otherwise bundle). The addition here is DialogProvider: the
+// modal is rendered directly rather than through the dialog stack, so
+// `useDialogContext` is stubbed.
+//
+// No `~/utils/trpc` mock: nothing this component reaches imports it once
+// `generation.utils` is stubbed, and a wholesale factory for it is what
+// `no-wholesale-module-mock` forbids.
+
+vi.mock('~/components/Dialog/dialogStore', () => ({
+  dialogStore: { trigger: vi.fn(), closeById: vi.fn() },
+  useDialogStore: vi.fn(() => []),
+  useIsLevelFocused: vi.fn(() => true),
+}));
+
+const onCloseMock = vi.fn();
+vi.mock('~/components/Dialog/DialogProvider', () => ({
+  useDialogContext: vi.fn(() => ({ opened: true, onClose: onCloseMock, zIndex: 300 })),
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: vi.fn(() => ({})),
+}));
+
+vi.mock('~/components/ImageGeneration/GenerationForm/generation.utils', () => ({
+  useGenerationConfig: vi.fn(() => ({ gateRules: [] })),
+}));
+
+vi.mock('~/components/RequireMembership/RequireMembership', () => ({
+  RequireMembership: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('~/components/SupportButton/SupportButton', () => ({
+  SupportButtonPolymorphic: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { WorkflowPicker, WorkflowPickerModal } from './WorkflowPicker';
+import { dialogStore } from '~/components/Dialog/dialogStore';
+
+const triggerMock = vi.mocked(dialogStore.trigger);
+
+describe('WorkflowPicker chip', () => {
+  beforeEach(() => {
+    triggerMock.mockReset();
+    onCloseMock.mockReset();
+  });
+
+  test('shows the selected workflow label and its input type', async () => {
+    renderWithProviders(<WorkflowPicker value="txt2img" onChange={vi.fn()} />);
+
+    const chip = page.getByRole('button', { name: /Create Image/i });
+    await expect.element(chip).toBeInTheDocument();
+    expect(chip.element().textContent).toContain('From text');
+  });
+
+  test('an image-input workflow reports "From image", not "From text"', async () => {
+    renderWithProviders(<WorkflowPicker value="img2img" onChange={vi.fn()} />);
+
+    const chip = page.getByRole('button', { name: /Image Variations/i });
+    await expect.element(chip).toBeInTheDocument();
+    expect(chip.element().textContent).toContain('From image');
+    expect(chip.element().textContent).not.toContain('From text');
+  });
+
+  test('clicking the chip opens the picker through dialogStore', async () => {
+    renderWithProviders(<WorkflowPicker value="txt2img" ecosystemId={1} onChange={vi.fn()} />);
+
+    const chip = page.getByRole('button', { name: /Create Image/i });
+    await expect.element(chip).toBeInTheDocument();
+    await chip.click();
+
+    expect(triggerMock).toHaveBeenCalledTimes(1);
+    const call = triggerMock.mock.calls[0][0] as {
+      id: string;
+      component: unknown;
+      props: { value?: string; ecosystemId?: number };
+    };
+    expect(call.id).toBe('workflow-picker');
+    // Pin the component too — the id alone passes if the chip opens v2's modal.
+    expect(call.component).toBe(WorkflowPickerModal);
+    expect(call.props.value).toBe('txt2img');
+    expect(call.props.ecosystemId).toBe(1);
+  });
+
+  test('no back arrow without onBack', async () => {
+    renderWithProviders(<WorkflowPicker value="img2img:upscale" onChange={vi.fn()} />);
+
+    await expect.element(page.getByRole('button', { name: /Upscale/i })).toBeInTheDocument();
+    expect(page.getByRole('button', { name: 'Back to previous workflow' }).elements()).toHaveLength(
+      0
+    );
+  });
+
+  test('the back arrow calls onBack when given', async () => {
+    const onBack = vi.fn();
+    renderWithProviders(
+      <WorkflowPicker value="img2img:upscale" onChange={vi.fn()} onBack={onBack} />
+    );
+
+    const back = page.getByRole('button', { name: 'Back to previous workflow' });
+    await expect.element(back).toBeInTheDocument();
+    await back.click();
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('WorkflowPickerModal', () => {
+  beforeEach(() => {
+    triggerMock.mockReset();
+    onCloseMock.mockReset();
+  });
+
+  test('lists both halves of a mode-strip pair as rows in one list', async () => {
+    renderWithProviders(
+      <WorkflowPickerModal value="txt2img" isMember={false} onChange={vi.fn()} />
+    );
+
+    await expect.element(page.getByText('Create Image', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText('Image Variations', { exact: true })).toBeInTheDocument();
+  });
+
+  test('the input filter hides text-input workflows and keeps image-input ones', async () => {
+    renderWithProviders(
+      <WorkflowPickerModal value="txt2img" isMember={false} onChange={vi.fn()} />
+    );
+
+    // `exact: true` is load-bearing: locators default to a case-insensitive
+    // SUBSTRING match on the accessible name, and every img2* row button also
+    // contains "From image" — without it this resolves to 11 elements and the
+    // strict-mode violation retries until the 15s budget expires.
+    const fromImage = page.getByRole('button', { name: 'From image', exact: true });
+    await expect.element(fromImage).toBeInTheDocument();
+    await fromImage.click();
+
+    // "Image Variations" survives the filter; "Create Image" — the current
+    // selection, and a text-input workflow — does not.
+    await expect.element(page.getByText('Image Variations', { exact: true })).toBeInTheDocument();
+    expect(page.getByText('Create Image', { exact: true }).elements()).toHaveLength(0);
+  });
+
+  test('selecting a row emits that workflow graph key and closes', async () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <WorkflowPickerModal value="txt2img" isMember={false} onChange={onChange} />
+    );
+
+    const row = page.getByText('Image Variations', { exact: true });
+    await expect.element(row).toBeInTheDocument();
+    await row.click();
+
+    // The whole tuple, not just the key: `graphKey` and `id` are identical for
+    // every workflow in the live config (no aliases exist today), so asserting
+    // the first argument alone cannot tell them apart. Pinning arity and order
+    // is the most this can honestly claim until an alias exists.
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('img2img', expect.any(Array), 'img2img');
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/form-graph/generation/inputs/WorkflowPicker.tsx
+++ b/src/components/form-graph/generation/inputs/WorkflowPicker.tsx
@@ -1,0 +1,424 @@
+import { Badge, Modal, Text, Tooltip, UnstyledButton } from '@mantine/core';
+import {
+  IconAlignLeft,
+  IconArrowLeft,
+  IconChevronDown,
+  IconCube,
+  IconDiamond,
+  IconLayoutGrid,
+  IconMusic,
+  IconPhoto,
+  IconVideo,
+} from '@tabler/icons-react';
+import clsx from 'clsx';
+import { useMemo, useState } from 'react';
+
+import { useDialogContext } from '~/components/Dialog/DialogProvider';
+import { dialogStore } from '~/components/Dialog/dialogStore';
+import { ExperimentalFlask } from '~/components/generation_v2/Experimental';
+import {
+  useAvailableWorkflowGroups,
+  useWorkflowGateStates,
+} from '~/components/generation_v2/inputs/workflow-visibility';
+import { RequireMembership } from '~/components/RequireMembership/RequireMembership';
+import { SupportButtonPolymorphic } from '~/components/SupportButton/SupportButton';
+import {
+  getWorkflowLabelForEcosystem,
+  workflowConfigByKey,
+  type WorkflowOption,
+} from '~/shared/data-graph/generation/config/workflows';
+import type { WorkflowCategory } from '~/shared/data-graph/generation/config/types';
+import type { GateItemState } from '~/shared/data-graph/generation/gates';
+
+/**
+ * The form-graph lane's workflow control: one chip, one modal, every workflow
+ * listed once with its input type as an attribute.
+ *
+ * Replaces generation_v2's four-segment `WorkflowInput` (one popover per output
+ * category) and the `getWorkflowModes` button strip beneath it. The strip set
+ * the same workflow key this picker sets, differing only on the input axis —
+ * which is the filter across the top here.
+ */
+
+const INPUT_TYPES = [
+  { id: 'text', label: 'From text', Icon: IconAlignLeft },
+  { id: 'image', label: 'From image', Icon: IconPhoto },
+  { id: 'video', label: 'From video', Icon: IconVideo },
+] as const;
+
+type InputTypeId = (typeof INPUT_TYPES)[number]['id'];
+type FilterId = InputTypeId | 'all';
+
+const inputTypeById = new Map<string, (typeof INPUT_TYPES)[number]>(
+  INPUT_TYPES.map((i) => [i.id, i])
+);
+
+const CATEGORY_ICONS: Record<WorkflowCategory, typeof IconPhoto> = {
+  image: IconPhoto,
+  video: IconVideo,
+  audio: IconMusic,
+  model3d: IconCube,
+};
+
+type WorkflowEntry = { option: WorkflowOption; gate?: GateItemState };
+type WorkflowGroupEntry = { category: WorkflowCategory; label: string; workflows: WorkflowEntry[] };
+
+/**
+ * Visible workflows, grouped by output category. Applies the same three filters
+ * the v2 picker did — ecosystems hidden by a gate rule, feature flags, then
+ * workflow-level gate rules — so a key hidden for this user never renders.
+ */
+function useWorkflowGroups(): WorkflowGroupEntry[] {
+  const grouped = useAvailableWorkflowGroups();
+  const { hiddenSet, stateMap } = useWorkflowGateStates();
+
+  return useMemo(
+    () =>
+      grouped.map((group) => ({
+        category: group.category,
+        label: group.label,
+        workflows: group.workflows
+          .filter((option) => !hiddenSet.has(option.graphKey))
+          .map((option) => ({ option, gate: stateMap.get(option.graphKey) })),
+      })),
+    [grouped, hiddenSet, stateMap]
+  );
+}
+
+/**
+ * The option to highlight. An alias shares its parent's graphKey, so prefer an
+ * exact id match, then the alias carrying the current ecosystem, then any match.
+ */
+function findSelected(groups: WorkflowGroupEntry[], value?: string, ecosystemId?: number) {
+  if (!value) return undefined;
+  const graphKey = workflowConfigByKey.get(value)?.variantOf ?? value;
+  let fallback: WorkflowEntry | undefined;
+
+  for (const group of groups) {
+    for (const entry of group.workflows) {
+      if (entry.option.id === value) return entry;
+      if (entry.option.graphKey !== graphKey) continue;
+      if (ecosystemId !== undefined && entry.option.ecosystemIds.includes(ecosystemId))
+        return entry;
+      fallback ??= entry;
+    }
+  }
+  return fallback;
+}
+
+/** A workflow whose ecosystems exclude the current one will move the form off it. */
+function switchesEcosystem(option: WorkflowOption, ecosystemId?: number) {
+  if (option.ecosystemIds.length === 0 || ecosystemId === undefined) return false;
+  return !option.ecosystemIds.includes(ecosystemId);
+}
+
+// =============================================================================
+// Row
+// =============================================================================
+
+function WorkflowRow({
+  entry,
+  isSelected,
+  ecosystemId,
+  isMember,
+  onSelect,
+}: {
+  entry: WorkflowEntry;
+  isSelected: boolean;
+  ecosystemId?: number;
+  isMember: boolean;
+  onSelect: () => void;
+}) {
+  const { option, gate } = entry;
+  const input = inputTypeById.get(option.inputType);
+  const InputIcon = input?.Icon ?? IconAlignLeft;
+
+  const body = (
+    <div className="min-w-0 flex-1">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <Text size="sm" fw={600} className="leading-tight">
+          {option.label}
+        </Text>
+        <ExperimentalFlask target={{ kind: 'workflow', key: option.graphKey }} size={16} />
+        {option.isNew && (
+          <Badge size="xs" color="green" variant="filled" radius="sm">
+            New
+          </Badge>
+        )}
+        {switchesEcosystem(option, ecosystemId) && (
+          <Badge size="xs" color="orange" variant="light" radius="sm">
+            Switches model
+          </Badge>
+        )}
+      </div>
+      {option.description && (
+        <Text size="xs" c="dimmed" className="mt-0.5 leading-snug">
+          {option.description}
+        </Text>
+      )}
+      <div className="mt-1.5 flex items-center gap-1 text-xs text-gray-6 dark:text-dark-2">
+        <InputIcon size={12} />
+        {input?.label}
+      </div>
+    </div>
+  );
+
+  if (gate?.state === 'disabled') {
+    return (
+      <Tooltip
+        label={gate.message ?? 'This workflow is currently unavailable'}
+        position="top"
+        withArrow
+        openDelay={300}
+      >
+        <div className="flex w-full cursor-not-allowed gap-3 rounded-lg border border-gray-2 p-3 opacity-50 dark:border-dark-4">
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-gray-2 dark:bg-dark-5">
+            <InputIcon size={15} />
+          </div>
+          {body}
+          <Badge size="xs" color="gray" variant="light">
+            Disabled
+          </Badge>
+        </div>
+      </Tooltip>
+    );
+  }
+
+  if (gate?.state === 'memberOnly' || (option.memberOnly && !isMember)) {
+    return (
+      <RequireMembership>
+        <SupportButtonPolymorphic className="!h-auto w-full !p-3 text-left">
+          <div className="flex w-full gap-3">
+            <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-gray-2 dark:bg-dark-5">
+              <IconDiamond size={15} />
+            </div>
+            {body}
+          </div>
+        </SupportButtonPolymorphic>
+      </RequireMembership>
+    );
+  }
+
+  return (
+    <UnstyledButton
+      onClick={onSelect}
+      aria-pressed={isSelected}
+      className={clsx(
+        'flex w-full gap-3 rounded-lg border p-3 text-left transition-colors',
+        isSelected
+          ? 'border-blue-5 bg-blue-0 dark:border-blue-8 dark:bg-blue-9/20'
+          : 'border-gray-2 hover:border-gray-4 dark:border-dark-4 dark:hover:border-dark-3'
+      )}
+    >
+      <div
+        className={clsx(
+          'flex size-8 shrink-0 items-center justify-center rounded-md',
+          isSelected ? 'bg-blue-6 text-white' : 'bg-gray-2 dark:bg-dark-5'
+        )}
+      >
+        <InputIcon size={15} />
+      </div>
+      {body}
+    </UnstyledButton>
+  );
+}
+
+// =============================================================================
+// Modal
+// =============================================================================
+
+type WorkflowPickerModalProps = {
+  value?: string;
+  ecosystemId?: number;
+  isMember: boolean;
+  onChange: (graphKey: string, ecosystemIds: number[], optionId: string) => void;
+};
+
+export function WorkflowPickerModal({
+  value,
+  ecosystemId,
+  isMember,
+  onChange,
+}: WorkflowPickerModalProps) {
+  const dialog = useDialogContext();
+  const groups = useWorkflowGroups();
+  const [filter, setFilter] = useState<FilterId>('all');
+  const selected = findSelected(groups, value, ecosystemId);
+
+  const counts = useMemo(() => {
+    const byInput = new Map<InputTypeId, number>();
+    let all = 0;
+    for (const group of groups)
+      for (const { option } of group.workflows) {
+        all++;
+        const key = option.inputType;
+        byInput.set(key, (byInput.get(key) ?? 0) + 1);
+      }
+    return { all, byInput };
+  }, [groups]);
+
+  const filters: { id: FilterId; label: string; Icon: typeof IconPhoto; count: number }[] = [
+    { id: 'all', label: 'All', Icon: IconLayoutGrid, count: counts.all },
+    ...INPUT_TYPES.map((i) => ({
+      id: i.id as FilterId,
+      label: i.label,
+      Icon: i.Icon,
+      count: counts.byInput.get(i.id) ?? 0,
+    })),
+  ];
+
+  function handleSelect(option: WorkflowOption) {
+    onChange(option.graphKey, option.ecosystemIds, option.id);
+    dialog.onClose();
+  }
+
+  return (
+    <Modal
+      {...dialog}
+      title={
+        <div>
+          <Text fw={600}>What are you making?</Text>
+          <Text size="xs" c="dimmed">
+            Operation and input, in one list
+          </Text>
+        </div>
+      }
+      size="lg"
+    >
+      <div
+        className="mb-3 flex flex-wrap gap-1.5"
+        role="group"
+        aria-label="Filter workflows by input"
+      >
+        {filters.map(({ id, label, Icon, count }) =>
+          count === 0 ? null : (
+            <UnstyledButton
+              key={id}
+              onClick={() => setFilter(id)}
+              aria-pressed={filter === id}
+              aria-label={label}
+              className={clsx(
+                'flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold',
+                filter === id
+                  ? 'border-gray-5 bg-gray-1 dark:border-dark-3 dark:bg-dark-5'
+                  : 'border-gray-2 text-gray-6 hover:border-gray-4 dark:border-dark-4 dark:text-dark-2'
+              )}
+            >
+              <Icon size={13} />
+              {label}
+              <span className="opacity-60">{count}</span>
+            </UnstyledButton>
+          )
+        )}
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {groups.map((group) => {
+          const workflows = group.workflows.filter(
+            ({ option }) => filter === 'all' || option.inputType === filter
+          );
+          if (!workflows.length) return null;
+          const CategoryIcon = CATEGORY_ICONS[group.category];
+
+          return (
+            <div key={group.category}>
+              <div className="mb-2 flex items-center gap-1.5 text-xs uppercase tracking-wide text-gray-6 dark:text-dark-2">
+                <CategoryIcon size={12} />
+                {group.label}
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {workflows.map((entry) => (
+                  <WorkflowRow
+                    key={entry.option.id}
+                    entry={entry}
+                    isSelected={entry.option.id === selected?.option.id}
+                    ecosystemId={ecosystemId}
+                    isMember={isMember}
+                    onSelect={() => handleSelect(entry.option)}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Modal>
+  );
+}
+
+// =============================================================================
+// Chip
+// =============================================================================
+
+export type WorkflowPickerProps = {
+  value?: string;
+  ecosystemId?: number;
+  onChange?: (graphKey: string, ecosystemIds: number[], optionId: string) => void;
+  isMember?: boolean;
+  disabled?: boolean;
+  className?: string;
+  /** Renders a back arrow beside the chip, for enhancement workflows. */
+  onBack?: () => void;
+};
+
+export function WorkflowPicker({
+  value,
+  ecosystemId,
+  onChange,
+  isMember = false,
+  disabled,
+  className,
+  onBack,
+}: WorkflowPickerProps) {
+  const groups = useWorkflowGroups();
+  const selected = findSelected(groups, value, ecosystemId);
+  const option = selected?.option;
+  const input = option ? inputTypeById.get(option.inputType) : undefined;
+  const CategoryIcon = option ? CATEGORY_ICONS[option.category] : IconLayoutGrid;
+  const label = option
+    ? getWorkflowLabelForEcosystem(option.graphKey, ecosystemId)
+    : 'Select a workflow';
+
+  function open() {
+    if (disabled) return;
+    dialogStore.trigger({
+      id: 'workflow-picker',
+      component: WorkflowPickerModal,
+      props: {
+        value,
+        ecosystemId,
+        isMember,
+        onChange: (graphKey: string, ecosystemIds: number[], optionId: string) =>
+          onChange?.(graphKey, ecosystemIds, optionId),
+      },
+    });
+  }
+
+  return (
+    <div className={clsx('flex min-w-0 items-center gap-1', className)}>
+      {onBack && (
+        <UnstyledButton
+          onClick={onBack}
+          aria-label="Back to previous workflow"
+          className="flex shrink-0 items-center rounded p-1 text-gray-6 hover:text-gray-9 dark:text-dark-2 dark:hover:text-dark-0"
+        >
+          <IconArrowLeft size={18} />
+        </UnstyledButton>
+      )}
+      <UnstyledButton
+        onClick={open}
+        disabled={disabled}
+        className={clsx(
+          'flex min-w-0 items-center gap-1.5 rounded-full border border-blue-5 bg-blue-0 px-3 py-1.5',
+          'text-sm font-semibold text-blue-7 dark:border-blue-8 dark:bg-blue-9/20 dark:text-blue-4',
+          disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-blue-1 dark:hover:bg-blue-9/30'
+        )}
+      >
+        <CategoryIcon size={14} className="shrink-0" />
+        <span className="truncate">{label}</span>
+        {input && <span className="shrink-0 font-normal opacity-70">· {input.label}</span>}
+        <IconChevronDown size={12} className="shrink-0" />
+      </UnstyledButton>
+    </div>
+  );
+}

--- a/src/components/form-graph/generation/inputs/checkpoint-picker.store.ts
+++ b/src/components/form-graph/generation/inputs/checkpoint-picker.store.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+
+/**
+ * The checkpoint picker's own ecosystem state, for the lifetime of one open.
+ *
+ * A store rather than component state because the rail and the consequence
+ * footer render into two different slots of the shared resource modal — they
+ * are siblings with no common ancestor to hold it.
+ *
+ * `committedEcosystem` lives here for a second reason: `dialogStore` captures a
+ * modal's props once, so the ecosystem the picker opened on goes stale as soon
+ * as the footer commits a different one. Tracking it in a closure variable does
+ * not help — mutating one re-renders nothing. Both slots subscribe here, so a
+ * commit updates the rail's highlight and the footer's copy together.
+ */
+type CheckpointPickerState = {
+  pendingEcosystem?: string;
+  committedEcosystem?: string;
+  setPendingEcosystem: (ecosystemKey?: string) => void;
+  setCommittedEcosystem: (ecosystemKey?: string) => void;
+};
+
+export const useCheckpointPickerStore = create<CheckpointPickerState>((set) => ({
+  pendingEcosystem: undefined,
+  committedEcosystem: undefined,
+  setPendingEcosystem: (ecosystemKey) => set({ pendingEcosystem: ecosystemKey }),
+  setCommittedEcosystem: (ecosystemKey) => set({ committedEcosystem: ecosystemKey }),
+}));
+
+/** Called on every open: no pending choice, committed to whatever the form has. */
+export const resetCheckpointPicker = (ecosystemKey?: string) =>
+  useCheckpointPickerStore.setState({
+    pendingEcosystem: undefined,
+    committedEcosystem: ecosystemKey,
+  });

--- a/src/components/form-graph/generation/inputs/openCheckpointPicker.tsx
+++ b/src/components/form-graph/generation/inputs/openCheckpointPicker.tsx
@@ -1,0 +1,112 @@
+import type { PartialResourceValue } from '~/components/generation_v2/inputs/resource-select.utils';
+import { openResourceSelectModal } from '~/components/Dialog/triggers/resource-select';
+import type { ResourceSelectOptions } from '~/components/ImageGeneration/GenerationForm/resource-select.types';
+import type { GenerationResource } from '~/shared/types/generation.types';
+import type { GateItemState } from '~/shared/data-graph/generation/gates';
+import type { ModelType } from '~/shared/utils/prisma/enums';
+
+import { EcosystemRail, EcosystemConsequenceFooter } from './EcosystemRail';
+import { resetCheckpointPicker, useCheckpointPickerStore } from './checkpoint-picker.store';
+
+/**
+ * The form's current additional resources, read from the store at click time.
+ * Subscribing to the field instead would re-render the checkpoint row on every
+ * strength change, and the footer is the only thing that wants this.
+ */
+export function readResources(store: {
+  getSnapshot: () => { state: unknown };
+}): PartialResourceValue[] {
+  const state = store.getSnapshot().state as { resources?: PartialResourceValue[] };
+  return state.resources ?? [];
+}
+
+/**
+ * Opens the resource picker as the CHECKPOINT picker: catalog in the middle,
+ * ecosystem rail down the left, consequence footer along the bottom.
+ *
+ * This is where the header's five controls end up. The rail is the old
+ * `BaseModelInput` pill and the footer is `ResourceAlerts`' information moved
+ * ahead of the commit; the modal itself only knows it was handed two slots.
+ */
+export function openCheckpointPicker({
+  title,
+  options,
+  ecosystem,
+  onSelect,
+  onEcosystemChange,
+  resources,
+  resourceTypes,
+}: {
+  title?: React.ReactNode;
+  options?: ResourceSelectOptions;
+  ecosystem: {
+    value?: string;
+    compatibleEcosystems?: string[];
+    excludeEcosystems?: string[];
+    ecosystemStates?: GateItemState[];
+    outputType?: 'image' | 'video' | 'audio' | 'model3d';
+    /**
+     * The graph's own answer for the CURRENT family, from the checkpoint field's
+     * meta. It resolves `opts.modelLocked ?? ecosystemDefaults.modelLocked`, so
+     * it catches graph-level locks (Flux on the draft workflow) that reading the
+     * ecosystem constants alone cannot see.
+     */
+    modelLocked?: boolean;
+  };
+  onSelect: (resource: GenerationResource) => void;
+  onEcosystemChange: (ecosystemKey: string) => void;
+  /** The form's current additional resources, for the footer's drop count. */
+  resources?: PartialResourceValue[];
+  resourceTypes?: ModelType[];
+}) {
+  resetCheckpointPicker(ecosystem.value);
+
+  const commitEcosystem = (ecosystemKey: string) => {
+    // Through the store, not a closure variable: both slots subscribe to it, so
+    // this is what moves the rail's highlight and the footer's copy onto the
+    // family that was just committed.
+    resetCheckpointPicker(ecosystemKey);
+    onEcosystemChange(ecosystemKey);
+  };
+
+  /**
+   * Picking a checkpoint from a pending family commits the family too, first —
+   * otherwise the form keeps the old ecosystem while holding a model that
+   * belongs to a different one. Ecosystem before model so the model write is
+   * the one that survives the graph's reconciliation.
+   */
+  const commitSelection = (resource: Parameters<typeof onSelect>[0]) => {
+    const { pendingEcosystem, committedEcosystem } = useCheckpointPickerStore.getState();
+    if (pendingEcosystem && pendingEcosystem !== committedEcosystem)
+      onEcosystemChange(pendingEcosystem);
+    resetCheckpointPicker(pendingEcosystem ?? committedEcosystem);
+    onSelect(resource);
+  };
+
+  openResourceSelectModal({
+    title,
+    options,
+    role: 'checkpoint',
+    onSelect: commitSelection,
+    onClose: () => resetCheckpointPicker(undefined),
+    rail: () => (
+      <EcosystemRail
+        value={ecosystem.value}
+        onChange={commitEcosystem}
+        compatibleEcosystems={ecosystem.compatibleEcosystems}
+        excludeEcosystems={ecosystem.excludeEcosystems}
+        ecosystemStates={ecosystem.ecosystemStates}
+        outputType={ecosystem.outputType}
+        resourceTypes={resourceTypes}
+        currentLocked={ecosystem.modelLocked}
+      />
+    ),
+    footer: () => (
+      <EcosystemConsequenceFooter
+        value={ecosystem.value}
+        onChange={commitEcosystem}
+        resources={resources}
+      />
+    ),
+  });
+}

--- a/src/components/generation_v2/inputs/BaseModelInput.tsx
+++ b/src/components/generation_v2/inputs/BaseModelInput.tsx
@@ -140,7 +140,7 @@ TriggerButton.displayName = 'TriggerButton';
 // List Content (shared between Popover and Modal)
 // =============================================================================
 
-interface BaseModelListContentProps {
+export interface BaseModelListContentProps {
   value?: string;
   recentItems: EcosystemDisplayItem[];
   groupedByFamily: FamilyGroup[];
@@ -166,7 +166,7 @@ interface BaseModelListContentProps {
   onSearchChange?: (value: string) => void;
 }
 
-function BaseModelListContent({
+export function BaseModelListContent({
   value,
   recentItems,
   groupedByFamily,
@@ -596,17 +596,27 @@ function groupItemsByFamily(items: EcosystemDisplayItem[]): FamilyGroup[] {
 // Component
 // =============================================================================
 
-export function BaseModelInput({
+/**
+ * Everything `BaseModelListContent` needs to render: the display items, their
+ * family grouping, recents, tab state and the group→ecosystem resolution that
+ * happens on select.
+ *
+ * Extracted so the form-graph checkpoint picker's ecosystem rail renders the
+ * same list from the same source rather than a second copy of it.
+ */
+export function useBaseModelPickerState({
   value,
   onChange,
   compatibleEcosystems,
   excludeEcosystems,
   ecosystemStates,
-  disabled,
   isCompatible,
-  getTargetWorkflow,
   outputType,
-}: BaseModelInputProps) {
+  onSelected,
+}: Omit<BaseModelInputProps, 'disabled' | 'label' | 'getTargetWorkflow'> & {
+  /** Fired after a selection commits — the trigger uses it to close and reset. */
+  onSelected?: () => void;
+}) {
   const excludeSet = useMemo(
     () => (excludeEcosystems?.length ? new Set(excludeEcosystems) : null),
     [excludeEcosystems]
@@ -615,9 +625,6 @@ export function BaseModelInput({
     () => (ecosystemStates?.length ? new Map(ecosystemStates.map((e) => [e.key, e])) : undefined),
     [ecosystemStates]
   );
-  const isMobile = useMediaQuery('(max-width: 768px)');
-  const [popoverOpened, { close: closePopover, open: openPopover }] = useDisclosure(false);
-  const [searchValue, setSearchValue] = useState('');
   const [recentEcosystems, setRecentEcosystems] = useLocalStorage<string[]>({
     key: RECENT_ECOSYSTEMS_KEY,
     defaultValue: [],
@@ -755,8 +762,7 @@ export function BaseModelInput({
         ) {
           onChange?.(lastUsed);
           trackRecentSelection(key);
-          closePopover();
-          setSearchValue('');
+          onSelected?.();
           return;
         }
       }
@@ -777,8 +783,7 @@ export function BaseModelInput({
     }
 
     trackRecentSelection(key);
-    closePopover();
-    setSearchValue('');
+    onSelected?.();
   };
 
   // Get recent items - resolve recent keys to current display items
@@ -806,6 +811,60 @@ export function BaseModelInput({
     },
     [setStoredTab]
   );
+
+  return {
+    readableName,
+    recentItems,
+    groupedByFamily,
+    allGroupedByFamily,
+    disabledStateMap,
+    hasIncompatibleItems,
+    activeTab,
+    handleTabChange,
+    handleSelect,
+    showRecentTab,
+  };
+}
+
+export function BaseModelInput({
+  value,
+  onChange,
+  compatibleEcosystems,
+  excludeEcosystems,
+  ecosystemStates,
+  disabled,
+  isCompatible,
+  getTargetWorkflow,
+  outputType,
+}: BaseModelInputProps) {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  const [popoverOpened, { close: closePopover, open: openPopover }] = useDisclosure(false);
+  const [searchValue, setSearchValue] = useState('');
+
+  const {
+    readableName,
+    recentItems,
+    groupedByFamily,
+    allGroupedByFamily,
+    disabledStateMap,
+    hasIncompatibleItems,
+    activeTab,
+    handleTabChange,
+    handleSelect,
+    showRecentTab,
+  } = useBaseModelPickerState({
+    value,
+    onChange,
+    compatibleEcosystems,
+    excludeEcosystems,
+    ecosystemStates,
+    isCompatible,
+    outputType,
+    onSelected: () => {
+      closePopover();
+      setSearchValue('');
+    },
+  });
 
   const openMobileModal = () => {
     dialogStore.trigger({

--- a/src/components/generation_v2/inputs/ResourceSelectMultipleInput.tsx
+++ b/src/components/generation_v2/inputs/ResourceSelectMultipleInput.tsx
@@ -31,6 +31,7 @@ import type {
   ResourceSelectOptions,
   ResourceSelectSource,
 } from '~/components/ImageGeneration/GenerationForm/resource-select.types';
+import type { ResourceSelectRole } from '~/components/ImageGeneration/GenerationForm/ResourceSelectProvider';
 import { useResourceDataContext } from './ResourceDataProvider';
 import {
   ResourceItemContent,
@@ -71,6 +72,12 @@ export interface ResourceSelectMultipleInputProps
   options?: ResourceSelectOptions;
   /** Source context for resource selection */
   selectSource?: ResourceSelectSource;
+  /**
+   * Which job the picker is doing. `resource` turns the modal multi-select and
+   * badges each card for compatibility. Omit for the historical one-at-a-time
+   * behaviour.
+   */
+  role?: ResourceSelectRole;
   /** Whether the input is disabled */
   disabled?: boolean;
   /** Resource type to filter by */
@@ -170,6 +177,7 @@ export function ResourceSelectMultipleInput({
   modalTitle,
   options = {},
   selectSource = 'generation',
+  role,
   disabled,
   resourceType,
   hideButton = false,
@@ -299,11 +307,17 @@ export function ResourceSelectMultipleInput({
         // Cast existing values since they should be hydrated by now
         onChange?.([...(value as ResourceSelectValue[]), resource]);
       },
+      onSelectMultiple:
+        role === 'resource'
+          ? (resources) => onChange?.([...(value as ResourceSelectValue[]), ...resources])
+          : undefined,
+      limit: limit !== undefined ? Math.max(limit - value.length, 0) : undefined,
       options: {
         ...resolvedOptions,
         excludeIds: [...(resolvedOptions.excludeIds ?? []), ...resourceIds],
       },
       selectSource,
+      role,
     });
   };
 

--- a/src/components/generation_v2/inputs/WorkflowInput.tsx
+++ b/src/components/generation_v2/inputs/WorkflowInput.tsx
@@ -24,22 +24,17 @@ import { dialogStore } from '~/components/Dialog/dialogStore';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { RequireMembership } from '~/components/RequireMembership/RequireMembership';
 import { SupportButtonPolymorphic } from '~/components/SupportButton/SupportButton';
-import { useGenerationConfig } from '~/components/ImageGeneration/GenerationForm/generation.utils';
 import {
-  filterWorkflowsByFeatureFlags,
-  filterWorkflowsByGatedEcosystems,
-  getAllWorkflowsGrouped,
   workflowOptionById,
   workflowConfigByKey,
   getWorkflowLabelForEcosystem,
 } from '~/shared/data-graph/generation/config/workflows';
-import {
-  mergeGateStates,
-  rulesToStates,
-  type GateItemState,
-} from '~/shared/data-graph/generation/gates';
-import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import type { GateItemState } from '~/shared/data-graph/generation/gates';
 import { ExperimentalFlask } from '~/components/generation_v2/Experimental';
+import {
+  useAvailableWorkflowGroups,
+  useWorkflowGateStates,
+} from '~/components/generation_v2/inputs/workflow-visibility';
 
 // =============================================================================
 // Types
@@ -316,14 +311,7 @@ function WorkflowListContent({
   // popover and the dialogStore modal that share this renderer get them. Mirrors
   // the workflow node's resolver so client + server agree: hidden keys drop out
   // of the list, the rest carry a per-state badge.
-  const { gateRules } = useGenerationConfig();
-  const { hiddenSet, stateMap } = useMemo(() => {
-    const { hidden, states } = mergeGateStates(undefined, rulesToStates(gateRules).workflows);
-    return {
-      hiddenSet: new Set(hidden),
-      stateMap: new Map(states.map((s) => [s.key, s])),
-    };
-  }, [gateRules]);
+  const { hiddenSet, stateMap } = useWorkflowGateStates();
 
   // Flatten all workflows with compatibility + gate info, dropping hidden keys.
   const allWorkflows = useMemo(() => {
@@ -506,22 +494,7 @@ export function WorkflowInput({
   const [audioOpened, { close: closeAudio, open: openAudio }] = useDisclosure(false);
   const [model3dOpened, { close: closeModel3d, open: openModel3d }] = useDisclosure(false);
 
-  // Get all workflows grouped by category, then drop any whose backing ecosystems
-  // are all HIDDEN by a gate rule for this user (so e.g. the Audio segment
-  // disappears when the only audio ecosystem is hidden and the user is gated).
-  const { gateRules } = useGenerationConfig();
-  const features = useFeatureFlags();
-  const options = useMemo(() => {
-    const hiddenEcosystems = new Set<string>();
-    for (const [key, r] of rulesToStates(gateRules).ecosystems)
-      if (r.state === 'hidden') hiddenEcosystems.add(key);
-    const all = getAllWorkflowsGrouped();
-    const ecoFiltered = filterWorkflowsByGatedEcosystems(all, hiddenEcosystems);
-    return filterWorkflowsByFeatureFlags(
-      ecoFiltered,
-      features as unknown as Record<string, boolean | undefined>
-    );
-  }, [gateRules, features]);
+  const options = useAvailableWorkflowGroups();
   const selected = getSelectedWorkflow(options, value, ecosystemId);
 
   // Separate image, video, audio, and 3D model categories

--- a/src/components/generation_v2/inputs/workflow-visibility.ts
+++ b/src/components/generation_v2/inputs/workflow-visibility.ts
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+
+import { useGenerationConfig } from '~/components/ImageGeneration/GenerationForm/generation.utils';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import {
+  filterWorkflowsByFeatureFlags,
+  filterWorkflowsByGatedEcosystems,
+  getAllWorkflowsGrouped,
+} from '~/shared/data-graph/generation/config/workflows';
+import {
+  mergeGateStates,
+  rulesToStates,
+  type GateItemState,
+} from '~/shared/data-graph/generation/gates';
+
+/**
+ * Who may see which workflow — the single answer for both pickers.
+ *
+ * `WorkflowInput` (data-graph lane) and `WorkflowPicker` (form-graph lane) are
+ * live at the same time and both have to decide this. Keeping a copy each meant
+ * a gate rule or a feature flag could be honoured in one lane and ignored in
+ * the other, which is exactly what the server-side resolver exists to prevent.
+ */
+
+/**
+ * Workflows grouped by output category, with the two list-level filters
+ * applied: options whose backing ecosystems are ALL hidden by a gate rule, and
+ * options behind a feature flag this user does not have.
+ */
+export function useAvailableWorkflowGroups() {
+  const { gateRules } = useGenerationConfig();
+  const features = useFeatureFlags();
+
+  return useMemo(() => {
+    const hiddenEcosystems = new Set<string>();
+    for (const [key, rule] of rulesToStates(gateRules).ecosystems)
+      if (rule.state === 'hidden') hiddenEcosystems.add(key);
+
+    return filterWorkflowsByFeatureFlags(
+      filterWorkflowsByGatedEcosystems(getAllWorkflowsGrouped(), hiddenEcosystems),
+      features as unknown as Record<string, boolean | undefined>
+    );
+  }, [gateRules, features]);
+}
+
+/**
+ * Per-workflow gate state, keyed by graphKey. Mirrors the workflow node's
+ * resolver so client and server agree: `hidden` keys drop out of the list
+ * entirely, the rest carry a state a row renders as a badge or an upsell.
+ */
+export function useWorkflowGateStates() {
+  const { gateRules } = useGenerationConfig();
+
+  return useMemo(() => {
+    const { hidden, states } = mergeGateStates(undefined, rulesToStates(gateRules).workflows);
+    return {
+      hiddenSet: new Set(hidden),
+      stateMap: new Map<string, GateItemState>(states.map((s) => [s.key, s])),
+    };
+  }, [gateRules]);
+}

--- a/src/shared/form-graph/generation/__tests__/flux-draft-coupling.test.ts
+++ b/src/shared/form-graph/generation/__tests__/flux-draft-coupling.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { generationHub } from '../hub.graph';
+import type { GenerationCtx } from '~/shared/data-graph/generation/context';
+
+const EXT: GenerationCtx = {
+  limits: { maxQuantity: 8, maxResources: 9, vidQuantity: 4 },
+  user: { isMember: true, tier: 'gold' },
+  flags: {},
+  gateRules: [],
+};
+
+const DRAFT = 699279;
+const STANDARD = 691639;
+
+describe('flux draft coupling, interactive lane', () => {
+  it('picking Draft from standard drags the workflow to txt2img:draft', () => {
+    const store = generationHub.createStore({ ext: EXT });
+    store.set({ workflow: 'txt2img', ecosystem: 'Flux1', prompt: 'x' });
+    store.set({ model: { id: STANDARD, model: { type: 'Checkpoint' } } });
+    expect((store.getField('model')?.value as { id: number }).id).toBe(STANDARD);
+
+    store.set({ model: { id: DRAFT, model: { type: 'Checkpoint' } } });
+    const s = store.getSnapshot().state as {
+      workflow: string;
+      model: { id: number };
+      fluxMode: string;
+    };
+    console.log('after draft pick:', s.workflow, s.model?.id, s.fluxMode);
+    expect(s.workflow).toBe('txt2img:draft');
+    expect(s.model.id).toBe(DRAFT);
+    expect(store.validate().success).toBe(true);
+  });
+
+  it('picking Standard while in draft drags the workflow back', () => {
+    const store = generationHub.createStore({ ext: EXT });
+    store.set({ workflow: 'txt2img:draft', ecosystem: 'Flux1', prompt: 'x' });
+    expect((store.getField('model')?.value as { id: number }).id).toBe(DRAFT);
+
+    store.set({ model: { id: STANDARD, model: { type: 'Checkpoint' } } });
+    const s = store.getSnapshot().state as { workflow: string; model: { id: number } };
+    console.log('after standard pick:', s.workflow, s.model?.id);
+    expect(s.workflow).toBe('txt2img');
+    expect(s.model.id).toBe(STANDARD);
+    expect(store.validate().success).toBe(true);
+  });
+
+  it('the parse boundary still lets the workflow win (oracle parity)', () => {
+    const result = generationHub.parse(
+      { workflow: 'txt2img', ecosystem: 'Flux1', prompt: 'x', model: DRAFT },
+      EXT
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { workflow: string; model: { id: number } };
+      expect(data.workflow).toBe('txt2img');
+      expect(data.model.id).toBe(STANDARD);
+    }
+  });
+});

--- a/src/shared/form-graph/generation/reconcile.ts
+++ b/src/shared/form-graph/generation/reconcile.ts
@@ -160,12 +160,43 @@ export const modelSelectorRules = {
   model: (
     value: unknown,
     { next }: { next: { ecosystem?: string; workflow?: string } }
-  ): SelectorCorrection | undefined =>
-    deriveCorrectionsFromModel(looseModel(value), {
-      ecosystem: next.ecosystem,
-      workflow: next.workflow,
-    }),
+  ): SelectorCorrection | undefined => {
+    const model = looseModel(value);
+    const current = { ecosystem: next.ecosystem, workflow: next.workflow };
+    const base = deriveCorrectionsFromModel(model, current);
+    const flux = fluxDraftWorkflowFor(model, {
+      ecosystem: base?.ecosystem ?? current.ecosystem,
+      workflow: base?.workflow ?? current.workflow,
+    });
+    if (!base && !flux) return undefined;
+    return { ...base, ...flux };
+  },
 };
+
+// flux.graph.ts's fluxVersionIds — inlined; importing the graph here would cycle
+const FLUX_DRAFT_ID = 699279;
+const FLUX_MODE_IDS = new Set([699279, 691639, 922358, 2068000, 1088507]);
+
+/**
+ * v1's INTERACTIVE flux draft coupling: picking the Draft build drags the
+ * workflow to txt2img:draft, and picking any other flux build while in draft
+ * drags it back. STORE LANE ONLY — at the parse boundary the workflow wins
+ * (probed 2026-09-01) and the model correct in flux.graph.ts enforces that,
+ * so this must never run in reconcileSelectors. Without it the correct
+ * reverts an interactive Draft pick before the user ever sees it.
+ */
+function fluxDraftWorkflowFor(
+  model: { id?: number } | undefined,
+  current: { ecosystem: string | undefined; workflow: string | undefined }
+): SelectorCorrection | undefined {
+  if (current.ecosystem !== 'Flux1' && current.ecosystem !== 'FluxKrea') return undefined;
+  const id = model?.id;
+  if (id == null || !FLUX_MODE_IDS.has(id)) return undefined;
+  if (id === FLUX_DRAFT_ID && current.workflow !== 'txt2img:draft')
+    return { workflow: 'txt2img:draft' };
+  if (id !== FLUX_DRAFT_ID && current.workflow === 'txt2img:draft') return { workflow: 'txt2img' };
+  return undefined;
+}
 
 export interface ReconcileResult {
   raw: Record<string, unknown>;


### PR DESCRIPTION
Implements the "Above the Prompt" proposal for the form-graph generation lane (flag `formGraphGenerator`, mod-only). The header's five controls become two: a workflow chip and a checkpoint row.

- WorkflowPicker: every workflow listed once with its input type as an attribute and a filter across the top, replacing the four-segment picker and the getWorkflowModes strip that set the same key.
- CheckpointRow: the checkpoint as one row (name, version, ecosystem) instead of a 52px card. Version stays a field beneath it.
- EcosystemRail: the ecosystem control moves out of the header and into the checkpoint picker, with a consequence footer that counts the resources a switch would actually drop, before the commit.
- ResourceSelectProvider gains opt-in `role`, `onSelectMultiple`, `limit`, `rail` and `footer`. Consumers that pass none behave as before; only the form-graph lane opts in.
- Resource picking gains batching: the card's primary click still adds one and closes, a separate control stages into a tray.

The picker's chrome changes for every consumer, not only the roled ones: wider modal, three-band layout, compact catalog tabs, a grid that fills its pane, and an always-reserved scrollbar gutter so a result set at the overflow threshold stops re-flowing.

Shared with the data-graph lane rather than forked: `useBaseModelPickerState` extracted from BaseModelInput so the rail renders the same ecosystem list, and workflow-visibility.ts so both pickers resolve gates and feature flags through one implementation.

Also includes the ModelVersionUpsertForm submit extraction and the form-graph reconcile changes authored alongside this work.