### PR TITLE
perf(apps): cache the /apps store catalog query behind a bust tag

### DIFF
--- a/src/components/Apps/AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx
@@ -334,4 +334,45 @@ describe('🔴 a sort change re-orders the store without emptying it', () => {
     // component's OTHER options too.
     expect(typeof captured?.getNextPageParam).toBe('function');
   });
+
+  /**
+   * 🔴 THE CLIENT HALF OF THE `/apps` CACHE (#529).
+   *
+   * The server now caches this query's keyset page for 180s (`CacheTTL.sm`) behind the
+   * `app-listing:catalog` bust tag. The client half is a `staleTime`: without one,
+   * react-query's default is ZERO, so every remount and every window refocus refetches
+   * a catalog that has not moved — and `/apps` is a page viewers leave and come
+   * straight back to.
+   *
+   * Asserted HERE, through the same capture as `placeholderData` above, for the same
+   * reason: every sibling spec mocks the query with a literal-returning function, so
+   * against those this option is inert and a guard would read as coverage while
+   * providing none. This reads the object the COMPONENT passed.
+   *
+   * The bound is asserted, not just presence: the value must be a positive number and
+   * must stay STRICTLY BELOW the server's 180 000 ms TTL, so the client can never be
+   * the longer of the two staleness sources — a client window outliving the server TTL
+   * would make `bustAppListingCatalogCache()` invisible for the difference.
+   */
+  test('the component supplies a staleTime, bounded below the server TTL', async () => {
+    mocks.sort = 'top-rated';
+    mocks.pending = [];
+    mocks.lastOptions = null as Record<string, unknown> | null;
+    renderWithProviders(<AppListingsMarketplaceBody />);
+    await expect.poll(() => mocks.lastOptions !== null).toBe(true);
+    const captured: Record<string, unknown> | null = mocks.lastOptions;
+    const staleTime = captured?.staleTime;
+    expect(
+      typeof staleTime,
+      'the store query passes no `staleTime`, so react-query refetches the whole ' +
+        'catalog on every remount and every window refocus (its default is 0). See #529.'
+    ).toBe('number');
+    expect(staleTime as number).toBeGreaterThan(0);
+    expect(
+      staleTime as number,
+      'the client staleTime is >= the server-side TTL (CacheTTL.sm, 180s) on ' +
+        '`listAvailableListings`. A client window longer than the server one makes the ' +
+        'explicit catalog busts invisible for the difference.'
+    ).toBeLessThan(180 * 1000);
+  });
 });

--- a/src/components/Apps/AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx
@@ -42,6 +42,13 @@ import { describe, expect, test, vi } from 'vitest';
 import { renderWithProviders } from '../../../test/component-setup';
 import type * as TrpcMod from '~/utils/trpc';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
