### PR TITLE
feat(apps): gate the Hidden tab on the slot flag, and widen the ?tab= fallback to every gated tab

### DIFF
--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -23,13 +23,27 @@ import type * as TrpcMod from '~/utils/trpc';
  *   · `no header CTA` — main renders `actions={<Button …>Browse marketplace</Button>}`.
  * The exact per-test messages are in the PR body.
  *
- * ── LATER ADDITION: the `Hidden` tab joins the SLOT gate ──────────────────────
- * `Hidden` lists slot installs the viewer has hidden from their model pages, so it now
+ * ── LATER ADDITION: `Hidden`, then `Apps & permissions`, join the SLOT gate ────
+ * `Hidden` lists slot installs the viewer has hidden from their model pages, so it
  * carries `features.appBlocks` exactly as `Installs` does. Its red-at-previous-state is
- * `the exact ledger` case below (which asserted a three-tab list) and the stale-link
- * case, which rendered a bar with NOTHING selected until `resolveActivityTab` stopped
- * testing the gated tab BY NAME. `Apps & permissions` stays ungated on purpose — see
- * the comment on that assertion.
+ * `the exact ledger` case below and the stale-link case, which rendered a bar with
+ * NOTHING selected until `resolveActivityTab` stopped testing the gated tab BY NAME.
+ *
+ * 🔴 `Apps & permissions` IS NOW GATED TOO, AND AN EARLIER REVISION OF THIS FILE ARGUED
+ * THE OPPOSITE. The retracted premise was that a page-flag-only viewer has scope grants
+ * to read. They do not: `ScopeGrantsPanel`'s only read is `blocks.listMyScopeGrants`,
+ * whose `enforceAppBlocksFlag` middleware evaluates the `app-blocks-enabled` Flipt key —
+ * exactly `features.appBlocks` — and returns `[]` without it, so the tab showed that
+ * cohort an empty state, always. `AppsSubNav.tsx` had already retracted the same premise
+ * for the same cohort (they cannot run a full-page app: `/apps/run/[slug]/[[...path]]`
+ * requires BOTH flags). Gating it displays nothing that was ever displayed.
+ *
+ * ── CONSEQUENCE: THE BAR NOW COLLAPSES ────────────────────────────────────────
+ * With three of four tabs gated, a slotless viewer is left with `Recent activity` alone,
+ * so the page hides its `Tabs.List` below two visible tabs (mirroring `AppsSubNav`'s
+ * `links.length < 2`). Every slotless arm below therefore waits on a PANEL, not a tab —
+ * there is no `role="tab"` to wait for, and a `getByRole('tab')` there would hang to
+ * timeout and read as a broken page.
  *
  * ── WHY THE MOCKS ARE THESE MOCKS ─────────────────────────────────────────────
  * The page module calls `createServerSideProps` at import time, which pulls the server
@@ -87,15 +101,38 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
     mutateAsync: vi.fn(),
     invalidate: vi.fn(),
   };
