### PR TITLE
feat(rewards-abuse): gate clustering on per-account reward persistence

### DIFF
--- a/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
+++ b/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
@@ -183,6 +183,16 @@ describe('rewards-abuse-prevention — detection shape', () => {
     expect(sql).not.toContain('AND startsWith');
   });
 
+  it('clusters over the previous COMPLETE day, not whatever is left of today', async () => {
+    await runWith({ award_types: ['dailyBoost'] });
+
+    // `createdDate > subtractDays(now(), 1)` reads as "the last 24 hours" and is not: createdDate
+    // is a Date, so the comparison lands on midnight and the predicate collapses to "today" —
+    // three hours of data at the 03:00 cron, against thresholds that assume a day.
+    expect(outerWhereOf(sqlOf())).toContain('createdDate = subtractDays(toDate(now()), 1)');
+    expect(outerWhereOf(sqlOf())).not.toContain('createdDate > subtractDays(now(), 1)');
+  });
+
   it('emits a cluster-size ceiling when max_user_count is set', async () => {
     await runWith({ max_user_count: 5 });
 
@@ -286,7 +296,7 @@ describe('rewards-abuse-prevention — scan bounds and config safety', () => {
     await runWith({});
 
     const sql = sqlOf();
-    expect(sql).toContain('createdDate > subtractDays(now(), 1)');
+    expect(sql).toContain('createdDate = subtractDays(toDate(now()), 1)');
     // `createdDate` is MATERIALIZED and prunes nothing; without this the scan reads the
     // whole table rather than the window it claims to.
     expect(sql).toContain('time > subtractDays(now(), 3)');
@@ -421,14 +431,18 @@ describe('rewards-abuse-prevention — per-account persistence gate', () => {
     const sql = sqlOf();
     expect(sql).toContain('GROUP BY toUserId, day');
     expect(sql).toContain('HAVING countIf(day_awarded >= day_cap) >= 10');
-    expect(sql).toContain('createdDate > subtractDays(now(), 30)');
+    expect(sql).toContain(
+      'createdDate BETWEEN subtractDays(toDate(now()), 30) AND subtractDays(toDate(now()), 1)'
+    );
   });
 
   it('bounds the wider window on the partition key as well as on createdDate', async () => {
     await runWith({ ...prefixConfig, min_cap_days: 10, cap_days_window: 14 });
 
     const sql = sqlOf();
-    expect(sql).toContain('createdDate > subtractDays(now(), 14)');
+    expect(sql).toContain(
+      'createdDate BETWEEN subtractDays(toDate(now()), 14) AND subtractDays(toDate(now()), 1)'
+    );
     // Why wider than the window: see DATE_BOUND_SLACK_DAYS.
     expect(sql).toContain('time > subtractDays(now(), 17)');
   });

--- a/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
+++ b/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
@@ -77,6 +77,7 @@ describe('rewards-abuse-prevention — sysRedis config read (STEP-3 soft-depende
     expect(chQuery).toHaveBeenCalledTimes(1); // detection query ran
     expect(result).toEqual({
       dryRun: false,
+      minCapDays: 0,
       usersDisabled: 0,
       wouldDisable: 0,
       ipsFlagged: 0,
@@ -92,6 +93,7 @@ describe('rewards-abuse-prevention — sysRedis config read (STEP-3 soft-depende
     expect(chQuery).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       dryRun: false,
+      minCapDays: 0,
       usersDisabled: 0,
       wouldDisable: 0,
       ipsFlagged: 0,
@@ -121,6 +123,10 @@ describe('rewards-abuse-prevention — sysRedis config read (STEP-3 soft-depende
 });
 
 const sqlOf = () => (chQuery.mock.calls[0]?.[0] as string) ?? '';
+// The outer query's own WHERE. Asserting the gate's ABSENCE here is what forbids the placement
+// that lets the cluster-size ceiling read a count the gate has already shrunk.
+const outerWhereOf = (sql: string) =>
+  sql.slice(sql.lastIndexOf('WHERE createdDate'), sql.indexOf('GROUP BY ip'));
 type DryRunReport = {
   dryRun: boolean;
   usersDisabled: number;
@@ -386,5 +392,202 @@ describe('rewards-abuse-prevention — decision log', () => {
 
     expect(chInsert).toHaveBeenCalledTimes(1);
     expect(logToAxiom).not.toHaveBeenCalled();
+  });
+});
+
+describe('rewards-abuse-prevention — per-account persistence gate', () => {
+  const prefixConfig = {
+    require_exclusive_ip: true,
+    award_types: [],
+    award_type_prefixes: ['encouragement:'],
+    cap_day_awarded: 100,
+  };
+
+  it('adds nothing at all when min_cap_days is absent', async () => {
+    await runWith(prefixConfig);
+
+    expect(sqlOf()).not.toContain('persistent_earners');
+  });
+
+  it('CONTROL: the same config with min_cap_days set does add it', async () => {
+    await runWith({ ...prefixConfig, min_cap_days: 10 });
+
+    expect(sqlOf()).toContain('persistent_earners');
+  });
+
+  it('counts a cap-day per user-day over the configured window', async () => {
+    await runWith({ ...prefixConfig, min_cap_days: 10 });
+
+    const sql = sqlOf();
+    expect(sql).toContain('GROUP BY toUserId, day');
+    expect(sql).toContain('HAVING countIf(day_awarded >= day_cap) >= 10');
+    expect(sql).toContain('createdDate > subtractDays(now(), 30)');
+  });
+
+  it('bounds the wider window on the partition key as well as on createdDate', async () => {
+    await runWith({ ...prefixConfig, min_cap_days: 10, cap_days_window: 14 });
+
+    const sql = sqlOf();
+    expect(sql).toContain('createdDate > subtractDays(now(), 14)');
+    // Why wider than the window: see DATE_BOUND_SLACK_DAYS.
+    expect(sql).toContain('time > subtractDays(now(), 17)');
+  });
+
+  it('takes the cap amount from config rather than assuming the encouragement cap', async () => {
+    await runWith({ ...prefixConfig, min_cap_days: 3, cap_day_awarded: 250 });
+
+    expect(sqlOf()).toContain('ceil(250 * max(be.multiplier)) AS day_cap');
+  });
+
+  it('measures cap-days on the same award types the clustering matches', async () => {
+    await runWith({
+      require_exclusive_ip: true,
+      award_types: ['dailyBoost'],
+      award_type_prefixes: [],
+      min_cap_days: 10,
+      cap_day_awarded: 25,
+    });
+
+    // Between the CTE header and its HAVING is the CTE's own WHERE: the type predicate has to
+    // be there, or cap-days are counted over every reward the account earns.
+    expect(sqlOf()).toMatch(
+      /persistent_earners[\s\S]*be\.type IN \('dailyBoost'\)[\s\S]*HAVING countIf/
+    );
+  });
+
+  it('CONTROL: the same parity holds for a prefix family, not just an exact list', async () => {
+    await runWith({ ...prefixConfig, min_cap_days: 10 });
+
+    const sql = sqlOf();
+    expect(sql).toMatch(
+      /persistent_earners[\s\S]*startsWith\(be\.type, 'encouragement:'\)[\s\S]*HAVING countIf/
+    );
+    // A CTE that hardcoded a type list would satisfy the dailyBoost test above and nothing else.
+    expect(sql).not.toContain('be.type IN (');
+    // Capped grants store an awardAmount of 0; counting them would make a cap-day out of a day
+    // the account spent entirely refused.
+    expect(sql).toMatch(/persistent_earners[\s\S]*AND awardAmount > 0[\s\S]*HAVING countIf/);
+  });
+
+  it('gates the counted users but NOT the IP total, so a mixed household loses exclusivity', async () => {
+    await runWith({ ...prefixConfig, min_cap_days: 10 });
+
+    const sql = sqlOf();
+    expect(sql).toContain(
+      "uniqExactIf(be.toUserId, startsWith(be.type, 'encouragement:') AND be.toUserId IN (SELECT uid FROM persistent_earners)) as user_count"
+    );
+    // Unfiltered on purpose: `ip_user_count` has to keep counting the casual earners, or the
+    // household is reduced to its one persistent user and passes exclusivity instead of failing it.
+    expect(sql).toContain('uniqExact(be.toUserId) as ip_user_count');
+    expect(sql).toContain('AND ip_user_count = user_count');
+    expect(sql).toContain(
+      "sumIf(awardAmount, startsWith(be.type, 'encouragement:') AND be.toUserId IN (SELECT uid FROM persistent_earners)) as awarded"
+    );
+    // The disable list, gated in its own right: without this it is every account that touched the
+    // IP, correct only for as long as the equality above survives.
+    expect(sql).toContain(
+      "groupUniqArrayIf(be.toUserId, startsWith(be.type, 'encouragement:') AND be.toUserId IN (SELECT uid FROM persistent_earners)) as user_ids"
+    );
+    expect(outerWhereOf(sql)).not.toContain('persistent_earners');
+  });
+
+  it('keeps the gate out of the WHERE with exclusivity off too, so the ceiling has a count to read', async () => {
+    await runWith({ ...prefixConfig, require_exclusive_ip: false, min_cap_days: 10 });
+
+    const sql = sqlOf();
+    expect(sql).toContain(
+      'uniqIf(be.toUserId, be.toUserId IN (SELECT uid FROM persistent_earners)) as user_count'
+    );
+    expect(sql).toContain('uniq(be.toUserId) as ip_user_count');
+    // The disable list has to be the gated users, not everyone the WHERE let through.
+    expect(sql).toContain(
+      'groupUniqArrayIf(be.toUserId, be.toUserId IN (SELECT uid FROM persistent_earners)) as user_ids'
+    );
+    // The aggregates here take the bare gate, so this branch's award-type filtering exists only
+    // in the WHERE: without it `awarded` sums every reward the persistent users earned.
+    expect(outerWhereOf(sql)).toContain("startsWith(be.type, 'encouragement:')");
+    expect(sql).toContain(
+      'sumIf(awardAmount, be.toUserId IN (SELECT uid FROM persistent_earners)) as awarded'
+    );
+  });
+
+  it('compares the cluster ceiling against a count the gate cannot shrink', async () => {
+    await runWith({
+      ...prefixConfig,
+      require_exclusive_ip: false,
+      min_cap_days: 10,
+      max_user_count: 5,
+    });
+
+    // `user_count` is gated, so an IP too large to be a farm would drop under the ceiling and be
+    // flagged for the first time — the one threshold the gate can LOOSEN rather than tighten.
+    expect(sqlOf()).toContain('AND ip_user_count <= 5');
+    expect(sqlOf()).not.toContain('AND user_count <= 5');
+  });
+
+  it('compares the ceiling against the ungated count with exclusivity ON as well', async () => {
+    await runWith({ ...prefixConfig, min_cap_days: 10, max_user_count: 5 });
+
+    // Equivalent today, because `ip_user_count = user_count` cannot flip false to true when only
+    // `user_count` shrinks. Pinned so that relaxing that equality does not silently re-open the
+    // ceiling the other branch's fix closed.
+    expect(sqlOf()).toContain('AND ip_user_count <= 5');
+  });
+
+  it('CONTROL: ungated, the ceiling still reads the matched count it always did', async () => {
+    await runWith({ require_exclusive_ip: false, award_types: ['dailyBoost'], max_user_count: 5 });
+
+    expect(sqlOf()).toContain('AND user_count <= 5');
+  });
+
+  it('measures the day against the account own multiplied ceiling, not a flat amount', async () => {
+    await runWith({ ...prefixConfig, min_cap_days: 10 });
+
+    const sql = sqlOf();
+    // A member on a 1.5x multiplier is capped at 150, so 100 paid is not a cap-day. The trimmed
+    // grant stores an already-multiplied amount with `multiplier` neutralised to 1.
+    expect(sql).toContain(
+      'sum(if(be.multiplier = 1, be.awardAmount, ceil(be.awardAmount * be.multiplier))) AS day_awarded'
+    );
+    expect(sql).toContain('ceil(100 * max(be.multiplier)) AS day_cap');
+  });
+
+  it('refuses a threshold with no cap to measure it against', async () => {
+    hGet.mockResolvedValue(
+      JSON.stringify({
+        require_exclusive_ip: true,
+        award_types: [],
+        award_type_prefixes: ['encouragement:'],
+        min_cap_days: 10,
+      })
+    );
+
+    await expect(rewardsAbusePrevention.run().result).rejects.toThrow(/cap_day_awarded/);
+    expect(chQuery).not.toHaveBeenCalled();
+  });
+
+  it('refuses a window wide enough to fail the run on a query timeout', async () => {
+    hGet.mockResolvedValue(
+      JSON.stringify({ ...prefixConfig, min_cap_days: 10, cap_days_window: 3650 })
+    );
+
+    // Named, so an unrelated validation error cannot stand in for this guard.
+    await expect(rewardsAbusePrevention.run().result).rejects.toThrow(/cap_days_window/);
+    expect(chQuery).not.toHaveBeenCalled();
+  });
+
+  it('reports the threshold it ran at, so a quiet run can be told from an ungated one', async () => {
+    chQuery.mockResolvedValue([]);
+
+    const result = await runWith({ ...prefixConfig, min_cap_days: 10, dryRun: true });
+
+    expect(result).toMatchObject({ minCapDays: 10 });
+  });
+
+  it('rejects a negative threshold rather than emitting a having-clause nothing can fail', async () => {
+    hGet.mockResolvedValue(JSON.stringify({ ...prefixConfig, min_cap_days: -1 }));
+
+    await expect(rewardsAbusePrevention.run().result).rejects.toThrow();
+    expect(chQuery).not.toHaveBeenCalled();
   });
 });

--- a/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
+++ b/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
@@ -69,7 +69,7 @@ beforeEach(() => {
 describe('rewards-abuse-prevention — sysRedis config read (STEP-3 soft-dependency)', () => {
   it('runs detection with a valid config (happy path)', async () => {
     hGet.mockResolvedValue(
-      JSON.stringify({ awarded: 5000, user_count: 5, award_types: ['dailyBoost'] })
+      JSON.stringify({ awarded: 5000, user_count: 5, award_types: ['dailyBoost'], dryRun: false })
     );
 
     const result = await rewardsAbusePrevention.run().result;
@@ -86,7 +86,9 @@ describe('rewards-abuse-prevention — sysRedis config read (STEP-3 soft-depende
   });
 
   it('treats a Buffer config reply (sentinel mode) as valid JSON', async () => {
-    hGet.mockResolvedValue(Buffer.from(JSON.stringify({ awarded: 5000, user_count: 5 }), 'utf8'));
+    hGet.mockResolvedValue(
+      Buffer.from(JSON.stringify({ awarded: 5000, user_count: 5, dryRun: false }), 'utf8')
+    );
 
     const result = await rewardsAbusePrevention.run().result;
 
@@ -193,6 +195,31 @@ describe('rewards-abuse-prevention — detection shape', () => {
     expect(outerWhereOf(sqlOf())).not.toContain('createdDate > subtractDays(now(), 1)');
   });
 
+  it('does not enforce on a config that never said to', async () => {
+    hGet.mockResolvedValue(JSON.stringify({ award_types: ['dailyBoost'] }));
+    chQuery.mockResolvedValue([
+      { ip: '203.0.113.9', user_count: 3, ip_user_count: 3, awarded: 9000, user_ids: [1, 2, 3] },
+    ]);
+
+    const result = await rewardsAbusePrevention.run().result;
+
+    // A config that is missing, half-written or reverted must not be able to disable anyone.
+    expect(result).toMatchObject({ dryRun: true, usersDisabled: 0, wouldDisable: 3 });
+    expect(dbQueryRawUnsafe).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: an explicit dryRun false still enforces', async () => {
+    hGet.mockResolvedValue(JSON.stringify({ award_types: ['dailyBoost'], dryRun: false }));
+    chQuery.mockResolvedValue([
+      { ip: '203.0.113.9', user_count: 3, ip_user_count: 3, awarded: 9000, user_ids: [1, 2, 3] },
+    ]);
+    dbQueryRawUnsafe.mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+    const result = await rewardsAbusePrevention.run().result;
+
+    expect(result).toMatchObject({ dryRun: false, usersDisabled: 3 });
+  });
+
   it('emits a cluster-size ceiling when max_user_count is set', async () => {
     await runWith({ max_user_count: 5 });
 
@@ -232,7 +259,7 @@ describe('rewards-abuse-prevention — dry run', () => {
     chQuery.mockResolvedValue(abusers);
     dbQueryRawUnsafe.mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }]);
 
-    const result = await runWith({ require_exclusive_ip: true });
+    const result = await runWith({ require_exclusive_ip: true, dryRun: false });
 
     expect(dbQueryRawUnsafe).toHaveBeenCalledTimes(1);
     expect(createNotification).toHaveBeenCalledTimes(1);
@@ -243,7 +270,7 @@ describe('rewards-abuse-prevention — dry run', () => {
     chQuery.mockResolvedValue(abusers);
     dbQueryRawUnsafe.mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }]);
 
-    const result = (await runWith({ require_exclusive_ip: true })) as DryRunReport;
+    const result = (await runWith({ require_exclusive_ip: true, dryRun: false })) as DryRunReport;
 
     // The fields that say WHAT was found have to survive the switch to enforcing, or a live run
     // that disables nobody cannot be told from one that found nothing.
@@ -360,7 +387,7 @@ describe('rewards-abuse-prevention — decision log', () => {
     // The flagged set is 1-4; the UPDATE skips 2 (Protected) and 4 (already ineligible).
     dbQueryRawUnsafe.mockResolvedValue([{ id: 1 }, { id: 3 }]);
 
-    await runWith({});
+    await runWith({ dryRun: false });
 
     const values = rowsWritten().values;
     expect(values.map((v) => v.disabledUserIds)).toEqual([[1], [3]]);
@@ -386,7 +413,7 @@ describe('rewards-abuse-prevention — decision log', () => {
     dbQueryRawUnsafe.mockResolvedValue([{ id: 1 }]);
     chInsert.mockRejectedValueOnce(new Error('clickhouse unreachable'));
 
-    const result = await runWith({});
+    const result = await runWith({ dryRun: false });
 
     // The accounts are already disabled by this point. Failing here would leave the database
     // changed and the run reported as failed.
@@ -398,7 +425,7 @@ describe('rewards-abuse-prevention — decision log', () => {
     chQuery.mockResolvedValue(twoClusters);
     dbQueryRawUnsafe.mockResolvedValue([{ id: 1 }]);
 
-    await runWith({});
+    await runWith({ dryRun: false });
 
     expect(chInsert).toHaveBeenCalledTimes(1);
     expect(logToAxiom).not.toHaveBeenCalled();

--- a/src/server/jobs/rewards-abuse-prevention.ts
+++ b/src/server/jobs/rewards-abuse-prevention.ts
@@ -41,36 +41,56 @@ export const rewardsAbusePrevention = createJob(
       )
     );
 
-    const matched = buildTypePredicate(abuseLimits);
+    const typePredicate = buildTypePredicate(abuseLimits);
+    const persistence = buildPersistenceGate(abuseLimits, typePredicate);
+    const matched = persistence.condition
+      ? `${typePredicate} AND ${persistence.condition}`
+      : typePredicate;
     const excludedIps = abuseLimits.excludedIps.map((ip) => `'${ip}'`);
-    const clusterCeiling =
-      abuseLimits.max_user_count !== undefined
-        ? `AND user_count <= ${abuseLimits.max_user_count}`
-        : '';
 
-    // Exclusivity has to count the users the type filter would have hidden, which costs a
-    // whole-day scan — so it moves the filter out of the WHERE only when it is switched on.
+    // Both non-default branches keep a filter out of the WHERE so `ip_user_count` can see the
+    // users it would have hidden, which costs a whole-day scan — hence only when one is on.
     //
-    // Exact, not `uniq`: the having-clause compares these two counts for EQUALITY, and an
-    // equality between two HyperLogLog estimates is unstable on exactly the boundary the test
-    // lives on.
+    // `uniqExact` in the exclusivity branch only: its having-clause compares the two counts for
+    // EQUALITY, and that is unstable between two HyperLogLog estimates.
+    //
+    // `user_ids` drives the disable write, so it is gated in every branch rather than relying on
+    // the exclusivity equality to make the two sets coincide.
+    //
+    // `max_user_count` is the one threshold that is an UPPER bound, so it has to read a count the
+    // persistence gate cannot shrink: gating the column the ceiling compares lets an IP too large
+    // to be a farm slip under it.
     const exclusivity = abuseLimits.require_exclusive_ip
       ? {
           where: '',
-          select: `uniqExactIf(be.toUserId, ${matched}) as user_count, uniqExact(be.toUserId) as ip_user_count, sumIf(awardAmount, ${matched}) as awarded`,
+          select: `uniqExactIf(be.toUserId, ${matched}) as user_count, uniqExact(be.toUserId) as ip_user_count, sumIf(awardAmount, ${matched}) as awarded, groupUniqArrayIf(be.toUserId, ${matched}) as user_ids`,
           having: 'AND ip_user_count = user_count',
+          ceiling: 'ip_user_count',
+        }
+      : persistence.condition
+      ? {
+          where: `AND ${typePredicate}`,
+          select: `uniqIf(be.toUserId, ${persistence.condition}) as user_count, uniq(be.toUserId) as ip_user_count, sumIf(awardAmount, ${persistence.condition}) as awarded, groupUniqArrayIf(be.toUserId, ${persistence.condition}) as user_ids`,
+          having: '',
+          ceiling: 'ip_user_count',
         }
       : {
           where: `AND ${matched}`,
-          select: `uniq(be.toUserId) as user_count, sum(awardAmount) as awarded`,
+          select: `uniq(be.toUserId) as user_count, sum(awardAmount) as awarded, array_agg(distinct be.toUserId) as user_ids`,
           having: '',
+          ceiling: 'user_count',
         };
 
+    const clusterCeiling =
+      abuseLimits.max_user_count !== undefined
+        ? `AND ${exclusivity.ceiling} <= ${abuseLimits.max_user_count}`
+        : '';
+
     const abusers = await clickhouse?.$query<Abuser>(`
+      ${persistence.cte}
       SELECT
         ip,
-        ${exclusivity.select},
-        array_agg(distinct be.toUserId) as user_ids
+        ${exclusivity.select}
       FROM buzzEvents be
       WHERE createdDate > subtractDays(now(), 1)
       AND time > subtractDays(now(), ${DATE_BOUND_SLACK_DAYS})
@@ -93,6 +113,7 @@ export const rewardsAbusePrevention = createJob(
     // nobody is otherwise indistinguishable from a run that found nothing.
     const found = {
       dryRun: abuseLimits.dryRun,
+      minCapDays: abuseLimits.min_cap_days,
       wouldDisable: new Set(usersToDisable).size,
       ipsFlagged: abusers?.length ?? 0,
       sample:
@@ -237,6 +258,42 @@ async function logDecisions({
   }
 }
 
+/**
+ * Sharing an IP says nothing about the person: a household reproduces the cluster shape exactly.
+ * This asks the separate question — does this ACCOUNT peg its own daily cap habitually — and
+ * every account has its own cap, so the IP's total cannot answer it.
+ *
+ *
+ * A cap-day compares the day against the account's OWN ceiling, both sides multiplied: a member
+ * on a 1.5x multiplier is capped at 150, so being paid 100 is not a cap-day. `awardAmount` carries
+ * the base award except on the one grant a day the cap trims, which stores the multiplied value
+ * and neutralises `multiplier` to 1.
+ */
+function buildPersistenceGate(abuseLimits: AbuseLimits, typePredicate: string) {
+  const { cap_days_window: window, cap_day_awarded: cap, min_cap_days: minCapDays } = abuseLimits;
+  if (!minCapDays || cap === undefined) return { cte: '', condition: '' };
+
+  return {
+    cte: `WITH persistent_earners AS (
+        SELECT toUserId AS uid
+        FROM (
+          SELECT be.toUserId AS toUserId, be.createdDate AS day,
+            sum(if(be.multiplier = 1, be.awardAmount, ceil(be.awardAmount * be.multiplier))) AS day_awarded,
+            ceil(${cap} * max(be.multiplier)) AS day_cap
+          FROM buzzEvents be
+          WHERE createdDate > subtractDays(now(), ${window})
+          AND time > subtractDays(now(), ${window + DATE_BOUND_SLACK_DAYS})
+          AND ${typePredicate}
+          AND awardAmount > 0
+          GROUP BY toUserId, day
+        )
+        GROUP BY uid
+        HAVING countIf(day_awarded >= day_cap) >= ${minCapDays}
+      )`,
+    condition: 'be.toUserId IN (SELECT uid FROM persistent_earners)',
+  };
+}
+
 // `encouragement` writes one buzzEvent type per entity kind (`encouragement:image`,
 // `:comment`, `:article`, …), so an exact-match list silently stops covering the family
 // the next time an entity kind is added.
@@ -265,16 +322,33 @@ const sqlSafeToken = z
   .string()
   .regex(/^[A-Za-z0-9_:.-]*$/, 'must not contain SQL-significant characters');
 
-const abuseLimitsSchema = z.object({
-  awarded: z.number().default(3000),
-  user_count: z.number().default(10),
-  max_user_count: z.number().optional(),
-  require_exclusive_ip: z.boolean().default(false),
-  dryRun: z.boolean().default(false),
-  excludedIps: sqlSafeToken.array().default(['1.1.1.1', '']), // "10.124.0.14","10.124.0.17","10.124.0.32","10.124.0.70","10.124.0.84","10.124.0.94"
-  award_types: sqlSafeToken.array().default(['dailyBoost']),
-  award_type_prefixes: sqlSafeToken.array().default([]),
-  user_conditions: z.string().array().optional(),
-});
+const abuseLimitsSchema = z
+  .object({
+    awarded: z.number().default(3000),
+    user_count: z.number().default(10),
+    max_user_count: z.number().optional(),
+    require_exclusive_ip: z.boolean().default(false),
+    dryRun: z.boolean().default(false),
+    excludedIps: sqlSafeToken.array().default(['1.1.1.1', '']), // "10.124.0.14","10.124.0.17","10.124.0.32","10.124.0.70","10.124.0.84","10.124.0.94"
+    award_types: sqlSafeToken.array().default(['dailyBoost']),
+    award_type_prefixes: sqlSafeToken.array().default([]),
+    min_cap_days: z.number().int().nonnegative().default(0),
+    // Bounded so a mistyped window fails validation rather than the nightly run; past ~90 days
+    // the aggregate outruns the page cache.
+    cap_days_window: z.number().int().positive().max(365).default(30),
+    // No default on purpose: `award_types` defaults to dailyBoost, capped at 25, so a borrowed
+    // 100 builds a gate nobody passes and reports it as a quiet night. The enforced cap is in
+    // `rewards:config`.
+    cap_day_awarded: z.number().int().positive().optional(),
+    user_conditions: z.string().array().optional(),
+  })
+  .superRefine((limits, ctx) => {
+    if (limits.min_cap_days > 0 && limits.cap_day_awarded === undefined)
+      ctx.addIssue({
+        code: 'custom',
+        path: ['cap_day_awarded'],
+        message: 'cap_day_awarded is required when min_cap_days is set',
+      });
+  });
 
 type AbuseLimits = z.infer<typeof abuseLimitsSchema>;

--- a/src/server/jobs/rewards-abuse-prevention.ts
+++ b/src/server/jobs/rewards-abuse-prevention.ts
@@ -337,7 +337,9 @@ const abuseLimitsSchema = z
     user_count: z.number().default(10),
     max_user_count: z.number().optional(),
     require_exclusive_ip: z.boolean().default(false),
-    dryRun: z.boolean().default(false),
+    // Defaults to a dry run because the failure mode is asymmetric: a missing or half-written
+    // config should not be able to disable anyone. Enforcing is an explicit `dryRun: false`.
+    dryRun: z.boolean().default(true),
     excludedIps: sqlSafeToken.array().default(['1.1.1.1', '']), // "10.124.0.14","10.124.0.17","10.124.0.32","10.124.0.70","10.124.0.84","10.124.0.94"
     award_types: sqlSafeToken.array().default(['dailyBoost']),
     award_type_prefixes: sqlSafeToken.array().default([]),

--- a/src/server/jobs/rewards-abuse-prevention.ts
+++ b/src/server/jobs/rewards-abuse-prevention.ts
@@ -18,6 +18,12 @@ const REPORT_SAMPLE_SIZE = 25;
 // createdDate window prunes without being able to change which rows match.
 const DATE_BOUND_SLACK_DAYS = 3;
 
+// The clustering day is the previous COMPLETE one. `createdDate > subtractDays(now(), 1)` reads
+// as "the last 24 hours" and is not: `createdDate` is a Date, so the comparison happens at
+// midnight and the predicate collapses to "today" — three hours of data at the 03:00 cron, against
+// thresholds that only make sense over a day. Fixing the day to yesterday also makes a run
+// reproducible, since what it sees no longer depends on the hour it fired.
+
 export const rewardsAbusePrevention = createJob(
   'rewards-abuse-prevention',
   '0 3 * * *',
@@ -92,7 +98,7 @@ export const rewardsAbusePrevention = createJob(
         ip,
         ${exclusivity.select}
       FROM buzzEvents be
-      WHERE createdDate > subtractDays(now(), 1)
+      WHERE createdDate = subtractDays(toDate(now()), 1)
       AND time > subtractDays(now(), ${DATE_BOUND_SLACK_DAYS})
       ${exclusivity.where}
       AND ip NOT IN (${excludedIps})
@@ -264,6 +270,9 @@ async function logDecisions({
  * every account has its own cap, so the IP's total cannot answer it.
  *
  *
+ * The window is `cap_days_window` COMPLETE days ending on the clustering day, for the same reason
+ * that day is fixed rather than rolling — see the note on DATE_BOUND_SLACK_DAYS.
+ *
  * A cap-day compares the day against the account's OWN ceiling, both sides multiplied: a member
  * on a 1.5x multiplier is capped at 150, so being paid 100 is not a cap-day. `awardAmount` carries
  * the base award except on the one grant a day the cap trims, which stores the multiplied value
@@ -281,7 +290,7 @@ function buildPersistenceGate(abuseLimits: AbuseLimits, typePredicate: string) {
             sum(if(be.multiplier = 1, be.awardAmount, ceil(be.awardAmount * be.multiplier))) AS day_awarded,
             ceil(${cap} * max(be.multiplier)) AS day_cap
           FROM buzzEvents be
-          WHERE createdDate > subtractDays(now(), ${window})
+          WHERE createdDate BETWEEN subtractDays(toDate(now()), ${window}) AND subtractDays(toDate(now()), 1)
           AND time > subtractDays(now(), ${window + DATE_BOUND_SLACK_DAYS})
           AND ${typePredicate}
           AND awardAmount > 0


### PR DESCRIPTION
## What

The nightly `rewards-abuse-prevention` job asks whether a set of accounts share an IP exclusively. It never asks whether any individual account behaves like a farm. Sharing an IP is the shape of a reward farm and also the shape of a household, so that single question cannot tell them apart.

This adds the second question, per **account**: over a configurable window, on how many days did this account reach its own daily cap for the award types being watched. Each account has its own cap, so an IP's total cannot answer it — a busy household looks busy at the IP while no individual pegs anything.

Three sysRedis options under `rewards:abuse-limits`, all no-ops by default:

| option | default | |
|---|---|---|
| `min_cap_days` | `0` | 0 disables the gate entirely — no CTE, no predicate |
| `cap_days_window` | `30` | bounded, so a mistyped window fails validation rather than the nightly run |
| `cap_day_awarded` | none | required once `min_cap_days` is set |

**Nothing here enables enforcement.** `dryRun` is untouched.

## The day window was wrong, and it had to be fixed for any of this to mean anything

`createdDate > subtractDays(now(), 1)` reads as "the last 24 hours" and is not. `createdDate` is a Date, so ClickHouse compares it at midnight, and at the 03:00 cron the predicate resolves to "createdDate is today" — a few hours of data, measured against thresholds that only mean something over a day. It also made a run's window depend on the hour it fired, so a hand-triggered run and a scheduled one were not the same job.

The clustering day is now the previous **complete** day. The cap-day aggregate had a quieter version of the same bug and is now a `BETWEEN` over complete days ending on the clustering day, so `cap_days_window: 30` means thirty whole days rather than twenty-nine and a fraction.

This is pre-existing and predates the gate. It is in this PR because picking a threshold against the old window would have been meaningless.

## Two things that are easy to undo by accident

**`max_user_count` must read a count the gate cannot shrink.** It is the one threshold that is an *upper* bound. Gate the column it compares and an IP too large to be a farm drops under the ceiling and gets flagged for the first time — the gate widens the net instead of narrowing it. With the ceiling reading an ungated count, the gated set is a strict subset of the ungated one.

**`user_ids` drives the disable write and is gated in its own right.** It used to be an ungated `array_agg`, correct only because the `ip_user_count = user_count` having-clause forced the two sets to coincide. Deleting that clause reads as a tidy-up once a persistence gate exists, and without this change it would quietly turn the disable list into every account that touched the IP — including the casual household earners the gate exists to protect.

## Verification

- Full unit suite green, `test:lint-rules` green, typecheck clean, lint clean (the two `no-explicit-any` warnings in the test file are pre-existing on `main`).
- The **emitted** query string — not a transcription — was dumped for all three config shapes, `EXPLAIN SYNTAX`'d, and both gated shapes executed read-only against production. The diff introduces a CTE referenced from inside `If`-aggregate arguments, `groupUniqArrayIf`, and integer/`Decimal` arithmetic inside an `if()`; none of that is obviously valid by inspection.
- After the window fix, the emitted query returns for the previous complete day exactly what a hand-written query for that date returned before it — the control on the change being the one intended.
- Mutation controls, each restore verified by `git hash-object`: gate forced off, gate moved into the outer `WHERE`, either branch's ceiling reverted to the gated count, `cap_day_awarded` given a default back, the multiplied ceiling flattened, the exclusivity having-clause deleted, the type filter dropped from the outer `WHERE`, the CTE measuring a different award family, and the day window reverted. All red. Three of those tests exist *because* the mutation initially passed.

## Review lanes

All five ran; the test lane ran alone.

| lane | outcome |
|---|---|
| correctness | Found the `max_user_count` widening. Fixed. Also flagged a non-finite literal path on a new numeric field — closed by `.int()`. |
| perf | No fix required. Corrected my cost claim: my timing was fully cache-served, so it is a warm floor. Confirmed the `time` bound is load-bearing, the CTE is evaluated once, and the type prefix uses the primary key. Its `.max()` suggestion is taken. |
| reuse | The gate is genuinely new — no existing helper answers cap attainment over a window. Its divergence findings are addressed in the schema comments; `status = 'capped'` was considered and rejected, see below. |
| intent | Confirmed scope, defaults and that enforcement is untouched. Found the mismatch between `cap_day_awarded`'s default and `award_types`' default, and a multiplier case where a cap-pegger scored no cap-days. Both fixed. |
| tests | Found three mutations the suite passed clean on, two on the disable path. All fixed; one of my fixes for it also passed its own mutation and had to be scoped again. |
| comment-review | Two comments were false, one of them made false by my own fix in this branch. Dated measurements removed. |
| docs-drift | No public doc drifted; the guard counts in `CLAUDE.md` are untouched and correct. Corrections landed in the private notes. |

**`status = 'capped'` was considered and not used.** A capped row means the account was *refused* after reaching the cap, not that it reached it — an account landing exactly on the cap and stopping writes none. It is also excluded by the existing `awardAmount > 0` filter, so it cannot be added as a second signal without changing that filter, and it would strand the thresholds this was modelled against.

**No typed audit columns were added** for the new options. They reach `rewards_abuse_decisions` inside the existing `config` JSON, and adding columns needs a hand-applied migration to land before the code or the writes vanish silently.

## `dryRun` now defaults to true

The safety feature in this PR is opt-in while its amplification is not: `min_cap_days` defaults to off, but the day-window fix widens what the **ungated** detector sees for everyone. A config written before this branch would therefore select a materially larger set, and if it also said `dryRun: false` it would act on all of it.

So the default is flipped. A config that is missing, half-written or reverted can no longer disable anyone; enforcing takes an explicit `dryRun: false`. The live config sets it explicitly, so nothing changes today. Five existing tests were relying on the old default to reach the destructive path and now say `dryRun: false` where they mean it.

## This is not sufficient for automatic enforcement, and should not be switched on as-is

An adversarial pass and a round of production validation both concluded that the persistence signal narrows the flagged population without changing its composition enough to act on automatically, and that single-day exclusivity is less stable than it looks. The signal that does separate the two populations is account shape, for which the job already has `user_conditions` on the destructive UPDATE.

The recommendation is to merge this, leave `dryRun` on, and treat the cluster list as input to moderator review rather than as an automatic action — which is what the original detector notes concluded before any of this was built. The evidence sits with the ticket and the private notes; it is deliberately not in this repo.

## Still to do after this merges

1. Set `min_cap_days` and `cap_day_awarded` in sysRedis — the gate does nothing until then.
2. A dry pass at that threshold, read back from the decision table rather than trusted from the response.
3. Deploy; the config is only meaningful against the fixed window.
4. Removing `dryRun` is a separate, deliberate decision.

Detection thresholds, the modelling behind them and the measured effect are deliberately kept out of this repo — see the private working notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

