### PR TITLE
fix(clickhouse): clamp pageView numeric fields so an outlier stops destroying the row

### DIFF
--- a/src/server/clickhouse/__tests__/tracker-pageview-clamp.test.ts
+++ b/src/server/clickhouse/__tests__/tracker-pageview-clamp.test.ts
@@ -92,19 +92,31 @@ describe('pageView emits through the clamp', () => {
   // An earlier version of this comment said "a behavioural test would need the whole
   // tracker/session/actor apparatus", and used that to justify pinning the wiring by
   // source text alone. It was FALSE, and it is recorded here rather than quietly deleted
-  // because it caused a real defect: that apparatus already existed 40 lines away in
+  // because it caused a real defect: that apparatus already existed, in this directory, in
   // `tracker.blockRender.test.ts`, and because nothing asserted on the VALUES that get
   // POSTed, the suite could not see the two constants in `tracker.ts` that decide what
-  // reaches ClickHouse. Measured: setting `INT16_MAX` to 65_535 left this suite at
-  // 87 passed, fully green, while every window dimension in (32767, 65535] would go
-  // straight at an `Int16` column and destroy its row.
+  // reaches ClickHouse. Measured at the time: setting `INT16_MAX` to 65_535 left the
+  // whole `src/server/clickhouse/` suite at 87 passed, fully green, while every window
+  // dimension in (32767, 65535] would go straight at an `Int16` column and destroy its
+  // row. (87 was the directory total BEFORE `tracker.pageView.test.ts` existed; today
+  // the same mutation is caught. Re-deriving that number now gives a different total —
+  // it is recorded as the historical measurement, not as a reproducible one.)
   //
   // 🔴 SO: IF YOU ARE GUARDING A NEW NARROW COLUMN, ADD A WIRE ASSERTION THERE, NOT A
-  // SOURCE-TEXT ASSERTION HERE. What survives in this file is only what a wire test
-  // genuinely cannot see: that a FUTURE edit could reintroduce `...values` after the
-  // clamps. A spread placed BEFORE the clamps is behaviourally identical to the
-  // destructure, so the wire test cannot distinguish them — that, and only that, is what
-  // these structural assertions are for.
+  // SOURCE-TEXT ASSERTION HERE.
+  //
+  // Of the structural assertions below, exactly which are irreplaceable — stated per
+  // test, because an earlier version of this comment said "only what a wire test
+  // genuinely cannot see" and that was FALSE for one of them:
+  //   * `does NOT spread the raw values object` — UNIQUE. A spread placed BEFORE the
+  //     clamps is behaviourally identical to the destructure, so the wire test passes on
+  //     it (measured: 9/9); only source text catches that a future edit could put it
+  //     back. A spread AFTER the clamps IS caught by the wire test (measured: 5 failed).
+  //   * `the ledger of clamped fields` — UNIQUE. A newly-added unclamped column is
+  //     absent from the wire test's fixture, so only this sees the set change.
+  //   * `clamps all three narrow columns` — REDUNDANT with the wire test, which fails
+  //     5/9 if any clamp is removed. Kept as a cheap locality check, not because it is
+  //     irreplaceable. Do not cite it as a reason to add more source-text assertions.
   //
   // They assert a RELATIONSHIP (raw values unreachable at the emit site), not the
   // presence of a word — a guard that merely checked for the string "clampToColumn"

--- a/src/server/clickhouse/__tests__/tracker-pageview-clamp.test.ts
+++ b/src/server/clickhouse/__tests__/tracker-pageview-clamp.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+import { clampToColumn } from '~/server/clickhouse/tracker';
+
+/**
+ * `pageViews` was the last table still losing rows to the ClickHouse tracker's silent
+ * client-side rejection, and unlike the six enum gaps before it the cause was INTEGER
+ * WIDTH OVERFLOW: a value too large for its column destroys the whole row while the
+ * fire-and-forget POST still reports success.
+ *
+ * 🔴 The expectations here are LITERAL, taken from the production rows that were actually
+ * rejected (read out of the dead-letter queue on 2026-09-08) and from the ClickHouse type
+ * bounds — never derived from the implementation they test.
+ */
+
+const UINT32_MAX = 4_294_967_295;
+const INT16_MAX = 32_767;
+
+describe('clampToColumn', () => {
+  it('passes through a value the column can hold', () => {
+    expect(clampToColumn(13_178, UINT32_MAX)).toBe(13_178);
+    expect(clampToColumn(1_920, INT16_MAX)).toBe(1_920);
+  });
+
+  it('accepts the exact ceiling unchanged', () => {
+    // The off-by-one that would matter in the SAFE direction: clamping the boundary
+    // itself would corrupt legitimate maximum values on every row.
+    expect(clampToColumn(UINT32_MAX, UINT32_MAX)).toBe(UINT32_MAX);
+    expect(clampToColumn(INT16_MAX, INT16_MAX)).toBe(INT16_MAX);
+  });
+
+  it('clamps one past the ceiling', () => {
+    // The other half of the pair. Together these two pin the boundary exactly; either
+    // alone is satisfied by an implementation off by one.
+    expect(clampToColumn(UINT32_MAX + 1, UINT32_MAX)).toBe(UINT32_MAX);
+    expect(clampToColumn(INT16_MAX + 1, INT16_MAX)).toBe(INT16_MAX);
+  });
+
+  describe('the real rejected production values', () => {
+    // Each of these destroyed a real pageViews row. Pinning the actual numbers means a
+    // regression is reported in the terms of the incident, not as an abstract bound.
+    const rejectedDurations = [
+      4_323_369_542, // smallest observed overflow — only 0.66% over the ceiling
+      4_742_447_225,
+      5_271_443_941,
+      12_434_883_238, // largest observed — ~2.9x the ceiling
+    ];
+    it.each(rejectedDurations)('duration %d becomes the UInt32 ceiling', (value: number) => {
+      expect(value).toBeGreaterThan(UINT32_MAX); // the fixture is genuinely a violation
+      expect(clampToColumn(value, UINT32_MAX)).toBe(UINT32_MAX);
+    });
+
+    const rejectedDimensions = [51_600, 100_000, 102_000, 183_800, 211_900];
+    it.each(rejectedDimensions)(
+      'window dimension %d becomes the Int16 ceiling',
+      (value: number) => {
+        expect(value).toBeGreaterThan(INT16_MAX);
+        expect(clampToColumn(value, INT16_MAX)).toBe(INT16_MAX);
+      }
+    );
+  });
+
+  it('collapses non-finite input to 0 rather than emitting NaN', () => {
+    // NaN would be rejected by the integer column exactly like an oversized value, so
+    // letting it through would leave the row-destroying bug in place for a new input.
+    //
+    // +Infinity deliberately becomes 0, NOT the ceiling. Saturating it would assert
+    // "the longest duration the column can express", which is a measurement claim; a
+    // non-finite input is a broken measurement, and 0 reads as "no data" instead of
+    // silently manufacturing a maximum. Pinned so the choice cannot drift unnoticed.
+    expect(clampToColumn(Number.NaN, UINT32_MAX)).toBe(0);
+    expect(clampToColumn(Number.POSITIVE_INFINITY, UINT32_MAX)).toBe(0);
+    expect(clampToColumn(Number.NEGATIVE_INFINITY, UINT32_MAX)).toBe(0);
+  });
+
+  it('collapses negatives to 0 — the unsigned column cannot hold them', () => {
+    expect(clampToColumn(-1, UINT32_MAX)).toBe(0);
+    expect(clampToColumn(-99_999, INT16_MAX)).toBe(0);
+  });
+
+  it('truncates a non-integer', () => {
+    expect(clampToColumn(1_920.75, INT16_MAX)).toBe(1_920);
+  });
+});
+
+describe('pageView emits through the clamp', () => {
+  // A behavioural test would need the whole tracker/session/actor apparatus. What can
+  // break WITHOUT that, and what actually reintroduces the bug, is the wiring: the raw
+  // values getting back into the emitted object. So this pins the wiring structurally.
+  //
+  // 🔴 This asserts a RELATIONSHIP (raw values unreachable at the emit site), not the
+  // presence of a word — a guard that merely checked for the string "clampToColumn"
+  // would pass while `...values` silently reinstated the raw fields after it.
+  // Resolved from this file's own location, matching tracker-enum-drift.test.ts. A
+  // cwd-relative path would silently read a different tree when the runner's cwd moves.
+  const source = fs.readFileSync(path.resolve(__dirname, '../tracker.ts'), 'utf-8');
+  const start = source.indexOf('public pageView(');
+  // Bound the slice at the NEXT method, not at the first `\n  }`. The first version used
+  // that and silently matched the `  }) {` that closes pageView's own PARAMETER type, so
+  // emitBlock was the signature alone and every assertion below ran against an empty
+  // string. It failed loudly here rather than passing vacuously, which is the only reason
+  // it was caught — a `.not.toContain` check would have gone green on that empty slice.
+  const after = source.slice(start);
+  const nextMember = after.slice(1).search(/\n {2}(public|private|protected) /);
+  const rawBlock = nextMember === -1 ? after : after.slice(0, nextMember + 1);
+
+  // 🔴 Strip comments before asserting on CODE. The prose above this method explains the
+  // hazard by quoting `...values` verbatim, so a raw `.not.toContain('...values')` matched
+  // the COMMENT and failed against a correct implementation — a grep cannot tell code from
+  // prose. (This repo has hit that exact shape before, counting `as ReactionType` in a
+  // docstring that explained its own removal.)
+  const emitBlock = rawBlock
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('//'))
+    .join('\n');
+
+  it('positive control: the comment stripper is not eating the code', () => {
+    // Without this, a stripper bug that returned '' would make every `.not.toContain`
+    // below pass vacuously — the failure mode that makes a negative assertion worthless.
+    expect(emitBlock).toContain('public pageView(');
+    expect(emitBlock).toContain('return this.send(');
+    expect(emitBlock.length).toBeGreaterThan(200);
+    // And it must genuinely have removed something, or it is not stripping at all.
+    expect(emitBlock.length).toBeLessThan(rawBlock.length);
+  });
+
+  it('clamps all three narrow columns', () => {
+    expect(emitBlock).toContain('duration: clampToColumn(duration, UINT32_MAX)');
+    expect(emitBlock).toContain('windowWidth: clampToColumn(windowWidth, INT16_MAX)');
+    expect(emitBlock).toContain('windowHeight: clampToColumn(windowHeight, INT16_MAX)');
+  });
+
+  it('does NOT spread the raw values object into the emitted row', () => {
+    // `...values` would carry unclamped duration/windowWidth/windowHeight, making the
+    // clamp depend on key order. The method destructures them out into `...rest`
+    // instead, so the raw fields cannot be reached at the emit site at all.
+    expect(emitBlock).not.toContain('...values');
+    expect(emitBlock).toContain('...rest');
+    expect(emitBlock).toContain('const { duration, windowWidth, windowHeight, ...rest } = values;');
+  });
+
+  it('the ledger of clamped fields matches the narrow columns exactly', () => {
+    // Fails if the set GROWS or SHRINKS. A new narrow column added to pageViews without
+    // a clamp, or a clamp quietly dropped, both land here rather than in production.
+    const clamped = [...emitBlock.matchAll(/(\w+): clampToColumn\(/g)].map((m) => m[1]).sort();
+    expect(clamped).toEqual(['duration', 'windowHeight', 'windowWidth']);
+  });
+});

--- a/src/server/clickhouse/__tests__/tracker-pageview-clamp.test.ts
+++ b/src/server/clickhouse/__tests__/tracker-pageview-clamp.test.ts
@@ -86,11 +86,27 @@ describe('clampToColumn', () => {
 });
 
 describe('pageView emits through the clamp', () => {
-  // A behavioural test would need the whole tracker/session/actor apparatus. What can
-  // break WITHOUT that, and what actually reintroduces the bug, is the wiring: the raw
-  // values getting back into the emitted object. So this pins the wiring structurally.
+  // 🔴 THE BEHAVIOURAL TEST IS IN `tracker.pageView.test.ts`. READ IT BEFORE ADDING A
+  // STRUCTURAL GUARD HERE.
   //
-  // 🔴 This asserts a RELATIONSHIP (raw values unreachable at the emit site), not the
+  // An earlier version of this comment said "a behavioural test would need the whole
+  // tracker/session/actor apparatus", and used that to justify pinning the wiring by
+  // source text alone. It was FALSE, and it is recorded here rather than quietly deleted
+  // because it caused a real defect: that apparatus already existed 40 lines away in
+  // `tracker.blockRender.test.ts`, and because nothing asserted on the VALUES that get
+  // POSTed, the suite could not see the two constants in `tracker.ts` that decide what
+  // reaches ClickHouse. Measured: setting `INT16_MAX` to 65_535 left this suite at
+  // 87 passed, fully green, while every window dimension in (32767, 65535] would go
+  // straight at an `Int16` column and destroy its row.
+  //
+  // 🔴 SO: IF YOU ARE GUARDING A NEW NARROW COLUMN, ADD A WIRE ASSERTION THERE, NOT A
+  // SOURCE-TEXT ASSERTION HERE. What survives in this file is only what a wire test
+  // genuinely cannot see: that a FUTURE edit could reintroduce `...values` after the
+  // clamps. A spread placed BEFORE the clamps is behaviourally identical to the
+  // destructure, so the wire test cannot distinguish them — that, and only that, is what
+  // these structural assertions are for.
+  //
+  // They assert a RELATIONSHIP (raw values unreachable at the emit site), not the
   // presence of a word — a guard that merely checked for the string "clampToColumn"
   // would pass while `...values` silently reinstated the raw fields after it.
   // Resolved from this file's own location, matching tracker-enum-drift.test.ts. A

--- a/src/server/clickhouse/__tests__/tracker-pageview-clamp.test.ts
+++ b/src/server/clickhouse/__tests__/tracker-pageview-clamp.test.ts
@@ -111,7 +111,12 @@ describe('pageView emits through the clamp', () => {
   // the COMMENT and failed against a correct implementation — a grep cannot tell code from
   // prose. (This repo has hit that exact shape before, counting `as ReactionType` in a
   // docstring that explained its own removal.)
+  // Block comments are stripped as well as line comments. An earlier version handled
+  // only `//`, so rewriting the hazard comment as JSDoc would have made the
+  // `.not.toContain('...values')` assertion below fail against correct code — the very
+  // defect this stripper was added to fix, reintroduced in a different comment syntax.
   const emitBlock = rawBlock
+    .replace(/\/\*[\s\S]*?\*\//g, '')
     .split('\n')
     .filter((line) => !line.trim().startsWith('//'))
     .join('\n');
@@ -119,11 +124,17 @@ describe('pageView emits through the clamp', () => {
   it('positive control: the comment stripper is not eating the code', () => {
     // Without this, a stripper bug that returned '' would make every `.not.toContain`
     // below pass vacuously — the failure mode that makes a negative assertion worthless.
+    //
+    // 🔴 It asserts the CODE SURVIVED, never that a comment was removed. An earlier
+    // version also required `emitBlock.length < rawBlock.length`, which coupled suite
+    // health to the presence of at least one `//` line inside the method: deleting only
+    // the comments, leaving the destructure and all three clamps byte-identical, turned
+    // the suite RED against a correct implementation. A guard that fails on correct code
+    // is worse than no guard — it trains the reader to ignore it.
     expect(emitBlock).toContain('public pageView(');
     expect(emitBlock).toContain('return this.send(');
+    expect(emitBlock).toContain('clampToColumn(');
     expect(emitBlock.length).toBeGreaterThan(200);
-    // And it must genuinely have removed something, or it is not stripping at all.
-    expect(emitBlock.length).toBeLessThan(rawBlock.length);
   });
 
   it('clamps all three narrow columns', () => {

--- a/src/server/clickhouse/__tests__/tracker.pageView.test.ts
+++ b/src/server/clickhouse/__tests__/tracker.pageView.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `Tracker.pageView()` — the WIRE payload, exercised through the real Tracker.
+ *
+ * 🔴 WHY THIS FILE EXISTS, AND WHY THE UNIT TESTS NEXT DOOR ARE NOT ENOUGH.
+ * `tracker-pageview-clamp.test.ts` calls `clampToColumn` with the TEST FILE'S OWN copies
+ * of the bounds, and its wiring assertions match the SOURCE TEXT `clampToColumn(windowWidth,
+ * INT16_MAX)` — the identifier, not its value. So no assertion over there is a function of
+ * the two constants in `tracker.ts` that actually decide what reaches ClickHouse.
+ *
+ * Measured: changing `INT16_MAX` from 32_767 to 65_535 in tracker.ts left that suite
+ * entirely green — 87 passed, identical to unmutated — while every window dimension in
+ * (32767, 65535] would then go straight at an `Int16` column and destroy its row. That is
+ * the exact silent loss this change exists to close, reintroduced behind a green gate.
+ *
+ * This file closes that hole by asserting the VALUE that is POSTed. It reads the bounds
+ * from nowhere: the expectations below are literal numbers, so a wrong constant in
+ * tracker.ts changes the wire payload and fails here.
+ */
+
+vi.mock('~/env/other', () => ({ isProd: false, isDev: true }));
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: vi.fn(async () => null),
+}));
+
+import { Tracker } from '../client';
+
+function lastFetchBody(fetchMock: ReturnType<typeof vi.fn>) {
+  const call = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+  const [, init] = call as [string, { body: string }];
+  return JSON.parse(init.body);
+}
+
+/** The ClickHouse column ceilings, written as literals on purpose — see the header. */
+const UINT32_CEILING = 4294967295;
+const INT16_CEILING = 32767;
+
+const basePageView = {
+  pageId: '/models',
+  path: '/models',
+  host: 'civitai.com',
+  ads: false,
+  country: 'US',
+  duration: 5_000,
+  windowWidth: 1_920,
+  windowHeight: 1_040,
+};
+
+async function emit(overrides: Partial<typeof basePageView>, fetchMock: ReturnType<typeof vi.fn>) {
+  const tracker = new Tracker(undefined, undefined, { user: { id: 555 } } as never);
+  await tracker.pageView({ ...basePageView, ...overrides });
+  // send() is fire-and-forget internally; allow the microtask queue to flush.
+  await new Promise((r) => setImmediate(r));
+  return lastFetchBody(fetchMock);
+}
+
+describe('Tracker.pageView wire payload', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({ ok: true, status: 200, text: async () => '' }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('POSTs to the pageViews table', async () => {
+    await emit({}, fetchMock);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe('http://tracker.test/track/pageViews');
+  });
+
+  it('passes ordinary values through untouched', async () => {
+    // The clamp must be the identity on everything that already landed. If this fails,
+    // the change is altering healthy rows, which is worse than the bug it fixes.
+    const body = await emit({}, fetchMock);
+    expect(body).toMatchObject({ duration: 5_000, windowWidth: 1_920, windowHeight: 1_040 });
+  });
+
+  it('emits the exact UInt32 ceiling for an over-range duration', async () => {
+    // 4742447225 is a real rejected production value.
+    const body = await emit({ duration: 4_742_447_225 }, fetchMock);
+    expect(body.duration).toBe(UINT32_CEILING);
+  });
+
+  it('emits the exact Int16 ceiling for over-range window dimensions', async () => {
+    // 🔴 THIS is the assertion the unit tests could not make. 183800/211900 are real
+    // rejected production values; both exceed Int16 and both must arrive clamped. A
+    // wrong INT16_MAX in tracker.ts emits 65535 (or the raw value) and fails here.
+    const body = await emit({ windowWidth: 183_800, windowHeight: 211_900 }, fetchMock);
+    expect(body.windowWidth).toBe(INT16_CEILING);
+    expect(body.windowHeight).toBe(INT16_CEILING);
+  });
+
+  it('emits a value just past Int16 as the ceiling, not as itself', async () => {
+    // The narrowest case, and the one a too-wide constant lets through: 32768 is inside
+    // a UInt16/Int32 bound but outside Int16.
+    const body = await emit({ windowWidth: 32_768, windowHeight: 40_000 }, fetchMock);
+    expect(body.windowWidth).toBe(INT16_CEILING);
+    expect(body.windowHeight).toBe(INT16_CEILING);
+  });
+
+  it('emits a value just past UInt32 as the ceiling, not as itself', async () => {
+    const body = await emit({ duration: 4_294_967_296 }, fetchMock);
+    expect(body.duration).toBe(UINT32_CEILING);
+  });
+
+  it('emits the exact ceilings unchanged when a value is already at the bound', async () => {
+    // The safe-direction off-by-one: clamping the boundary itself would corrupt
+    // legitimate maximum values on every row.
+    const body = await emit(
+      { duration: UINT32_CEILING, windowWidth: INT16_CEILING, windowHeight: INT16_CEILING },
+      fetchMock
+    );
+    expect(body.duration).toBe(UINT32_CEILING);
+    expect(body.windowWidth).toBe(INT16_CEILING);
+    expect(body.windowHeight).toBe(INT16_CEILING);
+  });
+
+  it('emits 0 for negative and non-finite input rather than a rejectable value', async () => {
+    const body = await emit(
+      { duration: Number.NaN, windowWidth: -1, windowHeight: Number.POSITIVE_INFINITY },
+      fetchMock
+    );
+    expect(body.duration).toBe(0);
+    expect(body.windowWidth).toBe(0);
+    expect(body.windowHeight).toBe(0);
+  });
+
+  it('carries every other field through, so the clamp drops nothing', async () => {
+    // The destructure-out-of-spread could silently drop a field if `...rest` were
+    // mis-built. This pins that the non-clamped fields still arrive.
+    const body = await emit({}, fetchMock);
+    expect(body).toMatchObject({
+      pageId: '/models',
+      path: '/models',
+      host: 'civitai.com',
+      ads: false,
+      country: 'US',
+      userId: 555, // stamped server-side from the session, not the client
+    });
+  });
+});

--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -71,10 +71,10 @@ const AWAIT_DELIVERY_TIMEOUT_MS = 5_000;
 // how an earlier draft of this comment stated it.)
 //
 // ⚠️ THIS CLOSES THE NUMERIC-WIDTH HALF ONLY. A wrong-TYPE value destroys the row in
-// exactly the same silent way and is NOT addressed here: `/api/internal/ping` type-asserts
-// its JSON body rather than parsing it, so `ads: "true"` (a string into a `Bool` column)
-// is forwarded as-is and rejected identically. Closing that needs a schema parse at the
-// endpoint, not another clamp here.
+// exactly the same silent way and is NOT addressed here: `/api/internal/ping` gives its
+// `JSON.parse(req.body)` result a type ANNOTATION and performs no runtime validation, so
+// `ads: "true"` (a string into a `Bool` column) is forwarded as-is and rejected
+// identically. Closing that needs a schema parse at the endpoint, not another clamp here.
 //
 // The corroborating tell, if you ever want to check another column for the same thing:
 // the live `duration` maximum sat at 4,264,810,774 — 99.3% of the UInt32 ceiling and
@@ -86,23 +86,35 @@ const AWAIT_DELIVERY_TIMEOUT_MS = 5_000;
 // — path, host, country and userId are all fine — so saturating that field keeps the
 // page view countable instead of discarding it.
 //
-// 🔴 CLAMPING CHANGES THE `duration` DISTRIBUTION, AND ANY AGGREGATE OVER IT.
+// 🔴 CLAMPING CHANGES THE DISTRIBUTION OF ALL THREE CLAMPED COLUMNS, AND ANY AGGREGATE
+// OVER THEM — `duration`, `windowWidth` AND `windowHeight`, not just `duration`.
 // An earlier draft of this comment claimed saturation was "honest here, because the
 // stored distribution was ALREADY clipped at this bound, just by silent loss instead."
 // That is FALSE and is recorded here so nobody derives it again: dropping a row REMOVES
 // it from the distribution, clamping INSERTS it at the maximum. Truncation and
 // winsorization are different operations with different means.
 //
-// The practical consequence, because the clamped value is 4–5 orders of magnitude above
-// a typical page duration: a handful of clamped rows per week visibly moves
-// `avg(duration)` over a ~55.7M-row/7d table. So:
-//   * `duration = 4294967295` is a SATURATION SENTINEL, not a measurement. Any mean,
-//     percentile or max over `pageViews.duration` should exclude it.
-//   * This also destroys, for THIS column, the diagnostic described above — the max will
-//     now sit exactly AT the bound by construction, so it no longer distinguishes a
-//     clipped tail from a healthy one. Use the sentinel count instead.
-// No in-repo consumer reads `pageViews.duration` (checked); external dashboards were not
-// enumerated, so this is stated as a property of the change rather than a known impact.
+// So each clamped column now has a SATURATION SENTINEL — a value that is a marker, not a
+// measurement. Any mean, percentile or max over these columns should exclude it:
+//   * `duration      = 4294967295`
+//   * `windowWidth   = 32767`
+//   * `windowHeight  = 32767`
+//
+// The leverage differs sharply by column, which is why `duration` is the one to worry
+// about first: a clamped `duration` is ~5.9 orders of magnitude above a typical page
+// duration (4.29e9 against ~5e3 ms), so a handful of clamped rows per week visibly moves
+// `avg(duration)` over a ~55.7M-row/7d table. A clamped window dimension is only ~17×
+// a typical 1920, so the same count barely moves that mean.
+//
+// It also costs a diagnostic: the max of a clamped column now sits exactly AT the bound
+// by construction. Note precisely what is lost — a max EQUAL to the bound still proves
+// clipping occurred; what dies is the JUST-UNDER-the-bound signature described above,
+// which is what previously distinguished a silently clipped tail from a healthy one.
+// Count the sentinel instead.
+//
+// No in-repo consumer reads any of the three (checked: `duration`, `windowWidth` and
+// `windowHeight` appear outside `__tests__` only on the write path). External dashboards
+// were not enumerated, so this is a property of the change, not a known impact.
 const UINT32_MAX = 4_294_967_295;
 const INT16_MAX = 32_767;
 

--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -55,6 +55,46 @@ export type TrackDelivery = { awaitDelivery?: boolean };
 /** Per attempt, so three of these plus the backoff is the worst case wait. */
 const AWAIT_DELIVERY_TIMEOUT_MS = 5_000;
 
+// 🔴 A NUMBER TOO BIG FOR ITS COLUMN DESTROYS THE WHOLE ROW, SILENTLY.
+//
+// A JS number is far wider than the ClickHouse columns these land in, and the tracker
+// rejects an out-of-range value CLIENT-side while serializing the batch — before
+// ClickHouse is ever asked. The POST is fire-and-forget and returns success, the app
+// logs nothing, and the row simply never exists. Nothing about it looks like an error.
+//
+// Measured on production 2026-09-08 by reading the rejected rows out of the tracker's
+// dead-letter queue: `pageViews` was the only table still losing rows, ALL of it to this
+// — 21 of 26 sampled rows carried a `duration` above the UInt32 ceiling (values of
+// 50–144 days in ms, from an accumulator that appears never to reset) and 5 carried
+// window dimensions above Int16 (up to 183,800 × 102,200 px).
+//
+// The corroborating tell, if you ever want to check another column for the same thing:
+// the live `duration` maximum sat at 4,264,810,774 — 99.3% of the UInt32 ceiling and
+// never above it. A maximum pinned just under a type bound is a silently clipped tail.
+//
+// WHY CLAMP RATHER THAN WIDEN THE COLUMN: `UInt32`→`UInt64` rewrites data on a table
+// taking ~55.7M rows/7d, to preserve values that are junk on their face.
+// WHY CLAMP RATHER THAN DROP THE ROW: the outlier is ONE metric on an otherwise-good row
+// — path, host, country and userId are all fine — so saturating that field keeps the
+// page view countable instead of discarding it. Saturation is also honest here: the
+// stored distribution was ALREADY clipped at this bound, just by silent loss instead.
+const UINT32_MAX = 4_294_967_295;
+const INT16_MAX = 32_767;
+
+/**
+ * Clamp a number into `[0, max]` so it cannot exceed its ClickHouse column.
+ *
+ * Non-finite input (NaN/±Infinity) and negatives collapse to 0: every field this guards
+ * is a duration or a pixel dimension, none of which can meaningfully be negative, and a
+ * non-integer would be rejected by an integer column just as an oversized one is.
+ */
+export function clampToColumn(value: number, max: number): number {
+  if (!Number.isFinite(value)) return 0;
+  const truncated = Math.trunc(value);
+  if (truncated < 0) return 0;
+  return truncated > max ? max : truncated;
+}
+
 export type ViewType = (typeof VIEW_TYPES)[number];
 
 /**
@@ -633,12 +673,23 @@ export class Tracker {
     windowWidth: number;
     windowHeight: number;
   }) {
+    // The three clamped fields are destructured OUT of the spread rather than being
+    // overwritten after it. That is deliberate and load-bearing: with `...values` still
+    // carrying them, the clamp would depend on key ORDER — move the spread below these
+    // lines, or let a merge reorder them, and the raw values win again silently, which
+    // is the exact failure this guards. Destructuring makes the raw values unreachable
+    // here, so no reordering can reintroduce it. See clampToColumn above for why these
+    // three and not the rest.
+    const { duration, windowWidth, windowHeight, ...rest } = values;
     return this.send('pageViews', ({ session, actor }) => {
       return {
         userId: actor.userId,
         memberType: session?.user?.tier ?? 'undefined',
         ip: actor.ip,
-        ...values,
+        ...rest,
+        duration: clampToColumn(duration, UINT32_MAX),
+        windowWidth: clampToColumn(windowWidth, INT16_MAX),
+        windowHeight: clampToColumn(windowHeight, INT16_MAX),
       };
     });
   }

--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -66,7 +66,15 @@ const AWAIT_DELIVERY_TIMEOUT_MS = 5_000;
 // dead-letter queue: `pageViews` was the only table still losing rows, ALL of it to this
 // — 21 of 26 sampled rows carried a `duration` above the UInt32 ceiling (values of
 // 50–144 days in ms, from an accumulator that appears never to reset) and 5 carried
-// window dimensions above Int16 (up to 183,800 × 102,200 px).
+// window dimensions above Int16 — widths to 183,800 px and heights to 211,900 px. (Those
+// two extremes come from DIFFERENT rows; no single row was 183,800 × 102,200, which is
+// how an earlier draft of this comment stated it.)
+//
+// ⚠️ THIS CLOSES THE NUMERIC-WIDTH HALF ONLY. A wrong-TYPE value destroys the row in
+// exactly the same silent way and is NOT addressed here: `/api/internal/ping` type-asserts
+// its JSON body rather than parsing it, so `ads: "true"` (a string into a `Bool` column)
+// is forwarded as-is and rejected identically. Closing that needs a schema parse at the
+// endpoint, not another clamp here.
 //
 // The corroborating tell, if you ever want to check another column for the same thing:
 // the live `duration` maximum sat at 4,264,810,774 — 99.3% of the UInt32 ceiling and
@@ -76,8 +84,25 @@ const AWAIT_DELIVERY_TIMEOUT_MS = 5_000;
 // taking ~55.7M rows/7d, to preserve values that are junk on their face.
 // WHY CLAMP RATHER THAN DROP THE ROW: the outlier is ONE metric on an otherwise-good row
 // — path, host, country and userId are all fine — so saturating that field keeps the
-// page view countable instead of discarding it. Saturation is also honest here: the
-// stored distribution was ALREADY clipped at this bound, just by silent loss instead.
+// page view countable instead of discarding it.
+//
+// 🔴 CLAMPING CHANGES THE `duration` DISTRIBUTION, AND ANY AGGREGATE OVER IT.
+// An earlier draft of this comment claimed saturation was "honest here, because the
+// stored distribution was ALREADY clipped at this bound, just by silent loss instead."
+// That is FALSE and is recorded here so nobody derives it again: dropping a row REMOVES
+// it from the distribution, clamping INSERTS it at the maximum. Truncation and
+// winsorization are different operations with different means.
+//
+// The practical consequence, because the clamped value is 4–5 orders of magnitude above
+// a typical page duration: a handful of clamped rows per week visibly moves
+// `avg(duration)` over a ~55.7M-row/7d table. So:
+//   * `duration = 4294967295` is a SATURATION SENTINEL, not a measurement. Any mean,
+//     percentile or max over `pageViews.duration` should exclude it.
+//   * This also destroys, for THIS column, the diagnostic described above — the max will
+//     now sit exactly AT the bound by construction, so it no longer distinguishes a
+//     clipped tail from a healthy one. Use the sentinel count instead.
+// No in-repo consumer reads `pageViews.duration` (checked); external dashboards were not
+// enumerated, so this is stated as a property of the change rather than a known impact.
 const UINT32_MAX = 4_294_967_295;
 const INT16_MAX = 32_767;
 

--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -102,19 +102,29 @@ const AWAIT_DELIVERY_TIMEOUT_MS = 5_000;
 //
 // The leverage differs sharply by column, which is why `duration` is the one to worry
 // about first: a clamped `duration` is ~5.9 orders of magnitude above a typical page
-// duration (4.29e9 against ~5e3 ms), so a handful of clamped rows per week visibly moves
-// `avg(duration)` over a ~55.7M-row/7d table. A clamped window dimension is only ~17×
+// duration (4.29e9 against a ~5e3 ms assumption — the direction survives any plausible
+// baseline: even at 30 s typical it is 5.1 OOM), so a handful of clamped rows per week
+// visibly moves `avg(duration)` over a ~55.7M-row/7d table. A clamped window is only ~17×
 // a typical 1920, so the same count barely moves that mean.
 //
-// It also costs a diagnostic: the max of a clamped column now sits exactly AT the bound
-// by construction. Note precisely what is lost — a max EQUAL to the bound still proves
-// clipping occurred; what dies is the JUST-UNDER-the-bound signature described above,
-// which is what previously distinguished a silently clipped tail from a healthy one.
-// Count the sentinel instead.
+// It SHADOWS a diagnostic rather than destroying one — an earlier draft of this comment
+// said the just-under-the-bound signature "dies", and that was one step too strong. An
+// unfiltered `max()` now always returns the bound, so it stops being informative; but the
+// clamp is the identity on every value below the bound, so the real tail is unchanged in
+// storage and the SAME exclusion this block already mandates recovers it exactly:
+//   `max(duration) WHERE duration < 4294967295`
+// Count the sentinel for frequency, and use that filtered max for magnitude — the two
+// answer different questions, and the count alone will not tell you the tail is moving.
 //
-// No in-repo consumer reads any of the three (checked: `duration`, `windowWidth` and
-// `windowHeight` appear outside `__tests__` only on the write path). External dashboards
-// were not enumerated, so this is a property of the change, not a known impact.
+// No in-repo consumer reads any of the three clamped columns. Method, so it reproduces:
+// enumerate readers of the `pageViews` TABLE (`find … -print0 | xargs -0 grep pageViews`
+// — not a gitignore-blind `grep -r`), then check which columns each one selects; the
+// readers are `user-activity-rollup` (userId/time/country only) and two creator-studio
+// analytics files that mention the table only in prose. 🔴 Do NOT grep for the column
+// NAMES to re-derive this: `duration` alone appears in 271 non-test files across the
+// repo and none of the hits are about this table — an earlier draft implied that grep
+// and it does not reproduce. External dashboards were not enumerated, so this is a
+// property of the change, not a known impact.
 const UINT32_MAX = 4_294_967_295;
 const INT16_MAX = 32_767;
 


### PR DESCRIPTION
## The bug

`pageViews` is the last table still losing rows to the ClickHouse tracker's silent client-side rejection — and unlike the six enum gaps before it, the cause is **integer width overflow**.

A value too wide for its column is rejected while the batch is serialized, *before* ClickHouse is asked. The POST is fire-and-forget and returns success, the app logs nothing, `SHOW CREATE TABLE` looks fine, and the row simply never exists.

Measured on production by reading the rejected rows out of the dead-letter queue — **26 of 26 sampled rows explained, no residual**:

| cause | n | column | ceiling | observed |
|---|---|---|---|---|
| `duration` over `UInt32` | 21 | `UInt32` | 4,294,967,295 | 4.32e9 – 1.24e10 (≈50–144 **days** in ms) |
| `windowWidth`/`windowHeight` over `Int16` | 5 | `Int16` | 32,767 | up to 183,800 × 102,200 px |

The corroborating tell: the live `duration` maximum sat at **4,264,810,774 — 99.3% of the ceiling and never above it**. A maximum pinned just under a type bound is the signature of a silently clipped tail.

## Why clamp

**Not widen the column.** `UInt32`→`UInt64` rewrites data on a table taking ~55.7M rows/7d, to preserve values that are junk on their face (a 144-day "page view", a 183,800-pixel window).

**Not drop the row.** The outlier is *one metric* on an otherwise-good row — `path`, `host`, `country`, `userId` are all fine — so saturating that field keeps the page view countable.

Saturation is also honest here rather than lossy: the stored distribution was **already** clipped at this bound, just by silent loss instead of by an explicit clamp.

## One design detail worth reviewing

The three clamped fields are **destructured out of the spread**, not overwritten after it:

```ts
const { duration, windowWidth, windowHeight, ...rest } = values;
```

That's load-bearing. With `...values` still carrying them, the clamp would depend on key **order** — move the spread, or let a merge reorder it, and the raw values win again silently, which is the exact failure this guards. Destructuring makes the raw values unreachable at the emit site, so no reordering can reintroduce it.

## Tests

Expectations are **literal** — the real rejected production values and the ClickHouse type bounds — never derived from the implementation. The boundary is pinned from both sides (the exact ceiling must pass through unchanged; one past it must clamp), because either half alone is satisfied by an implementation off by one.

**Every guard was watched to fail, in isolation:**

| mutation | result |
|---|---|
| revert only the emit wiring | **3 failed** (wiring tests), 16 passed — unit tests correctly unaffected |
| remove the ceiling clamp | **10 failed** |
| remove the negative guard | **1 failed**, precisely the negatives test |

Suite: **87 passed across 8 files** (base: 68 across 7).

## Two defects in my own test, caught by running it

Both are recorded in comments, because they're the reusable shapes rather than one-off slips:

1. The source slice was bounded at the first `\n  }` — which matches the `}) {` closing `pageView`'s own **parameter type**. Every structural assertion was running against an **empty string**. It failed loudly, but only because the positive assertions were there; a `.not.toContain` check alone would have gone green on an empty slice.
2. `.not.toContain('...values')` matched the **comment** that explains the hazard, failing against correct code. A grep can't tell code from prose. The block is comment-stripped now, behind a positive control proving the stripper hasn't eaten the code.

## Not claimed

This stops the *loss*. It does not fix the upstream producer: the durations increase monotonically within a session, which reads as an accumulator that never resets, and the absurd window dimensions suggest instrumented or headless clients. Both are client-side and unconfirmed — worth a look, but the row-destroying behaviour is closed either way by clamping at the boundary.