+// 🔴 THE REAL CONSTANT, not a literal. The bound below is a claim about the SERVER's
+// TTL on `listAvailableListings`; hardcoding `180 * 1000` means lowering that TTL
+// leaves this guard passing while the property it names (client window strictly
+// shorter than server window) is false. `CacheTTL` is a pure const object and
+// `~/server/common/constants` is already imported by components + sibling browser
+// specs, so it loads here.
+import { CacheTTL } from '~/server/common/constants';
 
 function makeCard(id: string, name: string): ListingCard {
   return {
@@ -350,9 +357,10 @@ describe('🔴 a sort change re-orders the store without emptying it', () => {
    * providing none. This reads the object the COMPONENT passed.
    *
    * The bound is asserted, not just presence: the value must be a positive number and
-   * must stay STRICTLY BELOW the server's 180 000 ms TTL, so the client can never be
-   * the longer of the two staleness sources — a client window outliving the server TTL
-   * would make `bustAppListingCatalogCache()` invisible for the difference.
+   * must stay STRICTLY BELOW the server's TTL — DERIVED from `CacheTTL.sm`, the same
+   * constant the service passes — so the client can never be the longer of the two
+   * staleness sources. A client window outliving the server TTL would make
+   * `bustAppListingCatalogCache()` invisible for the difference.
    */
   test('the component supplies a staleTime, bounded below the server TTL', async () => {
     mocks.sort = 'top-rated';
@@ -368,11 +376,17 @@ describe('🔴 a sort change re-orders the store without emptying it', () => {
         'catalog on every remount and every window refocus (its default is 0). See #529.'
     ).toBe('number');
     expect(staleTime as number).toBeGreaterThan(0);
+    // `CacheTTL` is in SECONDS; react-query's `staleTime` is in MILLISECONDS.
+    const serverTtlMs = CacheTTL.sm * 1000;
+    // Positive control on the derivation itself: a `CacheTTL` that failed to load (or an
+    // `sm` renamed away) would give `NaN`, and `toBeLessThan(NaN)` fails loudly rather
+    // than passing — but pin the unit anyway so a seconds/ms mix-up cannot pass either.
+    expect(serverTtlMs).toBeGreaterThan(1000);
     expect(
       staleTime as number,
-      'the client staleTime is >= the server-side TTL (CacheTTL.sm, 180s) on ' +
+      `the client staleTime is >= the server-side TTL (CacheTTL.sm = ${CacheTTL.sm}s) on ` +
         '`listAvailableListings`. A client window longer than the server one makes the ' +
         'explicit catalog busts invisible for the difference.'
-    ).toBeLessThan(180 * 1000);
+    ).toBeLessThan(serverTtlMs);
   });
 });

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -257,6 +257,27 @@ export function AppListingsMarketplaceBody() {
       enabled: hasAppsStoreAccess(features),
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       /**
+       * 🔴 60s. Without a `staleTime` react-query's default is ZERO, which means
+       * every remount and every window refocus refetches — and the `/apps` grid is
+       * a page viewers leave and come straight back to (open an app, hit back;
+       * tab away, tab back). Each of those was a fresh network round trip for a
+       * catalog that had not moved.
+       *
+       * WHY 60 AND NOT MORE: it is deliberately a THIRD of the server-side TTL
+       * (`CacheTTL.sm`, 180s, on `listAvailableListings`'s keyset query), so the
+       * client is never the longer of the two staleness sources. The moderator-
+       * visible worst case for a listing entering or leaving the store is bounded
+       * by the server side, which every listing-state mutation busts explicitly
+       * (`bustAppListingCatalogCache`) — a client window that outlived the server
+       * TTL would have made those busts invisible for the difference.
+       *
+       * It does NOT interact with `placeholderData` below: `staleTime` governs
+       * whether a cached entry for THIS key is refetched; `keepPreviousData`
+       * governs what is rendered while a DIFFERENT key loads. A sort/filter change
+       * is a new key, so it still fetches immediately regardless of this value.
+       */
+      staleTime: 60 * 1000,
+      /**
        * 🔴 KEEP THE PREVIOUS RESULT WHILE A NEW ONE LOADS. The query key is
        * `{kind, category, sort, limit}`, so every sort/filter change is a NEW
        * key — and without this `data` goes `undefined` for the duration of the

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -263,9 +263,13 @@ export function AppListingsMarketplaceBody() {
        * tab away, tab back). Each of those was a fresh network round trip for a
        * catalog that had not moved.
        *
-       * WHY 60 AND NOT MORE: it is deliberately a THIRD of the server-side TTL
-       * (`CacheTTL.sm`, 180s, on `listAvailableListings`'s keyset query), so the
-       * client is never the longer of the two staleness sources. The moderator-
+       * WHY 60 AND NOT MORE: the PROPERTY is that the client window stays strictly
+       * shorter than the server-side TTL (`CacheTTL.sm`, 180s at the time of writing,
+       * on `listAvailableListings`'s keyset query), so the client is never the longer
+       * of the two staleness sources. That inequality — and only that — is what
+       * `AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx` asserts, against
+       * the real constant. The specific 3× headroom is a judgement, not a pinned
+       * ratio: pick any value under `CacheTTL.sm`. The moderator-
        * visible worst case for a listing entering or leaving the store is bounded
        * by the server side, which every listing-state mutation busts explicitly
        * (`bustAppListingCatalogCache`) — a client window that outlived the server

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -4,6 +4,7 @@ import type { Readable } from 'node:stream';
 import { withAxiom } from '@civitai/next-axiom';
 import { env } from '~/env/server';
 import { dbWrite } from '~/server/db/client';
+import { bustAppListingCatalogCache } from '~/server/services/blocks/app-listing.service';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { isAppBlocksPipelineEnabled } from '~/server/services/app-blocks-flag';
 import { setCommitStatus } from '~/server/services/blocks/forgejo.service';
@@ -323,7 +324,9 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   // window. A replayed success callback short-circuits here before triggering
   // another apply Job or touching commit status.
   if (!(await markApplyTriggered(body.appBlockId, body.sha))) {
-    res.status(200).json({ ok: true, applied: false, reason: 'duplicate callback (replay-guarded)' });
+    res
+      .status(200)
+      .json({ ok: true, applied: false, reason: 'duplicate callback (replay-guarded)' });
     return;
   }
 
@@ -413,6 +416,13 @@ async function watchApplyJobAndRecord(args: {
         where: { id: args.appBlockId },
         data: { currentVersionDeployedAt: new Date() },
       });
+      // 🔴 Catalog bust: `currentVersionDeployedAt` IS the onsite DEPLOY GATE in
+      // `listAvailableListings` (`al.kind <> 'onsite' OR ab.current_version_deployed_at IS
+      // NOT NULL`). This is the ONE non-tRPC writer of it, so without a bust here a
+      // freshly-deployed onsite app stays INVISIBLE in the store for the whole TTL —
+      // the deploy succeeds and the app simply is not there.
+      await bustAppListingCatalogCache().catch(() => undefined);
+
       await markRequestDeployState(args.slug, args.sha, 'live');
       await safe(setCommitStatus, {
         slug: args.slug,

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -3504,9 +3504,15 @@ export class BlockRegistry {
     // `current_version_deployed_at`, via the deploy gate. A bust here was measured inert.
     //
     // If the catalog query ever grows a predicate over an `app_blocks` column this
-    // function writes, add the bust back — and add this function to the ledger in
+    // function writes, add the bust back — and add the row
+    // `'src/server/services/block-registry.service.ts::BlockRegistry::setMarketplaceMeta'`
+    // to `LEDGER` in
     // `~/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts`, which
     // is what will fail and make that a deliberate decision rather than an omission.
+    // (That spelling is exact and verified: the ledger's attributor names class methods
+    // `Class::method`. An earlier version of it was anchored at column 0 and reported an
+    // added bust here as an unrelated top-level helper, which made this instruction
+    // unfollowable.)
 
     return {
       appBlockId: updated.id,

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -1,7 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
-import { bustAppListingCatalogCache } from '~/server/services/blocks/app-listing.service';
 import { redis, REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { manifestSettingsSchema } from '~/server/schema/blocks/manifest-settings.meta.schema';
 import { SLUG_REGEX } from '~/server/schema/blocks/publish-request.schema';
@@ -3495,8 +3494,19 @@ export class BlockRegistry {
         featuredOrder: true,
       },
     });
-    // Catalog bust: `category` is a FILTER AXIS of the cached page, and a mod sets it here.
-    await bustAppListingCatalogCache().catch(() => undefined);
+    // 🔴 NO CATALOG BUST HERE, DELIBERATELY — and the reason is not "category doesn't
+    // matter", it is that this writes the WRONG TABLE for that cache. The `/apps` catalog
+    // statement filters `app_listings.category`; this function writes
+    // `app_blocks.category`. The two are synced in ONE direction and at ONE moment —
+    // `approveRequest` copies the block's curated scalars onto the listing on approve, and
+    // busts there. Nothing in the cached statement reads any column this function writes
+    // (`category`, `featured`, `featuredOrder`); of `app_blocks` it reads only
+    // `current_version_deployed_at`, via the deploy gate. A bust here was measured inert.
+    //
+    // If the catalog query ever grows a predicate over an `app_blocks` column this
+    // function writes, add the bust back — and add this function to the ledger in
+    // `~/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts`, which
+    // is what will fail and make that a deliberate decision rather than an omission.
 
     return {
       appBlockId: updated.id,

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { bustAppListingCatalogCache } from '~/server/services/blocks/app-listing.service';
 import { redis, REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { manifestSettingsSchema } from '~/server/schema/blocks/manifest-settings.meta.schema';
 import { SLUG_REGEX } from '~/server/schema/blocks/publish-request.schema';
@@ -3494,6 +3495,9 @@ export class BlockRegistry {
         featuredOrder: true,
       },
     });
+    // Catalog bust: `category` is a FILTER AXIS of the cached page, and a mod sets it here.
+    await bustAppListingCatalogCache().catch(() => undefined);
+
     return {
       appBlockId: updated.id,
       status: updated.status,

--- a/src/server/services/blocks/__tests__/app-collaborator.public-byline-offsite.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.public-byline-offsite.test.ts
@@ -47,12 +47,16 @@ const { mockDb } = vi.hoisted(() => ({
 vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
 vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (src: string) => src }));
 vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
-vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600, sm: 180 } }));
 vi.mock('~/server/utils/cache-helpers', () => ({
+  // 🔴 BOTH EXPORTS. `app-listing.service` now imports `bustCacheTag` as well as
+  // `queryCache` (it owns `bustAppListingCatalogCache`), and a one-key factory makes the
+  // WHOLE FILE fail to import with `No "bustCacheTag" export is defined on the … mock`.
   queryCache:
     () =>
     async (sql: unknown): Promise<unknown[]> =>
       mockDb.$queryRaw(sql),
+  bustCacheTag: vi.fn(async () => undefined),
 }));
 
 import { getListingDetail } from '../app-listing.service';

--- a/src/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts
@@ -1,0 +1,278 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
+import { describe, expect, it } from 'vitest';
+
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { stripCommentsAndStrings } from '../../../../../test/strip-comments';
+
+/**
+ * 🔴 `bustAppListingCatalogCache` CALL-SITE LEDGER — fails when the set GROWS or SHRINKS.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THIS FILE EXISTS
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The `/apps` catalog is served from a 180s `queryCache` entry (#529). That cache has
+ * two halves, and only one of them had coverage:
+ *
+ *   · CORRECTNESS OF THE KEY — that two viewers can never share an entry. Guarded by
+ *     `app-listing.catalog-cache.test.ts`.
+ *   · FRESHNESS — that every mutation which changes catalog membership or a cached
+ *     axis deletes the entry. Guarded by NOTHING, until this file. Measured: replacing
+ *     every `await bustAppListingCatalogCache().catch(() => undefined);` in the tree
+ *     with a no-op left the whole blocks tier green — 160 files, 3742 tests.
+ *
+ * That gap is not hypothetical, and it is not the kind a behavioural test finds either.
+ * It shipped in the very change that introduced the cache: `approveExternalRequest`
+ * `return`s into `applyApprovedRevision` for every approval of an edit to an
+ * already-live listing, BEFORE reaching its own bust, and `applyApprovedRevision` had
+ * none. The offsite branch there writes `contentRating` (the maturity gate),
+ * `category` (a cached filter) and `name` (the `sort='name'` sort key) straight onto
+ * the LIVE parent. A `g`→`r` re-rating sat in the cached SFW page for the full TTL.
+ *
+ * A per-mutation behavioural test would not have caught it: nobody writes a test for
+ * the function they forgot. What catches it is an ASSERTED SET — a ledger that goes red
+ * when a new listing mutation appears without a bust (GROWS), and equally red when an
+ * existing bust is deleted (SHRINKS).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHAT THIS DOES AND DOES NOT CLAIM
+ * ─────────────────────────────────────────────────────────────────────────────
+ * It pins WHERE the buster is called, by `<file>::<enclosing top-level function>`. It
+ * is STRUCTURAL, and a structural check type-checks straight past a buster that passes
+ * the wrong tag — so the behavioural half lives in
+ * `app-listing.catalog-cache.test.ts` ("the buster busts the CATALOG tag"), and the
+ * behavioural regression test for the revision path lives in
+ * `offsite-listing.onsite-revision.service.test.ts`.
+ *
+ * It also does NOT claim every entry is load-bearing. Several are deliberately INERT
+ * (a bust on a `draft`/`pending`/`removed` row the approved-only query already
+ * excludes) and are kept so the rule stays mechanical rather than a per-branch
+ * judgement; each such site says so at the call site. The ledger's job is that adding
+ * or removing one is a DECISION someone made on purpose.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHEN THIS GOES RED
+ * ─────────────────────────────────────────────────────────────────────────────
+ * · You added a listing mutation and a bust → add its `<file>::<fn>` to `LEDGER`.
+ * · You added a bust you did NOT intend → that is the finding; remove it.
+ * · You removed a bust → prove the mutation cannot change catalog membership or a
+ *   CACHED axis (`al.status`, `al.kind`, `al.category`, `al.content_rating`,
+ *   `al.revision_of_id`, `ab.current_version_deployed_at`, or the `sort_key` inputs
+ *   `al.name` / `al.created_at` / the metric rollup) — remembering that every
+ *   PROJECTION field on the card is hydrated live and can never be stale — then delete
+ *   the row here in the same commit.
+ * · You RENAMED the buster → the scan finds zero and the positive control below fires
+ *   first, naming the instrument rather than the code.
+ */
+
+const ROOT = process.cwd();
+
+const walk = (dir: string, out: string[] = []): string[] => {
+  for (const entry of readdirSync(dir)) {
+    // Dot-dirs cover `.git`, `.next`, `.turbo` in one rule.
+    if (entry === 'node_modules' || entry === 'dist' || entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+};
+
+/** Every repo root that could hold a caller. `src` is where they all are today. */
+const ROOTS = ['src', 'apps', 'packages', 'scripts'];
+
+const FILES = ROOTS.flatMap((r) => walk(join(ROOT, r)))
+  .map((f) => relative(ROOT, f).split(sep).join('/'))
+  // Tests are excluded: a spec asserting ON the buster is not a production caller, and
+  // counting one would let a deleted production bust be masked by its own test.
+  .filter((f) => !/(^|\/)(__tests__|__mocks__|tests?)\/|\.(test|spec)\.tsx?$/.test(f));
+
+/**
+ * A CALL, not a mention. `stripCommentsAndStrings` removes the prose (this codebase
+ * discusses the buster at length in comments), and the `\(` requires an invocation, so
+ * the `import { … }` line and the `export async function` definition are both excluded.
+ */
+const CALL_RE = /\bbustAppListingCatalogCache\s*\(/g;
+
+/**
+ * The enclosing TOP-LEVEL declaration for a match at `index` WITHIN `haystack`.
+ *
+ * 🔴 Anchored at column 0 (`^` with `m`) on purpose. A first version also accepted a
+ * two-space-indented `name(` so it could name a class method — and that alternative
+ * matched `  if (` and `  switch (`, so four real mutations were attributed to a
+ * function called `if`. There is no class-method call site left, and a ledger that
+ * reports a keyword as a producer is worse than one that reports `<module scope>`.
+ */
+const enclosingFn = (haystack: string, index: number) => {
+  const decls = [
+    ...haystack
+      .slice(0, index)
+      .matchAll(/^(?:export )?(?:async )?function (\w+)|^(?:export )?const (\w+) = /gm),
+  ];
+  const last = decls[decls.length - 1];
+  return last ? last[1] ?? last[2] : '<module scope>';
+};
+
+const findCallSites = () => {
+  const found: string[] = [];
+  for (const file of FILES) {
+    const source = readFileSync(join(ROOT, file), 'utf8');
+    // Cheap pre-filter: skip the ~99% of files that never mention it at all.
+    if (!source.includes('bustAppListingCatalogCache')) continue;
+    const code = stripCommentsAndStrings(source);
+    for (const m of code.matchAll(CALL_RE)) {
+      // 🔴 The buster's own DECLARATION in `app-listing.service` matches `name\s*\(` too.
+      // Skipping on `enclosingFn(...) === 'bustAppListingCatalogCache'` does NOT work:
+      // `enclosingFn` scans BACKWARD from the match, and at the declaration the match IS
+      // the declaration, so it reports whatever precedes it — which silently listed a
+      // neighbouring helper as a bust site. Test the text immediately before instead.
+      if (/\bfunction\s+$/.test(code.slice(Math.max(0, m.index - 40), m.index))) continue;
+      found.push(`${file}::${enclosingFn(code, m.index)}`);
+    }
+  }
+  return [...new Set(found)].sort();
+};
+
+/**
+ * 🔴 THE LEDGER. `<file>::<enclosing top-level function>`, sorted.
+ *
+ * Deduplicated on purpose: `updateListing` calls the buster from four of its status
+ * branches, and a fifth branch would be a code review question, not a ledger change.
+ * What the ledger pins is WHICH MUTATIONS bust, not how many `await`s each contains.
+ */
+const LEDGER = [
+  // The ONE non-tRPC writer of `current_version_deployed_at` — the onsite deploy gate
+  // in the cached statement. Without it a freshly-deployed app is simply absent.
+  'src/pages/api/internal/blocks/build-callback.ts::watchApplyJobAndRecord',
+  // Mints rows at `status:'approved'` — a go-live path, not a data migration.
+  'src/server/services/blocks/app-listing-backfill.service.ts::backfillAppListings',
+  // All three run `reDeriveContentRatingForModLiveEdit` inside their tx, which can RAISE
+  // `content_rating` — the `listingMatureFilter` axis.
+  'src/server/services/blocks/app-listing-assets.service.ts::addListingScreenshot',
+  'src/server/services/blocks/app-listing-assets.service.ts::setListingCover',
+  'src/server/services/blocks/app-listing-assets.service.ts::setListingIcon',
+  // Catalog membership + the live-parent scalar writes.
+  'src/server/services/blocks/offsite-listing.service.ts::applyApprovedRevision',
+  'src/server/services/blocks/offsite-listing.service.ts::approveExternalRequest',
+  'src/server/services/blocks/offsite-listing.service.ts::rejectExternalRequest',
+  'src/server/services/blocks/offsite-listing.service.ts::submitListingRevision',
+  'src/server/services/blocks/offsite-listing.service.ts::updateListing',
+  // Moderator + owner state transitions — every one of these is catalog membership.
+  'src/server/services/blocks/offsite-moderation.service.ts::claimListing',
+  'src/server/services/blocks/offsite-moderation.service.ts::delistListing',
+  'src/server/services/blocks/offsite-moderation.service.ts::purgeListing',
+  'src/server/services/blocks/offsite-moderation.service.ts::relistListing',
+  'src/server/services/blocks/offsite-moderation.service.ts::republishOwnListing',
+  'src/server/services/blocks/offsite-moderation.service.ts::resetListingToPending',
+  'src/server/services/blocks/offsite-moderation.service.ts::resetOnsiteListingToPending',
+  'src/server/services/blocks/offsite-moderation.service.ts::unpublishOwnListing',
+  // Onsite approve mints/flips the AppListing to `approved`.
+  'src/server/services/blocks/publish-request.service.ts::approveRequest',
+].sort();
+
+describe('🔴 bustAppListingCatalogCache CALL-SITE LEDGER', () => {
+  const SITES = findCallSites();
+
+  /**
+   * 🔴 INSTRUMENT FIRST. Every assertion below is a set comparison, and a scan wired to
+   * nothing produces an EMPTY set — which reads as "the ledger shrank", i.e. a confident
+   * finding about the code that is really a fact about the walk. Prove the walk found a
+   * real population and the regex can match before reading any verdict.
+   */
+  it('POSITIVE CONTROL: the scan enumerates a real population and can match', () => {
+    expect(FILES.length).toBeGreaterThan(500);
+    expect(FILES).toContain('src/server/services/blocks/offsite-listing.service.ts');
+    expect(SITES.length).toBeGreaterThan(10);
+    for (const root of ROOTS) {
+      expect(FILES.some((f) => f.startsWith(`${root}/`))).toBe(true);
+    }
+  });
+
+  /**
+   * 🔴 POSITIVE CONTROL ON THE REGEX + STRIPPER + `enclosingFn`, through the same code
+   * path the file scan uses. A `.catch(...)`-suffixed call, a bare `await` call and a
+   * class-method enclosure are all shapes present in the real tree; a prose mention and
+   * the import line are shapes that must NOT match.
+   */
+  it('POSITIVE CONTROL: the matcher matches calls, and only calls, and names them right', () => {
+    const sample = [
+      "import { bustAppListingCatalogCache } from '~/server/services/blocks/app-listing.service';",
+      '// A comment naming bustAppListingCatalogCache() must not count.',
+      // The DECLARATION must not count either — and note the helper before it, which is
+      // exactly what a backward scan reports if the declaration slips through.
+      'function neighbouringHelper() { return 1; }',
+      'export async function bustAppListingCatalogCache(): Promise<void> {}',
+      'export async function realCaller() {',
+      '  if (cond) {',
+      '    switch (x) {',
+      '      default:',
+      '        await bustAppListingCatalogCache().catch(() => undefined);',
+      '    }',
+      '  }',
+      '}',
+      'export async function secondCaller() {',
+      '  await bustAppListingCatalogCache();',
+      '}',
+    ].join('\n');
+    const code = stripCommentsAndStrings(sample);
+    const hits: string[] = [];
+    for (const m of code.matchAll(CALL_RE)) {
+      if (/\bfunction\s+$/.test(code.slice(Math.max(0, m.index - 40), m.index))) continue;
+      hits.push(enclosingFn(code, m.index));
+    }
+    expect(
+      hits,
+      'the matcher missed a real call shape, counted prose/an import/the declaration, ' +
+        'or attributed a call to an enclosing `if`/`switch` instead of its function.'
+    ).toEqual(['realCaller', 'secondCaller']);
+  });
+
+  /**
+   * 🔴 NEGATIVE CONTROL. A ledger that cannot go red is decorative. Perturb the SET the
+   * way a regression would — one entry removed (a deleted bust) and one added (a new
+   * mutation with a bust nobody recorded) — and confirm the comparison notices both.
+   * This is the mutation the assertion below is claimed to survive; run it, don't assume
+   * it.
+   */
+  it('NEGATIVE CONTROL: the comparison detects both a shrink and a growth', () => {
+    expect(SITES.slice(1)).not.toEqual(LEDGER);
+    expect([...SITES, 'src/server/services/blocks/new.service.ts::newMutation'].sort()).not.toEqual(
+      LEDGER
+    );
+  });
+
+  it('the set of catalog-bust call sites is EXACTLY the ledger', () => {
+    const missing = LEDGER.filter((e) => !SITES.includes(e));
+    const extra = SITES.filter((e) => !LEDGER.includes(e));
+    expect(
+      SITES,
+      'the set of `bustAppListingCatalogCache()` call sites changed.\n' +
+        `  REMOVED (a bust that was here and is gone): ${JSON.stringify(missing)}\n` +
+        `  ADDED   (a bust nobody recorded):           ${JSON.stringify(extra)}\n` +
+        'A REMOVAL means some listing mutation no longer invalidates the /apps catalog ' +
+        'entry, so the store grid can serve a delisted / re-rated / re-categorised row ' +
+        'for the whole CacheTTL.sm window. An ADDITION is fine — record it here in the ' +
+        'same commit, with one line saying which CACHED axis it moves (or that it is a ' +
+        'deliberately inert uniform-rule site). See this file`s header.'
+    ).toEqual(LEDGER);
+  });
+
+  /**
+   * 🔴 THE ENTRY THIS LEDGER WAS BUILT FOR, called out by name.
+   *
+   * `approveExternalRequest` returns into `applyApprovedRevision` before reaching its
+   * own bust, for EVERY approval of an edit to an already-live listing. The set
+   * assertion above covers it, but it covers it anonymously — this pins it so a future
+   * "tidy the ledger" pass cannot drop the row without reading why it is there.
+   */
+  it('🔴 `applyApprovedRevision` is in the ledger (it is NOT covered by its caller)', () => {
+    expect(
+      SITES,
+      '`applyApprovedRevision` does not bust. `approveExternalRequest` RETURNS into it ' +
+        'for every listing with `revisionOfId != null`, i.e. every approval of an edit ' +
+        'to an already-live listing, BEFORE reaching its own bust. Its offsite branch ' +
+        'writes contentRating (the maturity gate), category (a cached filter) and name ' +
+        '(the sort key) onto the LIVE parent.'
+    ).toContain('src/server/services/blocks/offsite-listing.service.ts::applyApprovedRevision');
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts
@@ -71,23 +71,47 @@ import { stripCommentsAndStrings } from '../../../../../test/strip-comments';
  * named `appListing`. A raw `$executeRaw` UPDATE against `app_listings`, or a write
  * behind a dynamically-named delegate, is invisible to it. No claim is made about those.
  *
+ * 🔴 AND TWO CACHED AXES DO NOT LIVE ON THIS TABLE AT ALL, so the scan can enumerate NO
+ * writers for them — a stronger blind spot than the one above, because the writers are
+ * ordinary, present, and busting nothing:
+ *   · the `app_listing_metrics` ROLLUP that feeds `sort='top-rated'` and `sort='popular'`.
+ *     `app-listing-review.service.ts::applyRecommendMetricDelta` writes
+ *     `thumbsUp/DownCount` on every review vote and busts only the recommend-MEAN tag;
+ *     `~/server/metrics/appListing.metrics.sql.ts` raw-upserts `install_count` — the
+ *     whole `sort='popular'` key and the `top-rated` tiebreak — on the metric job, and
+ *     busts nothing. (`open_count`, upserted alongside it, is NOT a cached axis: no
+ *     `sort_key` reads it.)
+ *   · nothing else — `ab.current_version_deployed_at` lives on `app_blocks`, but its one
+ *     writer IS covered, via `build-callback.ts::watchApplyJobAndRecord` in `LEDGER`.
+ * Both metric behaviours are DELIBERATE and are the right trade: busting the catalog on
+ * every review vote or metric-job pass would defeat the cache outright, and the cost is
+ * bounded at `CacheTTL.sm` of SORT lag — no row appears, disappears, or changes maturity.
+ * That is a decision, not a gap; but it means the "reads exactly … and NOTHING else" rule
+ * stated below is violated BY DESIGN on those two, and a reader applying the rule to a
+ * metrics writer would reach the wrong conclusion.
+ *
  * ─────────────────────────────────────────────────────────────────────────────
  * WHEN THIS GOES RED
  * ─────────────────────────────────────────────────────────────────────────────
  * · You added an `AppListing` mutation → either call `bustAppListingCatalogCache()`
  *   from it and add its `<file>::<fn>` to `LEDGER`, or add it to `EXEMPT` with a
- *   one-line reason saying which cached axis it provably does NOT move.
+ *   one-line reason clearing one of the two bars stated there.
  * · You removed a bust → prove the mutation cannot change catalog membership or a
  *   CACHED axis (`al.status`, `al.kind`, `al.category`, `al.content_rating`,
- *   `al.revision_of_id`, `ab.current_version_deployed_at`, or the `sort_key` inputs
- *   `al.name` / `al.created_at` / the metric rollup) — remembering that every
- *   PROJECTION field on the card is hydrated live and can never be stale — then move
- *   the row from `LEDGER` to `EXEMPT` in the same commit.
+ *   `al.revision_of_id`, `al.app_block_id`, `ab.current_version_deployed_at`, or the
+ *   `sort_key` inputs `al.name` / `al.created_at` / the metric rollup) — remembering
+ *   that every PROJECTION field on the card is hydrated live and can never be stale —
+ *   then move the row from `LEDGER` to `EXEMPT` in the same commit.
+ * · You added a caller to an `EXEMPT` bar-2 helper → see `CALLER_BUSTS`. That caller
+ *   need not write the table itself, which is exactly why prose could not hold it.
  * · You RENAMED the buster → the scan finds zero and the positive control below fires
  *   first, naming the instrument rather than the code.
  * · A site reports `<unattributed>` → the parser could not name its enclosing
  *   function. That is a defect in THIS FILE, not in the code under scan; fix
  *   `classifyBrace` rather than working around it.
+ * · A file fails the BRACE-BALANCE check → `stripCommentsAndStrings` left an unmatched
+ *   `{` or `}` behind (a regex literal is the known shape), so `buildFrames` would
+ *   mis-nest and attribute a write to the wrong real function. See `buildFrames`.
  */
 
 const ROOT = process.cwd();
@@ -113,9 +137,16 @@ const FILES = ROOTS.flatMap((r) => walk(join(ROOT, r)))
   .filter((f) => !/(^|\/)(__tests__|__mocks__|tests?)\/|\.(test|spec)\.tsx?$/.test(f));
 
 /**
- * A CALL, not a mention. `stripCommentsAndStrings` removes the prose (this codebase
- * discusses the buster at length in comments), and the `\(` requires an invocation, so
- * the `import { … }` line and the `export async function` definition are both excluded.
+ * A CALL, not a mention. Three separate exclusions, and they are NOT interchangeable —
+ * an earlier version of this comment credited `\(` with all of them, which is wrong in a
+ * way that invites deleting the one that matters:
+ *   · PROSE — removed by `stripCommentsAndStrings` (this codebase discusses the buster
+ *     at length in comments);
+ *   · the `import { … }` line — excluded by `\(`, since a specifier is not an invocation;
+ *   · the `export async function bustAppListingCatalogCache(…)` DECLARATION — NOT
+ *     excluded by `\(`, because a declaration's own parameter list matches `name\s*\(`
+ *     exactly like a call. The `\bfunction\s+$` lookback in `scan` is what drops it, as
+ *     that line's own comment says.
  */
 const CALL_RE = /\bbustAppListingCatalogCache\s*\(/g;
 
@@ -306,11 +337,47 @@ const classifyBrace = (code: string, braceIdx: number): Omit<Frame, 'start' | 'e
   return null;
 };
 
-const buildFrames = (code: string): Frame[] => {
+type Walk = {
+  frames: Frame[];
+  /** `#{` − `#}` over the whole file. Non-zero ⇒ the frames below are mis-nested. */
+  braceDelta: number;
+  /** The lowest depth the walk reached. Negative ⇒ a `}` arrived with no open frame. */
+  minDepth: number;
+};
+
+/**
+ * 🔴 THE FRAMES ARE ONLY AS GOOD AS THE STRIPPER, AND THE STRIPPER DOES NOT KNOW ABOUT
+ * REGEX LITERALS. `stripCommentsAndStrings` removes comments, template literals and
+ * quoted strings; a `{` or `}` inside a REGEX literal — `/^\s*\{/` — survives. One stray
+ * brace re-nests every frame after it, and the failure is SILENT AND WORSE THAN A CRASH:
+ * a write is not reported as `<unattributed>`, it is attributed to a DIFFERENT REAL
+ * FUNCTION, which then reads as covered because that function is in `LEDGER`/`EXEMPT`.
+ *
+ * Measured on this branch: inserting `const _jsonHead = /^\s*\{/;` into `acceptTransfer`
+ * (`app-ownership-transfer.service.ts`, a file with no bust sites, so the `LEDGER`
+ * equality pin cannot see the collapse) and appending an un-busting `forgetfulDelist()`
+ * that flips an approved row to `removed` left the ledger at 8 passed / 0 failed — the
+ * new writer folded into `acceptTransfer`, which is `EXEMPT`. That is exactly the writer
+ * this file exists to catch. The same mutant with a BALANCED regex fails correctly, so
+ * the brace is the variable, not the mutation.
+ *
+ * 🔴 SO THE WALK REPORTS ITS OWN BALANCE AND A TEST BELOW FAILS ON IT. That is the fix
+ * rather than teaching the stripper about regex literals, because a balance check cannot
+ * be walked by a shape nobody thought of: any construct that leaks an unmatched brace —
+ * regex literal or otherwise — is caught, whereas a regex-literal stripper only closes
+ * the one shape we happen to have seen (and `/` is genuinely ambiguous with division, so
+ * it would be a heuristic in a module two OTHER guards also depend on). 39 of the 5,123
+ * files in the tree do not balance after stripping; none contributes a site today, and
+ * each becomes a red build the day it gains one.
+ */
+const buildFrames = (code: string): Walk => {
   const frames: Frame[] = [];
   const stack: Frame[] = [];
+  let depth = 0;
+  let minDepth = 0;
   for (let i = 0; i < code.length; i++) {
     if (code[i] === '{') {
+      depth++;
       const hit = classifyBrace(code, i);
       const frame: Frame = {
         start: i,
@@ -325,13 +392,32 @@ const buildFrames = (code: string): Frame[] => {
       stack.push(frame);
       frames.push(frame);
     } else if (code[i] === '}') {
+      depth--;
+      if (depth < minDepth) minDepth = depth;
       const frame = stack.pop();
       if (frame) frame.end = i;
     }
   }
-  return frames;
+  return { frames, braceDelta: depth, minDepth };
 };
 
+/** Does this file's stripped text brace-balance? `minDepth` catches a `+1/−1` that cancels. */
+const braceImbalance = (walk: Walk): string | null =>
+  walk.braceDelta === 0 && walk.minDepth === 0
+    ? null
+    : `delta ${walk.braceDelta > 0 ? '+' : ''}${walk.braceDelta}, min depth ${walk.minDepth}`;
+
+/**
+ * `<unattributed>` vs `<module scope>` — these are DIFFERENT verdicts and only one is a
+ * defect, which is why the "every site resolves" test below filters for the first alone.
+ *   · `<unattributed>` — the site IS inside braces and the parser could not name the
+ *     frame. A parse failure; fix `classifyBrace`.
+ *   · `<module scope>` — the site is inside no braces at all, i.e. a genuine top-level
+ *     write. That is a correct answer, not a parse failure, and it needs no guard of its
+ *     own: `<file>::<module scope>` can never be in `LEDGER` (a top-level statement
+ *     cannot call the buster meaningfully) and would have to be typed by hand into
+ *     `EXEMPT`, so the headline coverage guard reports it, loudly and by name.
+ */
 const attribute = (frames: Frame[], index: number): string => {
   const enclosing = frames
     .filter((f) => f.start < index && index < f.end)
@@ -343,14 +429,30 @@ const attribute = (frames: Frame[], index: number): string => {
   return cls ? `${cls.name}::${outer.name}` : outer.name;
 };
 
-/** `{ busts, writes }` — both as sorted, de-duplicated `<file>::<fn>` sets. */
-const scan = (files: string[]) => {
+/** A CALL to `name`, excluding its own declaration — the `CALL_RE` rule, generalised. */
+const callsOf = (code: string, name: string) =>
+  [...code.matchAll(new RegExp(`\\b${name}\\s*\\(`, 'g'))].filter(
+    (m) => !/\bfunction\s+$/.test(code.slice(Math.max(0, m.index - 40), m.index))
+  );
+
+/**
+ * `{ busts, writes, helperCallers, imbalanced }` — the first three as sorted,
+ * de-duplicated `<file>::<fn>` sets, `imbalanced` as `<file> (…)` strings.
+ */
+const scan = (files: string[], helpers: string[]) => {
   const busts: string[] = [];
   const writes: string[] = [];
+  const helperCallers: Record<string, string[]> = Object.fromEntries(helpers.map((h) => [h, []]));
+  const imbalanced: string[] = [];
   for (const file of files) {
     const source = readFileSync(join(ROOT, file), 'utf8');
-    // Cheap pre-filter: skip the ~99% of files that mention neither.
-    if (!source.includes('bustAppListingCatalogCache') && !source.includes('appListing.')) continue;
+    // Cheap pre-filter: skip the ~99% of files that mention none of them.
+    if (
+      !source.includes('bustAppListingCatalogCache') &&
+      !source.includes('appListing.') &&
+      !helpers.some((h) => source.includes(h))
+    )
+      continue;
     const code = stripCommentsAndStrings(source);
     CALL_RE.lastIndex = 0;
     WRITE_RE.lastIndex = 0;
@@ -359,14 +461,28 @@ const scan = (files: string[]) => {
       (m) => !/\bfunction\s+$/.test(code.slice(Math.max(0, m.index - 40), m.index))
     );
     const writeHits = [...code.matchAll(WRITE_RE)];
-    if (!bustHits.length && !writeHits.length) continue;
-    const frames = buildFrames(code);
+    const helperHits = helpers.map((h) => [h, callsOf(code, h)] as const);
+    if (!bustHits.length && !writeHits.length && !helperHits.some(([, hits]) => hits.length))
+      continue;
+    const walk = buildFrames(code);
+    // Recorded, NOT skipped: attribution still runs, so exactly one test goes red and it
+    // is the one that names the real cause. Skipping would empty this file's sets and
+    // fire the LEDGER-equality guard too, for the same single finding.
+    const imbalance = braceImbalance(walk);
+    if (imbalance) imbalanced.push(`${file} (${imbalance})`);
+    const { frames } = walk;
     for (const m of bustHits) busts.push(`${file}::${attribute(frames, m.index)}`);
     for (const m of writeHits) writes.push(`${file}::${attribute(frames, m.index)}`);
+    for (const [h, hits] of helperHits)
+      for (const m of hits) helperCallers[h].push(`${file}::${attribute(frames, m.index)}`);
   }
   return {
     busts: [...new Set(busts)].sort(),
     writes: [...new Set(writes)].sort(),
+    helperCallers: Object.fromEntries(
+      Object.entries(helperCallers).map(([h, c]) => [h, [...new Set(c)].sort()])
+    ) as Record<string, string[]>,
+    imbalanced: imbalanced.sort(),
   };
 };
 
@@ -410,13 +526,32 @@ const LEDGER = [
 /**
  * 🔴 `AppListing` WRITERS THAT DELIBERATELY DO NOT BUST, each with the reason.
  *
- * The bar for a row here is that the write provably cannot move a CACHED axis of the
- * `/apps` keyset statement. That statement reads exactly: `al.id`, `al.status`,
- * `al.revision_of_id`, `al.kind`, `al.category`, `al.content_rating` (via
- * `listingMatureFilter`), `ab.current_version_deployed_at`, and the `sort_key` inputs
- * (`al.name`, `al.created_at`, the `app_listing_metrics` rollup). It reads NOTHING
- * else — every other column on the card is hydrated live below the cache and can never
- * be served stale.
+ * 🔴 THERE ARE TWO BARS, NOT ONE, AND A ROW MUST SAY WHICH IT CLEARS. An earlier version
+ * of this preamble stated only the first ("the write provably cannot move a CACHED
+ * axis") while the list already granted the second — so one row was exempt on an
+ * argument the stated bar does not admit, and a reader checking the list against the
+ * rule would have found a contradiction rather than the real reasoning:
+ *
+ *   1. CANNOT-MOVE — the write provably cannot move a cached axis. Every row below
+ *      except one clears this bar, and it is the bar to prefer.
+ *   2. CALLER-BUSTS — the write DOES move a cached axis, but it is an in-tx helper and
+ *      every one of its callers busts after the commit. This is strictly weaker: it
+ *      rests on a claim about the CALLER SET, which prose cannot hold and a reader
+ *      cannot check. A row claiming it MUST also appear in `CALLER_BUSTS` below, which
+ *      pins the caller set mechanically. Today exactly one row does
+ *      (`reDeriveContentRatingForModLiveEdit`). `routeRepublishToReviewInTx` also cites
+ *      its caller, but it independently clears bar 1 — its `where` selects
+ *      `status:'removed'`, so the row it moves is not a catalog member either way — so
+ *      it needs no pin.
+ *
+ * The cached statement reads exactly: `al.id`, `al.status`, `al.revision_of_id`,
+ * `al.kind`, `al.category`, `al.content_rating` (via `listingMatureFilter`),
+ * `al.app_block_id` (the join key onto `app_blocks` for the deploy gate),
+ * `ab.current_version_deployed_at`, and the `sort_key` inputs (`al.name`,
+ * `al.created_at`, the `app_listing_metrics` rollup). It reads NOTHING else — every
+ * other column on the card is hydrated live below the cache and can never be served
+ * stale. ⚠️ Two of those axes are not on this table and this scan cannot see their
+ * writers; the header's blind-spot section says which, and why that is deliberate.
  *
  * Each reason below was re-derived against the code at this commit, not inherited.
  */
@@ -424,9 +559,11 @@ const EXEMPT: Record<string, string> = {
   'src/server/services/blocks/app-listing-assets.service.ts::backfillListingAssets':
     'writes only `coverId` / `iconId`, both hydrated projection fields — no cached axis.',
   'src/server/services/blocks/app-listing-assets.service.ts::reDeriveContentRatingForModLiveEdit':
-    'DOES raise `content_rating`, but it is an in-tx helper with exactly three callers ' +
-    '(`setListingIcon`, `setListingCover`, `addListingScreenshot`) and all three bust ' +
-    'post-commit — a bust inside the tx would also fire on a rollback.',
+    'BAR 2 (CALLER-BUSTS), the only row here that is: it DOES raise `content_rating`. ' +
+    'Every caller busts post-commit — a bust inside the tx would also fire on a ' +
+    'rollback — and the caller set is pinned in `CALLER_BUSTS`, not asserted here in ' +
+    'prose, because a fourth caller is invisible to the writer scan (it issues no ' +
+    '`appListing.` write of its own).',
   'src/server/services/blocks/app-ownership-transfer.service.ts::acceptTransfer':
     'writes only `userId`; the cached statement never reads ownership and no sort or ' +
     'filter keys on it (same argument `claimListing` makes for its own inert bust).',
@@ -455,8 +592,40 @@ const EXEMPT: Record<string, string> = {
     'path that promotes it, and it busts.',
 };
 
+/**
+ * 🔴 THE CALLER SETS THAT BAR 2 OF `EXEMPT` RESTS ON.
+ *
+ * A helper listed here moves a cached axis and is exempt only because every caller busts
+ * after the commit. Nothing in the writer scan can see that: the dangerous new caller is
+ * one that runs the helper inside its own `dbWrite.$transaction` and issues NO
+ * `appListing.` write of its own, so it never enters `WRITERS` and no guard in this file
+ * mentions it.
+ *
+ * Measured on this branch: a fourth caller of exactly that shape, with no bust, left the
+ * ledger at 8 passed / 0 failed and the function absent from `WRITERS` entirely. If it
+ * landed, a moderator raising an approved listing `g`→`r` would sit in the cached SFW
+ * page for the full `CacheTTL.sm` — verbatim the narrative in this file's own header.
+ *
+ * So the set is pinned: every caller must be a `LEDGER` bust site, AND the set must be
+ * exactly what is recorded. The second half is bookkeeping, not safety — a fourth
+ * BUSTING caller is fine and its red is "record the decision", the same contract the
+ * `LEDGER` set assertion states for a new bust.
+ */
+const CALLER_BUSTS: Record<string, string[]> = {
+  reDeriveContentRatingForModLiveEdit: [
+    'src/server/services/blocks/app-listing-assets.service.ts::addListingScreenshot',
+    'src/server/services/blocks/app-listing-assets.service.ts::setListingCover',
+    'src/server/services/blocks/app-listing-assets.service.ts::setListingIcon',
+  ].sort(),
+};
+
 describe('🔴 /apps catalog freshness ledger', () => {
-  const { busts: SITES, writes: WRITERS } = scan(FILES);
+  const {
+    busts: SITES,
+    writes: WRITERS,
+    helperCallers: HELPER_CALLERS,
+    imbalanced: IMBALANCED,
+  } = scan(FILES, Object.keys(CALLER_BUSTS));
 
   /**
    * 🔴 INSTRUMENT FIRST. Every assertion below is a set comparison, and a scan wired to
@@ -519,7 +688,7 @@ describe('🔴 /apps catalog freshness ledger', () => {
       '}',
     ].join('\n');
     const code = stripCommentsAndStrings(sample);
-    const frames = buildFrames(code);
+    const { frames } = buildFrames(code);
     const bustHits = [...code.matchAll(new RegExp(CALL_RE.source, 'g'))]
       .filter((m) => !/\bfunction\s+$/.test(code.slice(Math.max(0, m.index - 40), m.index)))
       .map((m) => attribute(frames, m.index));
@@ -563,6 +732,53 @@ describe('🔴 /apps catalog freshness ledger', () => {
   });
 
   /**
+   * 🔴 CONTROL ON THE BRACE-BALANCE CHECK ITSELF, in both directions and on the EXACT
+   * shape that walked the ledger. A balance check that cannot go red would be the same
+   * decorative guard this file was rewritten to remove.
+   */
+  it('POSITIVE + NEGATIVE CONTROL: the brace walk sees an unmatched brace in a regex', () => {
+    const withRegex = (re: string) =>
+      buildFrames(
+        stripCommentsAndStrings(
+          ['export function f() {', `  const head = ${re};`, '  return head;', '}'].join('\n')
+        )
+      );
+    // The stripper removes comments/strings/templates — NOT regex literals. A brace
+    // inside one survives, and it is the leak this check exists for.
+    const unbalanced = withRegex('/^\\s*\\{/');
+    expect(
+      braceImbalance(unbalanced),
+      'the walk no longer notices an unmatched `{` left behind by a regex literal — ' +
+        'either the stripper started removing regexes (then say so and delete this ' +
+        'control) or the balance accounting is broken.'
+    ).toBe('delta +1, min depth 0');
+    // Same construct, balanced: the check must NOT fire, or it is noise that gets muted.
+    expect(braceImbalance(withRegex('/^\\s*\\{\\}/'))).toBeNull();
+    // A stray CLOSER followed by a stray OPENER cancels in the delta, so `minDepth` is
+    // the half that catches it — a `+1/−1` pair mis-nests just as badly as a lone `+1`.
+    expect(
+      braceImbalance(buildFrames(stripCommentsAndStrings('const a = /\\}/;\nconst b = /\\{/;\n')))
+    ).toBe('delta 0, min depth -1');
+  });
+
+  /**
+   * 🔴 THE FRAMES ARE ONLY TRUSTWORTHY IF THE FILE BALANCES. An unmatched brace surviving
+   * the stripper re-nests everything after it, and a write then reports a DIFFERENT REAL
+   * FUNCTION — no `<unattributed>`, no error, and the coverage guard reads as satisfied
+   * because the name it landed on is in `LEDGER`/`EXEMPT`. See `buildFrames`.
+   */
+  it('🔴 every scanned file brace-balances after stripping', () => {
+    expect(
+      IMBALANCED,
+      'these files still hold an unmatched `{`/`}` after `stripCommentsAndStrings`, so ' +
+        'their frames mis-nest and every attribution in them is unsound. The known ' +
+        'shape is a brace inside a REGEX LITERAL, which the stripper does not remove. ' +
+        'Fix the stripper (or the file), NOT this list — skipping the file would hide ' +
+        'exactly the un-busted writer this ledger exists to catch.'
+    ).toEqual([]);
+  });
+
+  /**
    * 🔴 FAIL LOUDLY RATHER THAN NAME THE WRONG FUNCTION. `<unattributed>` means the
    * backward parse hit a shape it does not model; every verdict below would then be
    * computed against a name that does not exist in the file.
@@ -593,6 +809,38 @@ describe('🔴 /apps catalog freshness ledger', () => {
         'to `LEDGER`. If it provably cannot, add it to `EXEMPT` with the reason. Every ' +
         'other column on the card is hydrated live and can never be stale.'
     ).toEqual([]);
+  });
+
+  /**
+   * 🔴 THE OTHER HALF OF THE COVERAGE RULE — the one the writer scan is BLIND to. See
+   * `CALLER_BUSTS`: a `EXEMPT` bar-2 row is only sound while every caller busts, and a
+   * new caller that writes nothing itself never appears in `WRITERS`.
+   */
+  it('🔴 every CALLER of an exempt-by-caller helper busts, and the caller set is pinned', () => {
+    for (const [helper, recorded] of Object.entries(CALLER_BUSTS)) {
+      const callers = HELPER_CALLERS[helper] ?? [];
+      // Instrument first: a rename makes the scan find zero, which would pass both
+      // assertions below vacuously if `recorded` were also emptied.
+      expect(
+        callers.length,
+        `no call sites found for \`${helper}\`. Either it was renamed (rename it here ` +
+          'too) or it is gone (delete its `EXEMPT` row and this entry).'
+      ).toBeGreaterThan(0);
+      expect(
+        callers.filter((c) => !SITES.includes(c)),
+        `these functions call \`${helper}\`, which RAISES a cached axis inside the ` +
+          "caller's transaction, and do NOT call `bustAppListingCatalogCache()`. That " +
+          'is the whole basis of its `EXEMPT` row. Bust after the commit and add the ' +
+          'caller to `LEDGER` — a bust inside the tx would fire on a rollback too.'
+      ).toEqual([]);
+      expect(
+        callers,
+        `the caller set of \`${helper}\` changed. Every caller busts (asserted above), ` +
+          'so this is bookkeeping: record the new one here in the same commit, exactly ' +
+          'as `LEDGER` requires for a new bust site. Do not widen it without reading ' +
+          'why the row is exempt.'
+      ).toEqual(recorded);
+    }
   });
 
   it('the set of catalog-bust call sites is EXACTLY the ledger', () => {
@@ -631,6 +879,15 @@ describe('🔴 /apps catalog freshness ledger', () => {
         `EXEMPT["${key}"] needs a real reason, not a placeholder`
       ).toBeGreaterThan(40);
     }
+    // The two lists are one mechanism: a `CALLER_BUSTS` pin exists to hold up a bar-2
+    // `EXEMPT` row, so a pin with no row is dead weight nobody will maintain.
+    expect(
+      Object.keys(CALLER_BUSTS).filter(
+        (h) => !Object.keys(EXEMPT).some((k) => k.endsWith(`::${h}`))
+      ),
+      '`CALLER_BUSTS` pins a helper that is not on `EXEMPT`. Either it now busts (drop ' +
+        'the pin) or its row was deleted (drop the pin).'
+    ).toEqual([]);
   });
 
   /**

--- a/src/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts
@@ -133,9 +133,10 @@ const WRITE_RE =
 // ENCLOSING-FUNCTION ATTRIBUTION
 // ---------------------------------------------------------------------------
 /**
- * 🔴 THIS IS A BACKWARD PARSE, NOT A PATTERN LIST — because two earlier pattern lists
- * each mis-attributed silently, in a different shape, and a silent wrong name is the
- * worst output this file can produce (it sends the reader to an unrelated function).
+ * 🔴 THIS IS A BACKWARD PARSE, NOT A PATTERN LIST — because THREE earlier pattern
+ * versions each mis-attributed silently, in a different shape, and a silent wrong name
+ * is the worst output this file can produce (it sends the reader to a function that had
+ * nothing to do with the site).
  *
  * The shapes that already bit us:
  *   · a two-space-indented `name(` alternative added to name class methods also matched
@@ -143,8 +144,8 @@ const WRITE_RE =
  *     called `if`;
  *   · dropping that alternative and anchoring at column 0 made class methods invisible
  *     instead: re-adding the bust inside `BlockRegistry.setMarketplaceMeta` reported it
- *     as `block-registry.service.ts::resolveRenderMode`, an unrelated top-level helper
- *     forty lines earlier — while a comment at that call site instructs a future
+ *     as `block-registry.service.ts::resolveRenderMode`, a top-level helper that is not
+ *     even nearby in that file — while a comment at that call site instructs a future
  *     maintainer to add exactly that function to this ledger;
  *   · a leftmost-match regex over a lookback window jumped to the PREVIOUS function
  *     whenever the signature contained an object-type parameter (`function f(opts: {`),
@@ -167,7 +168,6 @@ const RESERVED = new Set([
   'default', 'static', 'async', 'get', 'set',
 ]); // prettier-ignore
 
-const TYPE_CHARS = /[\w$\s.<>,[\]|&?]/;
 const isWs = (c: string) => c === ' ' || c === '\t' || c === '\n' || c === '\r';
 const isIdent = (c: string) => /[\w$]/.test(c);
 

--- a/src/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts
@@ -414,9 +414,11 @@ const braceImbalance = (walk: Walk): string | null =>
  *     frame. A parse failure; fix `classifyBrace`.
  *   · `<module scope>` — the site is inside no braces at all, i.e. a genuine top-level
  *     write. That is a correct answer, not a parse failure, and it needs no guard of its
- *     own: `<file>::<module scope>` can never be in `LEDGER` (a top-level statement
- *     cannot call the buster meaningfully) and would have to be typed by hand into
- *     `EXEMPT`, so the headline coverage guard reports it, loudly and by name.
+ *     own: neither list holds a `<module scope>` row today, so a new one lands in
+ *     neither `LEDGER` nor `EXEMPT` and the headline coverage guard reports it, loudly
+ *     and by name. (Nothing MECHANICALLY stops someone typing such a row in — the point
+ *     is that doing so is a deliberate act, which is the same contract every other row
+ *     is under, not a silent pass.)
  */
 const attribute = (frames: Frame[], index: number): string => {
   const enclosing = frames

--- a/src/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts
@@ -6,7 +6,8 @@ import { describe, expect, it } from 'vitest';
 import { stripCommentsAndStrings } from '../../../../../test/strip-comments';
 
 /**
- * 🔴 `bustAppListingCatalogCache` CALL-SITE LEDGER — fails when the set GROWS or SHRINKS.
+ * 🔴 `/apps` CATALOG FRESHNESS LEDGER — every `AppListing` WRITER either busts the
+ * catalog cache or is on an explicit `EXEMPT` list with a reason.
  *
  * ─────────────────────────────────────────────────────────────────────────────
  * WHY THIS FILE EXISTS
@@ -14,12 +15,10 @@ import { stripCommentsAndStrings } from '../../../../../test/strip-comments';
  * The `/apps` catalog is served from a 180s `queryCache` entry (#529). That cache has
  * two halves, and only one of them had coverage:
  *
- *   · CORRECTNESS OF THE KEY — that two viewers can never share an entry. Guarded by
- *     `app-listing.catalog-cache.test.ts`.
+ *   · CORRECTNESS OF THE KEY — that two viewer classes can never share an entry.
+ *     Guarded by `app-listing.catalog-cache.test.ts`.
  *   · FRESHNESS — that every mutation which changes catalog membership or a cached
- *     axis deletes the entry. Guarded by NOTHING, until this file. Measured: replacing
- *     every `await bustAppListingCatalogCache().catch(() => undefined);` in the tree
- *     with a no-op left the whole blocks tier green — 160 files, 3742 tests.
+ *     axis deletes the entry. Guarded by NOTHING, until this file.
  *
  * That gap is not hypothetical, and it is not the kind a behavioural test finds either.
  * It shipped in the very change that introduced the cache: `approveExternalRequest`
@@ -30,39 +29,65 @@ import { stripCommentsAndStrings } from '../../../../../test/strip-comments';
  * the LIVE parent. A `g`→`r` re-rating sat in the cached SFW page for the full TTL.
  *
  * A per-mutation behavioural test would not have caught it: nobody writes a test for
- * the function they forgot. What catches it is an ASSERTED SET — a ledger that goes red
- * when a new listing mutation appears without a bust (GROWS), and equally red when an
- * existing bust is deleted (SHRINKS).
+ * the function they forgot.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🔴 WHY IT ENUMERATES WRITERS AND NOT BUSTERS
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The first version of this file pinned only the SET OF BUST CALL SITES, and its
+ * header claimed that went red "when a new listing mutation appears without a bust".
+ * IT DID NOT, and that is the exact defect above: a mutation with no bust adds no call
+ * site, so the pinned set is unchanged and the ledger stays green. Measured on this
+ * branch — appending an `export async function forgetfulDelist()` that flips an
+ * approved row to `removed` with no bust left the bust-only ledger at 5 passed /
+ * 0 failed. A guard that reads as coverage while providing none is worse than no
+ * guard, because it stops anyone looking.
+ *
+ * So the primary assertion is INVERTED. The scan enumerates every writer of the
+ * `AppListing` table (`<client>.appListing.{create,createMany,update,updateMany,
+ * upsert,delete,deleteMany}`, including `tx.` forms inside a transaction), resolves
+ * each to its enclosing function, and requires that function to be EITHER a bust call
+ * site OR on `EXEMPT` with a one-line reason. A new un-busted mutation then fails by
+ * construction.
+ *
+ * The bust set is STILL pinned as `LEDGER`, for the other direction: deleting a bust
+ * removes a call site, which the writer scan alone cannot see.
  *
  * ─────────────────────────────────────────────────────────────────────────────
  * WHAT THIS DOES AND DOES NOT CLAIM
  * ─────────────────────────────────────────────────────────────────────────────
- * It pins WHERE the buster is called, by `<file>::<enclosing top-level function>`. It
- * is STRUCTURAL, and a structural check type-checks straight past a buster that passes
- * the wrong tag — so the behavioural half lives in
+ * Both halves are STRUCTURAL, and a structural check type-checks straight past a
+ * buster that passes the wrong tag — so the behavioural half lives in
  * `app-listing.catalog-cache.test.ts` ("the buster busts the CATALOG tag"), and the
  * behavioural regression test for the revision path lives in
  * `offsite-listing.onsite-revision.service.test.ts`.
  *
- * It also does NOT claim every entry is load-bearing. Several are deliberately INERT
- * (a bust on a `draft`/`pending`/`removed` row the approved-only query already
- * excludes) and are kept so the rule stays mechanical rather than a per-branch
- * judgement; each such site says so at the call site. The ledger's job is that adding
- * or removing one is a DECISION someone made on purpose.
+ * It also does NOT claim every `LEDGER` entry is load-bearing. Several busts are
+ * deliberately INERT today (a bust on a `draft`/`pending`/`removed` row the
+ * approved-only query already excludes); each such site says so at the call site. What
+ * the ledger pins is that adding or removing one is a DECISION someone made on purpose.
+ *
+ * It sees only what a lexical scan can see: a write issued through a Prisma delegate
+ * named `appListing`. A raw `$executeRaw` UPDATE against `app_listings`, or a write
+ * behind a dynamically-named delegate, is invisible to it. No claim is made about those.
  *
  * ─────────────────────────────────────────────────────────────────────────────
  * WHEN THIS GOES RED
  * ─────────────────────────────────────────────────────────────────────────────
- * · You added a listing mutation and a bust → add its `<file>::<fn>` to `LEDGER`.
- * · You added a bust you did NOT intend → that is the finding; remove it.
+ * · You added an `AppListing` mutation → either call `bustAppListingCatalogCache()`
+ *   from it and add its `<file>::<fn>` to `LEDGER`, or add it to `EXEMPT` with a
+ *   one-line reason saying which cached axis it provably does NOT move.
  * · You removed a bust → prove the mutation cannot change catalog membership or a
  *   CACHED axis (`al.status`, `al.kind`, `al.category`, `al.content_rating`,
  *   `al.revision_of_id`, `ab.current_version_deployed_at`, or the `sort_key` inputs
  *   `al.name` / `al.created_at` / the metric rollup) — remembering that every
- *   PROJECTION field on the card is hydrated live and can never be stale — then delete
- *   the row here in the same commit.
+ *   PROJECTION field on the card is hydrated live and can never be stale — then move
+ *   the row from `LEDGER` to `EXEMPT` in the same commit.
  * · You RENAMED the buster → the scan finds zero and the positive control below fires
  *   first, naming the instrument rather than the code.
+ * · A site reports `<unattributed>` → the parser could not name its enclosing
+ *   function. That is a defect in THIS FILE, not in the code under scan; fix
+ *   `classifyBrace` rather than working around it.
  */
 
 const ROOT = process.cwd();
@@ -95,46 +120,258 @@ const FILES = ROOTS.flatMap((r) => walk(join(ROOT, r)))
 const CALL_RE = /\bbustAppListingCatalogCache\s*\(/g;
 
 /**
- * The enclosing TOP-LEVEL declaration for a match at `index` WITHIN `haystack`.
- *
- * 🔴 Anchored at column 0 (`^` with `m`) on purpose. A first version also accepted a
- * two-space-indented `name(` so it could name a class method — and that alternative
- * matched `  if (` and `  switch (`, so four real mutations were attributed to a
- * function called `if`. There is no class-method call site left, and a ledger that
- * reports a keyword as a producer is worse than one that reports `<module scope>`.
+ * A WRITE to the `AppListing` table through any Prisma client handle — `dbWrite.`,
+ * `tx.`, `client.`, whatever the local binding is called. `\.\s*appListing\s*\.`
+ * cannot match the sibling delegates (`appListingReport`, `appListingScreenshot`,
+ * `appListingPublishRequest`, `appListingModerationEvent`): those need a word
+ * character where this requires a `.`.
  */
-const enclosingFn = (haystack: string, index: number) => {
-  const decls = [
-    ...haystack
-      .slice(0, index)
-      .matchAll(/^(?:export )?(?:async )?function (\w+)|^(?:export )?const (\w+) = /gm),
-  ];
-  const last = decls[decls.length - 1];
-  return last ? last[1] ?? last[2] : '<module scope>';
+const WRITE_RE =
+  /\.\s*appListing\s*\.\s*(?:create|createMany|update|updateMany|upsert|delete|deleteMany)\s*\(/g;
+
+// ---------------------------------------------------------------------------
+// ENCLOSING-FUNCTION ATTRIBUTION
+// ---------------------------------------------------------------------------
+/**
+ * 🔴 THIS IS A BACKWARD PARSE, NOT A PATTERN LIST — because two earlier pattern lists
+ * each mis-attributed silently, in a different shape, and a silent wrong name is the
+ * worst output this file can produce (it sends the reader to an unrelated function).
+ *
+ * The shapes that already bit us:
+ *   · a two-space-indented `name(` alternative added to name class methods also matched
+ *     `  if (` and `  switch (`, so four real mutations were attributed to a function
+ *     called `if`;
+ *   · dropping that alternative and anchoring at column 0 made class methods invisible
+ *     instead: re-adding the bust inside `BlockRegistry.setMarketplaceMeta` reported it
+ *     as `block-registry.service.ts::resolveRenderMode`, an unrelated top-level helper
+ *     forty lines earlier — while a comment at that call site instructs a future
+ *     maintainer to add exactly that function to this ledger;
+ *   · a leftmost-match regex over a lookback window jumped to the PREVIOUS function
+ *     whenever the signature contained an object-type parameter (`function f(opts: {`),
+ *     so `delistListing` was reported as `flipBackingBlockStatus`.
+ *
+ * So instead of guessing at the text, `classifyBrace` walks BACKWARD from each `{` with
+ * real bracket matching and decides what that brace opens. Frames are then nested by
+ * brace depth, and a site is attributed to the OUTERMOST enclosing function frame (so a
+ * `$transaction(async (tx) => { … })` callback still reports its owning service
+ * function), qualified by an enclosing class as `Class::method`.
+ *
+ * When it cannot name a frame it says `<unattributed>` and a test below FAILS on that,
+ * naming the file. Failing loudly is deliberate: a fourth mis-attribution shape is more
+ * likely than not, and the cost of a wrong name is higher than the cost of a red build.
+ */
+const RESERVED = new Set([
+  'if', 'for', 'while', 'switch', 'catch', 'return', 'do', 'else', 'with', 'typeof',
+  'await', 'yield', 'new', 'delete', 'void', 'in', 'of', 'case', 'function', 'class',
+  'super', 'this', 'throw', 'try', 'finally', 'import', 'export', 'const', 'let', 'var',
+  'default', 'static', 'async', 'get', 'set',
+]); // prettier-ignore
+
+const TYPE_CHARS = /[\w$\s.<>,[\]|&?]/;
+const isWs = (c: string) => c === ' ' || c === '\t' || c === '\n' || c === '\r';
+const isIdent = (c: string) => /[\w$]/.test(c);
+
+const skipWsBack = (code: string, j: number) => {
+  while (j >= 0 && isWs(code[j])) j--;
+  return j;
 };
 
-const findCallSites = () => {
-  const found: string[] = [];
-  for (const file of FILES) {
-    const source = readFileSync(join(ROOT, file), 'utf8');
-    // Cheap pre-filter: skip the ~99% of files that never mention it at all.
-    if (!source.includes('bustAppListingCatalogCache')) continue;
-    const code = stripCommentsAndStrings(source);
-    for (const m of code.matchAll(CALL_RE)) {
-      // 🔴 The buster's own DECLARATION in `app-listing.service` matches `name\s*\(` too.
-      // Skipping on `enclosingFn(...) === 'bustAppListingCatalogCache'` does NOT work:
-      // `enclosingFn` scans BACKWARD from the match, and at the declaration the match IS
-      // the declaration, so it reports whatever precedes it — which silently listed a
-      // neighbouring helper as a bust site. Test the text immediately before instead.
-      if (/\bfunction\s+$/.test(code.slice(Math.max(0, m.index - 40), m.index))) continue;
-      found.push(`${file}::${enclosingFn(code, m.index)}`);
+/** `code[j]` is `close`; return the index of its matching `open`, or -1. */
+const matchBack = (code: string, j: number, open: string, close: string) => {
+  let depth = 0;
+  while (j >= 0) {
+    if (code[j] === close) depth++;
+    else if (code[j] === open) {
+      depth--;
+      if (depth === 0) return j;
     }
+    j--;
   }
-  return [...new Set(found)].sort();
+  return -1;
+};
+
+/** Consume the identifier ending at `j`; returns it plus the index before it. */
+const identBack = (code: string, j: number) => {
+  const end = j + 1;
+  while (j >= 0 && isIdent(code[j])) j--;
+  return { name: code.slice(j + 1, end), before: j };
 };
 
 /**
- * 🔴 THE LEDGER. `<file>::<enclosing top-level function>`, sorted.
+ * Step backward over a return-type annotation (`: Promise<{ id: string }>`) and return
+ * the index of its leading `:`, or -1. Object types are matched as brackets, which is
+ * what a character-class scan could not do — that omission is what left `acceptTransfer`
+ * and `updateRevisionDraft` unattributed.
+ *
+ * 🔴 BOUNDED, because the `}` case makes this a bracket walk and an unbounded bracket
+ * walk RUNS AWAY: starting at the `}` that ends the previous function it hops the whole
+ * body and keeps going, eventually finding some unrelated `:` and reporting a type
+ * annotation that is not there. `MAX_TYPE_SPAN` caps the travel; a real annotation is
+ * far shorter, and exceeding it means the answer would have been a guess.
+ */
+const MAX_TYPE_SPAN = 400;
+const typeAnnotationStart = (code: string, from: number) => {
+  let j = from;
+  while (j >= 0 && from - j <= MAX_TYPE_SPAN) {
+    j = skipWsBack(code, j);
+    if (j < 0) return -1;
+    const c = code[j];
+    if (c === '}') j = matchBack(code, j, '{', '}') - 1;
+    else if (c === ']') j = matchBack(code, j, '[', ']') - 1;
+    else if (c === '>') j = matchBack(code, j, '<', '>') - 1;
+    else if (isIdent(c) || c === '.' || c === '|' || c === '&' || c === '?' || c === ',') j--;
+    else return c === ':' ? j : -1;
+  }
+  return -1;
+};
+
+type Frame = {
+  start: number;
+  end: number;
+  kind: 'fn' | 'class' | 'method' | 'block';
+  name: string;
+};
+
+/** What does the `{` at `braceIdx` open? */
+const classifyBrace = (code: string, braceIdx: number): Omit<Frame, 'start' | 'end'> | null => {
+  let j = skipWsBack(code, braceIdx - 1);
+  if (j < 0) return null;
+
+  // `class X … {`. FIRST, because its regex is anchored hard against the brace and so
+  // cannot false-positive, whereas the bracket walk below would step back over the `}`
+  // that closes the preceding function and mis-read what it found there.
+  const head = code.slice(Math.max(0, braceIdx - 300), braceIdx);
+  const cls =
+    /(?:^|[\s;{}])(?:export\s+)?(?:default\s+)?(?:abstract\s+)?class\s+(\w+)(?:\s+(?:extends|implements)\s+[\w$.,<>\s]*)?\s*$/.exec(
+      head
+    );
+  if (cls) return { kind: 'class', name: cls[1] };
+
+  // `… => {` — an arrow function. Named only when it is `const NAME = … => {`.
+  if (code[j] === '>' && code[j - 1] === '=') {
+    j = skipWsBack(code, j - 2);
+    const annotated = code[j] === ')' ? j : -1;
+    if (annotated >= 0) j = skipWsBack(code, matchBack(code, annotated, '(', ')') - 1);
+    else {
+      const param = identBack(code, j);
+      if (!param.name) return null;
+      j = skipWsBack(code, param.before);
+    }
+    const maybeAsync = identBack(code, j);
+    if (maybeAsync.name === 'async') j = skipWsBack(code, maybeAsync.before);
+    if (code[j] !== '=') return null; // an anonymous callback — no name to give it
+    j = skipWsBack(code, j - 1);
+    const colon = typeAnnotationStart(code, j);
+    if (colon >= 0) j = skipWsBack(code, colon - 1);
+    const named = identBack(code, j);
+    if (!named.name || RESERVED.has(named.name)) return null;
+    return { kind: 'fn', name: named.name };
+  }
+
+  // `… ( … ) [: T] {` — a function declaration, a class method, or `if`/`for`/`switch`.
+  let close = -1;
+  if (code[j] === ')') close = j;
+  else {
+    const colon = typeAnnotationStart(code, j);
+    if (colon >= 0) {
+      const p = skipWsBack(code, colon - 1);
+      if (code[p] === ')') close = p;
+    }
+  }
+  if (close >= 0) {
+    const open = matchBack(code, close, '(', ')');
+    if (open < 0) return null;
+    let p = skipWsBack(code, open - 1);
+    if (code[p] === '>') {
+      const lt = matchBack(code, p, '<', '>');
+      if (lt < 0) return null;
+      p = skipWsBack(code, lt - 1);
+    }
+    const named = identBack(code, p);
+    if (!named.name) return null;
+    const pre = code.slice(Math.max(0, named.before - 60), named.before + 1);
+    if (/\bfunction\s*\*?\s*$/.test(pre)) return { kind: 'fn', name: named.name };
+    // `if (…) {`, `for (…) {`, `catch (…) {`, and any bare call are excluded here.
+    if (RESERVED.has(named.name)) return null;
+    // A class-method header carries only member modifiers (or nothing) before the name.
+    if (
+      /(?:^|[\s;{}])(?:(?:public|private|protected|static|async|readonly|abstract|override|get|set)\s+)*$/.test(
+        pre
+      )
+    )
+      return { kind: 'method', name: named.name };
+    return null;
+  }
+
+  return null;
+};
+
+const buildFrames = (code: string): Frame[] => {
+  const frames: Frame[] = [];
+  const stack: Frame[] = [];
+  for (let i = 0; i < code.length; i++) {
+    if (code[i] === '{') {
+      const hit = classifyBrace(code, i);
+      const frame: Frame = {
+        start: i,
+        end: code.length,
+        kind: hit?.kind ?? 'block',
+        name: hit?.name ?? '',
+      };
+      // A method-shaped header is a function only when a class actually encloses it;
+      // otherwise it is an object-literal shorthand and must not shadow the real owner.
+      if (frame.kind === 'method')
+        frame.kind = stack.some((f) => f.kind === 'class') ? 'fn' : 'block';
+      stack.push(frame);
+      frames.push(frame);
+    } else if (code[i] === '}') {
+      const frame = stack.pop();
+      if (frame) frame.end = i;
+    }
+  }
+  return frames;
+};
+
+const attribute = (frames: Frame[], index: number): string => {
+  const enclosing = frames
+    .filter((f) => f.start < index && index < f.end)
+    .sort((a, b) => a.start - b.start);
+  const fns = enclosing.filter((f) => f.kind === 'fn');
+  if (!fns.length) return enclosing.length ? '<unattributed>' : '<module scope>';
+  const outer = fns[0];
+  const cls = enclosing.filter((f) => f.kind === 'class' && f.start < outer.start).pop();
+  return cls ? `${cls.name}::${outer.name}` : outer.name;
+};
+
+/** `{ busts, writes }` — both as sorted, de-duplicated `<file>::<fn>` sets. */
+const scan = (files: string[]) => {
+  const busts: string[] = [];
+  const writes: string[] = [];
+  for (const file of files) {
+    const source = readFileSync(join(ROOT, file), 'utf8');
+    // Cheap pre-filter: skip the ~99% of files that mention neither.
+    if (!source.includes('bustAppListingCatalogCache') && !source.includes('appListing.')) continue;
+    const code = stripCommentsAndStrings(source);
+    CALL_RE.lastIndex = 0;
+    WRITE_RE.lastIndex = 0;
+    const bustHits = [...code.matchAll(CALL_RE)].filter(
+      // 🔴 The buster's own DECLARATION in `app-listing.service` matches `name\s*\(` too.
+      (m) => !/\bfunction\s+$/.test(code.slice(Math.max(0, m.index - 40), m.index))
+    );
+    const writeHits = [...code.matchAll(WRITE_RE)];
+    if (!bustHits.length && !writeHits.length) continue;
+    const frames = buildFrames(code);
+    for (const m of bustHits) busts.push(`${file}::${attribute(frames, m.index)}`);
+    for (const m of writeHits) writes.push(`${file}::${attribute(frames, m.index)}`);
+  }
+  return {
+    busts: [...new Set(busts)].sort(),
+    writes: [...new Set(writes)].sort(),
+  };
+};
+
+/**
+ * 🔴 THE BUST LEDGER. `<file>::<enclosing function>`, sorted.
  *
  * Deduplicated on purpose: `updateListing` calls the buster from four of its status
  * branches, and a fifth branch would be a code review question, not a ledger change.
@@ -170,29 +407,78 @@ const LEDGER = [
   'src/server/services/blocks/publish-request.service.ts::approveRequest',
 ].sort();
 
-describe('🔴 bustAppListingCatalogCache CALL-SITE LEDGER', () => {
-  const SITES = findCallSites();
+/**
+ * 🔴 `AppListing` WRITERS THAT DELIBERATELY DO NOT BUST, each with the reason.
+ *
+ * The bar for a row here is that the write provably cannot move a CACHED axis of the
+ * `/apps` keyset statement. That statement reads exactly: `al.id`, `al.status`,
+ * `al.revision_of_id`, `al.kind`, `al.category`, `al.content_rating` (via
+ * `listingMatureFilter`), `ab.current_version_deployed_at`, and the `sort_key` inputs
+ * (`al.name`, `al.created_at`, the `app_listing_metrics` rollup). It reads NOTHING
+ * else — every other column on the card is hydrated live below the cache and can never
+ * be served stale.
+ *
+ * Each reason below was re-derived against the code at this commit, not inherited.
+ */
+const EXEMPT: Record<string, string> = {
+  'src/server/services/blocks/app-listing-assets.service.ts::backfillListingAssets':
+    'writes only `coverId` / `iconId`, both hydrated projection fields — no cached axis.',
+  'src/server/services/blocks/app-listing-assets.service.ts::reDeriveContentRatingForModLiveEdit':
+    'DOES raise `content_rating`, but it is an in-tx helper with exactly three callers ' +
+    '(`setListingIcon`, `setListingCover`, `addListingScreenshot`) and all three bust ' +
+    'post-commit — a bust inside the tx would also fire on a rollback.',
+  'src/server/services/blocks/app-ownership-transfer.service.ts::acceptTransfer':
+    'writes only `userId`; the cached statement never reads ownership and no sort or ' +
+    'filter keys on it (same argument `claimListing` makes for its own inert bust).',
+  'src/server/services/blocks/offsite-listing.service.ts::beginListingRevision':
+    "mints a shadow at `status:'draft'` with `revisionOfId` set — excluded twice over by " +
+    'the approved-only and `revision_of_id IS NULL` filters.',
+  'src/server/services/blocks/offsite-listing.service.ts::closeTerminalListing':
+    'deletes a `draft` row or flips `pending`→`removed`; neither status is `approved`, so ' +
+    'catalog membership is unchanged.',
+  'src/server/services/blocks/offsite-listing.service.ts::submitExternalListing':
+    "mints at `status:'draft'` — outside the approved-only query until an approve path " +
+    '(which busts) promotes it.',
+  'src/server/services/blocks/offsite-listing.service.ts::updateRevisionDraft':
+    'writes the draft shadow, plus the beta half onto the live parent. `is_beta` is not ' +
+    'in the cached statement and renders from the live per-page beta read.',
+  'src/server/services/blocks/offsite-moderation.service.ts::routeRepublishToReviewInTx':
+    'flips `removed`→`pending` (and floors `content_rating` on a non-approved row); its ' +
+    'only caller, `republishOwnListing`, busts anyway.',
+  'src/server/services/blocks/publish-request.service.ts::closeOnsiteResetListingOnWithdraw':
+    'flips `pending`→`removed` — neither status is in the catalog.',
+  'src/server/services/blocks/publish-request.service.ts::deleteOnsiteDraftListingForSlug':
+    "hard-deletes ONLY `{ kind:'onsite', appBlockId:null, status:'draft' }`; the narrowness " +
+    'is load-bearing for authorization (civitai#3984) and keeps it off the catalog.',
+  'src/server/services/blocks/publish-request.service.ts::submitVersion':
+    "mints the pre-approval onsite listing at `status:'draft'`; `approveRequest` is the " +
+    'path that promotes it, and it busts.',
+};
+
+describe('🔴 /apps catalog freshness ledger', () => {
+  const { busts: SITES, writes: WRITERS } = scan(FILES);
 
   /**
    * 🔴 INSTRUMENT FIRST. Every assertion below is a set comparison, and a scan wired to
    * nothing produces an EMPTY set — which reads as "the ledger shrank", i.e. a confident
    * finding about the code that is really a fact about the walk. Prove the walk found a
-   * real population and the regex can match before reading any verdict.
+   * real population and both regexes can match before reading any verdict.
    */
   it('POSITIVE CONTROL: the scan enumerates a real population and can match', () => {
     expect(FILES.length).toBeGreaterThan(500);
     expect(FILES).toContain('src/server/services/blocks/offsite-listing.service.ts');
     expect(SITES.length).toBeGreaterThan(10);
+    expect(WRITERS.length).toBeGreaterThan(15);
     for (const root of ROOTS) {
       expect(FILES.some((f) => f.startsWith(`${root}/`))).toBe(true);
     }
   });
 
   /**
-   * 🔴 POSITIVE CONTROL ON THE REGEX + STRIPPER + `enclosingFn`, through the same code
-   * path the file scan uses. A `.catch(...)`-suffixed call, a bare `await` call and a
-   * class-method enclosure are all shapes present in the real tree; a prose mention and
-   * the import line are shapes that must NOT match.
+   * 🔴 POSITIVE CONTROL ON THE REGEXES + STRIPPER + ATTRIBUTOR, through the same code
+   * path the file scan uses. Every shape here is one the real tree contains, and the
+   * last three are the three mis-attributions this parser replaced: a call nested inside
+   * `if`/`switch`, a class method, and a signature whose parameter is an object type.
    */
   it('POSITIVE CONTROL: the matcher matches calls, and only calls, and names them right', () => {
     const sample = [
@@ -211,34 +497,102 @@ describe('🔴 bustAppListingCatalogCache CALL-SITE LEDGER', () => {
       '  }',
       '}',
       'export async function secondCaller() {',
-      '  await bustAppListingCatalogCache();',
+      '  await dbWrite.$transaction(async (tx) => {',
+      '    await tx.appListing.updateMany({ where: {}, data: {} });',
+      '  });',
+      '}',
+      'export async function objectParamCaller(opts: {',
+      '  id: string;',
+      '}): Promise<{ ok: boolean }> {',
+      '  await dbWrite.appListing.update({ where: {}, data: {} });',
+      '  return { ok: true };',
+      '}',
+      'export class Registry {',
+      '  static async setMarketplaceMeta(input: { id: string }): Promise<void> {',
+      '    await bustAppListingCatalogCache();',
+      '  }',
+      '}',
+      // Sibling delegates must NOT be read as AppListing writes.
+      'export async function notAWriter() {',
+      '  await dbWrite.appListingReport.updateMany({ where: {}, data: {} });',
+      '  await dbWrite.appListingScreenshot.create({ data: {} });',
       '}',
     ].join('\n');
     const code = stripCommentsAndStrings(sample);
-    const hits: string[] = [];
-    for (const m of code.matchAll(CALL_RE)) {
-      if (/\bfunction\s+$/.test(code.slice(Math.max(0, m.index - 40), m.index))) continue;
-      hits.push(enclosingFn(code, m.index));
-    }
+    const frames = buildFrames(code);
+    const bustHits = [...code.matchAll(new RegExp(CALL_RE.source, 'g'))]
+      .filter((m) => !/\bfunction\s+$/.test(code.slice(Math.max(0, m.index - 40), m.index)))
+      .map((m) => attribute(frames, m.index));
+    const writeHits = [...code.matchAll(new RegExp(WRITE_RE.source, 'g'))].map((m) =>
+      attribute(frames, m.index)
+    );
     expect(
-      hits,
+      bustHits,
       'the matcher missed a real call shape, counted prose/an import/the declaration, ' +
-        'or attributed a call to an enclosing `if`/`switch` instead of its function.'
-    ).toEqual(['realCaller', 'secondCaller']);
+        'attributed a call to an enclosing `if`/`switch`, or could not name a class method.'
+    ).toEqual(['realCaller', 'Registry::setMarketplaceMeta']);
+    expect(
+      writeHits,
+      'the write matcher missed a `tx.`/`dbWrite.` write, mis-attributed one across an ' +
+        'object-type parameter, or matched a SIBLING delegate (appListingReport / ' +
+        'appListingScreenshot) that is not the AppListing table.'
+    ).toEqual(['secondCaller', 'objectParamCaller']);
   });
 
   /**
-   * 🔴 NEGATIVE CONTROL. A ledger that cannot go red is decorative. Perturb the SET the
-   * way a regression would — one entry removed (a deleted bust) and one added (a new
-   * mutation with a bust nobody recorded) — and confirm the comparison notices both.
-   * This is the mutation the assertion below is claimed to survive; run it, don't assume
-   * it.
+   * 🔴 NEGATIVE CONTROL. A ledger that cannot go red is decorative. Perturb each SET the
+   * way a regression would and confirm the comparisons notice.
    */
-  it('NEGATIVE CONTROL: the comparison detects both a shrink and a growth', () => {
+  it('NEGATIVE CONTROL: both comparisons detect a shrink and a growth', () => {
+    // The bust set: one entry removed (a deleted bust), one added (an unrecorded bust).
     expect(SITES.slice(1)).not.toEqual(LEDGER);
     expect([...SITES, 'src/server/services/blocks/new.service.ts::newMutation'].sort()).not.toEqual(
       LEDGER
     );
+    // The coverage rule, run over a SYNTHETIC writer set so this control keeps testing
+    // the comparison rather than re-testing the tree (the real verdict is the guard
+    // below; duplicating it here would make both go red for one finding).
+    const covered = (w: string) => SITES.includes(w) || w in EXEMPT;
+    const synthetic = [SITES[0], Object.keys(EXEMPT)[0]];
+    expect(synthetic.filter((w) => !covered(w))).toEqual([]);
+    expect(
+      [...synthetic, 'src/server/services/blocks/new.service.ts::forgetfulDelist'].filter(
+        (w) => !covered(w)
+      )
+    ).toEqual(['src/server/services/blocks/new.service.ts::forgetfulDelist']);
+  });
+
+  /**
+   * 🔴 FAIL LOUDLY RATHER THAN NAME THE WRONG FUNCTION. `<unattributed>` means the
+   * backward parse hit a shape it does not model; every verdict below would then be
+   * computed against a name that does not exist in the file.
+   */
+  it('every site resolves to a named enclosing function', () => {
+    const unresolved = [...SITES, ...WRITERS].filter((s) => s.endsWith('::<unattributed>'));
+    expect(
+      unresolved,
+      'the enclosing-function parser could not name these sites. That is a defect in ' +
+        'this test file (see `classifyBrace`), not in the code under scan — do not ' +
+        'work around it by editing the ledger.'
+    ).toEqual([]);
+  });
+
+  /**
+   * 🔴 THE HEADLINE GUARD, and the one the bust-only version of this file did NOT
+   * provide. Every writer of the `AppListing` table must either bust or be exempt.
+   */
+  it('🔴 every AppListing writer either busts the catalog cache or is EXEMPT', () => {
+    const unbusted = WRITERS.filter((w) => !SITES.includes(w) && !(w in EXEMPT));
+    expect(
+      unbusted,
+      'these functions write the `AppListing` table and neither call ' +
+        '`bustAppListingCatalogCache()` nor appear in `EXEMPT`. If the write can change ' +
+        'catalog MEMBERSHIP (`status`, `kind`, `revision_of_id`, the onsite deploy gate) ' +
+        'or a CACHED axis (`category`, `content_rating`, `name`/`created_at`/the metric ' +
+        'rollup that feed `sort_key`), call the buster after the commit and add the row ' +
+        'to `LEDGER`. If it provably cannot, add it to `EXEMPT` with the reason. Every ' +
+        'other column on the card is hydrated live and can never be stale.'
+    ).toEqual([]);
   });
 
   it('the set of catalog-bust call sites is EXACTLY the ledger', () => {
@@ -253,8 +607,30 @@ describe('🔴 bustAppListingCatalogCache CALL-SITE LEDGER', () => {
         'entry, so the store grid can serve a delisted / re-rated / re-categorised row ' +
         'for the whole CacheTTL.sm window. An ADDITION is fine — record it here in the ' +
         'same commit, with one line saying which CACHED axis it moves (or that it is a ' +
-        'deliberately inert uniform-rule site). See this file`s header.'
+        'deliberately inert defence-in-depth site). See this file`s header.'
     ).toEqual(LEDGER);
+  });
+
+  /**
+   * 🔴 KEEP `EXEMPT` FROM ROTTING. An entry naming a function that no longer writes the
+   * table is dead prose that will be trusted by the next reader; an entry that ALSO
+   * busts is a contradiction about which rule applies.
+   */
+  it('every EXEMPT entry is a current, non-busting writer', () => {
+    expect(
+      Object.keys(EXEMPT).filter((e) => !WRITERS.includes(e)),
+      'EXEMPT names a function that no longer writes `AppListing`. Delete the row.'
+    ).toEqual([]);
+    expect(
+      Object.keys(EXEMPT).filter((e) => SITES.includes(e)),
+      'EXEMPT names a function that DOES bust. Move it to `LEDGER`.'
+    ).toEqual([]);
+    for (const [key, reason] of Object.entries(EXEMPT)) {
+      expect(
+        reason.length,
+        `EXEMPT["${key}"] needs a real reason, not a placeholder`
+      ).toBeGreaterThan(40);
+    }
   });
 
   /**

--- a/src/server/services/blocks/__tests__/app-listing.catalog-cache.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.catalog-cache.test.ts
@@ -375,7 +375,7 @@ describe('/apps catalog cache — the key separates viewers', () => {
     const prefixes: string[] = [];
     for (const shape of shapes) prefixes.push(await prefixFor(shape));
     // The prefix must carry MORE than `<key>:<version>` — i.e. the axes are actually in
-    // there, rather than the five shapes happening to differ for some other reason.
+    // there, rather than the six shapes happening to differ for some other reason.
     for (const p of prefixes) {
       expect(
         p.split(':').length,

--- a/src/server/services/blocks/__tests__/app-listing.catalog-cache.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.catalog-cache.test.ts
@@ -1,0 +1,239 @@
+import fs from 'fs';
+import path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 THE `/apps` CATALOG CACHE CANNOT SERVE ONE VIEWER'S PAGE TO ANOTHER.
+ *
+ * `listAvailableListings` now reads its keyset id page through `queryCache`
+ * (`~/server/utils/cache-helpers`) with a 180s TTL and the `app-listing:catalog`
+ * bust tag. Caching a page whose CONTENTS DEPEND ON THE VIEWER is the single way
+ * this change can do harm, and it has two such axes:
+ *
+ *   · `scope` — `listingPublicVisibilityFilter`. `full` sees the whole approved
+ *     catalog; `public-external` sees OFFSITE listings only. That is the
+ *     public/onsite security boundary (civitai#3983 is the incident where it was
+ *     defaulted open). A cache that collided the two would serve on-site apps to
+ *     anonymous callers of `GET /api/v1/apps` — the same defect, arrived at from
+ *     the cache instead of from a `??`.
+ *
+ *   · `redCapable` — `listingMatureFilter`. A non-red-capable host must not be
+ *     shown `r`/`x` listings. A collision here serves mature cards onto a SFW
+ *     domain.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THIS ASSERTS ON THE DERIVED KEY, NOT ON WORDS IN THE SQL
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The sibling suite `app-listing.public-scope.test.ts` already guards the SQL
+ * TEXT (`al.kind = 'offsite'` present / absent). That is a guard on WORDS, and it
+ * says nothing about the cache: two statements can differ in text and still be
+ * asked to share an entry if the key is assembled by hand from a hand-listed set
+ * of axes.
+ *
+ * `queryCache` does not assemble the key by hand. It builds it as
+ * `[key, version, hashifyObject(query)].join(':')` over the WHOLE `Prisma.Sql` —
+ * text and bound params — so every axis interpolated into the statement is in the
+ * key BY CONSTRUCTION. This file pins exactly that property: it captures the
+ * `Prisma.Sql` the service hands `queryCache` for each viewer shape, derives the
+ * key the way `cache-helpers` derives it (with the REAL `hashifyObject`), and
+ * asserts the keys are distinct.
+ *
+ * Re-wording the SQL cannot satisfy this. Only actually making two viewer shapes
+ * produce the same statement can — which is precisely the defect.
+ *
+ * ⚠️ `redCapable` is a SECOND viewer-varying axis, and the reason the derived-key
+ * form matters: a hand-written key naming `scope` would look complete and still
+ * miss it. Nothing here enumerates axes.
+ */
+
+/**
+ * The capture. `queryCache(db, key, version)` is called once at MODULE level in the
+ * service, so this factory records the cache name/version there and the per-call
+ * `(sql, options)` on every invocation.
+ *
+ * It returns `[]`, which makes `listAvailableListings` short-circuit before the
+ * hydration — this file is about the KEY, not the rows, so no DB fixture is needed.
+ * DB deps come from the CANONICAL `dbMock` registered in `src/__tests__/setup.ts`.
+ * A per-file mock of `~/server/db/client` is forbidden by
+ * `no-direct-shared-module-mock` — and note that guard is TEXTUAL, so writing the
+ * forbidden call as a code sample in this very comment trips it too.
+ */
+const { cacheCalls, cacheBinding } = vi.hoisted(() => ({
+  cacheCalls: [] as { sql: unknown; options: { ttl?: number; tag?: unknown } | undefined }[],
+  cacheBinding: [] as { key: string; version?: string }[],
+}));
+
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600, sm: 180 } }));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  queryCache: (_db: unknown, key: string, version?: string) => {
+    cacheBinding.push({ key, version });
+    return async (sql: unknown, options?: { ttl?: number; tag?: unknown }): Promise<unknown[]> => {
+      cacheCalls.push({ sql, options });
+      return [];
+    };
+  },
+  // 🔴 BOTH EXPORTS. The service imports `bustCacheTag` too (it owns
+  // `bustAppListingCatalogCache`), and a one-key factory makes the whole FILE fail to
+  // import with `No "bustCacheTag" export is defined on the … mock`.
+  bustCacheTag: vi.fn(async () => undefined),
+}));
+
+import { hashifyObject } from '~/utils/string-helpers';
+import { listAvailableListings } from '../app-listing.service';
+import { APP_LISTING_CATALOG_TAG } from '../app-listing-cache.constants';
+import type { StoreVisibilityScope } from '~/server/services/app-blocks-flag';
+
+const BASE_INPUT = { kind: 'all', sort: 'newest', limit: 20 } as const;
+
+/** The most recent `(sql, options)` the service handed the cache. */
+function lastCall() {
+  const call = cacheCalls.at(-1);
+  if (!call) throw new Error('listAvailableListings never called the query cache');
+  return call;
+}
+
+/**
+ * Derive the redis key EXACTLY as `queryCache` does — same `hashifyObject`, same
+ * `[key, version, hash].join(':')`. Not a re-implementation of the hash: the real
+ * `hashifyObject` is imported and called on the real `Prisma.Sql`.
+ */
+function deriveKey(sql: unknown): string {
+  const binding = cacheBinding.at(-1);
+  if (!binding) throw new Error('queryCache was never bound');
+  return [binding.key, binding.version, hashifyObject(sql).toString()]
+    .filter((p) => p != null && p !== '')
+    .join(':');
+}
+
+/** Run the list path for one viewer shape and return the cache key it would use. */
+async function keyFor(opts: { scope?: StoreVisibilityScope; redCapable?: boolean }) {
+  await listAvailableListings({ ...BASE_INPUT }, opts);
+  return deriveKey(lastCall().sql);
+}
+
+beforeEach(() => {
+  cacheCalls.length = 0;
+  vi.clearAllMocks();
+});
+
+describe('/apps catalog cache — the key separates viewers', () => {
+  /**
+   * 🔴 POSITIVE CONTROL, FIRST. Every assertion below is "these two keys DIFFER",
+   * and that is also what you observe from a key derivation that is simply
+   * unstable — a hash over something with a timestamp or an object identity in it
+   * would make every pair differ and every guard below vacuously green.
+   *
+   * So prove the derivation is DETERMINISTIC for an unchanged viewer shape before
+   * reading anything into a difference.
+   */
+  it('is stable: the same viewer shape twice derives the SAME key', async () => {
+    const a = await keyFor({ scope: 'full', redCapable: false });
+    const b = await keyFor({ scope: 'full', redCapable: false });
+    expect(a).toBe(b);
+    // …and it is a real key, not an empty string two ways.
+    expect(a.startsWith('listAvailableAppListings:')).toBe(true);
+  });
+
+  it('🔴 scope `full` and `public-external` can never share a cache entry', async () => {
+    const full = await keyFor({ scope: 'full', redCapable: false });
+    const publicExternal = await keyFor({ scope: 'public-external', redCapable: false });
+    expect(
+      publicExternal,
+      'the public-external and full store scopes derive the SAME cache key, so an ' +
+        'anonymous /api/v1/apps caller can be served a page built for the full ' +
+        'catalog — on-site apps included. That is civitai#3983 re-opened through the ' +
+        'cache. `listingPublicVisibilityFilter` must emit DIFFERENT SQL per scope.'
+    ).not.toBe(full);
+  });
+
+  it('🔴 `none` (the fail-closed scope) cannot share an entry with either', async () => {
+    const none = await keyFor({ scope: undefined, redCapable: false });
+    const full = await keyFor({ scope: 'full', redCapable: false });
+    const publicExternal = await keyFor({ scope: 'public-external', redCapable: false });
+    expect(none).not.toBe(full);
+    expect(none).not.toBe(publicExternal);
+  });
+
+  it('🔴 redCapable true and false can never share a cache entry', async () => {
+    const red = await keyFor({ scope: 'full', redCapable: true });
+    const sfw = await keyFor({ scope: 'full', redCapable: false });
+    expect(
+      sfw,
+      'a red-capable and a SFW-only host derive the SAME cache key, so mature (r/x) ' +
+        'listings can be served onto a SFW domain from a page built for a red host. ' +
+        '`listingMatureFilter` must emit DIFFERENT SQL per capability.'
+    ).not.toBe(red);
+  });
+
+  /**
+   * The two axes TOGETHER. Each pair above is a 1-D claim; a key that folded the two
+   * axes into one bit would satisfy both and still collide `{full, sfw}` with
+   * `{public-external, red}`. Six pairs, all distinct.
+   */
+  it('🔴 all four (scope × redCapable) viewer shapes are pairwise distinct', async () => {
+    const shapes: { scope: StoreVisibilityScope; redCapable: boolean }[] = [
+      { scope: 'full', redCapable: true },
+      { scope: 'full', redCapable: false },
+      { scope: 'public-external', redCapable: true },
+      { scope: 'public-external', redCapable: false },
+    ];
+    const keys: string[] = [];
+    for (const shape of shapes) keys.push(await keyFor(shape));
+    expect(new Set(keys).size, `two viewer shapes collided: ${JSON.stringify(keys)}`).toBe(
+      shapes.length
+    );
+  });
+
+  /**
+   * The NON-viewer axes, for completeness — these are ordinary correctness rather
+   * than a disclosure boundary, but they are in the key by the same construction and
+   * a regression on them serves the wrong page just as surely.
+   */
+  it('kind, category, sort, limit and cursor each change the key', async () => {
+    const base = await keyFor({ scope: 'full', redCapable: false });
+    const variants: Record<string, Record<string, unknown>> = {
+      kind: { kind: 'offsite' },
+      category: { category: 'utility' },
+      sort: { sort: 'name' },
+      limit: { limit: 21 },
+    };
+    for (const [axis, over] of Object.entries(variants)) {
+      await listAvailableListings({ ...BASE_INPUT, ...over } as never, {
+        scope: 'full',
+        redCapable: false,
+      });
+      expect(deriveKey(lastCall().sql), `the \`${axis}\` axis is not in the cache key`).not.toBe(
+        base
+      );
+    }
+  });
+
+  it('the page is written with the catalog bust tag and the 180s TTL', async () => {
+    await keyFor({ scope: 'full', redCapable: false });
+    const { options } = lastCall();
+    expect(options?.tag).toEqual([APP_LISTING_CATALOG_TAG]);
+    expect(options?.ttl).toBe(180);
+  });
+
+  /**
+   * 🔴 DRIFT-GUARD ON THE FORMULA THIS FILE REPRODUCES.
+   *
+   * `deriveKey` above mirrors `queryCache`'s key construction. If `cache-helpers`
+   * ever stopped hashing the whole `Prisma.Sql` — hashing only `query.sql`, say, and
+   * dropping the bound params — every assertion in this file would keep passing
+   * while the property it claims to guard was gone. Pin the line.
+   */
+  it('cache-helpers still keys on a hash of the WHOLE Prisma.Sql', () => {
+    const src = fs.readFileSync(
+      path.join(process.cwd(), 'src/server/utils/cache-helpers.ts'),
+      'utf8'
+    );
+    const normalized = src.replace(/\s+/g, ' ');
+    expect(
+      normalized,
+      'queryCache no longer builds its key from `hashifyObject(query)` over the whole ' +
+        'Prisma.Sql. This suite derives keys that way, so it is now measuring itself. ' +
+        'Re-derive `deriveKey` against the new formula before trusting any result here.'
+    ).toContain("[key, version, hashifyObject(query).toString()].filter(isDefined).join(':')");
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing.catalog-cache.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.catalog-cache.test.ts
@@ -22,28 +22,44 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  *     domain.
  *
  * ─────────────────────────────────────────────────────────────────────────────
- * WHY THIS ASSERTS ON THE DERIVED KEY, NOT ON WORDS IN THE SQL
+ * 🔴 THE TWO LEVELS THIS FILE GUARDS, AND WHY THE SECOND ONE EXISTS
  * ─────────────────────────────────────────────────────────────────────────────
- * The sibling suite `app-listing.public-scope.test.ts` already guards the SQL
- * TEXT (`al.kind = 'offsite'` present / absent). That is a guard on WORDS, and it
- * says nothing about the cache: two statements can differ in text and still be
- * asked to share an entry if the key is assembled by hand from a hand-listed set
- * of axes.
  *
- * `queryCache` does not assemble the key by hand. It builds it as
- * `[key, version, hashifyObject(query)].join(':')` over the WHOLE `Prisma.Sql` —
- * text and bound params — so every axis interpolated into the statement is in the
- * key BY CONSTRUCTION. This file pins exactly that property: it captures the
- * `Prisma.Sql` the service hands `queryCache` for each viewer shape, derives the
- * key the way `cache-helpers` derives it (with the REAL `hashifyObject`), and
- * asserts the keys are distinct.
+ * (1) DERIVED KEYS DIFFER. The sibling suite `app-listing.public-scope.test.ts`
+ *     already guards the SQL TEXT (`al.kind = 'offsite'` present / absent). That
+ *     is a guard on WORDS and says nothing about the cache: two statements can
+ *     differ in text and still be asked to share an entry. So this file captures
+ *     the `Prisma.Sql` the service hands `queryCache` for each viewer shape,
+ *     derives the key the way `cache-helpers` derives it (with the REAL
+ *     `hashifyObject`), and asserts the keys are distinct.
  *
- * Re-wording the SQL cannot satisfy this. Only actually making two viewer shapes
- * produce the same statement can — which is precisely the defect.
+ * (2) 🔴 THE BOUNDARY IS NOT HASH-DEPENDENT. Level (1) is necessary and NOT
+ *     sufficient, and an earlier revision of this file stopped there. "Distinct
+ *     statements ⇒ distinct keys" assumes `hashifyObject` is INJECTIVE. It is
+ *     not: `hashify` (`~/utils/string-helpers`) is a **32-bit** rolling hash,
+ *     `hash = (hash << 5) - hash + chr; hash |= 0`. It is linear, so a collision
+ *     against a chosen target is CONSTRUCTED algebraically — not brute-forced —
+ *     and the attacker has the bytes to do it with: `decodeListingCursor` slices
+ *     `cursorSortKey` and `cursorId` out of a lenient base64url decode as
+ *     arbitrary free strings (only `cursorMean` is range-validated) and the
+ *     router bounds `cursor` only by `z.string().max(128)`. Both land in the
+ *     hashed statement as bound params. Two statements differing exactly at the
+ *     scope predicate (`TRUE` vs `al.kind = 'offsite'`) collide on the identical
+ *     32-bit hash with six tuning characters placed in the cursor.
+ *
+ *     The service's answer is NOT to widen the hash (global blast radius — it
+ *     keys caches, DOM ids and de-dup across the codebase). It is to lift the two
+ *     SECURITY-BOUNDARY axes OUT of the hashed payload and into the literal `key`
+ *     string: `listAvailableAppListings:<scope>:<red|sfw>`. A hash collision can
+ *     then only ever mix two pages WITHIN one viewer class.
+ *
+ *     So the tests below assert on the key with its hash segment REMOVED. That is
+ *     the half of the key a collision cannot touch, and it is the only form of
+ *     this guard that a 32-bit hash cannot walk past.
  *
  * ⚠️ `redCapable` is a SECOND viewer-varying axis, and the reason the derived-key
- * form matters: a hand-written key naming `scope` would look complete and still
- * miss it. Nothing here enumerates axes.
+ * form matters at level (1): a hand-written key naming `scope` would look complete
+ * and still miss it. Nothing here enumerates axes.
  */
 
 /**
@@ -79,8 +95,12 @@ vi.mock('~/server/utils/cache-helpers', () => ({
 }));
 
 import { hashifyObject } from '~/utils/string-helpers';
-import { listAvailableListings } from '../app-listing.service';
-import { APP_LISTING_CATALOG_TAG } from '../app-listing-cache.constants';
+import { bustCacheTag } from '~/server/utils/cache-helpers';
+import { bustAppListingCatalogCache, listAvailableListings } from '../app-listing.service';
+import {
+  APP_LISTING_CATALOG_TAG,
+  APP_LISTING_RECOMMEND_MEAN_TAG,
+} from '../app-listing-cache.constants';
 import type { StoreVisibilityScope } from '~/server/services/app-blocks-flag';
 
 const BASE_INPUT = { kind: 'all', sort: 'newest', limit: 20 } as const;
@@ -109,6 +129,29 @@ function deriveKey(sql: unknown): string {
 async function keyFor(opts: { scope?: StoreVisibilityScope; redCapable?: boolean }) {
   await listAvailableListings({ ...BASE_INPUT }, opts);
   return deriveKey(lastCall().sql);
+}
+
+/**
+ * 🔴 The key WITHOUT its hash segment — i.e. everything a `hashifyObject` collision
+ * cannot change.
+ *
+ * `queryCache` puts the hash LAST (`[key, version, hash].join(':')`), so dropping the
+ * final `:`-segment leaves exactly the literal `key` + `version` the service chose.
+ * Two viewer shapes whose PREFIXES differ cannot be made to share a redis entry by any
+ * collision, however constructed; two whose prefixes are equal are separated only by a
+ * 32-bit hash over attacker-influenced bytes.
+ *
+ * `keyPrefixIsolatesTheHash` below is the positive control that this really is dropping
+ * the hash and nothing else.
+ */
+function keyPrefix(key: string): string {
+  const parts = key.split(':');
+  return parts.slice(0, -1).join(':');
+}
+
+/** Run the list path for one viewer shape and return the HASH-INDEPENDENT key prefix. */
+async function prefixFor(opts: { scope?: StoreVisibilityScope; redCapable?: boolean }) {
+  return keyPrefix(await keyFor(opts));
 }
 
 beforeEach(() => {
@@ -206,6 +249,141 @@ describe('/apps catalog cache — the key separates viewers', () => {
         base
       );
     }
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // 🔴 LEVEL (2): THE BOUNDARY IS NOT HASH-DEPENDENT.
+  //
+  // Every assertion above this line is satisfied by "the two statements differ",
+  // which a 32-bit hash can undo. These are satisfied only by the boundary axes
+  // being LITERAL, UN-HASHED segments of the redis key.
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * 🔴 POSITIVE CONTROL ON `keyPrefix` ITSELF, and it has to come first.
+   *
+   * `keyPrefix` claims to strip the hash and leave the literal part. If it stripped
+   * MORE than the hash — or if the hash were not the last segment — every prefix
+   * assertion below would be measuring something other than what it says.
+   *
+   * The discriminating case is a NON-boundary axis: `sort` is interpolated into the
+   * statement and is NOT in the literal key. So changing it MUST move the full key
+   * (it is hashed) and MUST NOT move the prefix (it is not literal). One case, both
+   * directions, and it fails if `keyPrefix` slices at the wrong place.
+   */
+  it('keyPrefixIsolatesTheHash: a non-boundary axis moves the key but NOT the prefix', async () => {
+    const base = await keyFor({ scope: 'full', redCapable: false });
+    await listAvailableListings({ ...BASE_INPUT, sort: 'name' } as never, {
+      scope: 'full',
+      redCapable: false,
+    });
+    const other = deriveKey(lastCall().sql);
+    expect(other, '`sort` is not in the hashed statement at all').not.toBe(base);
+    expect(
+      keyPrefix(other),
+      '`keyPrefix` is not isolating the hash segment: a purely-hashed axis moved the ' +
+        'prefix too, so every prefix assertion below is measuring the hash after all.'
+    ).toBe(keyPrefix(base));
+    // …and the prefix is a real, non-empty literal, not two empty strings. (Note this
+    // assertion stays TRUE with the boundary axes hashed — it is a control, not a guard;
+    // the guards are below.)
+    expect(keyPrefix(base).startsWith('listAvailableAppListings:')).toBe(true);
+  });
+
+  /**
+   * 🔴 THE HEADLINE GUARD. `scope` — the public/onsite security boundary — must be a
+   * LITERAL segment of the cache key, so no `hashifyObject` collision can cross it.
+   *
+   * WHY A HASH COLLISION IS REACHABLE HERE, not theoretical: `hashify` is a 32-bit
+   * linear rolling hash and `decodeListingCursor` admits `cursorSortKey` / `cursorId`
+   * as arbitrary free strings straight into the hashed statement as bound params. Six
+   * tuning characters in the cursor are enough to collide the `full` statement with
+   * the `public-external` one. If the scope lived only inside the hash, that collision
+   * would serve on-site apps into the anonymous `GET /api/v1/apps` response
+   * (civitai#3983, re-opened through the cache) — and the reverse direction is cache
+   * poisoning.
+   */
+  it('🔴 `scope` is a LITERAL key segment — a hash collision cannot cross the store-scope boundary', async () => {
+    const full = await prefixFor({ scope: 'full', redCapable: false });
+    const publicExternal = await prefixFor({ scope: 'public-external', redCapable: false });
+    expect(
+      publicExternal,
+      'the store SCOPE is not in the un-hashed part of the cache key, so `full` and ' +
+        '`public-external` are separated ONLY by a 32-bit hash over a statement whose ' +
+        'cursor bytes the caller supplies. That hash is constructible: a crafted cursor ' +
+        'serves the full catalog (on-site apps included) to an anonymous /api/v1/apps ' +
+        'caller. Put `scope` back into the `key` string passed to `queryCache`.'
+    ).not.toBe(full);
+  });
+
+  /**
+   * The maturity gate, same property. A cross-capability collision serves `r`/`x`
+   * listings onto a SFW host.
+   */
+  it('🔴 `redCapable` is a LITERAL key segment — a hash collision cannot cross the maturity gate', async () => {
+    const red = await prefixFor({ scope: 'full', redCapable: true });
+    const sfw = await prefixFor({ scope: 'full', redCapable: false });
+    expect(
+      sfw,
+      'the maturity capability is not in the un-hashed part of the cache key, so a ' +
+        'red-capable and a SFW-only host are separated ONLY by a constructible 32-bit ' +
+        'hash. Put `redCapable` back into the `key` string passed to `queryCache`.'
+    ).not.toBe(red);
+  });
+
+  /**
+   * All FIVE viewer classes, on the hash-independent prefix. `none` is included: the
+   * router short-circuits it, but it is the fail-closed scope and must not be able to
+   * share an entry with a scope that returns rows.
+   *
+   * Pairwise-distinct prefixes is the whole property this change buys — stated once,
+   * over the full product, so a key that folded two axes into one bit cannot satisfy
+   * the 1-D cases above and slip through here.
+   */
+  it('🔴 every (scope × redCapable) viewer class has a distinct HASH-INDEPENDENT prefix', async () => {
+    const shapes: { scope?: StoreVisibilityScope; redCapable: boolean }[] = [
+      { scope: 'full', redCapable: true },
+      { scope: 'full', redCapable: false },
+      { scope: 'public-external', redCapable: true },
+      { scope: 'public-external', redCapable: false },
+      { scope: undefined, redCapable: false }, // → narrowStoreScope → 'none'
+    ];
+    const prefixes: string[] = [];
+    for (const shape of shapes) prefixes.push(await prefixFor(shape));
+    // The prefix must carry MORE than `<key>:<version>` — i.e. the axes are actually in
+    // there, rather than the five shapes happening to differ for some other reason.
+    for (const p of prefixes) {
+      expect(
+        p.split(':').length,
+        `the cache-key prefix "${p}" is just <key>:<version> — no viewer axis is literal`
+      ).toBeGreaterThan(2);
+    }
+    expect(
+      new Set(prefixes).size,
+      'two viewer classes share a hash-independent cache-key prefix, so only a 32-bit ' +
+        `hash separates them: ${JSON.stringify(prefixes)}`
+    ).toBe(shapes.length);
+  });
+
+  /**
+   * 🔴 BEHAVIOURAL, NOT STRUCTURAL. `bustAppListingCatalogCache` is the single buster
+   * every mutation calls; the ledger suite proves the CALL SITES are complete, and a
+   * structural check type-checks straight past a buster that busts the WRONG TAG.
+   * There are two tags in `app-listing-cache.constants`, and swapping them would make
+   * every mutation appear to bust while the catalog entry survived its full TTL.
+   */
+  it('🔴 the buster busts the CATALOG tag, not the recommend-mean tag', async () => {
+    await bustAppListingCatalogCache();
+    expect(bustCacheTag).toHaveBeenCalledTimes(1);
+    expect(
+      bustCacheTag,
+      '`bustAppListingCatalogCache` did not pass the catalog tag. Every one of the ' +
+        'listing mutations calls it and would report success while the /apps grid ' +
+        'stayed stale for the whole TTL.'
+    ).toHaveBeenCalledWith([APP_LISTING_CATALOG_TAG]);
+    // Negative half: the two tags are genuinely different strings, so the assertion
+    // above is not vacuously true of both.
+    expect(APP_LISTING_CATALOG_TAG).not.toBe(APP_LISTING_RECOMMEND_MEAN_TAG);
   });
 
   it('the page is written with the catalog bust tag and the 180s TTL', async () => {

--- a/src/server/services/blocks/__tests__/app-listing.catalog-cache.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.catalog-cache.test.ts
@@ -41,11 +41,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  *     against a chosen target is CONSTRUCTED algebraically — not brute-forced —
  *     and the attacker has the bytes to do it with: `decodeListingCursor` slices
  *     `cursorSortKey` and `cursorId` out of a lenient base64url decode as
- *     arbitrary free strings (only `cursorMean` is range-validated) and the
- *     router bounds `cursor` only by `z.string().max(128)`. Both land in the
- *     hashed statement as bound params. Two statements differing exactly at the
- *     scope predicate (`TRUE` vs `al.kind = 'offsite'`) collide on the identical
- *     32-bit hash with six tuning characters placed in the cursor.
+ *     arbitrary free strings (only `cursorMean` is range-validated) and the read
+ *     schema bounds `cursor` only by `z.string().max(128)`. Both land in the
+ *     hashed statement as bound params, which is what makes a collision between
+ *     the two scope predicates (`TRUE` vs `al.kind = 'offsite'`) CONSTRUCTIBLE
+ *     rather than something to brute-force.
+ *
+ *     ⚠️ Nothing here constructs one, and no test asserts a byte count for it. An
+ *     earlier version of this comment quoted "six tuning characters"; that figure
+ *     was never derived or pinned, so it is gone rather than replaced. It does not
+ *     need replacing: the guards below put the boundary OUTSIDE the hash entirely,
+ *     which makes the exact cost of a collision irrelevant rather than merely large.
  *
  *     The service's answer is NOT to widen the hash (global blast radius — it
  *     keys caches, DOM ids and de-dup across the codebase). It is to lift the two
@@ -63,9 +69,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  */
 
 /**
- * The capture. `queryCache(db, key, version)` is called once at MODULE level in the
- * service, so this factory records the cache name/version there and the per-call
- * `(sql, options)` on every invocation.
+ * The capture. `queryCache(db, key, version)` is called PER INVOCATION, inside
+ * `catalogPageCache(scope, redCapable)` — that is the fix this PR makes, because a
+ * module-level binding could only ever hold ONE key and so could not carry the viewer
+ * class. This factory therefore records a `cacheBinding` entry per call, not one for
+ * the module, and each entry is the key for the viewer shape that produced it.
  *
  * It returns `[]`, which makes `listAvailableListings` short-circuit before the
  * hydration — this file is about the KEY, not the rows, so no DB fixture is needed.
@@ -102,6 +110,9 @@ import {
   APP_LISTING_RECOMMEND_MEAN_TAG,
 } from '../app-listing-cache.constants';
 import type { StoreVisibilityScope } from '~/server/services/app-blocks-flag';
+// The runtime value set, from the leaf module that owns it (no imports of its own), so
+// the viewer-class count below is DERIVED rather than restated.
+import { STORE_VISIBILITY_SCOPES } from '~/shared/utils/store-visibility-scope';
 
 const BASE_INPUT = { kind: 'all', sort: 'newest', limit: 20 } as const;
 
@@ -296,10 +307,12 @@ describe('/apps catalog cache — the key separates viewers', () => {
    *
    * WHY A HASH COLLISION IS REACHABLE HERE, not theoretical: `hashify` is a 32-bit
    * linear rolling hash and `decodeListingCursor` admits `cursorSortKey` / `cursorId`
-   * as arbitrary free strings straight into the hashed statement as bound params. Six
-   * tuning characters in the cursor are enough to collide the `full` statement with
-   * the `public-external` one. If the scope lived only inside the hash, that collision
-   * would serve on-site apps into the anonymous `GET /api/v1/apps` response
+   * as arbitrary free strings straight into the hashed statement as bound params —
+   * enough attacker-chosen bytes to solve for a collision between the `full` statement
+   * and the `public-external` one instead of searching for it. (No test constructs one
+   * and no byte count is claimed; see the file header.) If the scope lived only inside
+   * the hash, that collision would serve on-site apps into the anonymous
+   * `GET /api/v1/apps` response
    * (civitai#3983, re-opened through the cache) — and the reverse direction is cache
    * poisoning.
    */
@@ -332,13 +345,17 @@ describe('/apps catalog cache — the key separates viewers', () => {
   });
 
   /**
-   * All FIVE viewer classes, on the hash-independent prefix. `none` is included: the
-   * router short-circuits it, but it is the fail-closed scope and must not be able to
-   * share an entry with a scope that returns rows.
+   * The WHOLE `scope × redCapable` product on the hash-independent prefix. `none` is
+   * included: the router short-circuits it, but it is the fail-closed scope and must
+   * not be able to share an entry with a scope that returns rows.
    *
    * Pairwise-distinct prefixes is the whole property this change buys — stated once,
    * over the full product, so a key that folded two axes into one bit cannot satisfy
    * the 1-D cases above and slip through here.
+   *
+   * 🔴 The count is DERIVED from `STORE_VISIBILITY_SCOPES`, not written down, so this
+   * also pins the cardinality claim `catalogPageCache` makes about the `cache_name`
+   * metric label. Adding a scope adds two classes and fails here until enumerated.
    */
   it('🔴 every (scope × redCapable) viewer class has a distinct HASH-INDEPENDENT prefix', async () => {
     const shapes: { scope?: StoreVisibilityScope; redCapable: boolean }[] = [
@@ -346,8 +363,15 @@ describe('/apps catalog cache — the key separates viewers', () => {
       { scope: 'full', redCapable: false },
       { scope: 'public-external', redCapable: true },
       { scope: 'public-external', redCapable: false },
+      { scope: 'none', redCapable: true },
       { scope: undefined, redCapable: false }, // → narrowStoreScope → 'none'
     ];
+    expect(
+      shapes.length,
+      'the viewer-class product changed size. `catalogPageCache` states the ' +
+        '`cache_name` label cardinality is bounded at (scopes x 2) — enumerate the new ' +
+        'classes here and update that note in the same commit.'
+    ).toBe(STORE_VISIBILITY_SCOPES.length * 2);
     const prefixes: string[] = [];
     for (const shape of shapes) prefixes.push(await prefixFor(shape));
     // The prefix must carry MORE than `<key>:<version>` — i.e. the axes are actually in

--- a/src/server/services/blocks/__tests__/app-listing.deploy-gate.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.deploy-gate.test.ts
@@ -44,12 +44,16 @@ const { mockDbRead } = vi.hoisted(() => ({
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
 vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (src: string) => src }));
 vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
-vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600, sm: 180 } }));
 vi.mock('~/server/utils/cache-helpers', () => ({
+  // 🔴 BOTH EXPORTS. `app-listing.service` now imports `bustCacheTag` as well as
+  // `queryCache` (it owns `bustAppListingCatalogCache`), and a one-key factory makes the
+  // WHOLE FILE fail to import with `No "bustCacheTag" export is defined on the … mock`.
   queryCache:
     () =>
     async (sql: unknown): Promise<unknown[]> =>
       mockDbRead.$queryRaw(sql),
+  bustCacheTag: vi.fn(async () => undefined),
 }));
 
 import { getListingDetail, listAvailableListings } from '../app-listing.service';

--- a/src/server/services/blocks/__tests__/app-listing.moderation.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.moderation.service.test.ts
@@ -29,18 +29,19 @@ const { mockDbRead } = vi.hoisted(() => ({
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
 vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (src: string) => src }));
 vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
-vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600, sm: 180 } }));
 vi.mock('~/server/utils/cache-helpers', () => ({
+  // 🔴 BOTH EXPORTS. `app-listing.service` now imports `bustCacheTag` as well as
+  // `queryCache` (it owns `bustAppListingCatalogCache`), and a one-key factory makes the
+  // WHOLE FILE fail to import with `No "bustCacheTag" export is defined on the … mock`.
   queryCache:
     () =>
     async (sql: unknown): Promise<unknown[]> =>
       mockDbRead.$queryRaw(sql),
+  bustCacheTag: vi.fn(async () => undefined),
 }));
 
-import {
-  listAllListingsForModeration,
-  projectModerationListing,
-} from '../app-listing.service';
+import { listAllListingsForModeration, projectModerationListing } from '../app-listing.service';
 
 /** A hydrated moderation row as `moderationListingSelect` returns it. */
 function modRow(over: Record<string, unknown> = {}) {

--- a/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
@@ -42,12 +42,16 @@ const { mockDbRead } = vi.hoisted(() => ({
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
 vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (src: string) => src }));
 vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
-vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600, sm: 180 } }));
 vi.mock('~/server/utils/cache-helpers', () => ({
+  // 🔴 BOTH EXPORTS. `app-listing.service` now imports `bustCacheTag` as well as
+  // `queryCache` (it owns `bustAppListingCatalogCache`), and a one-key factory makes the
+  // WHOLE FILE fail to import with `No "bustCacheTag" export is defined on the … mock`.
   queryCache:
     () =>
     async (sql: unknown): Promise<unknown[]> =>
       mockDbRead.$queryRaw(sql),
+  bustCacheTag: vi.fn(async () => undefined),
 }));
 
 import {

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -35,13 +35,17 @@ vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }
 // getEdgeUrl → identity so URL fields assert against the stored key.
 vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (src: string) => src }));
 vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
-vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600, sm: 180 } }));
 // queryCache → passthrough to the mocked $queryRaw (no Redis in unit tests).
 vi.mock('~/server/utils/cache-helpers', () => ({
+  // 🔴 BOTH EXPORTS. `app-listing.service` now imports `bustCacheTag` as well as
+  // `queryCache` (it owns `bustAppListingCatalogCache`), and a one-key factory makes the
+  // WHOLE FILE fail to import with `No "bustCacheTag" export is defined on the … mock`.
   queryCache:
     () =>
     async (sql: unknown): Promise<unknown[]> =>
       mockDbRead.$queryRaw(sql),
+  bustCacheTag: vi.fn(async () => undefined),
 }));
 
 import fs from 'fs';

--- a/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
@@ -345,7 +345,11 @@ describe('🔴 approveExternalRequest — the REVISION branch busts the catalog 
     ).toHaveBeenCalledWith([APP_LISTING_CATALOG_TAG]);
   });
 
-  it('onsite revision approve busts too (the rule is unconditional, not per-branch)', async () => {
+  // The onsite branch is assets-only and moves no cached axis, so this bust is inert
+  // today; `applyApprovedRevision` fires it for both branches rather than gating on
+  // `kind`. That is a property of THAT function, not a universal "every mutation busts"
+  // rule — see its comment, and the `EXEMPT` list in the ledger suite.
+  it('onsite revision approve busts too (unconditional across the two branches)', async () => {
     stageRevisionApprove('onsite');
     await approveExternalRequest({ publishRequestId: 'alpr_r', reviewerUserId: MOD });
     expect(bustCacheTag).toHaveBeenCalledWith([APP_LISTING_CATALOG_TAG]);

--- a/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
@@ -129,7 +129,9 @@ beforeEach(() => {
     c.appListingScreenshot.createMany.mockReset().mockResolvedValue({ count: 0 });
     c.appListingScreenshot.deleteMany.mockReset().mockResolvedValue({ count: 0 });
     c.appListingScreenshot.updateMany.mockReset().mockResolvedValue({ count: 0 });
-    c.appListingModerationEvent.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    c.appListingModerationEvent.create
+      .mockReset()
+      .mockImplementation(async (a: { data: unknown }) => a.data);
     // Default: the go-live scan-clean gate re-reads each asset's `ingestion` — echo
     // every queried id as `Scanned` so a normal approve passes. (The scan gate selects
     // `{ id, ingestion }`; the rating derive selects `{ nsfwLevel }` — tests that need a
@@ -142,7 +144,9 @@ beforeEach(() => {
     c.appListingPublishRequest.findUnique.mockReset().mockResolvedValue(null);
     c.appListingPublishRequest.findFirst.mockReset().mockResolvedValue(null);
     c.appListingPublishRequest.findMany.mockReset().mockResolvedValue([]);
-    c.appListingPublishRequest.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    c.appListingPublishRequest.create
+      .mockReset()
+      .mockImplementation(async (a: { data: unknown }) => a.data);
     c.appListingPublishRequest.updateMany.mockReset().mockResolvedValue({ count: 1 });
   }
   mockWrite.$transaction
@@ -479,8 +483,22 @@ describe('approveExternalRequest — supersede scopes by the REQUEST kind (no on
 describe('mod queue procs — widened to kind IN (onsite, offsite), each row carries kind', () => {
   it('listPendingOffsiteRequests: where widens to both kinds, select carries kind, onsite rows surface with kind:onsite', async () => {
     mockRead.appListingPublishRequest.findMany.mockResolvedValue([
-      { id: 'a', kind: 'onsite', slug: 'x', status: 'pending', appListingId: 'apl_s', appListing: {} },
-      { id: 'b', kind: 'offsite', slug: 'y', status: 'pending', appListingId: 'apl_o', appListing: {} },
+      {
+        id: 'a',
+        kind: 'onsite',
+        slug: 'x',
+        status: 'pending',
+        appListingId: 'apl_s',
+        appListing: {},
+      },
+      {
+        id: 'b',
+        kind: 'offsite',
+        slug: 'y',
+        status: 'pending',
+        appListingId: 'apl_o',
+        appListing: {},
+      },
     ]);
     const res = await listPendingOffsiteRequests({});
     const call = mockRead.appListingPublishRequest.findMany.mock.calls[0][0] as {
@@ -515,10 +533,24 @@ describe('mod queue procs — widened to kind IN (onsite, offsite), each row car
   it('listApprovedOffsiteRequests + listRejectedOffsiteRequests both widen the kind filter', async () => {
     await listApprovedOffsiteRequests({});
     await listRejectedOffsiteRequests({});
-    const approvedWhere = (mockRead.appListingPublishRequest.findMany.mock.calls[0][0] as { where: Record<string, unknown> }).where;
-    const rejectedWhere = (mockRead.appListingPublishRequest.findMany.mock.calls[1][0] as { where: Record<string, unknown> }).where;
-    expect(approvedWhere).toMatchObject({ status: 'approved', kind: { in: ['onsite', 'offsite'] } });
-    expect(rejectedWhere).toMatchObject({ status: 'rejected', kind: { in: ['onsite', 'offsite'] } });
+    const approvedWhere = (
+      mockRead.appListingPublishRequest.findMany.mock.calls[0][0] as {
+        where: Record<string, unknown>;
+      }
+    ).where;
+    const rejectedWhere = (
+      mockRead.appListingPublishRequest.findMany.mock.calls[1][0] as {
+        where: Record<string, unknown>;
+      }
+    ).where;
+    expect(approvedWhere).toMatchObject({
+      status: 'approved',
+      kind: { in: ['onsite', 'offsite'] },
+    });
+    expect(rejectedWhere).toMatchObject({
+      status: 'rejected',
+      kind: { in: ['onsite', 'offsite'] },
+    });
   });
 });
 
@@ -597,7 +629,7 @@ const LISTING_REQUEST_PRODUCERS: Record<string, string> = {
     'which is why the on-site half of this table was shadow-only.',
   'src/server/services/blocks/offsite-moderation.service.ts::routeRepublishToReviewInTx':
     '🔴 THE SECOND ON-SITE PRODUCER, and the one that falsified the invariant. BOTH ' +
-    "kinds (`kind: listing.kind`), NON-shadow — an owner republish whose assets differ " +
+    'kinds (`kind: listing.kind`), NON-shadow — an owner republish whose assets differ ' +
     'from the recorded approval baseline. Any consumer that reads `kind:onsite` as ' +
     '"therefore a shadow revision" is wrong about this row; discriminate on ' +
     '`revisionOfId`, never on `kind`.',
@@ -778,10 +810,7 @@ describe('🔴 AppListingPublishRequest PRODUCER LEDGER — fails when the set g
     // The ledger entry above is prose; this is the code it describes. Without it the
     // ledger could record a producer that does not actually reach the on-site half.
     const code = stripCommentsAndStrings(
-      readFileSync(
-        join(ROOT, 'src/server/services/blocks/offsite-moderation.service.ts'),
-        'utf8'
-      )
+      readFileSync(join(ROOT, 'src/server/services/blocks/offsite-moderation.service.ts'), 'utf8')
     );
     const fnStart = code.indexOf('function routeRepublishToReviewInTx');
     expect(fnStart).toBeGreaterThan(-1); // the ledger key must still name a real function
@@ -824,7 +853,10 @@ describe('the shape of a kind:onsite AppListingPublishRequest minted by submitLi
     const res = await submitListingRevision({ shadowId: 'apl_shadow', userId: CALLER });
     expect(res).toMatchObject({ shadowId: 'apl_shadow', slug: 'my-app' });
 
-    const created = mockWrite.appListingPublishRequest.create.mock.calls[0][0].data as Record<string, unknown>;
+    const created = mockWrite.appListingPublishRequest.create.mock.calls[0][0].data as Record<
+      string,
+      unknown
+    >;
     // 🔴 the request is kind:onsite AND points at the SHADOW — so widening the queue
     // gates to include onsite surfaces exactly media revisions, nothing else.
     expect(created.kind).toBe('onsite');

--- a/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
@@ -12,6 +12,11 @@ import {
   listApprovedOffsiteRequests,
   listRejectedOffsiteRequests,
 } from '~/server/services/blocks/offsite-listing.service';
+import { bustCacheTag } from '~/server/utils/cache-helpers';
+// Type-only, for the partial-mock spread below — a runtime `typeof import(...)` inside
+// the factory is an `import()` type annotation, which `consistent-type-imports` forbids.
+import type * as CacheHelpers from '~/server/utils/cache-helpers';
+import { APP_LISTING_CATALOG_TAG } from '~/server/services/blocks/app-listing-cache.constants';
 
 /**
  * W13 — ONSITE listing-media revision CONSOLIDATION service tests.
@@ -81,6 +86,20 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
 const { mockNotify } = vi.hoisted(() => ({ mockNotify: vi.fn(async () => undefined) }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+/**
+ * 🔴 PARTIAL mock — spread the REAL module and override ONE export.
+ *
+ * `offsite-listing.service` statically imports `app-listing.service`, which imports
+ * `queryCache` + `bustCacheTag` from here. A hand-written factory listing only those two
+ * would make this file fail to import the moment any other module in that graph reaches
+ * for a third export, and the failure would present as every case in this suite
+ * rejecting. Spreading `importOriginal()` cannot go stale that way — and the real module
+ * already loads fine in this suite today (it did before this mock existed).
+ */
+vi.mock('~/server/utils/cache-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof CacheHelpers>()),
+  bustCacheTag: vi.fn(async () => undefined),
+}));
 vi.mock('~/server/services/blocks/app-listing-notify', () => ({
   notifyAppListingOwner: mockNotify,
 }));
@@ -283,6 +302,60 @@ describe('approveExternalRequest — OFFSITE revision approve is BYTE-IDENTICAL 
     expect(copy.data).toHaveProperty('contentRating');
     // The asset-floor derivation DID read Image levels (proves resolveApprovalContentRating ran).
     expect(mockWrite.image.findMany).toHaveBeenCalled();
+  });
+});
+
+/**
+ * 🔴 REGRESSION: THE REVISION-APPROVE PATH BUSTS THE `/apps` CATALOG CACHE (#529).
+ *
+ * `approveExternalRequest` `return`s into `applyApprovedRevision` for any listing with
+ * `revisionOfId != null` — i.e. EVERY approval of an edit to an already-live listing —
+ * and that `return` happens BEFORE the caller's own
+ * `await bustAppListingCatalogCache()`. When the cache shipped, the revision path had
+ * no bust of its own, so the whole class was uncovered.
+ *
+ * Its offsite branch writes onto the LIVE parent, and three of the columns it writes are
+ * axes of the CACHED keyset statement rather than of the live-hydrated card:
+ *   · `contentRating` — via `resolveApprovalContentRating`, which can RAISE it. A
+ *     `g`→`r` re-rating left un-busted keeps the newly-`r` cover in the cached SFW page
+ *     for the rest of the 180s TTL.
+ *   · `category` — the cached query filters `al.category`, so a move leaves the app in
+ *     the wrong filtered grid.
+ *   · `name` — the `sort='name'` sort key, cached as `sort_key`.
+ *
+ * Asserted BEHAVIOURALLY (the tag actually reaching `bustCacheTag`, through a real
+ * approve) rather than structurally: the sibling ledger suite
+ * `app-listing.catalog-bust-ledger.test.ts` pins the call SITE, and a structural check
+ * type-checks straight past a bust that passes the wrong tag.
+ */
+describe('🔴 approveExternalRequest — the REVISION branch busts the catalog cache', () => {
+  it('offsite revision approve busts with the catalog tag (the path that writes the parent scalars)', async () => {
+    stageRevisionApprove('offsite');
+    await approveExternalRequest({ publishRequestId: 'alpr_r', reviewerUserId: MOD });
+    expect(
+      bustCacheTag,
+      'the revision-approve path did not bust the /apps catalog cache. This branch ' +
+        'writes contentRating / category / name onto the LIVE parent and `return`s ' +
+        'before `approveExternalRequest`s own bust, so a g->r re-rating stays in the ' +
+        'cached SFW page for the whole CacheTTL.sm window.'
+    ).toHaveBeenCalledWith([APP_LISTING_CATALOG_TAG]);
+  });
+
+  it('onsite revision approve busts too (the rule is unconditional, not per-branch)', async () => {
+    stageRevisionApprove('onsite');
+    await approveExternalRequest({ publishRequestId: 'alpr_r', reviewerUserId: MOD });
+    expect(bustCacheTag).toHaveBeenCalledWith([APP_LISTING_CATALOG_TAG]);
+  });
+
+  /**
+   * 🔴 NEGATIVE CONTROL on the spy itself. `bustCacheTag` is asserted above by the call
+   * it receives; if the mock were wired to nothing it would also never be called by a
+   * path that legitimately does not bust — and both cases look identical from a passing
+   * assertion. Prove the spy starts CLEAN each case, so a hit above is genuinely caused
+   * by the approve and not left over from a previous one.
+   */
+  it('NEGATIVE CONTROL: the bust spy is clean before an approve runs', () => {
+    expect(bustCacheTag).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
@@ -65,6 +65,17 @@ const { db, s3, holder } = vi.hoisted(() => {
   return { db, s3, holder };
 });
 
+// 🔴 `approveRequest` LAZILY imports `app-listing.service` for its catalog-cache bust
+// (#529), and that module statically imports `~/server/utils/cache-helpers`, whose module
+// BODY builds a logger off the real env. Against this file's minimal `~/env/server` stub
+// that construction throws `TypeError: Cannot read properties of undefined (reading
+// 'includes')` at import time — inside the approve, so every approve case rejects rather
+// than reporting a missing mock. Stub the two exports the listing service uses.
+vi.mock('~/server/utils/cache-helpers', () => ({
+  queryCache: () => async (): Promise<unknown[]> => [],
+  bustCacheTag: vi.fn(async () => undefined),
+}));
+
 vi.mock('~/server/services/blocks/app-block-notify', () => ({
   notifyAppBlockSubmitter: vi.fn(async () => undefined),
 }));

--- a/src/server/services/blocks/__tests__/publish-request.notify.service.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.notify.service.test.ts
@@ -54,6 +54,17 @@ const { mockNotify, db, s3, holder } = vi.hoisted(() => {
   return { mockNotify, db, s3, holder };
 });
 
+// 🔴 `approveRequest` LAZILY imports `app-listing.service` for its catalog-cache bust
+// (#529), and that module statically imports `~/server/utils/cache-helpers`, whose module
+// BODY builds a logger off the real env. Against this file's minimal `~/env/server` stub
+// that construction throws `TypeError: Cannot read properties of undefined (reading
+// 'includes')` at import time — inside the approve, so every approve case rejects rather
+// than reporting a missing mock. Stub the two exports the listing service uses.
+vi.mock('~/server/utils/cache-helpers', () => ({
+  queryCache: () => async (): Promise<unknown[]> => [],
+  bustCacheTag: vi.fn(async () => undefined),
+}));
+
 vi.mock('~/server/services/blocks/app-block-notify', () => ({
   notifyAppBlockSubmitter: mockNotify,
 }));
@@ -262,7 +273,10 @@ describe('rejectRequest — submitter notification (post-commit, best-effort)', 
     // The rejection row committed before the notify.
     expect(db.write.appBlockPublishRequest.update).toHaveBeenCalledWith({
       where: { id: 'req_rej_1' },
-      data: expect.objectContaining({ status: 'rejected', rejectionReason: 'Uses a disallowed scope' }),
+      data: expect.objectContaining({
+        status: 'rejected',
+        rejectionReason: 'Uses a disallowed scope',
+      }),
     });
   });
 

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -1267,11 +1267,17 @@ export async function setListingIcon(
     });
     await reDeriveContentRatingForModLiveEdit(tx, listing, user);
   });
-  // Catalog bust: the card's `iconUrl` moved. AND the tx may have RAISED `content_rating`
-  // via `reDeriveContentRatingForModLiveEdit` — the `listingMatureFilter` axis the cached
-  // page is keyed on. That helper runs INSIDE the transaction, so its bust belongs here,
+  // Catalog bust: the tx may have RAISED `content_rating` via
+  // `reDeriveContentRatingForModLiveEdit` — the `listingMatureFilter` axis the cached page
+  // IS keyed on. That helper runs INSIDE the transaction, so its bust belongs here,
   // post-commit, at each of its three callers: a bust fired inside the tx would also fire
   // on a rollback.
+  //
+  // ⚠️ NOT because "the card's `iconUrl` moved" — that reason is wrong and the earlier
+  // version of this comment gave it. The cache holds `{id, sort_key}` ONLY; every
+  // projection field on the card (`iconUrl` included) comes from the LIVE hydration below
+  // it in `listAvailableListings`, so it can never be served stale. The rating is the
+  // whole reason this bust exists.
   await bustAppListingCatalogCache().catch(() => undefined);
 
   return { status: 'attached', iconId: validated.imageId, scanPending: validated.scanPending };
@@ -1296,8 +1302,8 @@ export async function setListingCover(
     });
     await reDeriveContentRatingForModLiveEdit(tx, listing, user);
   });
-  // Catalog bust: the card's `coverUrl`, plus the same in-tx `content_rating` re-derive as
-  // the icon path above.
+  // Catalog bust: the same in-tx `content_rating` re-derive as the icon path above — that
+  // is the cached axis. (`coverUrl` is NOT: it is hydrated live, see the icon path's note.)
   await bustAppListingCatalogCache().catch(() => undefined);
 
   return { status: 'attached', coverId: validated.imageId, scanPending: validated.scanPending };

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -3,6 +3,7 @@ import type { Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
 
 import { dbRead, dbWrite } from '~/server/db/client';
+import { bustAppListingCatalogCache } from '~/server/services/blocks/app-listing.service';
 import { logToAxiom } from '~/server/logging/client';
 import { NsfwLevel } from '~/server/common/enums';
 import {
@@ -1266,6 +1267,13 @@ export async function setListingIcon(
     });
     await reDeriveContentRatingForModLiveEdit(tx, listing, user);
   });
+  // Catalog bust: the card's `iconUrl` moved. AND the tx may have RAISED `content_rating`
+  // via `reDeriveContentRatingForModLiveEdit` — the `listingMatureFilter` axis the cached
+  // page is keyed on. That helper runs INSIDE the transaction, so its bust belongs here,
+  // post-commit, at each of its three callers: a bust fired inside the tx would also fire
+  // on a rollback.
+  await bustAppListingCatalogCache().catch(() => undefined);
+
   return { status: 'attached', iconId: validated.imageId, scanPending: validated.scanPending };
 }
 
@@ -1288,6 +1296,10 @@ export async function setListingCover(
     });
     await reDeriveContentRatingForModLiveEdit(tx, listing, user);
   });
+  // Catalog bust: the card's `coverUrl`, plus the same in-tx `content_rating` re-derive as
+  // the icon path above.
+  await bustAppListingCatalogCache().catch(() => undefined);
+
   return { status: 'attached', coverId: validated.imageId, scanPending: validated.scanPending };
 }
 
@@ -1341,6 +1353,10 @@ export async function addListingScreenshot(
     });
     await reDeriveContentRatingForModLiveEdit(tx, listing, user);
   });
+  // Catalog bust: a screenshot can RAISE `content_rating` via the same in-tx re-derive,
+  // flipping the maturity gate the cached page is keyed on.
+  await bustAppListingCatalogCache().catch(() => undefined);
+
   return { status: 'attached', id, order: nextOrder, scanPending };
 }
 

--- a/src/server/services/blocks/app-listing-backfill.service.ts
+++ b/src/server/services/blocks/app-listing-backfill.service.ts
@@ -1,4 +1,5 @@
 import { dbRead, dbWrite } from '~/server/db/client';
+import { bustAppListingCatalogCache } from '~/server/services/blocks/app-listing.service';
 // The AppBlock→AppListing mapping is the SINGLE SOURCE OF TRUTH for the listing
 // shape, shared with `publish-request.service.approveRequest` (the go-forward
 // auto-create-on-approve path) so the two can never drift. Re-exported below so
@@ -187,6 +188,11 @@ export async function backfillAppListings(
       });
     }
   }
+
+  // Catalog bust: the backfill mints rows at `status: 'approved'` — a GO-LIVE path, not a
+  // data migration (see the actionability gate above). Guarded on a real write: a dry run
+  // wrote nothing, and a run that created nothing has nothing to invalidate.
+  if (!dryRun && result.created > 0) await bustAppListingCatalogCache().catch(() => undefined);
 
   return result;
 }

--- a/src/server/services/blocks/app-listing-cache.constants.ts
+++ b/src/server/services/blocks/app-listing-cache.constants.ts
@@ -27,10 +27,26 @@
 
 /**
  * The unified `/apps` store CATALOG page cache (`listAvailableListings`'s keyset
- * query). Busted by every mutation that can change catalog MEMBERSHIP (approve,
- * delist, relist, claim, purge, reset-to-pending, unpublish, republish, reject) or
- * the CARD CONTENT / FILTER AXES the cached page carries (name, tagline, category,
- * icon/cover/screenshot, content rating, and the onsite deploy gate).
+ * query).
+ *
+ * 🔴 WHAT IS ACTUALLY CACHED IS `{ id, sort_key }` PER ROW — NOTHING ELSE. Read that
+ * before deciding whether a new mutation needs a bust, because the intuitive model
+ * ("the cache holds the card") is wrong and gives the wrong answer in both directions.
+ * The card's projection fields — tagline, description, icon/cover/screenshot URLs, the
+ * owner chip, the beta badge — are hydrated by a LIVE query below the cache on every
+ * request, so they can never be served stale and a write that touches only those needs
+ * no bust.
+ *
+ * A bust is needed when a write moves something the CACHED STATEMENT itself reads:
+ *   · catalog MEMBERSHIP — `al.status` (approved-only), `al.kind`, `al.revision_of_id`,
+ *     and `ab.current_version_deployed_at` (the onsite deploy gate);
+ *   · a FILTER axis — `al.category`, `al.content_rating` (the maturity gate);
+ *   · a `sort_key` input — `al.name`, `al.created_at`, or the `app_listing_metrics`
+ *     rollup.
+ *
+ * The asserted, mechanical form of that rule — every `AppListing` writer either busts
+ * or is on an `EXEMPT` list with a reason — lives in
+ * `~/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts`.
  */
 export const APP_LISTING_CATALOG_TAG = 'app-listing:catalog';
 

--- a/src/server/services/blocks/app-listing-cache.constants.ts
+++ b/src/server/services/blocks/app-listing-cache.constants.ts
@@ -39,14 +39,35 @@
  *
  * A bust is needed when a write moves something the CACHED STATEMENT itself reads:
  *   · catalog MEMBERSHIP — `al.status` (approved-only), `al.kind`, `al.revision_of_id`,
- *     and `ab.current_version_deployed_at` (the onsite deploy gate);
+ *     and, through the deploy gate, `al.app_block_id` (the join key onto `app_blocks`)
+ *     plus `ab.current_version_deployed_at`;
  *   · a FILTER axis — `al.category`, `al.content_rating` (the maturity gate);
  *   · a `sort_key` input — `al.name`, `al.created_at`, or the `app_listing_metrics`
  *     rollup.
  *
+ * `al.app_block_id` is on that list because the statement reads it, not because anything
+ * moves it today: the only write of the column onto an EXISTING row is `approveRequest`'s
+ * link step, guarded `where: { status: 'draft' }`, and it busts anyway; every other write
+ * of it is a `create` that mints at `status:'draft'`. It is listed so the next writer of
+ * the column is checked against the rule rather than against a list it is missing from.
+ *
+ * 🔴 TWO CACHED AXES DO NOT LIVE ON `app_listings`, AND BOTH HAVE LIVE NON-BUSTING
+ * WRITERS. The `app_listing_metrics` rollup feeds `sort='top-rated'` (thumbs) and
+ * `sort='popular'` (`install_count`), and it is written by
+ * `app-listing-review.service.ts` on every review vote (which busts only the
+ * recommend-MEAN tag) and by `~/server/metrics/appListing.metrics.sql.ts` on the metric
+ * job (which busts nothing). That is DELIBERATE and is the right trade — busting the
+ * catalog per vote or per metric pass would defeat the cache, while the cost is bounded
+ * at one `CacheTTL.sm` window of SORT lag, with no row appearing, disappearing or
+ * changing maturity. It is called out because the "moves something the statement reads
+ * ⇒ bust" rule above is, by design, not applied to them, and a reader applying it to a
+ * metrics writer would reach the wrong conclusion.
+ *
  * The asserted, mechanical form of that rule — every `AppListing` writer either busts
  * or is on an `EXEMPT` list with a reason — lives in
- * `~/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts`.
+ * `~/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts`. Note the
+ * scope: it enumerates writers through the `appListing` Prisma delegate, so neither
+ * off-table writer above is inside any guard it provides.
  */
 export const APP_LISTING_CATALOG_TAG = 'app-listing:catalog';
 

--- a/src/server/services/blocks/app-listing-cache.constants.ts
+++ b/src/server/services/blocks/app-listing-cache.constants.ts
@@ -1,0 +1,47 @@
+/**
+ * App Store Listings (W13) — the CACHE TAG names for the listing read path.
+ *
+ * ── WHY THIS IS ITS OWN LEAF MODULE (imports NOTHING) ────────────────────────────
+ * 🔴 THESE MUST NOT LIVE IN `app-listing.service.ts`. Both `app-listings.router.ts`
+ * and `blocks.router.ts` deliberately keep the listing/app-surface SERVICES out of
+ * their eager import graph and reach them through `await import(…)` at call time —
+ * `app-listings.router.ts` states the rule at its own lazy-import site, and
+ * `blocks.router.ts` has eight such sites for `user-app-surface.service` alone. The
+ * point of that pattern is that a hot router's module graph never drags in the
+ * Prisma client (and everything the services pull in behind it).
+ *
+ * Exporting a plain string constant from a heavy service defeats it silently: the
+ * static `import { TAG } from './app-listing.service'` needed to name the tag makes
+ * every one of those lazy imports GRAPH-INERT — the module is already loaded, so the
+ * `await import(…)` resolves from cache and buys nothing. Nothing errors, and the
+ * cost only becomes visible later, when someone adds an import to the service.
+ *
+ * The precedent, with the measured version of this failure, is
+ * `src/server/services/blocks/scope-activity-predicate.ts` — read its header. Same
+ * shape here, one step cheaper: this module has no imports at all, not even a type.
+ *
+ * It also keeps the one-key `vi.mock` factories in the block suites honest: a suite
+ * that stubs a mutation service can import the tag names without instantiating the
+ * read service.
+ */
+
+/**
+ * The unified `/apps` store CATALOG page cache (`listAvailableListings`'s keyset
+ * query). Busted by every mutation that can change catalog MEMBERSHIP (approve,
+ * delist, relist, claim, purge, reset-to-pending, unpublish, republish, reject) or
+ * the CARD CONTENT / FILTER AXES the cached page carries (name, tagline, category,
+ * icon/cover/screenshot, content rating, and the onsite deploy gate).
+ */
+export const APP_LISTING_CATALOG_TAG = 'app-listing:catalog';
+
+/**
+ * The store-wide Bayesian-prior recommend MEAN (`getGlobalRecommendMean`, 1h).
+ *
+ * 🔴 PRE-EXISTING TAG STRING — the value is unchanged. It was previously declared
+ * as a private literal in TWO places (`app-listing.service.ts`'s
+ * `getGlobalRecommendMean` and `app-listing-review.service.ts`'s
+ * `bustRecommendMeanCache`), i.e. a producer and its only buster each spelling the
+ * same string independently. Both now read it from here, so a rename cannot desync
+ * the write side from the bust side.
+ */
+export const APP_LISTING_RECOMMEND_MEAN_TAG = 'app-listing:recommend-global-mean';

--- a/src/server/services/blocks/app-listing-review.service.ts
+++ b/src/server/services/blocks/app-listing-review.service.ts
@@ -16,6 +16,7 @@ import {
   type UpsertAppListingReviewInput,
 } from '~/server/schema/blocks/app-listing-review.schema';
 import { bustCacheTag } from '~/server/utils/cache-helpers';
+import { APP_LISTING_RECOMMEND_MEAN_TAG } from '~/server/services/blocks/app-listing-cache.constants';
 import {
   throwAuthorizationError,
   throwBadRequestError,
@@ -59,14 +60,17 @@ import {
 // getGlobalRecommendMean, tag below, 1h). The per-listing card/detail counts are
 // read straight off the AppListingMetric rollup (uncached), so only the global
 // mean needs busting when a review shifts the counters.
-const GLOBAL_RECOMMEND_MEAN_TAG = 'app-listing:recommend-global-mean';
+// 🔴 The tag string is now the SHARED constant, not a private literal re-spelled
+// here. The producer (`getGlobalRecommendMean`, which writes the tagged key) and
+// this, its only buster, previously declared the same string independently — so a
+// rename on one side silently stopped busting the other. Both read the leaf module.
 
 /**
  * Bust the store-wide recommend-mean cache after a review write. Fire-and-forget
  * (a cache-bus outage must never fail the review).
  */
 async function bustRecommendMeanCache(): Promise<void> {
-  await bustCacheTag([GLOBAL_RECOMMEND_MEAN_TAG]);
+  await bustCacheTag([APP_LISTING_RECOMMEND_MEAN_TAG]);
 }
 
 /** The compound-unique lookup key for `AppListingReview(appListingId, userId)`. */

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -833,9 +833,12 @@ function catalogPageCache(scope: StoreVisibilityScope, redCapable: boolean) {
  * is a bug, when a whole enumerated list of them are deliberate and correct. The cached
  * statement reads
  * `al.status`, `al.kind`, `al.revision_of_id`, `al.category`, `al.content_rating`,
- * `ab.current_version_deployed_at` and the `sort_key` inputs (`al.name`,
- * `al.created_at`, the metric rollup) — and nothing else. Every other column on the
- * card is hydrated live below the cache and can never be served stale.
+ * `al.app_block_id` + `ab.current_version_deployed_at` (the deploy gate and its join
+ * key) and the `sort_key` inputs (`al.name`, `al.created_at`, the metric rollup) — and
+ * nothing else. Every other column on the card is hydrated live below the cache and can
+ * never be served stale. ⚠️ The metric rollup is on `app_listing_metrics`, not on this
+ * table, and its two writers deliberately do NOT bust; `APP_LISTING_CATALOG_TAG`'s
+ * header in `app-listing-cache.constants.ts` states that exception in full.
  *
  * Some busts ARE kept on paths that are inert today, as cheap defence-in-depth against
  * a future edit promoting the row into the catalog: `updateListing`'s `removed` and

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -830,7 +830,8 @@ function catalogPageCache(scope: StoreVisibilityScope, redCapable: boolean) {
  * listing-state mutation busts". Several call sites used to invoke the latter as a
  * "uniform rule"; it is not uniform, and stating it that way made a reader's model of
  * the cache wrong in the expensive direction — it implies that a writer WITHOUT a bust
- * is a bug, when a whole enumerated list of them are deliberate and correct. The cached statement reads
+ * is a bug, when a whole enumerated list of them are deliberate and correct. The cached
+ * statement reads
  * `al.status`, `al.kind`, `al.revision_of_id`, `al.category`, `al.content_rating`,
  * `ab.current_version_deployed_at` and the `sort_key` inputs (`al.name`,
  * `al.created_at`, the metric rollup) — and nothing else. Every other column on the
@@ -838,9 +839,14 @@ function catalogPageCache(scope: StoreVisibilityScope, redCapable: boolean) {
  *
  * Some busts ARE kept on paths that are inert today, as cheap defence-in-depth against
  * a future edit promoting the row into the catalog: `updateListing`'s `removed` and
- * `draft`/`pending` branches, its material-shadow branch, `submitListingRevision`, and
- * `claimListing`. Each says so at its own call site. They are a judgement, not the
- * rule.
+ * `draft`/`pending` branches, its material-shadow branch, `submitListingRevision`,
+ * `rejectExternalRequest` and `claimListing`. Each says so at its own call site. They
+ * are a judgement, not the rule.
+ *
+ * ⚠️ THAT LIST IS PROSE AND NOTHING ASSERTS ON IT. The ledger pins WHICH functions bust
+ * and which are `EXEMPT`; it does not pin which of the busts are inert, because that is
+ * a claim about the SQL a branch can write rather than about a call site. Re-derive it
+ * from the call-site comments rather than trusting the enumeration here.
  *
  * The asserted form of the rule — every `AppListing` writer either busts or is on an
  * `EXEMPT` list with a reason — is

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -725,23 +725,54 @@ export async function getGlobalRecommendMean(): Promise<number> {
 // ---------------------------------------------------------------------------
 
 /**
- * The read-through cache for the `/apps` store's keyset id page.
+ * Build the read-through cache for the `/apps` store's keyset id page, for ONE
+ * viewer class.
  *
- * 🔴 WHY `queryCache` + A BUST TAG, AND NOT THE ALTERNATIVES.
+ * 🔴 THE TWO SECURITY-BOUNDARY AXES ARE LITERAL KEY SEGMENTS, NOT HASH INPUT.
  *
- * · **The key is `hashifyObject(Prisma.Sql)`** — `queryCache` builds it as
- *   `[key, version, hashifyObject(query)].join(':')` over the WHOLE statement,
- *   text and bound params (`~/server/utils/cache-helpers`). Every axis this page
- *   varies on — `kind`, `category`, `sort`, `cursor`, `limit`, the maturity gate
- *   `listingMatureFilter(redCapable)` and the store-scope gate
- *   `listingPublicVisibilityFilter(scope)` — is interpolated into that ONE
- *   statement, so **each is in the cache key BY CONSTRUCTION**. A hand-assembled
- *   key is a list someone has to keep complete; this one cannot omit an axis,
- *   because omitting it would mean the SQL did not depend on it either. That
- *   structural property is what makes it safe to cache a page whose contents are
- *   VIEWER-VARYING: `scope` (a public/onsite security boundary) and `redCapable`
- *   (a maturity gate) can never collide into one entry.
- *   `__tests__/app-listing.catalog-cache.test.ts` pins exactly that.
+ * `queryCache` builds its redis key as `[key, version, hashifyObject(query)]
+ * .join(':')` (`~/server/utils/cache-helpers`). `hashifyObject` → `hashify`
+ * (`~/utils/string-helpers`) is a **32-bit** rolling hash
+ * (`hash = (hash << 5) - hash + chr; hash |= 0`). It is neither injective nor
+ * one-way, and it is LINEAR — collisions against a chosen target are constructed
+ * algebraically, not brute-forced. An earlier revision of this code passed a
+ * single constant `key` and relied on "every axis is interpolated into the
+ * statement, so every axis is in the key". That reasoning silently assumes the
+ * hash is injective, and it is not.
+ *
+ * It matters because an ATTACKER SUPPLIES HASHED BYTES. `decodeListingCursor`
+ * slices `cursorSortKey` and `cursorId` out of a lenient base64url decode as
+ * arbitrary free strings (only `cursorMean` is range-validated), the router
+ * validates `cursor` only as `z.string().max(128)`, and both land in this
+ * statement as bound params. That is enough tuning room to steer the 32-bit hash
+ * onto any target value.
+ *
+ * So the two axes that are SECURITY BOUNDARIES are lifted out of the hashed
+ * payload and into the `key` string itself:
+ *
+ *   · `scope` — `listingPublicVisibilityFilter`. `full` is the whole approved
+ *     catalog; `public-external` is offsite-only. That is the public/onsite
+ *     boundary (civitai#3983). A cross-scope collision would serve on-site apps
+ *     into the anonymous `GET /api/v1/apps` response, and the reverse direction
+ *     is cache poisoning.
+ *   · `redCapable` — `listingMatureFilter`. A cross-capability collision serves
+ *     `r`/`x` listings onto a SFW host.
+ *
+ * With both in the literal prefix, a hash collision can only ever mix two pages
+ * WITHIN one viewer class — the class boundary is no longer hash-dependent.
+ * `__tests__/app-listing.catalog-cache.test.ts` pins that the boundary lives in
+ * the un-hashed segments.
+ *
+ * The remaining axes (`kind`, `category`, `sort`, `cursor`, `limit`) stay in the
+ * hash. They are ordinary correctness, not a disclosure boundary: the worst a
+ * constructed collision buys there is the attacker's own page served back to
+ * themselves under a different filter, within their own viewer class.
+ *
+ * 🔴 DO NOT "FIX" THIS BY WIDENING `hashify` — it is used across the codebase for
+ * cache keys, DOM ids and de-dup, so changing its output is a global blast radius.
+ * The containment belongs here, at the one call site that has a security boundary.
+ *
+ * Why `queryCache` + a bust tag, and not the alternatives:
  *
  * · **NOT `fetchThroughCache`** — it takes no `tag` option, so `bustCacheTag`
  *   cannot drive it and a moderator's approve/delist would not be visible until
@@ -754,8 +785,18 @@ export async function getGlobalRecommendMean(): Promise<number> {
  * · **NOT a generation counter** — a counter folded into the key leaves the old
  *   entries in redis to expire on their own, so a bust multiplies the keyspace
  *   instead of reclaiming it. The tag set holds the exact keys to delete.
+ *
+ * ⚠️ `key` is also the `cache_name` label on the hit/miss counters. Its cardinality
+ * is bounded at 6 (3 scopes × 2 capabilities) — every component is a closed enum,
+ * never a request-controlled string.
  */
-const listAvailableListingsCache = queryCache(dbRead, 'listAvailableAppListings', 'v1');
+function catalogPageCache(scope: StoreVisibilityScope, redCapable: boolean) {
+  return queryCache(
+    dbRead,
+    `listAvailableAppListings:${scope}:${redCapable ? 'red' : 'sfw'}`,
+    'v1'
+  );
+}
 
 /**
  * Bust the `/apps` store catalog cache. THE one buster — every listing-state
@@ -819,15 +860,25 @@ export async function listAvailableListings(
   // a card's mutable projection fields are never served from two different ages.
   // `nextCursor` is derived from these (now cached) rows, same as there.
   //
+  // The cache is built PER VIEWER CLASS: `scope` and `redCapable` are literal segments
+  // of the redis key, deliberately outside the 32-bit `hashifyObject` of the statement.
+  // See {@link catalogPageCache} for why that is load-bearing rather than stylistic.
+  //
   // TTL = `CacheTTL.sm` (180s). The catalog is MOD-GATED and low-churn: rows enter and
   // leave only through moderator approve/delist/reject/purge or an owner
-  // unpublish/republish, and EVERY one of those paths calls
-  // `bustAppListingCatalogCache()` — so the TTL is not the freshness mechanism, it is
-  // the backstop for the one path that has no mutation to hang a bust on (a redis bus
-  // failure, or a row that ages into visibility). 180s keeps that backstop short enough
-  // that a missed bust is a blip rather than an outage, while still collapsing the
-  // burst of identical cold reads that a `/apps` page load produces.
-  const idRows = await listAvailableListingsCache<{ id: string; sort_key: string }[]>(
+  // unpublish/republish, and every one of those paths calls
+  // `bustAppListingCatalogCache()`.
+  //
+  // 🔴 WHAT THE TTL IS AND IS NOT. It is a bound on staleness for the paths that have
+  // no mutation to hang a bust on — chiefly a row that ages into visibility. It is NOT
+  // a redis-outage backstop: `queryCache` has no try/catch and no fail-open (unlike
+  // `fetchThroughCache`), so a redis outage does not degrade to a live DB read here, it
+  // throws — a 500 on `/apps` and on `GET /api/v1/apps`. That is the dependency this
+  // change accepts; the TTL does nothing about it. What 180s does buy is collapsing the
+  // burst of identical cold reads a `/apps` page load produces, at a staleness a missed
+  // bust cannot stretch past.
+  const cacheable = catalogPageCache(scope, redCapable);
+  const idRows = await cacheable<{ id: string; sort_key: string }[]>(
     Prisma.sql`
     SELECT al.id, ${sortKeyExpr} AS sort_key
     FROM app_listings al

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -35,7 +35,14 @@ import {
   readListingBetaManyForRender,
   type ListingBetaRead,
 } from '~/server/services/blocks/app-listing-beta.service';
-import { queryCache } from '~/server/utils/cache-helpers';
+import { bustCacheTag, queryCache } from '~/server/utils/cache-helpers';
+// The cache TAG NAMES live in a dependency-free LEAF module, never here — a router
+// that must `await import()` this service cannot name a constant exported from it
+// without making that lazy import graph-inert. See that module's header.
+import {
+  APP_LISTING_CATALOG_TAG,
+  APP_LISTING_RECOMMEND_MEAN_TAG,
+} from '~/server/services/blocks/app-listing-cache.constants';
 
 /**
  * App Store Listings (W13) — P2a UNIFIED STORE READ PATH service.
@@ -708,9 +715,60 @@ export async function getGlobalRecommendMean(): Promise<number> {
       WHERE al.status = 'approved'
         AND (m.thumbs_up_count + m.thumbs_down_count) > 0
     `,
-    { ttl: CacheTTL.hour, tag: ['app-listing:recommend-global-mean'] }
+    { ttl: CacheTTL.hour, tag: [APP_LISTING_RECOMMEND_MEAN_TAG] }
   );
   return rows[0]?.mean ?? DEFAULT_RECOMMEND_MEAN;
+}
+
+// ---------------------------------------------------------------------------
+// The unified store CATALOG cache (`listAvailableListings`) + its ONE buster.
+// ---------------------------------------------------------------------------
+
+/**
+ * The read-through cache for the `/apps` store's keyset id page.
+ *
+ * 🔴 WHY `queryCache` + A BUST TAG, AND NOT THE ALTERNATIVES.
+ *
+ * · **The key is `hashifyObject(Prisma.Sql)`** — `queryCache` builds it as
+ *   `[key, version, hashifyObject(query)].join(':')` over the WHOLE statement,
+ *   text and bound params (`~/server/utils/cache-helpers`). Every axis this page
+ *   varies on — `kind`, `category`, `sort`, `cursor`, `limit`, the maturity gate
+ *   `listingMatureFilter(redCapable)` and the store-scope gate
+ *   `listingPublicVisibilityFilter(scope)` — is interpolated into that ONE
+ *   statement, so **each is in the cache key BY CONSTRUCTION**. A hand-assembled
+ *   key is a list someone has to keep complete; this one cannot omit an axis,
+ *   because omitting it would mean the SQL did not depend on it either. That
+ *   structural property is what makes it safe to cache a page whose contents are
+ *   VIEWER-VARYING: `scope` (a public/onsite security boundary) and `redCapable`
+ *   (a maturity gate) can never collide into one entry.
+ *   `__tests__/app-listing.catalog-cache.test.ts` pins exactly that.
+ *
+ * · **NOT `fetchThroughCache`** — it takes no `tag` option, so `bustCacheTag`
+ *   cannot drive it and a moderator's approve/delist would not be visible until
+ *   the TTL expired.
+ *
+ * · **NOT `clearCacheByPattern`** — banned for bust-on-mutation; see that
+ *   function's own header. A prior use ran a cluster SCAN over a ~60M-key shard,
+ *   producing redis timeouts and 504 waves, and was reverted.
+ *
+ * · **NOT a generation counter** — a counter folded into the key leaves the old
+ *   entries in redis to expire on their own, so a bust multiplies the keyspace
+ *   instead of reclaiming it. The tag set holds the exact keys to delete.
+ */
+const listAvailableListingsCache = queryCache(dbRead, 'listAvailableAppListings', 'v1');
+
+/**
+ * Bust the `/apps` store catalog cache. THE one buster — every listing-state
+ * mutation calls this and nothing else.
+ *
+ * Fire-and-forget by the caller's convention (mirrors `bustRecommendMeanCache` in
+ * `app-listing-review.service`): a cache-bus outage must never fail the mutation
+ * that already committed. The worst case of a swallowed failure is a stale store
+ * grid for at most `CacheTTL.sm`; the worst case of a thrown one is a moderator
+ * action that reports failure after having succeeded.
+ */
+export async function bustAppListingCatalogCache(): Promise<void> {
+  await bustCacheTag([APP_LISTING_CATALOG_TAG]);
 }
 
 // ---------------------------------------------------------------------------
@@ -756,7 +814,21 @@ export async function listAvailableListings(
   const kindParam = kind === 'all' ? null : kind;
   const categoryParam = category ?? null;
 
-  const idRows = await dbRead.$queryRaw<{ id: string; sort_key: string }[]>(Prisma.sql`
+  // 🔴 CACHED. Only the keyset ID PAGE is cached — the hydration below stays a live
+  // read, exactly as `getPostsInfinite` (`~/server/services/post.service`) does it, so
+  // a card's mutable projection fields are never served from two different ages.
+  // `nextCursor` is derived from these (now cached) rows, same as there.
+  //
+  // TTL = `CacheTTL.sm` (180s). The catalog is MOD-GATED and low-churn: rows enter and
+  // leave only through moderator approve/delist/reject/purge or an owner
+  // unpublish/republish, and EVERY one of those paths calls
+  // `bustAppListingCatalogCache()` — so the TTL is not the freshness mechanism, it is
+  // the backstop for the one path that has no mutation to hang a bust on (a redis bus
+  // failure, or a row that ages into visibility). 180s keeps that backstop short enough
+  // that a missed bust is a blip rather than an outage, while still collapsing the
+  // burst of identical cold reads that a `/apps` page load produces.
+  const idRows = await listAvailableListingsCache<{ id: string; sort_key: string }[]>(
+    Prisma.sql`
     SELECT al.id, ${sortKeyExpr} AS sort_key
     FROM app_listings al
     LEFT JOIN app_listing_metrics m ON m.app_listing_id = al.id
@@ -786,7 +858,9 @@ export async function listAvailableListings(
       )
     ORDER BY sort_key ${dir}, al.id ${dir}
     LIMIT ${limit + 1}
-  `);
+  `,
+    { ttl: CacheTTL.sm, tag: [APP_LISTING_CATALOG_TAG] }
+  );
 
   const trimmed = idRows.slice(0, limit);
   const last = trimmed[trimmed.length - 1];

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -763,10 +763,35 @@ export async function getGlobalRecommendMean(): Promise<number> {
  * `__tests__/app-listing.catalog-cache.test.ts` pins that the boundary lives in
  * the un-hashed segments.
  *
- * The remaining axes (`kind`, `category`, `sort`, `cursor`, `limit`) stay in the
- * hash. They are ordinary correctness, not a disclosure boundary: the worst a
- * constructed collision buys there is the attacker's own page served back to
- * themselves under a different filter, within their own viewer class.
+ * 🔴 WHAT IS LEFT UN-CONTAINED, STATED AS A RESIDUAL RATHER THAN A REASSURANCE. The
+ * remaining axes (`kind`, `category`, `sort`, `cursor`, `limit`) stay in the hash, and
+ * a constructed collision across them is CROSS-USER CACHE POISONING of the shared
+ * `/apps` grid — not, as an earlier version of this comment said, "the attacker's own
+ * page served back to themselves". The entry is shared by every viewer in the class,
+ * and `full` is the class for ordinary logged-in users. The attacker's crafted-cursor
+ * request MISSES, so it is the request that WRITES the colliding key; every later
+ * reader deriving that key HITS it. So one request can pin the store's first page to
+ * an arbitrary filtered — or empty — result for up to `CacheTTL.sm` (180s) for everyone
+ * in that class.
+ *
+ * What it is NOT is a disclosure boundary: every row in a poisoned page came from a
+ * statement carrying the SAME `scope` and `redCapable` predicates, so no listing
+ * appears that the viewer was not already entitled to see. That is the whole reason
+ * those two axes, and only those two, were lifted out of the hash.
+ *
+ * This residual is ACCEPTED, deliberately, and the cost of accepting it is the 180s
+ * grid defect above. The alternative to accepting it is putting the remaining axes in
+ * the literal key too, and the blocker is `cursor`: it is a free-form 128-byte string,
+ * so lifting it out of the hash makes the redis keyspace AND the `cache_name` metric
+ * label request-controlled and unbounded — exactly the property the note at the bottom
+ * of this comment relies on. (`kind`, `category` and `sort` are closed enums and
+ * `limit` is 1..50, so those four could be lifted; they would multiply the label
+ * cardinality by their product, and they do not help while `cursor` stays hashed,
+ * because `cursor` is the tuning room the collision is built out of.) Widening
+ * `hashify` is the other alternative and it is global — see below.
+ *
+ * If that trade stops holding, the fix is to key on a per-axis allowlist plus a
+ * cursor DIGEST computed with a real hash, not to widen `hashify`.
  *
  * 🔴 DO NOT "FIX" THIS BY WIDENING `hashify` — it is used across the codebase for
  * cache keys, DOM ids and de-dup, so changing its output is a global blast radius.
@@ -799,8 +824,28 @@ function catalogPageCache(scope: StoreVisibilityScope, redCapable: boolean) {
 }
 
 /**
- * Bust the `/apps` store catalog cache. THE one buster — every listing-state
- * mutation calls this and nothing else.
+ * Bust the `/apps` store catalog cache. THE one buster — nothing else deletes the tag.
+ *
+ * 🔴 THE RULE IS "BUST WHEN A CACHED AXIS OR CATALOG MEMBERSHIP MOVES", NOT "every
+ * listing-state mutation busts". Several call sites used to invoke the latter as a
+ * "uniform rule"; it is not uniform, and stating it that way made a reader's model of
+ * the cache wrong in the expensive direction — it implies that a writer WITHOUT a bust
+ * is a bug, when a whole enumerated list of them are deliberate and correct. The cached statement reads
+ * `al.status`, `al.kind`, `al.revision_of_id`, `al.category`, `al.content_rating`,
+ * `ab.current_version_deployed_at` and the `sort_key` inputs (`al.name`,
+ * `al.created_at`, the metric rollup) — and nothing else. Every other column on the
+ * card is hydrated live below the cache and can never be served stale.
+ *
+ * Some busts ARE kept on paths that are inert today, as cheap defence-in-depth against
+ * a future edit promoting the row into the catalog: `updateListing`'s `removed` and
+ * `draft`/`pending` branches, its material-shadow branch, `submitListingRevision`, and
+ * `claimListing`. Each says so at its own call site. They are a judgement, not the
+ * rule.
+ *
+ * The asserted form of the rule — every `AppListing` writer either busts or is on an
+ * `EXEMPT` list with a reason — is
+ * `~/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts`. That
+ * file, not this paragraph, is what a new mutation has to satisfy.
  *
  * Fire-and-forget by the caller's convention (mirrors `bustRecommendMeanCache` in
  * `app-listing-review.service`): a cache-bus outage must never fail the mutation

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1505,11 +1505,14 @@ export async function updateListing(opts: {
       // the `approved` trivial-only branch makes.
       const data = buildListingPatchData(effectivePatch, patchOpts);
       await dbWrite.appListing.update({ where: { id: listingId }, data });
-      // Catalog bust: UNIFORM RULE, not a cached axis — this branch edits a `removed`
+      // Catalog bust: DEFENCE IN DEPTH, not a cached axis. This branch edits a `removed`
       // (owner-unpublished) row, which the approved-only catalog query already excludes, so
       // it is INERT today. Of the trivial fields it can write, only `category` is a cached
       // axis at all (tagline/description are hydrated live); it becomes load-bearing the
-      // moment such a row is republished, and that path busts too.
+      // moment such a row is republished, and that path busts too. Kept because the cost is
+      // one tag delete on a rare owner action — NOT because "every mutation busts": a
+      // number of `AppListing` writers deliberately do not, enumerated as `EXEMPT` in
+      // `~/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts`.
       await bustAppListingCatalogCache().catch(() => undefined);
 
       return { listingId, status: listing.status, requiresReview: false, shadowId: null };
@@ -1527,9 +1530,9 @@ export async function updateListing(opts: {
       // keeps reviewing the now-updated row (it references the row, not a snapshot).
       const data = buildListingPatchData(effectivePatch, patchOpts);
       await dbWrite.appListing.update({ where: { id: listingId }, data });
-      // Catalog bust: UNIFORM RULE, not a cached axis — a `draft`/`pending` row is outside
-      // the approved-only catalog query, so this is INERT today. Same reasoning as the
-      // `removed` branch above.
+      // Catalog bust: DEFENCE IN DEPTH, not a cached axis — a `draft`/`pending` row is
+      // outside the approved-only catalog query, so this is INERT today. Same reasoning as
+      // the `removed` branch above, including the part about the rule not being uniform.
       await bustAppListingCatalogCache().catch(() => undefined);
 
       return { listingId, status: listing.status, requiresReview: false, shadowId: null };
@@ -1595,13 +1598,15 @@ export async function updateListing(opts: {
         await tx.appListing.update({ where: { id: shadowId }, data: shadowData });
         if (betaData) await tx.appListing.update({ where: { id: listingId }, data: betaData });
       });
-      // Catalog bust: UNIFORM RULE, not a cached axis. The MATERIAL half is staged on a
+      // Catalog bust: DEFENCE IN DEPTH, not a cached axis. The MATERIAL half is staged on a
       // shadow (excluded from the catalog by both the approved-only and `revision_of_id IS
       // NULL` filters), and the beta half writes `isBeta` to the LIVE parent — but the cache
       // holds `{id, sort_key}` only and `isBeta` is a hydrated projection field, so it can
-      // never be served stale. INERT today; kept so the rule stays mechanical. (Note the
-      // asymmetry with `updateRevisionDraft`, which writes the same beta half to the same
-      // live parent and has NO bust — also correct, for the same reason.)
+      // never be served stale. INERT today; kept because it costs one tag delete on a path
+      // that already runs a transaction. 🔴 It is NOT evidence of a uniform rule:
+      // `updateRevisionDraft` writes the SAME beta half to the SAME live parent and has no
+      // bust, and that is equally correct — it is an `EXEMPT` row in
+      // `~/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts`.
       await bustAppListingCatalogCache().catch(() => undefined);
 
       return { listingId, status: listing.status, requiresReview: true, shadowId };
@@ -1905,10 +1910,13 @@ export async function submitListingRevision(opts: {
       changelog,
     },
   });
-  // Catalog bust: UNIFORM RULE — every listing-state mutation busts. Today this writes only
-  // a publish-request row against a `draft` shadow, which the approved-only catalog query
-  // already excludes, so the bust is a no-op. It is here so that the rule is mechanical
-  // rather than a per-branch judgement a future parent write could quietly fall outside of.
+  // Catalog bust: DEFENCE IN DEPTH. Today this writes only a publish-request row against a
+  // `draft` shadow, which the approved-only catalog query already excludes, so the bust is a
+  // no-op. It is kept against a future parent write being added to this path — a judgement
+  // about THIS function, not an instance of a universal rule (see
+  // `bustAppListingCatalogCache`'s header, and the `EXEMPT` list in
+  // `~/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts` for the
+  // writers that correctly do not bust).
   await bustAppListingCatalogCache().catch(() => undefined);
 
   return { publishRequestId, shadowId, slug: shadow.revisionOf.slug };
@@ -3741,8 +3749,12 @@ async function applyApprovedRevision(opts: {
   //     leaves the app in the wrong filtered grid.
   //   · `name` — the `sort='name'` sort key, cached as `sort_key`.
   // The onsite branch is assets-only and touches none of those, but the bust is
-  // unconditional here for the same reason it is unconditional everywhere else: a
-  // per-branch judgement is the thing that goes stale.
+  // unconditional across the two branches of THIS function rather than gated on which
+  // one ran — the gate would be a per-branch judgement inside a function whose branches
+  // already share a return path, and it would save one tag delete on a mod action. That
+  // is a statement about this function, not a universal rule: a number of `AppListing`
+  // writers correctly do not bust at all, enumerated as `EXEMPT` in
+  // `~/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts`.
   //
   // Post-commit and fire-and-forget, matching every sibling site — a cache-bus outage
   // must never fail an approval that has already committed.
@@ -3887,8 +3899,14 @@ export async function rejectExternalRequest(opts: {
       },
     });
   }
-  // Catalog bust: reject deletes the draft, or — for a reset-to-pending, formerly-live
-  // listing — delists it via `closeTerminalListing`. Both are catalog membership changes.
+  // Catalog bust: DEFENCE IN DEPTH, and the justification this comment used to give was
+  // wrong — it said both outcomes are "catalog membership changes". Neither is. Reject
+  // reaches the table only through `closeTerminalListing`, which DELETES a `draft` or
+  // flips `pending`→`removed`; the catalog query is approved-only, so both rows were
+  // already outside it and the bust is INERT today. It is kept because reject is a rare
+  // moderator action and this function is the one most likely to grow a live-parent write
+  // (a revision reject already reads the parent). If `closeTerminalListing` ever gains an
+  // `approved` branch, this becomes load-bearing with no further edit.
   await bustAppListingCatalogCache().catch(() => undefined);
 }
 

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1505,7 +1505,11 @@ export async function updateListing(opts: {
       // the `approved` trivial-only branch makes.
       const data = buildListingPatchData(effectivePatch, patchOpts);
       await dbWrite.appListing.update({ where: { id: listingId }, data });
-      // Catalog bust: an in-place edit of card fields (tagline / description / category).
+      // Catalog bust: UNIFORM RULE, not a cached axis — this branch edits a `removed`
+      // (owner-unpublished) row, which the approved-only catalog query already excludes, so
+      // it is INERT today. Of the trivial fields it can write, only `category` is a cached
+      // axis at all (tagline/description are hydrated live); it becomes load-bearing the
+      // moment such a row is republished, and that path busts too.
       await bustAppListingCatalogCache().catch(() => undefined);
 
       return { listingId, status: listing.status, requiresReview: false, shadowId: null };
@@ -1523,7 +1527,9 @@ export async function updateListing(opts: {
       // keeps reviewing the now-updated row (it references the row, not a snapshot).
       const data = buildListingPatchData(effectivePatch, patchOpts);
       await dbWrite.appListing.update({ where: { id: listingId }, data });
-      // Catalog bust: an in-place edit of card fields (tagline / description / category).
+      // Catalog bust: UNIFORM RULE, not a cached axis — a `draft`/`pending` row is outside
+      // the approved-only catalog query, so this is INERT today. Same reasoning as the
+      // `removed` branch above.
       await bustAppListingCatalogCache().catch(() => undefined);
 
       return { listingId, status: listing.status, requiresReview: false, shadowId: null };
@@ -1542,7 +1548,10 @@ export async function updateListing(opts: {
         // false), so writing it is a harmless no-op.
         const data = buildListingPatchData(effectivePatch, patchOpts);
         await dbWrite.appListing.update({ where: { id: listingId }, data });
-        // Catalog bust: a trivial in-place edit of a LIVE listing — card fields move.
+        // Catalog bust: LOAD-BEARING. This is the one edit branch that writes a LIVE
+        // (approved) row, and `category` — trivial by the material/trivial split, cached by
+        // the `al.category` filter — is exactly what it can move. (`tagline`/`description`
+        // are hydrated live and could never be stale; only `category` needs this.)
         await bustAppListingCatalogCache().catch(() => undefined);
 
         return { listingId, status: listing.status, requiresReview: false, shadowId: null };
@@ -1586,8 +1595,13 @@ export async function updateListing(opts: {
         await tx.appListing.update({ where: { id: shadowId }, data: shadowData });
         if (betaData) await tx.appListing.update({ where: { id: listingId }, data: betaData });
       });
-      // Catalog bust: the MATERIAL half is staged on a shadow, but the beta half writes to
-      // the LIVE parent — and `isBeta` is a card field.
+      // Catalog bust: UNIFORM RULE, not a cached axis. The MATERIAL half is staged on a
+      // shadow (excluded from the catalog by both the approved-only and `revision_of_id IS
+      // NULL` filters), and the beta half writes `isBeta` to the LIVE parent — but the cache
+      // holds `{id, sort_key}` only and `isBeta` is a hydrated projection field, so it can
+      // never be served stale. INERT today; kept so the rule stays mechanical. (Note the
+      // asymmetry with `updateRevisionDraft`, which writes the same beta half to the same
+      // live parent and has NO bust — also correct, for the same reason.)
       await bustAppListingCatalogCache().catch(() => undefined);
 
       return { listingId, status: listing.status, requiresReview: true, shadowId };
@@ -3712,6 +3726,27 @@ async function applyApprovedRevision(opts: {
       where: { id: shadowId, revisionOfId: { not: null } },
     });
   });
+
+  // 🔴 Catalog bust. THIS PATH IS NOT COVERED BY THE ONE IN `approveExternalRequest` —
+  // that caller `return`s into this function BEFORE reaching its bust, and it does so
+  // for EVERY approval of an edit to an already-live listing (`revisionOfId != null`),
+  // not for some corner case.
+  //
+  // The offsite branch above writes onto the LIVE parent, and two of the columns it
+  // writes are axes of the CACHED statement, not merely of the live-hydrated card:
+  //   · `contentRating` — via `resolveApprovalContentRating`, which can RAISE it. A
+  //     `g`→`r` re-rating that is not busted leaves the newly-`r` listing sitting in
+  //     the cached SFW page (`listingMatureFilter`) for the rest of the TTL.
+  //   · `category` — the cached query filters on `al.category`, so a category move
+  //     leaves the app in the wrong filtered grid.
+  //   · `name` — the `sort='name'` sort key, cached as `sort_key`.
+  // The onsite branch is assets-only and touches none of those, but the bust is
+  // unconditional here for the same reason it is unconditional everywhere else: a
+  // per-branch judgement is the thing that goes stale.
+  //
+  // Post-commit and fire-and-forget, matching every sibling site — a cache-bus outage
+  // must never fail an approval that has already committed.
+  await bustAppListingCatalogCache().catch(() => undefined);
 
   return { publishRequestId: request.id, listingId: parentId, slug: parent.slug };
 }

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -5,6 +5,7 @@ import { TRPCError } from '@trpc/server';
 import { Prisma } from '@prisma/client';
 
 import { dbRead, dbWrite } from '~/server/db/client';
+import { bustAppListingCatalogCache } from '~/server/services/blocks/app-listing.service';
 import {
   listingAssetTooLargeReason,
   MAX_LISTING_ASSET_SIZE_BYTES,
@@ -1504,6 +1505,9 @@ export async function updateListing(opts: {
       // the `approved` trivial-only branch makes.
       const data = buildListingPatchData(effectivePatch, patchOpts);
       await dbWrite.appListing.update({ where: { id: listingId }, data });
+      // Catalog bust: an in-place edit of card fields (tagline / description / category).
+      await bustAppListingCatalogCache().catch(() => undefined);
+
       return { listingId, status: listing.status, requiresReview: false, shadowId: null };
     }
     case 'rejected':
@@ -1519,6 +1523,9 @@ export async function updateListing(opts: {
       // keeps reviewing the now-updated row (it references the row, not a snapshot).
       const data = buildListingPatchData(effectivePatch, patchOpts);
       await dbWrite.appListing.update({ where: { id: listingId }, data });
+      // Catalog bust: an in-place edit of card fields (tagline / description / category).
+      await bustAppListingCatalogCache().catch(() => undefined);
+
       return { listingId, status: listing.status, requiresReview: false, shadowId: null };
     }
     case 'approved': {
@@ -1535,6 +1542,9 @@ export async function updateListing(opts: {
         // false), so writing it is a harmless no-op.
         const data = buildListingPatchData(effectivePatch, patchOpts);
         await dbWrite.appListing.update({ where: { id: listingId }, data });
+        // Catalog bust: a trivial in-place edit of a LIVE listing — card fields move.
+        await bustAppListingCatalogCache().catch(() => undefined);
+
         return { listingId, status: listing.status, requiresReview: false, shadowId: null };
       }
       // MATERIAL change → stage on a shadow. The parent stays LIVE untouched; the
@@ -1576,6 +1586,10 @@ export async function updateListing(opts: {
         await tx.appListing.update({ where: { id: shadowId }, data: shadowData });
         if (betaData) await tx.appListing.update({ where: { id: listingId }, data: betaData });
       });
+      // Catalog bust: the MATERIAL half is staged on a shadow, but the beta half writes to
+      // the LIVE parent — and `isBeta` is a card field.
+      await bustAppListingCatalogCache().catch(() => undefined);
+
       return { listingId, status: listing.status, requiresReview: true, shadowId };
     }
     default:
@@ -1877,6 +1891,12 @@ export async function submitListingRevision(opts: {
       changelog,
     },
   });
+  // Catalog bust: UNIFORM RULE — every listing-state mutation busts. Today this writes only
+  // a publish-request row against a `draft` shadow, which the approved-only catalog query
+  // already excludes, so the bust is a no-op. It is here so that the rule is mechanical
+  // rather than a per-branch judgement a future parent write could quietly fall outside of.
+  await bustAppListingCatalogCache().catch(() => undefined);
+
   return { publishRequestId, shadowId, slug: shadow.revisionOf.slug };
 }
 
@@ -3363,6 +3383,9 @@ export async function approveExternalRequest(opts: {
     details: { slug: listing.slug, name: listing.name, listingId: appListingId, reason: null },
   });
 
+  // Catalog bust: approve puts the listing INTO the store catalog.
+  await bustAppListingCatalogCache().catch(() => undefined);
+
   return { publishRequestId, listingId: appListingId, slug: request.slug };
 }
 
@@ -3829,6 +3852,9 @@ export async function rejectExternalRequest(opts: {
       },
     });
   }
+  // Catalog bust: reject deletes the draft, or — for a reset-to-pending, formerly-live
+  // listing — delists it via `closeTerminalListing`. Both are catalog membership changes.
+  await bustAppListingCatalogCache().catch(() => undefined);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -978,7 +978,13 @@ export async function claimListing(opts: {
     }
   });
 
-  // Catalog bust: claim reassigns ownership, which moves the card's creator chip.
+  // Catalog bust: kept for the UNIFORM RULE (every listing-state mutation busts), not for a
+  // cached axis — stated honestly so nobody later reasons from a wrong premise. Claim moves
+  // `userId`, and the creator chip that renders from it is hydrated LIVE; the cache holds
+  // `{id, sort_key}` only, and no sort or filter here keys on ownership. So this bust is
+  // currently INERT. It costs one tag delete on a rare mod action and it means the rule is
+  // mechanical rather than a per-branch judgement a future ownership-aware sort could
+  // quietly fall outside of.
   await bustAppListingCatalogCache().catch(() => undefined);
 
   return { appListingId: input.appListingId, userId: input.targetUserId };

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -978,13 +978,15 @@ export async function claimListing(opts: {
     }
   });
 
-  // Catalog bust: kept for the UNIFORM RULE (every listing-state mutation busts), not for a
-  // cached axis — stated honestly so nobody later reasons from a wrong premise. Claim moves
-  // `userId`, and the creator chip that renders from it is hydrated LIVE; the cache holds
-  // `{id, sort_key}` only, and no sort or filter here keys on ownership. So this bust is
-  // currently INERT. It costs one tag delete on a rare mod action and it means the rule is
-  // mechanical rather than a per-branch judgement a future ownership-aware sort could
-  // quietly fall outside of.
+  // Catalog bust: DEFENCE IN DEPTH, not a cached axis — stated honestly so nobody later
+  // reasons from a wrong premise. Claim moves `userId`, and the creator chip that renders
+  // from it is hydrated LIVE; the cache holds `{id, sort_key}` only, and no sort or filter
+  // here keys on ownership. So this bust is currently INERT. It is kept because it costs one
+  // tag delete on a rare mod action and a future ownership-aware sort would need it.
+  // 🔴 NOT an instance of "every listing-state mutation busts" — that rule was invoked here
+  // and it is false. `acceptTransfer` (`app-ownership-transfer.service`) moves the SAME
+  // `userId` column and correctly does NOT bust; it is an `EXEMPT` row in
+  // `~/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts`.
   await bustAppListingCatalogCache().catch(() => undefined);
 
   return { appListingId: input.appListingId, userId: input.targetUserId };

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -2,6 +2,7 @@ import { TRPCError } from '@trpc/server';
 import type { Prisma } from '@prisma/client';
 
 import { dbRead, dbWrite } from '~/server/db/client';
+import { bustAppListingCatalogCache } from '~/server/services/blocks/app-listing.service';
 import {
   APP_LISTING_REPORT_REASONS,
   OFFSITE_MOD_REASON_MIN,
@@ -661,6 +662,9 @@ export async function delistListing(opts: {
     details: { slug: listing.slug, name: listing.name, listingId: input.appListingId, reason },
   });
 
+  // Catalog bust: delist removes the listing from the store catalog.
+  await bustAppListingCatalogCache().catch(() => undefined);
+
   return { appListingId: input.appListingId, status: 'removed' };
 }
 
@@ -762,6 +766,9 @@ export async function relistListing(opts: {
       )
       .catch(() => undefined);
   }
+
+  // Catalog bust: relist puts the listing back into the store catalog.
+  await bustAppListingCatalogCache().catch(() => undefined);
 
   return { appListingId: input.appListingId, status: 'approved' };
 }
@@ -971,6 +978,9 @@ export async function claimListing(opts: {
     }
   });
 
+  // Catalog bust: claim reassigns ownership, which moves the card's creator chip.
+  await bustAppListingCatalogCache().catch(() => undefined);
+
   return { appListingId: input.appListingId, userId: input.targetUserId };
 }
 
@@ -1128,6 +1138,9 @@ export async function purgeListing(opts: {
       );
     }
   }
+
+  // Catalog bust: purge deletes the row (and releases the slug) — catalog membership.
+  await bustAppListingCatalogCache().catch(() => undefined);
 
   return { appListingId: input.appListingId, purged: true };
 }
@@ -1398,6 +1411,9 @@ export async function resetListingToPending(opts: {
     details: { slug, name, listingId: input.appListingId, reason },
   });
 
+  // Catalog bust: reset-to-pending drops the row out of the approved-only catalog.
+  await bustAppListingCatalogCache().catch(() => undefined);
+
   return { appListingId: input.appListingId, status: 'pending', publishRequestId };
 }
 
@@ -1614,6 +1630,9 @@ export async function resetOnsiteListingToPending(opts: {
     details: { slug: listing.slug, name: listing.name, listingId: input.appListingId, reason },
   });
 
+  // Catalog bust: onsite reset-to-pending — same membership change as the offsite path.
+  await bustAppListingCatalogCache().catch(() => undefined);
+
   return { appListingId: input.appListingId, status: 'pending', publishRequestId };
 }
 
@@ -1757,6 +1776,9 @@ export async function unpublishOwnListing(opts: {
       },
     });
   });
+
+  // Catalog bust: owner-unpublish removes the listing from the store catalog.
+  await bustAppListingCatalogCache().catch(() => undefined);
 
   return { appListingId: input.appListingId, status: 'removed' };
 }
@@ -2046,6 +2068,9 @@ export async function republishOwnListing(opts: {
       )
       .catch(() => undefined);
   }
+
+  // Catalog bust: owner-republish restores the listing to the catalog (or moves it to pending).
+  await bustAppListingCatalogCache().catch(() => undefined);
 
   // 🔴 The narrowing is on the LOCAL, not on a re-read: `reviewReason` is assigned inside
   // the transaction callback and TypeScript cannot see through the closure, so it is

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -3336,6 +3336,19 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
     );
   }
 
+  // Catalog bust: an onsite approve mints/flips the AppListing to `approved`, i.e. it
+  // puts the app INTO the store catalog.
+  //
+  // 🔴 LAZY IMPORT, DELIBERATELY. This module keeps `~/server/db/client` and `~/env/server`
+  // out of its STATIC graph on purpose (see the import header, and its own
+  // `await import('~/server/db/client')` at the top of this function) so the pure-helper
+  // suites can load it without Prisma. `app-listing.service` imports both statically, so a
+  // top-level import here would quietly undo that.
+  const { bustAppListingCatalogCache } = await import(
+    '~/server/services/blocks/app-listing.service'
+  );
+  await bustAppListingCatalogCache().catch(() => undefined);
+
   return {
     publishRequestId: request.id,
     appBlockId,

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -3344,10 +3344,28 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
   // `await import('~/server/db/client')` at the top of this function) so the pure-helper
   // suites can load it without Prisma. `app-listing.service` imports both statically, so a
   // top-level import here would quietly undo that.
-  const { bustAppListingCatalogCache } = await import(
-    '~/server/services/blocks/app-listing.service'
-  );
-  await bustAppListingCatalogCache().catch(() => undefined);
+  //
+  // 🔴 THE `try` WRAPS THE IMPORT, NOT JUST THE CALL. `.catch()` on the call covers a
+  // rejected bust; it does nothing for a THROW out of `await import(...)` — a module-load
+  // failure anywhere in `app-listing.service`'s static graph (it pulls in Prisma, env and
+  // redis) would propagate out of `approveRequest` here, AFTER the DB writes, the build
+  // trigger and the notification have all committed. That is precisely the outcome the
+  // comment above forbids, arrived at from the import instead of from the call. Same
+  // posture as the notification step at the top of this block.
+  try {
+    const { bustAppListingCatalogCache } = await import(
+      '~/server/services/blocks/app-listing.service'
+    );
+    await bustAppListingCatalogCache();
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[approveRequest] catalog cache bust failed (id=${params.publishRequestId}); ` +
+        `approve stands, the store grid self-corrects within CacheTTL.sm: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+    );
+  }
 
   return {
     publishRequestId: request.id,


### PR DESCRIPTION
`appListings.listAvailable` — the query behind the whole `/apps` store grid — had **no server-side cache**. Every page load was a cold DB read of a keyset query that joins `app_listing_metrics` and computes a Bayesian sort key. This adds one.

Refs #529.

> **Numbers in this body were re-derived at the current head.** Every count, ratio and cross-reference below was measured against this branch on 2026-09-08, not carried forward from an earlier round. Where a claim from an earlier round turned out to be unpinned or wrong, it says so rather than being quietly replaced.

---

## The design, and why not the alternatives

The cache is **`queryCache` + a bust tag**, wrapping the raw keyset query inside `listAvailableListings`. Hydration and the `nextCursor` derivation are untouched — `nextCursor` comes off the (now cached) `idRows`, exactly as `getPostsInfinite` does it in `src/server/services/post.service.ts`.

**What is cached is `{ id, sort_key }` per row, and nothing else.** Every projection field on a card — tagline, description, icon/cover/screenshot URLs, the owner chip, the beta badge — comes from a **live** hydration below the cache on every request. That distinction decides which mutations need a bust, and getting it wrong in either direction is the main way this change could have been wrong. It is stated in the tag's own module doc (`app-listing-cache.constants.ts`), which is the first thing a maintainer reads.

**Two of the query's axes are viewer-varying, and they are LITERAL key segments, not hash input.**

`cache-helpers`'s `queryCache` builds its key as `[key, version, hashifyObject(query)].join(':')`. `hashifyObject` → `hashify` is a **32-bit linear rolling hash**, and `decodeListingCursor` admits `cursorSortKey` / `cursorId` as arbitrary free strings straight into the hashed statement as bound params (the read schema bounds `cursor` only by `z.string().max(128)`). So a collision against a chosen target is *constructible*, not something to brute-force. An earlier revision of this change relied on "every axis is interpolated into the statement, therefore every axis is in the key", which silently assumes the hash is injective. It is not.

The fix is to lift the two axes that are **security boundaries** out of the hashed payload and into the literal key — `listAvailableAppListings:<scope>:<red|sfw>`:

- `scope` — the public/onsite boundary. A collision would serve on-site apps to anonymous callers of `GET /api/v1/apps`, i.e. civitai#3983 re-opened through the cache rather than through a `??`.
- `redCapable` — the maturity gate. A collision would serve `r`/`x` cards onto a SFW domain.

With both in the prefix, a hash collision can only ever mix two pages **within** one viewer class.

🔴 **The residual is stated as a residual.** The remaining axes (`kind`, `category`, `sort`, `cursor`, `limit`) stay in the hash, and a constructed collision across them is **cross-user cache poisoning of the shared `/apps` grid** — the attacker's crafted-cursor request MISSES, so it is the request that WRITES the colliding key, and every later reader deriving that key HITS it. One request can pin the store's first page to an arbitrary filtered or empty result for up to 180s for everyone in that class. (A previous round's comment described this as "the attacker's own page served back to themselves", which was wrong; it is fixed in the code comment too.) It is **not** a disclosure boundary — every row in a poisoned page came from a statement carrying the same `scope` and `redCapable` predicates. It is accepted deliberately: containing the rest means putting `cursor`, a free 128-byte string, into the literal key, which makes the keyspace and the `cache_name` metric label request-controlled and unbounded.

**Not `fetchThroughCache`** — it has no `tag` option, so `bustCacheTag` cannot drive it and a moderator approve/delist would be invisible until the TTL expired.

**Not `clearCacheByPattern`** — banned for bust-on-mutation by its own header in `cache-helpers.ts`: a prior use ran a cluster SCAN over a ~60M-key shard → redis timeouts → 504 waves, and was reverted.

**Not a generation counter** — a counter folded into the key leaves the superseded entries in redis to expire on their own, so a bust *multiplies* the keyspace instead of reclaiming it. The tag set holds the exact keys to delete.

**Not widening `hashify`** — it keys caches, DOM ids and de-dup across the codebase; changing its output is a global blast radius. The containment belongs at the one call site that has a security boundary.

**TTL = `CacheTTL.sm` (180s).** The catalog is mod-gated and low-churn, so the TTL is not the freshness mechanism — the busts are. It is the backstop for the path that has no mutation to hang a bust on (a row that ages into visibility). It is explicitly **not** a redis-outage backstop: `queryCache` has no fail-open, so a redis outage 500s `/apps` rather than degrading to a live read. That is the dependency this change accepts.

---

## The leaf constants module

New: `src/server/services/blocks/app-listing-cache.constants.ts`, importing **nothing**. Exports `APP_LISTING_CATALOG_TAG` (new) and `APP_LISTING_RECOMMEND_MEAN_TAG` (the *existing* tag string, previously duplicated as a private literal in `app-listing.service.ts` and `app-listing-review.service.ts` — a producer and its only buster each spelling it independently). Both sites now read the shared const.

It is not in `app-listing.service.ts` on purpose. `app-listings.router.ts` and `blocks.router.ts` deliberately `await import()` their services to keep the Prisma client out of the router import graph — `blocks.router.ts` has **8** such sites for `user-app-surface.service` alone (re-counted at head). Exporting a constant from a heavy service makes those lazy imports **graph-inert**: nothing errors, and the cost only reappears later when someone adds an import to the service. Precedent and the measured version of that failure: `src/server/services/blocks/scope-activity-predicate.ts`.

---

## Bust sites, and the rule

🔴 **The rule is "bust when a cached axis or catalog membership moves" — NOT "every listing-state mutation busts".** Earlier rounds of this PR invoked the latter as a "UNIFORM RULE" at five call sites. It is false, and stating it that way makes a reader's model of the cache wrong in the expensive direction: it implies a writer without a bust is a bug, when a whole enumerated list of them are deliberate and correct. All five sites now say what they actually are — cheap defence-in-depth on a path that is inert today — and name which.

The cached statement reads exactly `al.id`, `al.status`, `al.revision_of_id`, `al.kind`, `al.category`, `al.content_rating`, `al.app_block_id` (the join key onto `app_blocks` for the deploy gate), `ab.current_version_deployed_at`, and the `sort_key` inputs (`al.name`, `al.created_at`, the `app_listing_metrics` rollup). A write that moves one of those needs a bust. A write that moves anything else does not.

`al.app_block_id` was missing from this list until round 4. It is latent rather than live: the only write of that column onto an **existing** row is `approveRequest`'s link step, guarded `where: { status: 'draft' }` (`publish-request.service.ts`), and it busts anyway — every other write of it is a `create` that mints at `status:'draft'`. It is listed so the next writer of the column is checked against the rule rather than against a list it is missing from.

🔴 **Two of those axes do not live on `app_listings`, and the rule is violated on them BY DESIGN.** The `app_listing_metrics` rollup feeds `sort='top-rated'` (thumbs) and `sort='popular'` (`install_count`), and it has two live writers that do **not** bust: `app-listing-review.service.ts` on every review vote (it busts only the recommend-MEAN tag) and `src/server/metrics/appListing.metrics.sql.ts` on the metric job (it busts nothing). That is the right trade — busting per vote or per metric pass would defeat the cache, while the cost is bounded at one `CacheTTL.sm` window of **sort** lag, with no row appearing, disappearing or changing maturity — but nothing said so, so a reader applying the rule to a metrics writer reached the wrong conclusion. It is now stated in all four places the axis list appears, and the ledger suite's blind-spot section names it as a blind spot the writer scan structurally cannot cover (the writers are on a different table, so no `appListing.` delegate call exists to enumerate).

One exported helper, `bustAppListingCatalogCache()`, fired post-commit as `await bustAppListingCatalogCache().catch(() => undefined)` — the posture of `bustRecommendMeanCache` in `app-listing-review.service.ts`. A cache-bus outage must never fail a mutation that already committed.

**19 bust sites**, pinned by name in the ledger suite. Load-bearing ones:

| Site | Cached axis it moves |
|---|---|
| `approveRequest` (`publish-request.service.ts`) | mints/flips to `approved` — membership |
| `approveExternalRequest`, `applyApprovedRevision` (`offsite-listing.service.ts`) | membership; and `applyApprovedRevision` writes `contentRating` / `category` / `name` onto the **live parent** |
| `delistListing`, `relistListing`, `purgeListing`, `resetListingToPending`, `resetOnsiteListingToPending`, `unpublishOwnListing`, `republishOwnListing` (`offsite-moderation.service.ts`) | membership |
| `updateListing`'s `approved` trivial-only branch (`offsite-listing.service.ts`) | `category` on a live row |
| `setListingIcon` / `setListingCover` / `addListingScreenshot` (`app-listing-assets.service.ts`) | `content_rating`, via the in-tx `reDeriveContentRatingForModLiveEdit` |
| `backfillAppListings` (`app-listing-backfill.service.ts`) | mints at `status:'approved'`. Guarded `if (!dryRun && result.created > 0)` |
| 🔴 `watchApplyJobAndRecord` (`build-callback.ts`) | **non-tRPC.** Writes `currentVersionDeployedAt` — the onsite deploy gate in the cached query. Without it a freshly-deployed onsite app is invisible for the whole TTL |

The remaining sites (`claimListing`, `rejectExternalRequest`, `submitListingRevision`, `updateListing`'s `removed` / `draft`-`pending` / material-shadow branches) are **inert today** and each says so, with what would make it load-bearing.

⚠️ Two justifications from earlier rounds were **wrong and are corrected in the code**, not quietly dropped:
- the icon/cover busts were explained as "the card's `iconUrl` moved". `iconUrl` is hydrated live and can never be stale; the **content-rating re-derive** is the whole reason those busts exist.
- `rejectExternalRequest`'s bust was explained as "both outcomes are catalog membership changes". Neither is — it reaches the table only through `closeTerminalListing`, which deletes a `draft` or flips `pending`→`removed`, both already outside the approved-only query.

🔴 **`BlockRegistry.setMarketplaceMeta` has NO bust, deliberately.** It writes `app_blocks.category`; the catalog statement filters `app_listings.category`. Different table, different column. Its comment now names the exact ledger row to add — `'src/server/services/block-registry.service.ts::BlockRegistry::setMarketplaceMeta'` — if the cached query ever grows a predicate over an `app_blocks` column it writes.

**`approveRequest` uses a lazy `await import`**, not a static one, and the `try` wraps the **import** as well as the call: `publish-request.service.ts` deliberately keeps `~/server/db/client` and `~/env/server` out of its static graph so its pure-helper suites can load it without Prisma, and a module-load failure anywhere in `app-listing.service`'s static graph would otherwise propagate out of `approveRequest` after the DB writes had committed.

---

## 🔴 The freshness guard: enumerate WRITERS, not busters

`src/server/services/blocks/__tests__/app-listing.catalog-bust-ledger.test.ts` (**11 tests**).

An earlier round of this file pinned only the SET OF BUST CALL SITES and its header claimed that went red "when a new listing mutation appears without a bust". **It did not** — a mutation with no bust adds no call site, so the pinned set is unchanged and the ledger stays green. Measured on this branch: appending an `export async function forgetfulDelist()` that flips an approved row to `removed` with no bust left the bust-only ledger at **5 passed / 0 failed**. That is the same zero-call-site condition as the original `applyApprovedRevision` defect the header cited as proof it would have caught it, so the guard was reading as coverage while providing none.

The primary assertion is now **inverted**. The scan enumerates every writer of the `AppListing` table (`<client>.appListing.{create,createMany,update,updateMany,upsert,delete,deleteMany}`, `tx.` forms included) across `src`/`apps`/`packages`/`scripts`, resolves each to its enclosing function, and requires that function to be **either** a bust call site **or** on an `EXEMPT` map with a one-line reason. A new un-busted mutation fails by construction. The bust set is still pinned separately, for the direction the writer scan cannot see: deleting a bust.

**`EXEMPT` (11), each reason re-derived against the code at this commit:**

| Writer | Why it does not bust |
|---|---|
| `backfillListingAssets` | writes only `coverId` / `iconId` — hydrated projection fields |
| `reDeriveContentRatingForModLiveEdit` | does raise `content_rating`, but is an in-tx helper whose callers all bust post-commit (a bust inside the tx would fire on a rollback too). **The caller set is now pinned mechanically** in `CALLER_BUSTS` — see round 4 below |
| `acceptTransfer` | writes only `userId`; the statement never reads ownership |
| `beginListingRevision`, `submitExternalListing`, `submitVersion` | mint at `status:'draft'` |
| `closeTerminalListing`, `closeOnsiteResetListingOnWithdraw`, `routeRepublishToReviewInTx` | move between non-`approved` statuses |
| `updateRevisionDraft` | writes the draft shadow plus `is_beta` on the parent; `is_beta` is not in the cached statement |
| `deleteOnsiteDraftListingForSlug` | deletes only `{kind:'onsite', appBlockId:null, status:'draft'}` |

A hygiene test keeps `EXEMPT` from rotting: every entry must still be a current writer, must not also bust, and must carry a real reason.

### 🔴 The attributor is a backward parse, and it fails loudly

Three pattern-list versions each mis-attributed **silently**, which is the worst output this file can produce — it sends the reader to an unrelated function:

1. a two-space-indented `name(` alternative added to name class methods also matched `  if (` and `  switch (`, so four real mutations were attributed to a function called `if`;
2. removing that and anchoring at column 0 made class methods invisible instead — re-adding the bust inside `BlockRegistry.setMarketplaceMeta` reported it as `block-registry.service.ts::resolveRenderMode`, an unrelated top-level helper, **while a comment at that call site instructs a maintainer to add that function to the ledger**;
3. a leftmost-match regex over a lookback window jumped to the *previous* function whenever a signature contained an object-type parameter (`function f(opts: {`), so `delistListing` was reported as `flipBackingBlockStatus`.

It now walks backward from each `{` with real bracket matching, nests frames by brace depth, and names class methods `Class::method`. When it cannot name a frame it emits `<unattributed>` and a test fails on that — which is how `acceptTransfer` and `updateRevisionDraft` were found (a character-class scan could not step back over `Promise<{ … }>`).

**Mutation results (all three verbatim in the PR discussion):**

| Mutant | Result |
|---|---|
| new un-busted writer `forgetfulDelist` appended to `offsite-moderation.service.ts` | **1 failed** — `🔴 every AppListing writer either busts the catalog cache or is EXEMPT`, naming `…offsite-moderation.service.ts::forgetfulDelist`. Mutant compiled (root typecheck still 13, none in that file) |
| `claimListing`'s bust deleted | **2 failed** — the coverage guard names `…::claimListing`, and the ledger comparison reports `REMOVED: ["…::claimListing"]` |
| bust re-added inside `BlockRegistry.setMarketplaceMeta` | **1 failed** — `ADDED: ["src/server/services/block-registry.service.ts::BlockRegistry::setMarketplaceMeta"]`, i.e. the exact string that call site's comment tells you to add |

---

## The key guard

`src/server/services/blocks/__tests__/app-listing.catalog-cache.test.ts` (**13 tests**). It asserts on the **derived cache key** — the real `hashifyObject` applied to the real `Prisma.Sql` captured on its way into `queryCache`, joined the way `cache-helpers` joins it — with the hash segment **removed**, because that is the half a collision cannot touch. A first test pins that the derivation is deterministic for an unchanged shape, so "these differ" is not vacuously true, and a drift-guard fails if `cache-helpers` stops keying on the whole `Prisma.Sql`.

The viewer-class product is now enumerated in full and its size is **derived from `STORE_VISIBILITY_SCOPES`**, not written down — which also pins the `cache_name` label-cardinality claim `catalogPageCache` makes. Adding a scope fails this test until the new classes are enumerated.

⚠️ An earlier round's comment quoted "**six tuning characters** in the cursor are enough to collide the two scope statements". That figure was never derived or pinned by anything, so it is **gone rather than replaced**. What is true and sufficient: the hash is 32-bit and linear and the attacker controls two free strings in the hashed payload, so a collision is constructible; and the guard puts the boundary outside the hash entirely, which makes the exact cost irrelevant.

---

## Client

`AppListingsMarketplaceBody.tsx` — the `useInfiniteQuery` had no `staleTime`, so react-query's default of **0** refetched on every remount and every window focus, on a page viewers leave and immediately return to. Now `staleTime: 60 * 1000`.

The **property** is that the client window stays strictly shorter than the server TTL, so the client can never be the longer of the two staleness sources; a client window outliving the server TTL would make the explicit busts invisible for the difference. That inequality — and only that — is what the browser spec asserts, against the real `CacheTTL.sm` rather than a literal. The 3× headroom is a judgement, not a pinned ratio (an earlier round's body called it "deliberately a third of the server TTL", which reads as a pinned relationship and is not one).

Mutating `staleTime` to `600 * 1000`:

```
AssertionError: the client staleTime is >= the server-side TTL (CacheTTL.sm = 180s) on
`listAvailableListings`. A client window longer than the server one makes the explicit
catalog busts invisible for the difference.: expected 600000 to be less than 180000
```

It does not interact with `placeholderData: keepPreviousData` (untouched): `staleTime` governs refetch of *this* key, `keepPreviousData` governs what renders while a *different* key loads.

---

## Round 4 — three findings, all in the guard, none in the payload

A fourth adversarial round found **no payload defect** and confirmed all 11 `EXEMPT` reasons hold. Every finding was in the ledger guard itself, which is round 3's whole deliverable.

### F1 🔴 The ledger could be walked silently by an unbalanced brace in a regex literal

`buildFrames` nests frames by brace depth over text from `stripCommentsAndStrings`, which removes comments, template literals and quoted strings — but **not regex literals**. A `{` or `}` inside one survives, every frame after it re-nests, and a write is then attributed to a *different real function*: no `<unattributed>`, no error, and the coverage guard reads as satisfied because the name it landed on is in `LEDGER`/`EXEMPT`.

Demonstrated end-to-end, with the mutation isolated to the brace:

| Arm | Ledger file | Result |
|---|---|---|
| `const _jsonHead = /^\s*\{/;` in `acceptTransfer` + un-busting `forgetfulDelist()` appended, both in `app-ownership-transfer.service.ts` | at `0960cebd8f` | **8 passed / 0 failed** — the new writer folded into `acceptTransfer`, which is `EXEMPT`, so it read as covered |
| same mutant | with F1 | **1 failed** — `🔴 every scanned file brace-balances after stripping`, reporting `src/server/services/blocks/app-ownership-transfer.service.ts (delta +1, min depth 0)` |
| same mutant, regex **balanced** (`/^\s*\{\}/`) | with F1 | **1 failed** — `🔴 every AppListing writer either busts the catalog cache or is EXEMPT`, naming `…app-ownership-transfer.service.ts::forgetfulDelist`. The brace is the variable, not the mutation |

`app-ownership-transfer.service.ts` was chosen because it holds **no** bust sites, so the `LEDGER` equality pin cannot see the collapse — that is the silent case. Reachability is real: **39 of the 5,123** scanned files do not brace-balance after stripping, one of them (`src/pages/apps/[appBlockId]/index.tsx`, delta +2) already inside the scan population via `dbRead.appListing.findFirst`. None contributes a site today, so nothing is mis-attributed now; each becomes a red build the day it gains a writer.

**The fix is a brace-balance counter in `buildFrames` that fails loudly**, not a regex-literal stripper. A balance check cannot be walked by a construct nobody thought of, whereas a stripper only closes the shape we happened to see — and `/` is genuinely ambiguous with division in a module two **other** guards also depend on. `minDepth` is tracked alongside the delta so a `+1/−1` pair that cancels is still caught. The imbalanced file is **recorded, not skipped**: attribution still runs, so exactly one test goes red and it is the one naming the real cause.

### F2 🟡 An exemption resting on an unasserted caller-set claim

`reDeriveContentRatingForModLiveEdit`'s `EXEMPT` reason said it "is an in-tx helper with exactly three callers … and all three bust post-commit". True, and **nothing asserted it** — and the dangerous caller is invisible to the writer scan *by construction*, because it issues no `appListing.` write of its own.

| Arm | Result |
|---|---|
| a 4th caller running the helper inside `dbWrite.$transaction` with no bust (`relabelListingAssetsInTx`, reads via `findUniqueOrThrow`) at `0960cebd8f` | **8 passed / 0 failed**; the function never appears in `WRITERS` |
| same mutant with F2 | **1 failed** — `🔴 every CALLER of an exempt-by-caller helper busts, and the caller set is pinned`, naming `…app-listing-assets.service.ts::relabelListingAssetsInTx` |
| same mutant **plus** a post-commit bust | **2 failed** — the SITES half passes and only the bookkeeping pin fires (`the caller set … changed`, 4 vs 3), alongside the ordinary `LEDGER` "a bust nobody recorded" red. Both assertions are separately reachable |

If that caller had landed, a moderator raising an approved listing `g`→`r` would sit in the cached SFW page for the full `CacheTTL.sm` — verbatim the narrative this file's header opens with.

`CALLER_BUSTS` is a map, so a second helper exempted on the same argument is a one-line addition, and a hygiene assertion requires every pinned helper to still be an `EXEMPT` row.

**Secondary, same row:** the `EXEMPT` preamble said "the bar for a row here is that the write provably cannot move a CACHED axis". This row moves one; it is exempt on a **caller** argument. The preamble now states both bars, says which one each kind of row claims, and requires a bar-2 row to carry a `CALLER_BUSTS` pin. (`routeRepublishToReviewInTx` also cites its caller, but independently clears bar 1 — its `where` selects `status:'removed'`, so it moves no catalog member — so it needs no pin.)

### F3 🟡 The cached-axis list was incomplete in four places

`al.app_block_id` and the off-table metric writers, corrected in the ledger suite, `app-listing.service.ts`, `app-listing-cache.constants.ts` and this body — see "Bust sites, and the rule" above.

### Also

- `app-listing.catalog-cache.test.ts` said "the five shapes"; the enumerated product is **six** (`STORE_VISIBILITY_SCOPES.length * 2` = 3 × 2, and six literal rows).
- The `CALL_RE` comment credited its `\(` with excluding the buster's own declaration. It does not — a declaration's parameter list matches `name\s*\(` exactly like a call; the `\bfunction\s+$` lookback in `scan` is what drops it, as that line's own comment says. All three exclusions are now named separately.
- `attribute()` can return `<module scope>`, which the "every site resolves to a named enclosing function" test does not filter. That is deliberate and now documented: it is a *correct* answer (a genuine top-level write), not a parse failure, and it needs no guard of its own — neither list holds a `<module scope>` row today, so a new one lands in neither `LEDGER` nor `EXEMPT` and the headline coverage guard reports it by name. Nothing *mechanically* stops someone typing such a row in; the point is that doing so is a deliberate act, the same contract every other row is under, rather than a silent pass.

---

## Verification (re-run at the current head)

**Typecheck — base-vs-HEAD, `NODE_OPTIONS=--max-old-space-size=12288`.** Both runs in the **same** working tree, swapping the changed files between their base and head contents: a separate worktree is not a valid instrument here, because `packages/` resolves through the primary clone's `node_modules` symlink and an unbuilt worktree reported **54** root errors instead of 13, purely from build state.

| Config | base | HEAD | |
|---|---|---|---|
| `node scripts/typecheck.mjs` | 13 | 13 | **byte-identical output** |
| `node scripts/typecheck.mjs -p tsconfig.tests.json` | 1205 | 1205 | identical after normalising line numbers |

The 1205 is also the **positive control**: a config that reports a large non-zero count is demonstrably wired to the code. Re-measured for round 4 (base = `0960cebd8f`, swapped in the same tree, restored and sha256-verified afterwards): the main config's 13 error lines are **identical as a sorted set**; the tests config is 1205 vs 1205 and **identical on `(file, line, column, TS####, order-insensitive message tokens)`**. Its residual textual diff is 36 lines in two unrelated files (`resolve-nav-items.test.ts`, `process-vault-items.test.ts`) where tsc printed a union's members and an object type's properties in a different order — same location, same code, same members. The 3 pre-existing errors in `offsite-listing.onsite-revision.service.test.ts` are present identically on base.

**Tests.**

- Blocks tier, `vitest run --project unit src/server/services/blocks` — **168 files / 4225 tests, all green** at this head, against **168 / 4222** with the four changed files swapped back to their previous contents in the **same tree**. The +3 are round 4's new ledger assertions (that file goes 8 → 11 tests). ⚠️ An earlier round of this body quoted `165 files / 3885 tests` for this tier; that did not reproduce and is corrected here — 165 is the count of `__tests__/*.test.ts` *files on disk*, while the `unit` project's `src/**/*.test.ts` include selects 168 under this directory. A cold run of the same command in a `cp -a` copy reported `28 failed | 140 passed` with **3845 tests passed and 0 failed** — the dep-optimizer cascade (`Cannot find module …/node_modules/.vite/…/deps_ssr/prom-client.js`), i.e. suites that fail to *import* rather than to assert; 3885 is close enough to 3845 that the old figure may have been taken from a partially-cascaded run. Warm runs in the worktree were 57.8s and 59.7s.
- `AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx` — **4 passed** warm. The browser tier cold-cascades: the first run failed to import (stale vite dep-optimizer cache) and the second reported 4 failed with `Cannot read properties of null (reading 'useSyncExternalStore')`, a duplicated-React symptom of the same cache. An untouched control spec passing in between is what identified it as environmental. Wall time discriminates: 18.05s on the poisoned run vs 7.08s warm.
- `npx prettier --check` on all **22** changed files → clean. `npx eslint` → 2 errors, both pre-existing `no-explicit-any` on `build-callback.ts`'s `safe()` helper, unchanged by this PR.

**CI.** `tekton / typecheck` shows ERROR at the previous head. It is **not** a type error: the TaskRun's own condition reads `TaskRun cancelled as the PipelineRun it belongs to has timed out`, and the PipelineRun reads `failed due to tasks failed to finish within "1h0m0s"`. Two pipelineruns for this PR overlapped (`pr-check-4717-hxh8t` at 02:25:19Z on `abf7e5b02`, `pr-check-4717-wdglh` at 02:27:20Z on `37aef4ed3`); the earlier one's typecheck **passed**, the later one's was starved and cancelled at the hour. The only commit between those two revisions is a prettier-formatting commit. The same check passes on all 7 other open PRs sampled (`gh pr list --state open --limit 8`). This body's CI claims must be re-read after this round's push, which triggers a fresh run.

**Test-scaffold changes this forced** (each is the documented one-key-`vi.mock` trap):

- `app-listing.service.test.ts`, `app-listing.public-scope.test.ts`, `app-listing.deploy-gate.test.ts`, `app-listing.moderation.service.test.ts`, `app-collaborator.public-byline-offsite.test.ts` — their cache-helpers factories exported only `queryCache`; the service now imports `bustCacheTag` too, so each would have died with `No "bustCacheTag" export is defined on the … mock`. Their `~/server/common/constants` stubs also gained `CacheTTL.sm`.
- `publish-request.listingSync.test.ts`, `publish-request.notify.service.test.ts` — these did not mock cache-helpers at all; `approveRequest`'s lazy import of the listing service pulled the real module, whose body builds a logger off the real env, throwing `TypeError: Cannot read properties of undefined (reading 'includes')` *inside* the approve. Stubbed.
- `offsite-listing.onsite-revision.service.test.ts` uses a **partial** mock (spread `importOriginal()`, override `bustCacheTag`) so it cannot go stale when that graph reaches for a third export.
- The new suites use the **canonical `dbMock`** rather than a per-file `~/server/db/client` mock, which `no-direct-shared-module-mock` forbids. (That guard is textual — it also fires on the forbidden call written as a code sample in a comment.)