-  /** The reads whose CONTENT this file depends on — everything else is inert. */
-  const DATA: Record<string, unknown> = {
-    // EMPTY on purpose: the empty states are where the three surviving marketplace
-    // anchors live, and their presence is one of the criteria under test.
-    'blocks.listMySubscriptions': [],
-    'blocks.listMyScopeGrants': [],
-    'blocks.listMyAppActivity': { pages: [{ items: [], nextCursor: null }] },
-    'blocks.listMyScopeInvocations': { pages: [{ items: [], nextCursor: null }] },
-    'blocks.getNavSummary': {
+  /**
+   * The reads whose CONTENT this file depends on — everything else is inert.
+   *
+   * 🔴 VALUES ARE THUNKS, EVALUATED PER `useQuery` CALL, so an arm's flags can decide
+   * what a procedure returns. A fixture that hard-codes the SAME value in every flag arm
+   * cannot observe the mutant that matters: it can only ever produce the constant's own
+   * value, so the assertion is blind to whether the server would have refused the read.
+   */
+  const DATA: Record<string, () => unknown> = {
+    // EMPTY on purpose: the empty states are where the surviving marketplace anchors
+    // live, and their presence is one of the criteria under test.
+    'blocks.listMySubscriptions': () => [],
+    // 🔴 MIRRORS `enforceAppBlocksFlag`, NOT A CONSTANT. The real procedure evaluates the
+    // `app-blocks-enabled` Flipt key — exactly `features.appBlocks` — and short-circuits
+    // to `[]` without it. Encoding that here is what makes "the permissions panel is
+    // empty for a slotless viewer" a consequence of the flag rather than of the fixture.
+    'blocks.listMyScopeGrants': () =>
+      mocks.flags.appBlocks
+        ? [
+            {
+              appBlockId: 1,
+              blockId: 'demo-block',
+              name: 'Demo App',
+              slug: 'demo-app',
+              scopes: ['read:profile'],
+              surfaces: { modelInstallCount: 1, subscriptionScopes: [] },
+            },
+          ]
+        : [],
+    'blocks.listMyAppActivity': () => ({ pages: [{ items: [], nextCursor: null }] }),
+    'blocks.listMyScopeInvocations': () => ({ pages: [{ items: [], nextCursor: null }] }),
+    'blocks.getNavSummary': () => ({
       hasInstalls: true,
       hasActivity: true,
       hasSubmissions: false,
@@ -103,15 +140,16 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
       isReviewer: false,
       hasEditableApps: false,
       hasPendingInvites: false,
-    },
+    }),
   };
-  const node = (data?: unknown): unknown =>
+  const node = (read?: () => unknown): unknown =>
     new Proxy(
       {},
       {
         get(_t, key: string) {
           if (key === 'useQuery' || key === 'useInfiniteQuery') {
-            return () => (data === undefined ? inert : { ...inert, data });
+            // Called at RENDER time, so `mocks.flags` is the arm's own value.
+            return () => (read === undefined ? inert : { ...inert, data: read() });
           }
           if (key === 'useMutation') return () => inert;
           if (key === 'invalidate' || key === 'fetch') return vi.fn();
@@ -247,23 +285,28 @@ describe('🔴 the INSTALL-ONLY tabs are gated on the SLOT flag', () => {
     // per-model installs they have HIDDEN — is exactly what they cannot have.
     mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: true };
     renderWithProviders(<AppActivityPage />);
-    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    await expect.element(page.getByText(/Recent actions apps have taken/)).toBeInTheDocument();
     expect(
       pageTab('Installs'),
       'the Installs tab must be hidden without appBlocks'
     ).toBeUndefined();
     expect(pageTab('Hidden'), 'the Hidden tab must be hidden without appBlocks').toBeUndefined();
+    // 🔴 `Apps & permissions` IS GATED TOO, and its DATA SOURCE is the reason. The panel's
+    // only read is `blocks.listMyScopeGrants`, whose `enforceAppBlocksFlag` middleware
+    // returns `[]` for exactly this viewer — so ungated the tab showed them the "No apps
+    // installed or subscribed yet." empty state, always. There was no cohort for whom it
+    // held content. (An earlier revision of this file argued the opposite; that premise
+    // was false at the data layer and is retracted.)
+    expect(
+      pageTab('Apps & permissions'),
+      'the permissions tab must be hidden without appBlocks — its own query refuses'
+    ).toBeUndefined();
     // 🔴 THE WHOLE LIST, NOT JUST THE ABSENCES — pinned as an exact ledger so that
-    // gating a THIRD tab cannot slip through green, and so the floor below is visible.
-    //
-    // 🔴 `Apps & permissions` SURVIVES DELIBERATELY. Scope grants are the consent/audit
-    // surface: this very viewer invokes scopes through full-page apps with no install
-    // row, so gating it would hide the record of access from the people it records.
-    // That asymmetry is the decision — do not unify it with the two tabs above.
-    expect(pageTabs().map((el) => el.textContent?.trim())).toEqual([
-      'Recent activity',
-      'Apps & permissions',
-    ]);
+    // gating or un-gating a tab cannot slip through green. It is EMPTY rather than
+    // one-long because exactly ONE tab survives the gates and the bar then collapses
+    // (see the `< 2` test below); the panel itself still renders, which is what the
+    // `expect.element` above asserts.
+    expect(pageTabs().map((el) => el.textContent?.trim())).toEqual([]);
   });
 
   test('🔴 a stale `?tab=hidden` link renders a PAGE, not an empty bar', async () => {
@@ -276,10 +319,12 @@ describe('🔴 the INSTALL-ONLY tabs are gated on the SLOT flag', () => {
     mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: true };
     router.query = { tab: 'hidden' };
     renderWithProviders(<AppActivityPage />);
-    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
-    // A tab is SELECTED at all — this is the half that was empty.
-    expect(selectedPageTab(), 'some tab must be selected').toBeDefined();
-    expect(selectedPageTab()?.textContent?.trim()).toBe('Recent activity');
+    // 🔴 ASSERTED ON THE PANEL, NOT THE TAB. This viewer's bar now collapses (one visible
+    // tab), so there is no `role="tab"` to select — the symptom this guards against is
+    // "a blank page", and the panel's own copy is what proves a page rendered. Falling
+    // back is still what puts `activity` in `Tabs.value`; if the resolver handed Mantine
+    // the unrendered `hidden`, no panel would render and this element would be absent.
+    await expect.element(page.getByText(/Recent actions apps have taken/)).toBeInTheDocument();
   });
 
   test('🔴 …and the SAME link still selects Hidden for a viewer who HAS the flag', async () => {
@@ -292,30 +337,48 @@ describe('🔴 the INSTALL-ONLY tabs are gated on the SLOT flag', () => {
     expect(selectedPageTab()?.textContent?.trim()).toBe('Hidden');
   });
 
-  test('🔴 the bar has NO `< 2` collapse because 2 is the FLOOR, not a case', async () => {
-    // `AppsSubNav` hides its bar below two rows. This bar cannot reach that state: the
-    // slotless viewer above is the WORST case and still gets two tabs, and a viewer
-    // with neither runtime flag gets `<NotFound />` (the negative control below), not a
-    // one-tab bar. So a collapse here would be a branch that never executes.
-    // `appsActivityTabs.test.ts` holds the unit-tier tripwire on that floor.
+  test('🔴 the bar COLLAPSES at one visible tab, mirroring `AppsSubNav`', async () => {
+    // `AppsSubNav` hides its bar below two rows (`links.length < 2`). This bar now does
+    // the same, and the branch is REACHABLE: with `permissions` gated on the slot flag,
+    // the slotless viewer is left with `activity` alone, and a one-tab bar is chrome
+    // offering no choice. `appsActivityTabs.test.ts` holds the unit-tier tripwire that
+    // `visibleActivityTabs(SLOTLESS).length === 1`.
     mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: true };
     renderWithProviders(<AppActivityPage />);
-    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
-    expect(pageTabs().length, 'the minimum rendered tab count is 2').toBe(2);
+    await expect.element(page.getByText(/Recent actions apps have taken/)).toBeInTheDocument();
+    expect(pageTabs().length, 'a one-tab bar must not render at all').toBe(0);
   });
 
-  test('🔴 …and the page still LOADS for that viewer (criterion 2, client half)', async () => {
-    // The page body re-checks the gate with `canAccessAppsActivity`. If that had stayed
-    // on `appBlocks` alone this would render `<NotFound />` and no tabs at all — which is
-    // what makes the tab test above non-vacuous rather than a test of a 404.
-    mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: true };
+  test('🔴 POSITIVE CONTROL: the bar DOES render above the threshold', async () => {
+    // Without this, the collapse above is satisfied by a page that never renders a bar.
+    // Same component, one flag flipped: four tabs survive, so the list is present.
+    mocks.flags = { appBlocks: true, appBlocksPages: true, appListings: true };
     renderWithProviders(<AppActivityPage />);
     await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
-    expect(pageTabs().length).toBeGreaterThan(0);
+    expect(pageTabs().map((el) => el.textContent?.trim())).toEqual([
+      'Recent activity',
+      'Installs',
+      'Apps & permissions',
+      'Hidden',
+    ]);
+  });
+
+  test('🔴 …and the page still LOADS for the slotless viewer (criterion 2, client half)', async () => {
+    // The page body re-checks the gate with `canAccessAppsActivity`. If that had stayed
+    // on `appBlocks` alone this would render `<NotFound />` and no content at all — which
+    // is what makes the collapse test above non-vacuous rather than a test of a 404.
+    // Asserted on the PANEL, since this viewer's bar is collapsed by design.
+    mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: true };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByText(/Recent actions apps have taken/)).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="mock-notfound"]')).toBeNull();
   });
 
   test('🔴 NEGATIVE CONTROL: NEITHER runtime flag renders no tabs at all', async () => {
-    // Guards the three cases above against a body that renders the page unconditionally.
+    // Guards the cases above against a body that renders the page unconditionally.
+    // 🔴 LOAD-BEARING NOW THAT THE BAR COLLAPSES: "zero tabs" is no longer a signature
+    // unique to the 404, so this arm asserts the 404 MARKER, and the case above asserts
+    // the marker's ABSENCE. Neither is inferable from the tab count any more.
     mocks.flags = { appBlocks: false, appBlocksPages: false, appListings: true };
     renderWithProviders(<AppActivityPage />);
     await expect.element(page.getByTestId('mock-notfound')).toBeInTheDocument();
@@ -331,14 +394,24 @@ describe('🔴 the header marketplace CTA is gone; the empty-state anchors remai
     // back under different words.
     renderWithProviders(<AppActivityPage />);
     await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
-    // THREE, not one: Mantine's `Tabs.Panel` is `keepMounted` by default, so every
-    // panel's children are in the DOM regardless of which tab is selected. That is what
-    // makes ONE assertion cover all three empty states — `EmptyActivity`, the Installs
-    // `EmptyState` and the permissions `EmptyState`.
+    // TWO, not one: Mantine's `Tabs.Panel` is `keepMounted` by default, so every panel's
+    // children are in the DOM regardless of which tab is selected. That is what makes ONE
+    // assertion cover both surviving empty states — `EmptyActivity` and the Installs
+    // `EmptyState`.
+    //
+    // 🔴 TWO RATHER THAN THREE BECAUSE THE FIXTURE STOPPED LYING. This arm holds
+    // `appBlocks: true`, so `blocks.listMyScopeGrants` now returns a GRANT (mirroring the
+    // real procedure, which only short-circuits to `[]` without that flag) and the
+    // permissions panel renders its grid instead of an empty state. When the fixture
+    // hard-coded `[]` in every arm, that third anchor was an artefact of the fixture, not
+    // of the page.
     expect(
       bodyMarketplaceLinks().map((el) => el.textContent?.trim()),
       'the header CTA is back, or an empty-state anchor is gone'
-    ).toEqual(['Browse the marketplace', 'Browse the marketplace', 'Browse the marketplace']);
+    ).toEqual(['Browse the marketplace', 'Browse the marketplace']);
+    // …and the permissions panel really did render CONTENT rather than an empty state —
+    // the positive control that makes the count above a fact about the flag.
+    expect(page.getByText('Demo App').elements().length).toBeGreaterThan(0);
   });
 
   /**
@@ -362,14 +435,15 @@ describe('🔴 the header marketplace CTA is gone; the empty-state anchors remai
     // the STORE gate passes on nothing.
     mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: false };
     renderWithProviders(<AppActivityPage />);
-    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    // The bar is collapsed for this viewer (one visible tab), so wait on the PANEL.
+    await expect.element(page.getByText(/Recent actions apps have taken/)).toBeInTheDocument();
     expect(
       bodyMarketplaceLinks().map((el) => el.textContent?.trim()),
       'a link into a `notFound` was offered to a viewer with no store access'
     ).toEqual([]);
     // …and the page itself still rendered, so the empty anchor list is not the empty list
-    // of a 404. Two empty states mount for this viewer (activity + permissions); the
-    // Installs panel is slot-flag-gated away.
+    // of a 404. Exactly ONE empty state mounts for this viewer — `EmptyActivity`; the
+    // Installs, permissions and Hidden panels are all slot-flag-gated away.
     expect(page.getByText(/No activity yet/).elements().length).toBeGreaterThan(0);
   });
 
@@ -378,15 +452,16 @@ describe('🔴 the header marketplace CTA is gone; the empty-state anchors remai
     // also be satisfied by empty states that lost their CTA for everyone.
     mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: true };
     renderWithProviders(<AppActivityPage />);
-    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    // Bar collapsed for this viewer — wait on the panel.
+    await expect.element(page.getByText(/Recent actions apps have taken/)).toBeInTheDocument();
     expect(bodyMarketplaceLinks().length).toBeGreaterThan(0);
   });
 
   test('🔴 NEGATIVE CONTROL: the count is not trivially "whatever renders"', async () => {
-    // At `origin/main` this same query returns FOUR anchors — the three empty states plus
-    // the `AppsPageLayout` `actions` button, whose text is `Browse marketplace` (no
-    // "the"). So the assertion above is red there on both the length AND the extra
-    // member, and neither half is a copy match against a string this test invented.
+    // At `origin/main` this same query returns FOUR anchors — three empty states plus the
+    // `AppsPageLayout` `actions` button, whose text is `Browse marketplace` (no "the").
+    // So the assertion above is red there on both the length AND the extra member, and
+    // neither half is a copy match against a string this test invented.
     renderWithProviders(<AppActivityPage />);
     await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
     expect(bodyMarketplaceLinks().length).toBeGreaterThan(0);

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -23,6 +23,14 @@ import type * as TrpcMod from '~/utils/trpc';
  *   · `no header CTA` — main renders `actions={<Button …>Browse marketplace</Button>}`.
  * The exact per-test messages are in the PR body.
  *
+ * ── LATER ADDITION: the `Hidden` tab joins the SLOT gate ──────────────────────
+ * `Hidden` lists slot installs the viewer has hidden from their model pages, so it now
+ * carries `features.appBlocks` exactly as `Installs` does. Its red-at-previous-state is
+ * `the exact ledger` case below (which asserted a three-tab list) and the stale-link
+ * case, which rendered a bar with NOTHING selected until `resolveActivityTab` stopped
+ * testing the gated tab BY NAME. `Apps & permissions` stays ungated on purpose — see
+ * the comment on that assertion.
+ *
  * ── WHY THE MOCKS ARE THESE MOCKS ─────────────────────────────────────────────
  * The page module calls `createServerSideProps` at import time, which pulls the server
  * graph into a browser bundle — stubbed, exactly as `AppsWideLayout.geometry.test.tsx`
@@ -224,18 +232,19 @@ describe('the page opens on Recent activity', () => {
   });
 });
 
-describe('🔴 the Installs tab is gated on the SLOT flag', () => {
+describe('🔴 the INSTALL-ONLY tabs are gated on the SLOT flag', () => {
   test('present for a viewer WITH appBlocks', async () => {
     mocks.flags = { appBlocks: true, appBlocksPages: false, appListings: true };
     renderWithProviders(<AppActivityPage />);
     await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
     expect(pageTab('Installs'), 'a slot-flag viewer must get the Installs tab').toBeDefined();
+    expect(pageTab('Hidden'), 'a slot-flag viewer must get the Hidden tab').toBeDefined();
   });
 
   test('🔴 ABSENT for a viewer with appBlocksPages but NOT appBlocks', async () => {
     // The cohort criterion 2 widened the page for. They have activity and no slot
-    // install, so the tab's own content — subscriptions and per-model installs — is
-    // exactly what they cannot have.
+    // install, so those tabs' own content — subscriptions, per-model installs, and the
+    // per-model installs they have HIDDEN — is exactly what they cannot have.
     mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: true };
     renderWithProviders(<AppActivityPage />);
     await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
@@ -243,12 +252,56 @@ describe('🔴 the Installs tab is gated on the SLOT flag', () => {
       pageTab('Installs'),
       'the Installs tab must be hidden without appBlocks'
     ).toBeUndefined();
-    // …and the page is still a page: the other three tabs render.
+    expect(pageTab('Hidden'), 'the Hidden tab must be hidden without appBlocks').toBeUndefined();
+    // 🔴 THE WHOLE LIST, NOT JUST THE ABSENCES — pinned as an exact ledger so that
+    // gating a THIRD tab cannot slip through green, and so the floor below is visible.
+    //
+    // 🔴 `Apps & permissions` SURVIVES DELIBERATELY. Scope grants are the consent/audit
+    // surface: this very viewer invokes scopes through full-page apps with no install
+    // row, so gating it would hide the record of access from the people it records.
+    // That asymmetry is the decision — do not unify it with the two tabs above.
     expect(pageTabs().map((el) => el.textContent?.trim())).toEqual([
       'Recent activity',
       'Apps & permissions',
-      'Hidden',
     ]);
+  });
+
+  test('🔴 a stale `?tab=hidden` link renders a PAGE, not an empty bar', async () => {
+    // THE SYMPTOM the resolver fix exists to prevent, asserted where it is actually
+    // felt. `?tab=hidden` is a link this viewer can legitimately hold — a teammate's
+    // share, a bookmark from before a flag moved, their own history. Before the
+    // resolver widened, `hidden` was handed to `Tabs.value` while no such tab was
+    // rendered, and Mantine drew a bar with NOTHING selected over an empty panel: a
+    // blank page with no error and no console warning.
+    mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: true };
+    router.query = { tab: 'hidden' };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    // A tab is SELECTED at all — this is the half that was empty.
+    expect(selectedPageTab(), 'some tab must be selected').toBeDefined();
+    expect(selectedPageTab()?.textContent?.trim()).toBe('Recent activity');
+  });
+
+  test('🔴 …and the SAME link still selects Hidden for a viewer who HAS the flag', async () => {
+    // NEGATIVE CONTROL for the fallback above: without it, a page that ignored `?tab=`
+    // entirely, or one that hard-coded the default, would pass that test.
+    mocks.flags = { appBlocks: true, appBlocksPages: true, appListings: true };
+    router.query = { tab: 'hidden' };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    expect(selectedPageTab()?.textContent?.trim()).toBe('Hidden');
+  });
+
+  test('🔴 the bar has NO `< 2` collapse because 2 is the FLOOR, not a case', async () => {
+    // `AppsSubNav` hides its bar below two rows. This bar cannot reach that state: the
+    // slotless viewer above is the WORST case and still gets two tabs, and a viewer
+    // with neither runtime flag gets `<NotFound />` (the negative control below), not a
+    // one-tab bar. So a collapse here would be a branch that never executes.
+    // `appsActivityTabs.test.ts` holds the unit-tier tripwire on that floor.
+    mocks.flags = { appBlocks: false, appBlocksPages: true, appListings: true };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByRole('tab', { name: /Recent activity/ })).toBeInTheDocument();
+    expect(pageTabs().length, 'the minimum rendered tab count is 2').toBe(2);
   });
 
   test('🔴 …and the page still LOADS for that viewer (criterion 2, client half)', async () => {

--- a/src/components/Apps/__tests__/appsActivityTabs.test.ts
+++ b/src/components/Apps/__tests__/appsActivityTabs.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ACTIVITY_TAB_LABELS,
   ACTIVITY_TAB_QUERY_KEY,
   ACTIVITY_TAB_VALUES,
   activityTabQuery,
   DEFAULT_ACTIVITY_TAB,
-  INSTALL_GATED_ACTIVITY_TABS,
   isActivityTab,
   isActivityTabVisible,
   resolveActivityTab,
+  SLOT_GATED_ACTIVITY_TABS,
   visibleActivityTabs,
 } from '~/components/Apps/appsActivityTabs';
 
@@ -67,42 +68,61 @@ describe('isActivityTab', () => {
 });
 
 describe('tab visibility', () => {
-  const OPEN = { canSeeInstallOnlyTabs: true };
-  const SLOTLESS = { canSeeInstallOnlyTabs: false };
+  const OPEN = { canSeeSlotGatedTabs: true };
+  const SLOTLESS = { canSeeSlotGatedTabs: false };
 
-  it('🔴 the install-gated ledger is exactly the two SLOT-INSTALL tabs', () => {
-    // Pinned as a ledger, not a floor: this set decides both what the page renders AND
-    // what `?tab=` honours, so a silent addition or removal must fail here first.
-    expect([...INSTALL_GATED_ACTIVITY_TABS]).toEqual(['subscriptions', 'hidden']);
+  it('🔴 the slot-gated ledger is exactly the three tabs whose DATA is slot-gated', () => {
+    // Pinned as a ledger, not a floor: this set decides what the page renders, which
+    // panels mount AND what `?tab=` honours, so a silent addition or removal must fail
+    // here first. `permissions` is in it because `blocks.listMyScopeGrants` — the panel's
+    // only read — runs `enforceAppBlocksFlag` and returns `[]` without `features.appBlocks`.
+    expect([...SLOT_GATED_ACTIVITY_TABS]).toEqual(['subscriptions', 'permissions', 'hidden']);
   });
 
-  it('🔴 `permissions` is NOT gated — the consent/audit surface stays reachable', () => {
-    // A full-page app (`appBlocksPages`) invokes scopes with no install row, so a
-    // page-only viewer has grants to read and revoke here. This is the deliberate
-    // asymmetry with the two tabs above; do not unify the predicates.
-    expect(isActivityTabVisible('permissions', SLOTLESS)).toBe(true);
+  it('🔴 `activity` is the ONLY ungated tab', () => {
+    // NEGATIVE CONTROL for the ledger: without this, a predicate that gated everything
+    // (or nothing) would satisfy the set assertion above.
     expect(isActivityTabVisible('activity', SLOTLESS)).toBe(true);
-  });
-
-  it('a slot-flag viewer sees every tab; a page-only viewer sees the ungated two', () => {
-    expect([...visibleActivityTabs(OPEN)]).toEqual([...ACTIVITY_TAB_VALUES]);
-    expect([...visibleActivityTabs(SLOTLESS)]).toEqual(['activity', 'permissions']);
-  });
-
-  it('🔴 THE FLOOR IS 2 — which is why the page has no `< 2` bar collapse', () => {
-    // `AppsSubNav` hides its bar below two rows. This bar has no such branch because
-    // the state is unreachable: `activity` and `permissions` are both ungated, and the
-    // page 404s (`canAccessAppsActivity`) for anyone holding neither runtime flag. A
-    // collapse would be a branch that can never execute — coverage-shaped and inert.
-    //
-    // 🔴 THIS TEST IS THE TRIPWIRE. Gate `permissions` (or `activity`) and the floor
-    // drops to 1, this goes red, and the collapse becomes real, reachable work.
-    for (const opts of [OPEN, SLOTLESS]) {
-      expect(visibleActivityTabs(opts).length).toBeGreaterThanOrEqual(2);
+    for (const tab of SLOT_GATED_ACTIVITY_TABS) {
+      expect(isActivityTabVisible(tab, SLOTLESS), `${tab} must be gated`).toBe(false);
+      // …and the SAME tab is visible WITH the flag, so the line above cannot be
+      // satisfied by a predicate that always returns false.
+      expect(isActivityTabVisible(tab, OPEN), `${tab} must be visible with the flag`).toBe(true);
     }
-    // …and the minimum is exactly 2, not vacuously large: naming it pins WHICH viewer
-    // is the worst case, so a later gate cannot pass by shrinking a different arm.
-    expect(visibleActivityTabs(SLOTLESS).length).toBe(2);
+  });
+
+  it('a slot-flag viewer sees every tab; a slotless viewer sees ONE', () => {
+    expect([...visibleActivityTabs(OPEN)]).toEqual([...ACTIVITY_TAB_VALUES]);
+    expect([...visibleActivityTabs(SLOTLESS)]).toEqual(['activity']);
+  });
+
+  it('🔴 THE FLOOR IS 1, AND THE PAGE COLLAPSES ITS BAR THERE', () => {
+    // The state the previous round proved unreachable and correctly declined to build a
+    // branch for. Gating `permissions` made it reachable, so `activity.tsx` now hides its
+    // `Tabs.List` below two visible tabs, mirroring `AppsSubNav`'s `links.length < 2`.
+    //
+    // 🔴 THIS IS THE TRIPWIRE FOR THAT COLLAPSE. Asserted as an EXACT count, not a
+    // `<= 2`: a bound would stay green if a later change put a second tab back and left
+    // the collapse as dead code, which is the state this test exists to rule out.
+    expect(visibleActivityTabs(SLOTLESS).length).toBe(1);
+    // …and the collapse is genuinely CONDITIONAL, not always-on: the flag-holding arm is
+    // above the threshold, so the bar must render for them.
+    expect(visibleActivityTabs(OPEN).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('every tab has a label, and they are the strings the bar renders', () => {
+    // The page maps `visibleActivityTabs` through this record, so a missing or renamed
+    // entry is a rendered tab with no name. Pinned literally rather than looped, because
+    // a loop over the record's own keys would pass whatever it contains.
+    expect(ACTIVITY_TAB_LABELS).toEqual({
+      activity: 'Recent activity',
+      subscriptions: 'Installs',
+      permissions: 'Apps & permissions',
+      hidden: 'Hidden',
+    });
+    for (const tab of ACTIVITY_TAB_VALUES) {
+      expect(ACTIVITY_TAB_LABELS[tab], `${tab} needs a label`).toBeTruthy();
+    }
   });
 
   it('🔴 the DEFAULT tab is visible to EVERY viewer — the fallback must land somewhere', () => {
@@ -116,8 +136,8 @@ describe('tab visibility', () => {
 });
 
 describe('resolveActivityTab', () => {
-  const OPEN = { canSeeInstallOnlyTabs: true };
-  const SLOTLESS = { canSeeInstallOnlyTabs: false };
+  const OPEN = { canSeeSlotGatedTabs: true };
+  const SLOTLESS = { canSeeSlotGatedTabs: false };
 
   it('an absent / unknown / prototype-key value falls back to the default', () => {
     for (const raw of [undefined, null, '', 'nope', 'constructor', '__proto__', 7]) {
@@ -148,15 +168,14 @@ describe('resolveActivityTab', () => {
     // 🔴 RED AT `origin/main` FOR `hidden`: the resolver tested `first ===
     // 'subscriptions'` by NAME, so gating `hidden` shipped precisely that blank page.
     // Looping the ledger is what keeps this honest when a third tab is gated.
-    for (const tab of INSTALL_GATED_ACTIVITY_TABS) {
+    for (const tab of SLOT_GATED_ACTIVITY_TABS) {
       expect(resolveActivityTab(tab, SLOTLESS), `${tab} must fall back`).toBe('activity');
       // NEGATIVE CONTROL: with the flag, the SAME value is honoured — so the assertion
       // above cannot be satisfied by a resolver that always returns the default.
       expect(resolveActivityTab(tab, OPEN), `${tab} must be honoured`).toBe(tab);
     }
-    // …and the UNGATED tabs are unaffected by that flag — the fallback is scoped to the
+    // …and the UNGATED tab is unaffected by that flag — the fallback is scoped to the
     // ledger, not applied to everything.
-    expect(resolveActivityTab('permissions', SLOTLESS)).toBe('permissions');
     expect(resolveActivityTab('activity', SLOTLESS)).toBe('activity');
   });
 });

--- a/src/components/Apps/__tests__/appsActivityTabs.test.ts
+++ b/src/components/Apps/__tests__/appsActivityTabs.test.ts
@@ -4,8 +4,11 @@ import {
   ACTIVITY_TAB_VALUES,
   activityTabQuery,
   DEFAULT_ACTIVITY_TAB,
+  INSTALL_GATED_ACTIVITY_TABS,
   isActivityTab,
+  isActivityTabVisible,
   resolveActivityTab,
+  visibleActivityTabs,
 } from '~/components/Apps/appsActivityTabs';
 
 /**
@@ -63,9 +66,58 @@ describe('isActivityTab', () => {
   });
 });
 
+describe('tab visibility', () => {
+  const OPEN = { canSeeInstallOnlyTabs: true };
+  const SLOTLESS = { canSeeInstallOnlyTabs: false };
+
+  it('🔴 the install-gated ledger is exactly the two SLOT-INSTALL tabs', () => {
+    // Pinned as a ledger, not a floor: this set decides both what the page renders AND
+    // what `?tab=` honours, so a silent addition or removal must fail here first.
+    expect([...INSTALL_GATED_ACTIVITY_TABS]).toEqual(['subscriptions', 'hidden']);
+  });
+
+  it('🔴 `permissions` is NOT gated — the consent/audit surface stays reachable', () => {
+    // A full-page app (`appBlocksPages`) invokes scopes with no install row, so a
+    // page-only viewer has grants to read and revoke here. This is the deliberate
+    // asymmetry with the two tabs above; do not unify the predicates.
+    expect(isActivityTabVisible('permissions', SLOTLESS)).toBe(true);
+    expect(isActivityTabVisible('activity', SLOTLESS)).toBe(true);
+  });
+
+  it('a slot-flag viewer sees every tab; a page-only viewer sees the ungated two', () => {
+    expect([...visibleActivityTabs(OPEN)]).toEqual([...ACTIVITY_TAB_VALUES]);
+    expect([...visibleActivityTabs(SLOTLESS)]).toEqual(['activity', 'permissions']);
+  });
+
+  it('🔴 THE FLOOR IS 2 — which is why the page has no `< 2` bar collapse', () => {
+    // `AppsSubNav` hides its bar below two rows. This bar has no such branch because
+    // the state is unreachable: `activity` and `permissions` are both ungated, and the
+    // page 404s (`canAccessAppsActivity`) for anyone holding neither runtime flag. A
+    // collapse would be a branch that can never execute — coverage-shaped and inert.
+    //
+    // 🔴 THIS TEST IS THE TRIPWIRE. Gate `permissions` (or `activity`) and the floor
+    // drops to 1, this goes red, and the collapse becomes real, reachable work.
+    for (const opts of [OPEN, SLOTLESS]) {
+      expect(visibleActivityTabs(opts).length).toBeGreaterThanOrEqual(2);
+    }
+    // …and the minimum is exactly 2, not vacuously large: naming it pins WHICH viewer
+    // is the worst case, so a later gate cannot pass by shrinking a different arm.
+    expect(visibleActivityTabs(SLOTLESS).length).toBe(2);
+  });
+
+  it('🔴 the DEFAULT tab is visible to EVERY viewer — the fallback must land somewhere', () => {
+    // `resolveActivityTab` returns `DEFAULT_ACTIVITY_TAB` for a tab the viewer cannot
+    // see. If the default were itself gated, the fallback would hand Mantine a value
+    // absent from the rendered list: the exact blank page it exists to prevent.
+    for (const opts of [OPEN, SLOTLESS]) {
+      expect(isActivityTabVisible(DEFAULT_ACTIVITY_TAB, opts)).toBe(true);
+    }
+  });
+});
+
 describe('resolveActivityTab', () => {
-  const OPEN = { canSeeInstalls: true };
-  const SLOTLESS = { canSeeInstalls: false };
+  const OPEN = { canSeeInstallOnlyTabs: true };
+  const SLOTLESS = { canSeeInstallOnlyTabs: false };
 
   it('an absent / unknown / prototype-key value falls back to the default', () => {
     for (const raw of [undefined, null, '', 'nope', 'constructor', '__proto__', 7]) {
@@ -92,11 +144,20 @@ describe('resolveActivityTab', () => {
     // That tab is not rendered for them, so selecting it would leave the bar with no
     // active tab over an empty panel — a blank page with no error. This is a link a
     // page-only viewer can legitimately receive.
-    expect(resolveActivityTab('subscriptions', SLOTLESS)).toBe('activity');
-    // …and the OTHER tabs are unaffected by that flag — the fallback is scoped to the
-    // gated tab, not applied to everything.
+    //
+    // 🔴 RED AT `origin/main` FOR `hidden`: the resolver tested `first ===
+    // 'subscriptions'` by NAME, so gating `hidden` shipped precisely that blank page.
+    // Looping the ledger is what keeps this honest when a third tab is gated.
+    for (const tab of INSTALL_GATED_ACTIVITY_TABS) {
+      expect(resolveActivityTab(tab, SLOTLESS), `${tab} must fall back`).toBe('activity');
+      // NEGATIVE CONTROL: with the flag, the SAME value is honoured — so the assertion
+      // above cannot be satisfied by a resolver that always returns the default.
+      expect(resolveActivityTab(tab, OPEN), `${tab} must be honoured`).toBe(tab);
+    }
+    // …and the UNGATED tabs are unaffected by that flag — the fallback is scoped to the
+    // ledger, not applied to everything.
     expect(resolveActivityTab('permissions', SLOTLESS)).toBe('permissions');
-    expect(resolveActivityTab('hidden', SLOTLESS)).toBe('hidden');
+    expect(resolveActivityTab('activity', SLOTLESS)).toBe('activity');
   });
 });
 

--- a/src/components/Apps/appsActivityTabs.ts
+++ b/src/components/Apps/appsActivityTabs.ts
@@ -122,9 +122,8 @@ export const ACTIVITY_TAB_LABELS: Record<ActivityTab, string> = {
  * slot flag), so `?tab=subscriptions`, `?tab=permissions` and `?tab=hidden` are all links
  * a page-only viewer can legitimately receive — from a teammate, a bookmark taken before a
  * flag moved, or their own history. Handing that value to `Tabs.value` selects a tab that
- * is not in the list
- * and Mantine renders a bar with nothing active over an empty panel: a blank page with
- * no error. Falling back is the only outcome that is a page.
+ * is not in the list, and Mantine renders a bar with nothing active over an empty panel:
+ * a blank page with no error. Falling back is the only outcome that is a page.
  *
  * 🔴 THE FALLBACK IS DERIVED FROM THE VISIBILITY PREDICATE, NEVER FROM A TAB NAME
  * SPELLED HERE. It used to test `first === 'subscriptions'` — a check that stayed green

--- a/src/components/Apps/appsActivityTabs.ts
+++ b/src/components/Apps/appsActivityTabs.ts
@@ -33,56 +33,81 @@ export function isActivityTab(value: unknown): value is ActivityTab {
 }
 
 /**
- * The tabs whose CONTENT is governed by the `appBlocks` SLOT flag, and which the page
- * therefore renders only for a viewer who holds it.
+ * The tabs whose CONTENT the `appBlocks` SLOT flag governs, and which the page therefore
+ * renders only for a viewer who holds it.
  *
- * 🔴 A LEDGER, NOT AN ACCUMULATION OF BOOLEANS. Both of these tabs are about SLOT
- * INSTALLS — `subscriptions` lists them, `hidden` lists the ones the viewer has hidden
- * from their model pages — so they share ONE predicate rather than one flag each. That
- * is what lets {@link resolveActivityTab} take a single `canSeeInstallOnlyTabs` and
- * stay correct as the set grows: add a tab here and its `?tab=` fallback comes with it.
+ * 🔴 A LEDGER, NOT AN ACCUMULATION OF BOOLEANS. Every tab here shares ONE predicate
+ * rather than carrying one flag each, which is what lets {@link resolveActivityTab} take
+ * a single `canSeeSlotGatedTabs` and stay correct as the set grows: add a tab here and
+ * both its `?tab=` fallback and its place in {@link visibleActivityTabs} come with it.
  *
- * 🔴 `permissions` IS DELIBERATELY NOT HERE, AND THAT IS A DECISION, NOT AN OVERSIGHT.
- * Scope grants are a consent/audit surface: a full-page app (`appBlocksPages`) invokes
- * scopes with no install row at all, so a viewer holding only the page flag has grants
- * to read and revoke and no `subscriptions` row to reach them through. Gating it on the
- * slot flag would hide the record of access from exactly the people whose access it
- * records. Do not "tidy" the two into one uniform predicate.
+ * 🔴 EACH ENTRY IS HERE BECAUSE ITS OWN DATA SOURCE IS GATED ON THE SAME FLAG — the tab's
+ * predicate is its content's gate restated, never a separate policy:
+ *   · `subscriptions` and `hidden` are SLOT-INSTALL surfaces. `subscriptions` lists
+ *     `block_user_subscriptions` rows; `hidden` lists the ones the viewer has hidden from
+ *     their model pages. Slot installs are `appBlocks`-gated, so without it there are none.
+ *   · `permissions` reads `blocks.listMyScopeGrants` and NOTHING else — one `useQuery`
+ *     with no `enabled:`. That procedure runs `enforceAppBlocksFlag`, which evaluates the
+ *     `app-blocks-enabled` Flipt key (exactly `features.appBlocks`) and short-circuits to
+ *     `[]` for anyone without it. So the panel rendered "No apps installed or subscribed
+ *     yet." for every slotless viewer, ALWAYS — there was no cohort for whom the ungated
+ *     tab showed anything. Gating it loses nothing that was ever displayed, and it closes
+ *     the #3899 / #4668 class: a tab offered whose own gate refuses its content.
+ *
+ * 🔴 `permissions` USED TO BE EXCLUDED ON THE PREMISE THAT A PAGE-FLAG-ONLY VIEWER HAS
+ * GRANTS TO READ. That premise is false at the data layer (above), and it was ALREADY
+ * retracted one file over: `AppsSubNav.tsx` records that such a viewer cannot run a
+ * full-page app at all (`/apps/run/[slug]/[[...path]].tsx` requires BOTH flags) and cannot
+ * install, so they generate no scope invocations to have grants FROM. Do not reinstate it.
  */
-export const INSTALL_GATED_ACTIVITY_TABS = [
+export const SLOT_GATED_ACTIVITY_TABS = [
   'subscriptions',
+  'permissions',
   'hidden',
 ] as const satisfies readonly ActivityTab[];
 
 /**
  * What the viewer's sight of the gated tabs turns on — the `appBlocks` slot flag.
  *
- * ONE field, not one per tab: the rule is "can this viewer see the install-only tabs",
+ * ONE field, not one per tab: the rule is "can this viewer see the slot-gated tabs",
  * and spelling it per-tab is how the resolver drifted out of step with the page.
  */
-export type ActivityTabVisibility = { canSeeInstallOnlyTabs: boolean };
+export type ActivityTabVisibility = { canSeeSlotGatedTabs: boolean };
 
 /** Whether `tab` renders for a viewer with the given visibility. */
 export function isActivityTabVisible(tab: ActivityTab, opts: ActivityTabVisibility): boolean {
-  if (opts.canSeeInstallOnlyTabs) return true;
-  return !(INSTALL_GATED_ACTIVITY_TABS as readonly ActivityTab[]).includes(tab);
+  if (opts.canSeeSlotGatedTabs) return true;
+  return !(SLOT_GATED_ACTIVITY_TABS as readonly ActivityTab[]).includes(tab);
 }
 
 /**
  * The tabs the page renders for this viewer, in render order.
  *
- * 🔴 THE MINIMUM IS 2, AND THAT IS WHY THERE IS NO `< 2` COLLAPSE HERE. `AppsSubNav`
- * hides its bar when fewer than two rows survive its gates; this bar has no such
- * branch because it cannot reach that state — `activity` and `permissions` are BOTH
- * ungated, and the page itself 404s (`canAccessAppsActivity`) for anyone who holds
- * neither runtime flag, so every viewer who can load the page sees at least those two.
- * A collapse would be a branch that can never execute, which reads as coverage while
- * providing none. `appsActivityTabs.test.ts` pins the floor at 2: if a later change
- * gates `permissions`, that test goes red and the collapse becomes real work.
+ * 🔴 THE MINIMUM IS 1, AND THE PAGE COLLAPSES ITS BAR THERE. `activity` is the only
+ * ungated tab, so a viewer without the slot flag gets exactly `['activity']` — and
+ * `activity.tsx` hides its `Tabs.List` below two visible tabs, mirroring `AppsSubNav`'s
+ * `links.length < 2` behaviour. A one-tab bar is chrome that offers no choice.
+ *
+ * 🔴 THIS IS THE PAGE'S ONLY SOURCE FOR WHICH TABS TO RENDER. `activity.tsx` maps over
+ * this result instead of hand-spelling a `&&` per tab, so the ledger above cannot
+ * disagree with the bar: the four hand-spelled guards it replaced were invisible to the
+ * node-env `unit` project, and deleting one of them left this suite fully green.
  */
 export function visibleActivityTabs(opts: ActivityTabVisibility): readonly ActivityTab[] {
   return ACTIVITY_TAB_VALUES.filter((tab) => isActivityTabVisible(tab, opts));
 }
+
+/**
+ * The visible LABEL for each tab, kept here rather than inline in the page so the render
+ * loop has no per-tab branch left and the `unit` project can pin the strings. Icons stay
+ * in `activity.tsx` — they are React, and this module is deliberately React-free.
+ */
+export const ACTIVITY_TAB_LABELS: Record<ActivityTab, string> = {
+  activity: 'Recent activity',
+  subscriptions: 'Installs',
+  permissions: 'Apps & permissions',
+  hidden: 'Hidden',
+};
 
 /**
  * Resolve the tab to render from the raw `router.query.tab` value.
@@ -93,10 +118,11 @@ export function visibleActivityTabs(opts: ActivityTabVisibility): readonly Activ
  * the FIRST entry, which is what every other query reader in this area does.
  *
  * 🔴 A TAB THE VIEWER CANNOT SEE FALLS BACK TO THE DEFAULT, IT DOES NOT RENDER EMPTY.
- * `Installs` and `Hidden` are gated on `features.appBlocks` (the slot flag), so
- * `/apps/activity?tab=subscriptions` and `?tab=hidden` are links a page-only viewer can
- * legitimately receive — from a teammate, a bookmark taken before a flag moved, or their
- * own history. Handing that value to `Tabs.value` selects a tab that is not in the list
+ * `Installs`, `Apps & permissions` and `Hidden` are gated on `features.appBlocks` (the
+ * slot flag), so `?tab=subscriptions`, `?tab=permissions` and `?tab=hidden` are all links
+ * a page-only viewer can legitimately receive — from a teammate, a bookmark taken before a
+ * flag moved, or their own history. Handing that value to `Tabs.value` selects a tab that
+ * is not in the list
  * and Mantine renders a bar with nothing active over an empty panel: a blank page with
  * no error. Falling back is the only outcome that is a page.
  *

--- a/src/components/Apps/appsActivityTabs.ts
+++ b/src/components/Apps/appsActivityTabs.ts
@@ -33,6 +33,58 @@ export function isActivityTab(value: unknown): value is ActivityTab {
 }
 
 /**
+ * The tabs whose CONTENT is governed by the `appBlocks` SLOT flag, and which the page
+ * therefore renders only for a viewer who holds it.
+ *
+ * 🔴 A LEDGER, NOT AN ACCUMULATION OF BOOLEANS. Both of these tabs are about SLOT
+ * INSTALLS — `subscriptions` lists them, `hidden` lists the ones the viewer has hidden
+ * from their model pages — so they share ONE predicate rather than one flag each. That
+ * is what lets {@link resolveActivityTab} take a single `canSeeInstallOnlyTabs` and
+ * stay correct as the set grows: add a tab here and its `?tab=` fallback comes with it.
+ *
+ * 🔴 `permissions` IS DELIBERATELY NOT HERE, AND THAT IS A DECISION, NOT AN OVERSIGHT.
+ * Scope grants are a consent/audit surface: a full-page app (`appBlocksPages`) invokes
+ * scopes with no install row at all, so a viewer holding only the page flag has grants
+ * to read and revoke and no `subscriptions` row to reach them through. Gating it on the
+ * slot flag would hide the record of access from exactly the people whose access it
+ * records. Do not "tidy" the two into one uniform predicate.
+ */
+export const INSTALL_GATED_ACTIVITY_TABS = [
+  'subscriptions',
+  'hidden',
+] as const satisfies readonly ActivityTab[];
+
+/**
+ * What the viewer's sight of the gated tabs turns on — the `appBlocks` slot flag.
+ *
+ * ONE field, not one per tab: the rule is "can this viewer see the install-only tabs",
+ * and spelling it per-tab is how the resolver drifted out of step with the page.
+ */
+export type ActivityTabVisibility = { canSeeInstallOnlyTabs: boolean };
+
+/** Whether `tab` renders for a viewer with the given visibility. */
+export function isActivityTabVisible(tab: ActivityTab, opts: ActivityTabVisibility): boolean {
+  if (opts.canSeeInstallOnlyTabs) return true;
+  return !(INSTALL_GATED_ACTIVITY_TABS as readonly ActivityTab[]).includes(tab);
+}
+
+/**
+ * The tabs the page renders for this viewer, in render order.
+ *
+ * 🔴 THE MINIMUM IS 2, AND THAT IS WHY THERE IS NO `< 2` COLLAPSE HERE. `AppsSubNav`
+ * hides its bar when fewer than two rows survive its gates; this bar has no such
+ * branch because it cannot reach that state — `activity` and `permissions` are BOTH
+ * ungated, and the page itself 404s (`canAccessAppsActivity`) for anyone who holds
+ * neither runtime flag, so every viewer who can load the page sees at least those two.
+ * A collapse would be a branch that can never execute, which reads as coverage while
+ * providing none. `appsActivityTabs.test.ts` pins the floor at 2: if a later change
+ * gates `permissions`, that test goes red and the collapse becomes real work.
+ */
+export function visibleActivityTabs(opts: ActivityTabVisibility): readonly ActivityTab[] {
+  return ACTIVITY_TAB_VALUES.filter((tab) => isActivityTabVisible(tab, opts));
+}
+
+/**
  * Resolve the tab to render from the raw `router.query.tab` value.
  *
  * `raw` is deliberately `unknown`: Next hands back `string | string[] | undefined`
@@ -41,17 +93,21 @@ export function isActivityTab(value: unknown): value is ActivityTab {
  * the FIRST entry, which is what every other query reader in this area does.
  *
  * 🔴 A TAB THE VIEWER CANNOT SEE FALLS BACK TO THE DEFAULT, IT DOES NOT RENDER EMPTY.
- * `Installs` is gated on `features.appBlocks` (the slot flag), so
- * `/apps/activity?tab=subscriptions` is a link a page-only viewer can legitimately
- * receive — from a teammate, a bookmark taken before a flag moved, or their own
- * history. Handing that value to `Tabs.value` selects a tab that is not in the list
+ * `Installs` and `Hidden` are gated on `features.appBlocks` (the slot flag), so
+ * `/apps/activity?tab=subscriptions` and `?tab=hidden` are links a page-only viewer can
+ * legitimately receive — from a teammate, a bookmark taken before a flag moved, or their
+ * own history. Handing that value to `Tabs.value` selects a tab that is not in the list
  * and Mantine renders a bar with nothing active over an empty panel: a blank page with
  * no error. Falling back is the only outcome that is a page.
+ *
+ * 🔴 THE FALLBACK IS DERIVED FROM THE VISIBILITY PREDICATE, NEVER FROM A TAB NAME
+ * SPELLED HERE. It used to test `first === 'subscriptions'` — a check that stayed green
+ * while `hidden` was gated and shipped exactly the blank page above.
  */
-export function resolveActivityTab(raw: unknown, opts: { canSeeInstalls: boolean }): ActivityTab {
+export function resolveActivityTab(raw: unknown, opts: ActivityTabVisibility): ActivityTab {
   const first = Array.isArray(raw) ? raw[0] : raw;
   if (!isActivityTab(first)) return DEFAULT_ACTIVITY_TAB;
-  if (first === 'subscriptions' && !opts.canSeeInstalls) return DEFAULT_ACTIVITY_TAB;
+  if (!isActivityTabVisible(first, opts)) return DEFAULT_ACTIVITY_TAB;
   return first;
 }
 

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -480,18 +480,22 @@ function HiddenBlocksPanel() {
 export default function AppActivityPage() {
   const features = useFeatureFlags();
   const router = useRouter();
-  // 🔴 The Installs tab's gate is the `appBlocks` SLOT flag; the PAGE's is
+  // 🔴 The install-only tabs' gate is the `appBlocks` SLOT flag; the PAGE's is
   // `appBlocks || appBlocksPages`. A tab's predicate is its content's own gate,
   // restated — and this one is NON-VACUOUS only because the page gate widened.
-  const canSeeInstalls = !!features.appBlocks;
+  // `INSTALL_GATED_ACTIVITY_TABS` is the ledger of which tabs that covers
+  // (`subscriptions` + `hidden`, both slot-install surfaces) and the resolver reads the
+  // SAME predicate, so a `?tab=` deep link can never select a tab this page did not
+  // render. `permissions` is deliberately NOT in it — see that constant's comment.
+  const canSeeInstallOnlyTabs = !!features.appBlocks;
   const { data: subs, isLoading } = trpc.blocks.listMySubscriptions.useQuery(undefined, {
-    enabled: canSeeInstalls,
+    enabled: canSeeInstallOnlyTabs,
   });
 
   // 🔴 URL-backed, controlled tabs. `resolveActivityTab` returns the default for an
   // absent value, so an empty first-render `router.query` renders what SSR did.
   const activeTab = resolveActivityTab(router.query[ACTIVITY_TAB_QUERY_KEY], {
-    canSeeInstalls,
+    canSeeInstallOnlyTabs,
   });
 
   const groupedApps = useMemo(() => groupSubscriptionsByApp(subs ?? []), [subs]);
@@ -555,18 +559,34 @@ export default function AppActivityPage() {
             <Tabs.Tab value="activity" leftSection={<IconHistory size={14} />}>
               Recent activity
             </Tabs.Tab>
-            {canSeeInstalls && (
+            {canSeeInstallOnlyTabs && (
               <Tabs.Tab value="subscriptions" leftSection={<IconPlugConnected size={14} />}>
                 Installs
               </Tabs.Tab>
             )}
+            {/* 🔴 UNGATED ON PURPOSE, unlike its two neighbours. Scope grants are the
+                consent/audit surface: a full-page app (`appBlocksPages`) invokes scopes
+                with no install row, so a viewer holding only the page flag has grants
+                here and nothing on `Installs` to reach them through. Gating this would
+                hide the record of access from the people whose access it records. */}
             <Tabs.Tab value="permissions" leftSection={<IconShieldLock size={14} />}>
               Apps & permissions
             </Tabs.Tab>
-            <Tabs.Tab value="hidden" leftSection={<IconEyeOff size={14} />}>
-              Hidden
-            </Tabs.Tab>
+            {/* Hidden lists SLOT installs the viewer has hidden from their model pages,
+                so it carries the slot flag exactly as `Installs` does. */}
+            {canSeeInstallOnlyTabs && (
+              <Tabs.Tab value="hidden" leftSection={<IconEyeOff size={14} />}>
+                Hidden
+              </Tabs.Tab>
+            )}
           </Tabs.List>
+
+          {/* 🔴 NO `< 2` COLLAPSE HERE, and its absence is deliberate. `AppsSubNav`
+              hides its bar below two rows; this bar cannot reach that state — `activity`
+              and `permissions` are both ungated and the page 404s for anyone holding
+              neither runtime flag, so the floor is 2. A collapse would be a branch that
+              never executes. If `permissions` is ever gated, the floor test in
+              `appsActivityTabs.test.ts` goes red — add the collapse then. */}
 
           <Tabs.Panel value="activity" pt="md">
             <Stack gap="sm">
@@ -580,7 +600,7 @@ export default function AppActivityPage() {
 
           {/* 🔴 THE PANEL IS GATED TOO. A `Tabs.Panel` with no tab is unreachable but
               still MOUNTS its children on every render. */}
-          {canSeeInstalls && (
+          {canSeeInstallOnlyTabs && (
             <Tabs.Panel value="subscriptions" pt="md">
               {isLoading ? (
                 <Center py="xl">
@@ -611,16 +631,20 @@ export default function AppActivityPage() {
             </Stack>
           </Tabs.Panel>
 
-          <Tabs.Panel value="hidden" pt="md">
-            <Stack gap="sm">
-              <Text size="sm" c="dimmed">
-                Apps you've hidden on this device. Hiding is local to your browser — it never
-                affects the publisher's install or other viewers. Restore one to have it show on its
-                model page again.
-              </Text>
-              <HiddenBlocksPanel />
-            </Stack>
-          </Tabs.Panel>
+          {/* 🔴 THE PANEL IS GATED TOO — same reason as `subscriptions` above: an
+              unreachable `Tabs.Panel` still MOUNTS its children on every render. */}
+          {canSeeInstallOnlyTabs && (
+            <Tabs.Panel value="hidden" pt="md">
+              <Stack gap="sm">
+                <Text size="sm" c="dimmed">
+                  Apps you've hidden on this device. Hiding is local to your browser — it never
+                  affects the publisher's install or other viewers. Restore one to have it show on
+                  its model page again.
+                </Text>
+                <HiddenBlocksPanel />
+              </Stack>
+            </Tabs.Panel>
+          )}
         </Tabs>
       </AppsPageLayout>
     </>

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -42,11 +42,15 @@ import type {
 import { BlockScopeList } from '~/components/Apps/BlockScopeList';
 import { AppActivityPanel } from '~/components/Apps/AppActivityPanel';
 import {
+  ACTIVITY_TAB_LABELS,
   ACTIVITY_TAB_QUERY_KEY,
   activityTabQuery,
   isActivityTab,
+  isActivityTabVisible,
   resolveActivityTab,
+  visibleActivityTabs,
 } from '~/components/Apps/appsActivityTabs';
+import type { ActivityTab } from '~/components/Apps/appsActivityTabs';
 import { resolveActivityPageAccess } from '~/components/Apps/resolveActivityPageAccess';
 import { canAccessAppsActivity, hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -477,26 +481,44 @@ function HiddenBlocksPanel() {
   );
 }
 
+/**
+ * The icon for each tab. Lives here rather than beside `ACTIVITY_TAB_LABELS` because
+ * `appsActivityTabs.ts` is deliberately React-free (that is what lets it run in the
+ * node-env `unit` project). Typed as a total `Record` so adding a tab to
+ * `ACTIVITY_TAB_VALUES` fails the build here rather than rendering an undefined icon.
+ */
+const ACTIVITY_TAB_ICONS: Record<ActivityTab, typeof IconHistory> = {
+  activity: IconHistory,
+  subscriptions: IconPlugConnected,
+  permissions: IconShieldLock,
+  hidden: IconEyeOff,
+};
+
 export default function AppActivityPage() {
   const features = useFeatureFlags();
   const router = useRouter();
-  // 🔴 The install-only tabs' gate is the `appBlocks` SLOT flag; the PAGE's is
+  // 🔴 The gated tabs' predicate is the `appBlocks` SLOT flag; the PAGE's is
   // `appBlocks || appBlocksPages`. A tab's predicate is its content's own gate,
   // restated — and this one is NON-VACUOUS only because the page gate widened.
-  // `INSTALL_GATED_ACTIVITY_TABS` is the ledger of which tabs that covers
-  // (`subscriptions` + `hidden`, both slot-install surfaces) and the resolver reads the
-  // SAME predicate, so a `?tab=` deep link can never select a tab this page did not
-  // render. `permissions` is deliberately NOT in it — see that constant's comment.
-  const canSeeInstallOnlyTabs = !!features.appBlocks;
+  // `SLOT_GATED_ACTIVITY_TABS` is the ledger of which tabs that covers, and everything
+  // below — the bar, the panels and the `?tab=` resolver — reads it through this ONE
+  // value, so none of them can disagree with another.
+  const visibility = { canSeeSlotGatedTabs: !!features.appBlocks };
   const { data: subs, isLoading } = trpc.blocks.listMySubscriptions.useQuery(undefined, {
-    enabled: canSeeInstallOnlyTabs,
+    enabled: visibility.canSeeSlotGatedTabs,
   });
 
   // 🔴 URL-backed, controlled tabs. `resolveActivityTab` returns the default for an
   // absent value, so an empty first-render `router.query` renders what SSR did.
-  const activeTab = resolveActivityTab(router.query[ACTIVITY_TAB_QUERY_KEY], {
-    canSeeInstallOnlyTabs,
-  });
+  const activeTab = resolveActivityTab(router.query[ACTIVITY_TAB_QUERY_KEY], visibility);
+
+  // 🔴 THE BAR IS DERIVED, NOT HAND-SPELLED. This used to be four `canSee… &&` guards
+  // inline in the JSX below — four sites the node-env `unit` project could not see, so
+  // deleting one of them (rendering a tab whose panel stayed gated) left that whole
+  // suite green and only the report-only `component` tier caught it. Mapping the
+  // ledger's own output means the unit-tier guard on `SLOT_GATED_ACTIVITY_TABS` now
+  // governs what actually renders.
+  const visibleTabs = visibleActivityTabs(visibility);
 
   const groupedApps = useMemo(() => groupSubscriptionsByApp(subs ?? []), [subs]);
 
@@ -555,38 +577,23 @@ export default function AppActivityPage() {
           }}
           variant="outline"
         >
-          <Tabs.List>
-            <Tabs.Tab value="activity" leftSection={<IconHistory size={14} />}>
-              Recent activity
-            </Tabs.Tab>
-            {canSeeInstallOnlyTabs && (
-              <Tabs.Tab value="subscriptions" leftSection={<IconPlugConnected size={14} />}>
-                Installs
-              </Tabs.Tab>
-            )}
-            {/* 🔴 UNGATED ON PURPOSE, unlike its two neighbours. Scope grants are the
-                consent/audit surface: a full-page app (`appBlocksPages`) invokes scopes
-                with no install row, so a viewer holding only the page flag has grants
-                here and nothing on `Installs` to reach them through. Gating this would
-                hide the record of access from the people whose access it records. */}
-            <Tabs.Tab value="permissions" leftSection={<IconShieldLock size={14} />}>
-              Apps & permissions
-            </Tabs.Tab>
-            {/* Hidden lists SLOT installs the viewer has hidden from their model pages,
-                so it carries the slot flag exactly as `Installs` does. */}
-            {canSeeInstallOnlyTabs && (
-              <Tabs.Tab value="hidden" leftSection={<IconEyeOff size={14} />}>
-                Hidden
-              </Tabs.Tab>
-            )}
-          </Tabs.List>
-
-          {/* 🔴 NO `< 2` COLLAPSE HERE, and its absence is deliberate. `AppsSubNav`
-              hides its bar below two rows; this bar cannot reach that state — `activity`
-              and `permissions` are both ungated and the page 404s for anyone holding
-              neither runtime flag, so the floor is 2. A collapse would be a branch that
-              never executes. If `permissions` is ever gated, the floor test in
-              `appsActivityTabs.test.ts` goes red — add the collapse then. */}
+          {/* 🔴 A `< 2` COLLAPSE, MIRRORING `AppsSubNav`'s `links.length < 2` — and it is
+              REACHABLE, which is why it exists. A viewer without the slot flag sees only
+              `Recent activity`, and a one-tab bar is chrome offering no choice. (The
+              earlier state of this file argued the floor was 2 and declined to build a
+              branch that could never run; gating `permissions` inverted that.) */}
+          {visibleTabs.length >= 2 && (
+            <Tabs.List>
+              {visibleTabs.map((tab) => {
+                const Icon = ACTIVITY_TAB_ICONS[tab];
+                return (
+                  <Tabs.Tab key={tab} value={tab} leftSection={<Icon size={14} />}>
+                    {ACTIVITY_TAB_LABELS[tab]}
+                  </Tabs.Tab>
+                );
+              })}
+            </Tabs.List>
+          )}
 
           <Tabs.Panel value="activity" pt="md">
             <Stack gap="sm">
@@ -598,9 +605,11 @@ export default function AppActivityPage() {
             </Stack>
           </Tabs.Panel>
 
-          {/* 🔴 THE PANEL IS GATED TOO. A `Tabs.Panel` with no tab is unreachable but
-              still MOUNTS its children on every render. */}
-          {canSeeInstallOnlyTabs && (
+          {/* 🔴 THE PANEL IS GATED TOO, THROUGH THE SAME PREDICATE THE BAR USES. A
+              `Tabs.Panel` with no tab is unreachable but still MOUNTS its children on
+              every render. Reading `isActivityTabVisible` rather than a local boolean is
+              what makes "the bar and the panels cannot disagree" a fact about the code. */}
+          {isActivityTabVisible('subscriptions', visibility) && (
             <Tabs.Panel value="subscriptions" pt="md">
               {isLoading ? (
                 <Center py="xl">
@@ -620,20 +629,27 @@ export default function AppActivityPage() {
             </Tabs.Panel>
           )}
 
-          <Tabs.Panel value="permissions" pt="md">
-            <Stack gap="sm">
-              <Text size="sm" c="dimmed">
-                What each app you've installed can request, and where you have it. This is a
-                reflection of the current state — to revoke access, remove the install or
-                subscription on the Installs tab.
-              </Text>
-              <ScopeGrantsPanel />
-            </Stack>
-          </Tabs.Panel>
+          {/* 🔴 GATED, AND ITS OWN DATA SOURCE IS WHY. `ScopeGrantsPanel`'s only read is
+              `blocks.listMyScopeGrants`, whose `enforceAppBlocksFlag` middleware returns
+              `[]` for a viewer without `features.appBlocks` — so ungated this panel showed
+              the "No apps installed or subscribed yet." empty state to every such viewer,
+              always. Gating it displays nothing that was ever displayed. */}
+          {isActivityTabVisible('permissions', visibility) && (
+            <Tabs.Panel value="permissions" pt="md">
+              <Stack gap="sm">
+                <Text size="sm" c="dimmed">
+                  What each app you've installed can request, and where you have it. This is a
+                  reflection of the current state — to revoke access, remove the install or
+                  subscription on the Installs tab.
+                </Text>
+                <ScopeGrantsPanel />
+              </Stack>
+            </Tabs.Panel>
+          )}
 
           {/* 🔴 THE PANEL IS GATED TOO — same reason as `subscriptions` above: an
               unreachable `Tabs.Panel` still MOUNTS its children on every render. */}
-          {canSeeInstallOnlyTabs && (
+          {isActivityTabVisible('hidden', visibility) && (
             <Tabs.Panel value="hidden" pt="md">
               <Stack gap="sm">
                 <Text size="sm" c="dimmed">

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -631,7 +631,7 @@ export default function AppActivityPage() {
 
           {/* 🔴 GATED, AND ITS OWN DATA SOURCE IS WHY. `ScopeGrantsPanel`'s only read is
               `blocks.listMyScopeGrants`, whose `enforceAppBlocksFlag` middleware returns
-              `[]` for a viewer without `features.appBlocks` — so ungated this panel showed
+              `[]` for a viewer without the `appBlocks` slot flag — so ungated this showed
               the "No apps installed or subscribed yet." empty state to every such viewer,
               always. Gating it displays nothing that was ever displayed. */}
           {isActivityTabVisible('permissions', visibility) && (


### PR DESCRIPTION
## What changed

`/apps/activity` renders four tabs: `activity`, `subscriptions` (labelled **Installs**), `permissions`, `hidden`. Only `subscriptions` was gated.

| Tab | Before | After | Why |
|---|---|---|---|
| `activity` | ungated | **ungated** | the page's own feed; it is the default tab |
| `subscriptions` | `features.appBlocks` | **unchanged** | slot installs — the slot flag governs its content |
| `permissions` | ungated | **ungated — deliberately** | see below |
| `hidden` | ungated | **`features.appBlocks`** | it lists the same slot installs, the ones the viewer has hidden from their model pages |

`hidden` is gated on **both** its `Tabs.Tab` and its `Tabs.Panel`. The panel matters independently: an unreachable `Tabs.Panel` still mounts its children on every render.

The gate on `hidden` is not merely defensible, it removes a **guaranteed-empty** tab: `hideBlock` (`src/components/AppBlocks/hiddenBlocks.ts:99`) has exactly one production call site, `IframeHost.tsx:732` — the slot host, which is itself `appBlocks`-gated. A viewer without the slot flag has never rendered a slot, so has never hidden one, so their Hidden tab could only ever render its empty state. (Hiding is device-local, so if the flag returns, so does the list.)

### `permissions` stays ungated, and that is a decision

Scope grants are a **consent/audit** surface. A full-page app (`appBlocksPages`) invokes scopes with **no install row at all**, so a viewer holding only the page flag has grants to read and to revoke — and, once `Installs` is gated away from them, nothing else on the page that reaches those grants. Gating `permissions` on the slot flag would hide the record of access from exactly the people whose access it records. Clawgate #532 is open about that under-reporting.

The asymmetry is recorded in a comment at each site (`INSTALL_GATED_ACTIVITY_TABS`, the `Tabs.Tab`, and the browser assertion) so a later pass does not "tidy" the three tabs into one uniform predicate.

## The resolver fallback — the bug this would otherwise have shipped

`resolveActivityTab` fell back to the default for a tab the viewer cannot see, but it tested the gated tab **by name**:

```ts
if (first === 'subscriptions' && !opts.canSeeInstalls) return DEFAULT_ACTIVITY_TAB;
```

The file's own comment explains what happens when that check misses: handing Mantine a `Tabs.value` that is not in the rendered list produces *"a bar with nothing active over an empty panel: a blank page with no error"*. So gating `hidden` without widening the resolver ships precisely that, for anyone opening a stale or shared `/apps/activity?tab=hidden` link without `appBlocks` — a teammate's share, a bookmark taken before a flag moved, their own history.

Widened so the rule is derived rather than spelled:

- `INSTALL_GATED_ACTIVITY_TABS` — the ledger (`subscriptions`, `hidden`), pinned by a test.
- `isActivityTabVisible(tab, opts)` — **one** predicate, read by both the resolver and the page.
- `visibleActivityTabs(opts)` — the rendered set, in render order.
- The options bag collapsed from a per-tab boolean to a single `canSeeInstallOnlyTabs`, which is the rule the code actually implements. Gate a third tab in future and its `?tab=` fallback comes with it, for free.

Still pure and React-free — it stays in the node `unit` tier deliberately.

### Red → green

**Unit tier, the resolver, before widening** (`vitest run --project 'unit*' src/components/Apps/__tests__/appsActivityTabs.test.ts`):

```
FAIL  |unit| src/components/Apps/__tests__/appsActivityTabs.test.ts > resolveActivityTab > 🔴 `?tab=subscriptions` falls back for a viewer WITHOUT the slot flag
AssertionError: expected 'hidden' to be 'activity' // Object.is equality

Expected: "activity"
Received: "hidden"
```

Green after: **17 passed (17)**.

**Browser tier, the three page-tier guards run against `origin/main`'s ungated page** (measured in a clean detached worktree at `origin/main` with this PR's spec copied in — 3 failed / 13 passed):

```
AssertionError: the Hidden tab must be hidden without appBlocks: expected <button …(9)>…(2)</button> to be undefined
AssertionError: expected 'Hidden' to be 'Recent activity' // Object.is equality
AssertionError: the minimum rendered tab count is 2: expected 3 to be 2
```

**The isolating mutant** — because the two halves of this change could each pass while the pair is broken. Page gated (this PR's `activity.tsx`) + resolver still name-based, everything else identical. Exactly **1 failed / 15 passed**, and the one failure is the blank bar itself:

```
FAIL  … > 🔴 a stale `?tab=hidden` link renders a PAGE, not an empty bar
AssertionError: some tab must be selected: expected undefined to be defined
```

That is the guard failing for its own specific reason, on a reachable input, with the rest of the file still green — not a mutant that died to a neighbour.

## The one-tab collapse: NOT reachable, so NOT implemented

The request was to hide the tab bar below 2 visible tabs, mirroring `AppsSubNav`'s documented `< 2` collapse (`AppsSubNav.tsx:372`, `if (links.length < 2) return null;`).

**That state cannot occur here.** Evidence, from the code:

1. `activity` and `permissions` are both rendered **unconditionally** — neither is behind a flag, and neither is conditional on having content (`hidden` was not conditional on there being hidden blocks either; `HiddenBlocksPanel` renders its own empty state).
2. The page itself 404s for anyone holding neither runtime flag: `if (!canAccessAppsActivity(features)) return <NotFound />;`, where `canAccessAppsActivity` is `appBlocks || appBlocksPages`.

So every viewer who can load the page at all sees at least `activity` + `permissions`. The floor is **2**, and the worst case is a viewer with `appBlocksPages` but not `appBlocks`, who sees exactly those two.

A `< 2` collapse would therefore be a branch that can never execute — which reads as coverage while providing none, and would be the thing a future reader trusts instead of re-checking. **Not shipped.** Both tiers pin the floor instead, so the day someone gates `permissions` the tests go red and point at the collapse as real, reachable work:

- unit: `🔴 THE FLOOR IS 2 — which is why the page has no `< 2` bar collapse` (asserts `>= 2` for every viewer **and** `=== 2` for the worst case, so a later gate cannot pass by shrinking a different arm)
- browser: `🔴 the bar has NO `< 2` collapse because 2 is the FLOOR, not a case`
- a code comment at the `Tabs.List` site and on `visibleActivityTabs` recording the same, and naming the test that will go red

Also pinned: `🔴 the DEFAULT tab is visible to EVERY viewer` — if the default were ever gated, the fallback would itself hand Mantine a value absent from the rendered list, i.e. the exact blank page the fallback exists to prevent.

## Verification

**Typecheck, base-vs-HEAD** (both configs; `origin/main` measured in a clean detached worktree, not inferred):

| config | `origin/main` | HEAD |
|---|---|---|
| `node scripts/typecheck.mjs` (root) | **13** | **13** |
| `NODE_OPTIONS=--max-old-space-size=12288 npx tsc --noEmit -p tsconfig.tests.json` | **1205** | **1205** |

Both baselines are non-zero and reproduced exactly, which is the positive control that the runs actually completed — at the 4 GB default the tests config OOMs, exits 134 and prints `0 errors`. No error in either run names any file this PR touches.

**Tests** (warm; the browser tier cold-cascades for 1–2 runs — the discriminator is wall time, 255 s of timeouts cold vs 7.9 s warm, and the same spec failed identically at `origin/main` cold):

- unit — `appsActivityTabs`, `subNavRowsMatchPageGates`, `chromeNavAlignsWithSubNav`, `resolveActivityPageAccess`, `appsStoreAccessCallSites`: **5 files / 66 tests passed**
- browser — the four `AppsSubNav*.browser.test.tsx` specs + `AppActivityPage.browser.test.tsx`: **5 files / 111 tests passed**

**Lint / format** on the four changed files:

- `npx prettier --check` — clean (validated against a deliberately misformatted file first, so the pass is not a glob that matched nothing)
- `npx eslint` — 5 `react/no-unescaped-entities` errors in `activity.tsx`, **all pre-existing**: `origin/main` reports the identical 5 (same apostrophes in body copy, shifted line numbers). Zero delta. The other three files are clean.

## Out of scope

`SUB_NAV_LINKS` ordering is untouched — `Build` at index 5 / `Review` at 6 is intended and confirmed.
