### PR TITLE
fix(apps): gate per-user App Storage on the RUN capability, not authoring

### DIFF
--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -118,10 +118,25 @@ function validClaims(over: Record<string, unknown> = {}) {
   };
 }
 
-function fakeCtx() {
+/**
+ * The `app-blocks-enabled` (RUN) cohort, by user id. The mock flag evaluator
+ * below reads this set, so a test can enable/disable the capability for the
+ * SESSION user and for the TOKEN SUBJECT independently — which is the only way
+ * to tell the `enforceAppBlocksFlag` middleware (evaluates `ctx.user`) apart
+ * from the per-subject assertion inside `resolveStorageContext`. Both refuse
+ * with the same code AND the same message, so a test that leaves the two
+ * identities equal can pass for the wrong reason.
+ */
+const runEnabledUserIds = new Set<number>();
+
+/** The SESSION user on the host page — distinct id from the token subject where
+ *  a test needs to isolate which of the two gates fired. */
+const SESSION_USER = { id: 1, isModerator: false, tier: 'free' };
+
+function fakeCtx(user: unknown = SESSION_USER) {
   return {
     acceptableOrigin: true,
-    user: undefined,
+    user,
     apiKeyId: null,
     tokenScope: TokenScope.Full,
     req: { headers: {} } as never,
@@ -153,12 +168,23 @@ beforeEach(() => {
   mockProvisionReviewPreview.mockClear();
 
   // Sane defaults the happy-path tests inherit.
-  mockIsAppBlocksEnabled.mockImplementation(async () => true);
+  // The RUN capability (`app-blocks-enabled`) is per-user: it is evaluated once
+  // by the middleware against `ctx.user` and once by resolveStorageContext
+  // against the TOKEN SUBJECT. Model it as a cohort membership so those two
+  // evaluations can disagree, and fail closed when there is no hydrated user
+  // (a vanished subject → undefined → global eval → base-false flag).
+  runEnabledUserIds.clear();
+  runEnabledUserIds.add(SESSION_USER.id);
+  runEnabledUserIds.add(42);
+  mockIsAppBlocksEnabled.mockImplementation(async (opts?: { user?: { id?: number } }) => {
+    const id = opts?.user?.id;
+    return id != null && runEnabledUserIds.has(id);
+  });
   mockParseSubjectUserId.mockImplementation((sub: string) => (sub === 'anon' ? null : 42));
-  // The storage resolver re-asserts the resolved viewer is an app AUTHOR
-  // (assertViewerIsAppDeveloper → getSessionUserById + isAppBlocksAuthorEnabled).
-  // Default the happy path to a moderator subject; the author capability defaults
-  // to the mod-floor (mirrors the flag absent → mods pass, non-mods don't).
+  // The storage resolver hydrates the token subject (getSessionUserById) and
+  // asserts a capability against it. Default the happy path to a moderator
+  // subject, who holds every capability; the author capability defaults to the
+  // mod-floor (mirrors the flag absent → mods pass, non-mods don't).
   mockGetUserById.mockResolvedValue({ id: 42, isModerator: true });
   mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: true });
   mockIsAppBlocksAuthorEnabled.mockImplementation(
@@ -179,7 +205,7 @@ beforeEach(() => {
 
 describe('apps.storage shared gates', () => {
   it('rejects when the Flipt flag is dark', async () => {
-    mockIsAppBlocksEnabled.mockImplementationOnce(async () => false);
+    mockIsAppBlocksEnabled.mockImplementation(async () => false);
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toBeInstanceOf(
       TRPCError
@@ -227,48 +253,112 @@ describe('apps.storage shared gates', () => {
     ).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
   });
 
-  // App Blocks authoring is mod OR the app-dev-testers cohort. A block token
-  // whose subject resolves to a non-author (non-mod, no cohort grant) is rejected
-  // with FORBIDDEN by the shared resolveStorageContext gate — across every op.
-  it('rejects a non-mod resolved viewer with FORBIDDEN (get)', async () => {
+  // ── Per-user storage is gated on the RUN capability, not the AUTHOR one ──────
+  //
+  // REGRESSION (the defect): the shared resolver used to assert the AUTHORING
+  // capability (`app-blocks-author`) against the token subject. Once the run
+  // cohort widened past the author cohort, a user who could legitimately open an
+  // app got FORBIDDEN on all five storage ops — so no stateful app could save
+  // anything, and could not read back what it had already saved. Reading/writing
+  // your OWN data inside an app you are allowed to run is a consumer capability.
+  it('a NON-AUTHOR subject holding the run capability can READ its own storage', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
-    mockGetSessionUser.mockResolvedValueOnce({ id: 42, isModerator: false });
+    // Not an author: no mod floor, and the author cohort refuses this subject.
+    mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: false });
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    mockPool.query.mockResolvedValueOnce({ rows: [{ value: { saved: true } }], rowCount: 1 });
+
     const caller = appsRouter.createCaller(fakeCtx() as never);
-    await expect(
-      caller.storage.get({ blockToken: 't', key: 'k' })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
-    // The non-mod must never reach the data pool.
+    const out = await caller.storage.get({ blockToken: 't', key: 'k' });
+
+    expect(out).toEqual({ value: { saved: true } });
+    expect(mockPool.query).toHaveBeenCalled();
+  });
+
+  it('a NON-AUTHOR subject holding the run capability can WRITE its own storage', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: false });
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    mockPool.query
+      // quota row
+      .mockResolvedValueOnce({ rows: [{ used_bytes: '0', row_count: '0' }], rowCount: 1 })
+      // no existing row for this key
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } });
+
+    expect(out.ok).toBe(true);
+    const sqls = (mockClient.query.mock.calls as Array<[string, unknown?]>).map((c) => c[0]);
+    expect(sqls.some((s) => s.includes('INSERT INTO "app_generate_from_model".kv'))).toBe(true);
+  });
+
+  // KILL-SWITCH, still fail-closed. The subject id differs from the session
+  // user's so ONLY the per-subject assertion can produce this refusal — the
+  // middleware sees a run-enabled `ctx.user` and passes. Both gates throw the
+  // same code and message, so without that split this test would pass even if
+  // the per-subject assertion were deleted outright.
+  it('refuses a subject WITHOUT the run capability, even when the session user has it (get)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:77' }));
+    mockParseSubjectUserId.mockImplementation(() => 77);
+    mockGetSessionUser.mockResolvedValue({ id: 77, isModerator: false });
+    runEnabledUserIds.delete(77); // session user (id 1) stays enabled
+
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+      message: 'Apps are not enabled',
+    });
+    // Proof the middleware let this through and the SUBJECT gate is what refused:
+    // the token was verified and the subject was hydrated before the throw.
+    expect(mockVerifyBlockToken).toHaveBeenCalled();
+    expect(mockGetSessionUser).toHaveBeenCalledWith(77);
+    // The refused subject must never reach the data pool.
     expect(mockPool.query).not.toHaveBeenCalled();
   });
 
-  it('rejects a non-mod resolved viewer with FORBIDDEN (set)', async () => {
-    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
-    mockGetSessionUser.mockResolvedValueOnce({ id: 42, isModerator: false });
+  it('refuses a subject WITHOUT the run capability, even when the session user has it (set)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:77' }));
+    mockParseSubjectUserId.mockImplementation(() => 77);
+    mockGetSessionUser.mockResolvedValue({ id: 77, isModerator: false });
+    runEnabledUserIds.delete(77);
+
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
       caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED', message: 'Apps are not enabled' });
+    expect(mockGetSessionUser).toHaveBeenCalledWith(77);
     expect(mockClient.query).not.toHaveBeenCalled();
   });
 
-  it('rejects a vanished resolved viewer with FORBIDDEN (getSessionUserById → null)', async () => {
-    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
-    mockGetSessionUser.mockResolvedValueOnce(null);
+  // Positive control for the pair above: the ONLY thing that changed is the
+  // subject's cohort membership, so if the assertion above were inert this case
+  // would be indistinguishable from it.
+  it('the same subject IS admitted once it holds the run capability', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:77' }));
+    mockParseSubjectUserId.mockImplementation(() => 77);
+    mockGetSessionUser.mockResolvedValue({ id: 77, isModerator: false });
+    runEnabledUserIds.add(77);
+    mockPool.query.mockResolvedValueOnce({ rows: [{ value: 1 }], rowCount: 1 });
+
     const caller = appsRouter.createCaller(fakeCtx() as never);
-    await expect(
-      caller.storage.get({ blockToken: 't', key: 'k' })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(await caller.storage.get({ blockToken: 't', key: 'k' })).toEqual({ value: 1 });
   });
 
-  it('accepts an author-capable NON-MOD subject (cohort widening): reaches the data pool', async () => {
-    // A curated non-mod author (granted app-blocks-author) whose block declares
-    // apps:storage:* must NOT be blocked at the storage gate — the KV op proceeds.
-    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
-    mockGetSessionUser.mockResolvedValueOnce({ id: 42, isModerator: false });
-    mockIsAppBlocksAuthorEnabled.mockResolvedValueOnce(true);
+  it('fails closed on an unhydratable subject (getSessionUserById → null)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:77' }));
+    mockParseSubjectUserId.mockImplementation(() => 77);
+    // A vanished subject hydrates to null → the flag gets no user → global eval
+    // → a base-false flag can never match a segment → refused.
+    mockGetSessionUser.mockResolvedValue(null);
+
     const caller = appsRouter.createCaller(fakeCtx() as never);
-    await caller.storage.get({ blockToken: 't', key: 'k' });
-    expect(mockPool.query).toHaveBeenCalled();
+    await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+      message: 'Apps are not enabled',
+    });
+    expect(mockGetSessionUser).toHaveBeenCalledWith(77);
+    expect(mockPool.query).not.toHaveBeenCalled();
   });
 
   // Fix 3 / audit A5 (design-gaps H4): storage is a DECLARED, approved scope —
@@ -726,6 +816,24 @@ describe('apps.storage — run-for-real preview namespace', () => {
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
     expect(mockProvisionReviewPreview).not.toHaveBeenCalled();
     expect(mockClient.query).not.toHaveBeenCalled();
+  });
+
+  // INVARIANT GUARD (not a regression test — this behaviour is unchanged): the
+  // review-preview branch is a reviewer action whose rows land in the reviewing
+  // MOD's own namespace, so it keeps the AUTHORING gate. Widening the ordinary
+  // per-user path to the run capability must not widen this one: a subject that
+  // holds the run capability but is not an author is still refused here.
+  it('review-preview still asserts the AUTHORING capability (run capability alone is not enough)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims());
+    mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: false });
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Apps authoring is not enabled for this account',
+    });
+    expect(mockProvisionReviewPreview).not.toHaveBeenCalled();
+    expect(mockPool.query).not.toHaveBeenCalled();
   });
 
   it('ORPHAN GUARD: a run-for-real token for a VANISHED request refuses (no re-provision)', async () => {

--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -174,8 +174,12 @@ beforeEach(() => {
   // The RUN capability (`app-blocks-enabled`) is per-user: it is evaluated once
   // by the middleware against `ctx.user` and once by resolveStorageContext
   // against the TOKEN SUBJECT. Model it as a cohort membership so those two
-  // evaluations can disagree, and fail closed when there is no hydrated user
-  // (a vanished subject → undefined → global eval → base-false flag).
+  // evaluations can disagree. A user-less eval returns false here, matching the
+  // live base-false flag — but that is NOT what makes production fail closed on
+  // a vanished subject: both capability gates now throw on an explicit null
+  // check before any flag evaluation, so this mock's no-user answer is never
+  // reached on that path (see the `unhydratable subject` blocks below, which
+  // pin the refusal under a base-TRUE flag too).
   runEnabledUserIds.clear();
   runEnabledUserIds.add(SESSION_USER.id);
   runEnabledUserIds.add(42);
@@ -951,5 +955,114 @@ describe('apps.storage — run-for-real preview namespace', () => {
       caller.storage.get({ blockToken: 't', key: 'k' })
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
     expect(mockProvisionReviewPreview).not.toHaveBeenCalled();
+  });
+
+  // ── Fail-closed on an unhydratable subject, ON THIS BRANCH ──────────────────
+  // This branch RETURNS before `assertAppBlocksEnabledForTokenUser` ever runs,
+  // so `assertViewerIsAppDeveloper` is the ONLY subject check it makes — the
+  // null guard on the other gate does not cover it, and a case on the ordinary
+  // path does not exercise it.
+  //
+  // Measured at both points on the flag-config dimension: `app-blocks-author`
+  // absent / base-false (today) and base-true. The second is the one that a
+  // gate leaning on the flag fails — `isAppBlocksAuthorEnabled` has no mod floor
+  // for a null user and falls through to a contextless GLOBAL eval, which a
+  // plain base-`enabled: true` flag matches.
+  describe('unhydratable subject on the review-preview branch', () => {
+    beforeEach(() => {
+      // Valid token whose `sub` parses, but the session hub has no user for it.
+      mockGetSessionUser.mockResolvedValue(null);
+    });
+
+    it("is refused under TODAY's absent / base-false author flag (get)", async () => {
+      mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims());
+
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        // The null guard's OWN message, not the capability refusal's
+        // 'Apps authoring is not enabled for this account' — pinning which of
+        // the two refusals inside this gate fired.
+        message: 'review token subject could not be resolved',
+      });
+      expect(mockGetSessionUser).toHaveBeenCalledWith(42);
+      // Refused BEFORE the orphan-guard read and before any provisioning, i.e.
+      // at the point in the branch where the subject is first known.
+      expect(mockDbRead.appBlockPublishRequest.findUnique).not.toHaveBeenCalled();
+      expect(mockProvisionReviewPreview).not.toHaveBeenCalled();
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+
+    // The structural case: the author flag says YES even for a null user.
+    const baseTrueAuthorFlag = async () => true;
+
+    it('is STILL refused when the author flag evaluates TRUE for a null user (get)', async () => {
+      mockIsAppBlocksAuthorEnabled.mockImplementation(baseTrueAuthorFlag);
+      mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims());
+      // A row is waiting: if the gate admits, `get` resolves WITH it, so this
+      // case cannot pass merely because the query returned nothing.
+      mockPool.query.mockResolvedValue({ rows: [{ value: 'preview-row' }], rowCount: 1 });
+
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: 'review token subject could not be resolved',
+      });
+      expect(mockProvisionReviewPreview).not.toHaveBeenCalled();
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+
+    it('is STILL refused when the author flag evaluates TRUE for a null user (set)', async () => {
+      mockIsAppBlocksAuthorEnabled.mockImplementation(baseTrueAuthorFlag);
+      mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims());
+
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
+      ).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: 'review token subject could not be resolved',
+      });
+      // No preview schema provisioned, and no row written on the vanished
+      // subject's behalf into the reviewing mod's namespace.
+      expect(mockProvisionReviewPreview).not.toHaveBeenCalled();
+      expect(mockPool.connect).not.toHaveBeenCalled();
+      expect(mockClient.query).not.toHaveBeenCalled();
+    });
+
+    // POSITIVE CONTROL for the pair above. Same base-true author mock, same
+    // branch, same subject id — the ONLY change is that the subject hydrates.
+    // If the guard refused unconditionally, or the base-true mock never reached
+    // the gate, this would fail too and the pair above would prove nothing.
+    it('admits a subject that DOES hydrate, under the same base-true author flag', async () => {
+      mockIsAppBlocksAuthorEnabled.mockImplementation(baseTrueAuthorFlag);
+      mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: false });
+      mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims());
+      mockPool.query.mockResolvedValue({ rows: [{ value: 'preview-row' }], rowCount: 1 });
+
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      const out = await caller.storage.get({ blockToken: 't', key: 'k' });
+
+      expect(out.value).toBe('preview-row');
+      expect(mockProvisionReviewPreview).toHaveBeenCalledWith({ publishRequestId: 'pubreq_aaa' });
+    });
+
+    // Every other refusal in resolveStorageContext increments the ops counter;
+    // this one must too, or a valid token refused here is visible only in a raw
+    // request log (audit 🟡-4). INVARIANT GUARD, not regression coverage for the
+    // null check: this case also passed before the guard existed, because the
+    // capability refusal it hit instead was already counted. What it does pin is
+    // the new guard's OWN `inc` — deleting that line alone turns it red.
+    it('counts the refusal on the ops counter (op + outcome)', async () => {
+      const inc = vi.mocked(appStorageOpsCounter.inc);
+      inc.mockClear();
+      mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims());
+
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toBeInstanceOf(
+        TRPCError
+      );
+      expect(inc).toHaveBeenCalledWith({ op: 'get', outcome: 'unauthorized' });
+    });
   });
 });

--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -97,6 +97,9 @@ vi.mock('~/server/services/user.service', () => ({
 
 import { appsRouter } from '../apps.router';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
+// Globally stubbed in src/__tests__/setup.ts (promMetricStub) — `.inc` is a
+// vi.fn(), so the refusal-instrumentation assertions below can read it.
+import { appStorageOpsCounter } from '~/server/prom/client';
 
 function validClaims(over: Record<string, unknown> = {}) {
   return {
@@ -345,20 +348,124 @@ describe('apps.storage shared gates', () => {
     expect(await caller.storage.get({ blockToken: 't', key: 'k' })).toEqual({ value: 1 });
   });
 
-  it('fails closed on an unhydratable subject (getSessionUserById → null)', async () => {
+  // ── Fail-closed on an unhydratable subject ──────────────────────────────────
+  // Audit 🟡-2. A subject the session hub cannot resolve (deleted account,
+  // transient miss) must be refused by an EXPLICIT null check, not by whatever
+  // `app-blocks-enabled` happens to evaluate to when it is handed no user.
+  // Handing it `undefined` takes the no-user GLOBAL eval, which refuses today
+  // only because the live flag is base-`false`; a plain base-`enabled: true`
+  // flag matches every entityId including the contextless global one.
+  //
+  // So the property is measured at BOTH points on the flag-config dimension:
+  // base-false (today) and base-true (the documented GA shape). The second case
+  // is the structural one — it fails against a gate that leans on the flag.
+  describe('unhydratable subject', () => {
+    beforeEach(() => {
+      mockParseSubjectUserId.mockImplementation(() => 77);
+      // A vanished subject: the token is valid and its `sub` parses, but the
+      // hub has no user for it.
+      mockGetSessionUser.mockResolvedValue(null);
+    });
+
+    it('is refused under TODAY\'s base-false flag (get)', async () => {
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:77' }));
+
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+        code: 'UNAUTHORIZED',
+        // The null guard's OWN message, not the flag gate's 'Apps are not
+        // enabled' — pinning which of the two refusals fired.
+        message: 'block token subject could not be resolved',
+      });
+      expect(mockGetSessionUser).toHaveBeenCalledWith(77);
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+
+    // The POST-GA model: `app-blocks-enabled` is base-`enabled: true`, so it
+    // resolves TRUE for every eval — including the no-user global eval a null
+    // subject would produce. A gate whose fail-closed is only spelled (pass
+    // `undefined`, let the flag say no) ADMITS here and lets `get` read and
+    // `set` write on the vanished subject's behalf.
+    const baseTrueFlag = async () => true;
+
+    it('is STILL refused when the flag evaluates TRUE for a null user (base-true / GA shape, get)', async () => {
+      mockIsAppBlocksEnabled.mockImplementation(baseTrueFlag);
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:77' }));
+      // A row is waiting: if the gate admits, the op succeeds and returns it,
+      // so this case cannot pass by the query merely being empty.
+      mockPool.query.mockResolvedValue({ rows: [{ value: 'other-users-row' }], rowCount: 1 });
+
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+        code: 'UNAUTHORIZED',
+        message: 'block token subject could not be resolved',
+      });
+      expect(mockGetSessionUser).toHaveBeenCalledWith(77);
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+
+    it('is STILL refused when the flag evaluates TRUE for a null user (base-true / GA shape, set)', async () => {
+      mockIsAppBlocksEnabled.mockImplementation(baseTrueFlag);
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:77' }));
+
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
+      ).rejects.toMatchObject({
+        code: 'UNAUTHORIZED',
+        message: 'block token subject could not be resolved',
+      });
+      // No row is written on the vanished subject's behalf.
+      expect(mockPool.connect).not.toHaveBeenCalled();
+      expect(mockClient.query).not.toHaveBeenCalled();
+    });
+
+    // POSITIVE CONTROL for the two cases above. Same base-true flag mock, same
+    // subject id — the ONLY thing that changes is that the subject hydrates. If
+    // the guard refused unconditionally (or the base-true mock were not
+    // actually reaching the gate), this would fail too and the pair above would
+    // prove nothing.
+    it('admits a subject that DOES hydrate, under the same base-true flag', async () => {
+      mockIsAppBlocksEnabled.mockImplementation(baseTrueFlag);
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:77' }));
+      mockGetSessionUser.mockResolvedValue({ id: 77, isModerator: false });
+      mockPool.query.mockResolvedValueOnce({ rows: [{ value: 1 }], rowCount: 1 });
+
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      expect(await caller.storage.get({ blockToken: 't', key: 'k' })).toEqual({ value: 1 });
+    });
+
+    // Audit 🟡-4: every other refusal in resolveStorageContext increments the
+    // ops counter; the capability refusals did not, which is why the defect
+    // behind this change was only visible in a raw request log.
+    it('counts the refusal on the ops counter (op + outcome)', async () => {
+      const inc = vi.mocked(appStorageOpsCounter.inc);
+      inc.mockClear();
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:77' }));
+
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toBeInstanceOf(
+        TRPCError
+      );
+      expect(inc).toHaveBeenCalledWith({ op: 'get', outcome: 'unauthorized' });
+    });
+  });
+
+  // The OTHER capability refusal on this path — subject hydrates, but does not
+  // hold the run capability — must be counted too (audit 🟡-4).
+  it('counts a run-capability refusal on the ops counter', async () => {
+    const inc = vi.mocked(appStorageOpsCounter.inc);
+    inc.mockClear();
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:77' }));
     mockParseSubjectUserId.mockImplementation(() => 77);
-    // A vanished subject hydrates to null → the flag gets no user → global eval
-    // → a base-false flag can never match a segment → refused.
-    mockGetSessionUser.mockResolvedValue(null);
+    mockGetSessionUser.mockResolvedValue({ id: 77, isModerator: false });
+    runEnabledUserIds.delete(77);
 
     const caller = appsRouter.createCaller(fakeCtx() as never);
-    await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
-      code: 'UNAUTHORIZED',
-      message: 'Apps are not enabled',
-    });
-    expect(mockGetSessionUser).toHaveBeenCalledWith(77);
-    expect(mockPool.query).not.toHaveBeenCalled();
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED', message: 'Apps are not enabled' });
+    expect(inc).toHaveBeenCalledWith({ op: 'set', outcome: 'unauthorized' });
   });
 
   // Fix 3 / audit A5 (design-gaps H4): storage is a DECLARED, approved scope —

--- a/src/server/routers/apps-shared.router.ts
+++ b/src/server/routers/apps-shared.router.ts
@@ -5,15 +5,23 @@
 // the per-app datastore to PUBLIC cross-user writes. The per-user KV path
 // (apps.router) is scoped by every query to the writer's OWN
 // (block_instance_id, user_id) rows, and is gated on the RUN capability
-// (`app-blocks-enabled`, via apps.router's `assertAppBlocksEnabledForTokenUser`)
-// — i.e. whoever may open the app at all. It is NO LONGER limited to app
-// authors: `assertViewerIsAppDeveloper` left that path when per-user storage was
-// re-gated on the run capability, and now guards only the mod review-preview
-// ("run for real") branch. Here, by contrast, a write is readable, votable and
-// reportable by OTHER users of the app, which is what every control below
-// (min-trust, per-user row cap, rate limits, revocation, content safety) is
-// answering. See the hardened design (`shared-storage-design.md`, "HARDENED per
-// design security review"). Read that before touching auth/counter/trust logic.
+// (`app-blocks-enabled`, via apps.router's `assertAppBlocksEnabledForTokenUser`).
+// It is NO LONGER limited to app authors: `assertViewerIsAppDeveloper` left that
+// path when per-user storage was re-gated on the run capability, and now guards
+// only the mod review-preview ("run for real") branch. That is CLOSE TO, but not
+// identical to, "whoever may open the app at all" — the block-token mint gates on
+// `getFeatureFlags({ user }).appBlocks`, which falls back to the static
+// `availability: ['mod']` evaluation when Flipt returns null, whereas
+// `isAppBlocksEnabled` has no mod floor. So with Flipt unavailable a moderator can
+// mint a token that the per-user KV gate then refuses: a divergence in the SAFE
+// direction, on a path that is already degraded.
+//
+// Here, by contrast, a write is readable, votable and reportable by OTHER users
+// of the app, which is what every control below (min-trust, per-user row cap,
+// rate limits, revocation, content safety) is answering. The security review that
+// motivated those controls is not a document in this repo; the rationale that
+// survives is the per-control comments below — read those before touching
+// auth/counter/trust logic.
 //
 // Data model (per-app schema `app_<slug>`, provisioned by AppStorageProvisioner):
 //   - shared_kv(key ULID PK [SERVER-generated], author_user_id, value jsonb, …)

--- a/src/server/routers/apps-shared.router.ts
+++ b/src/server/routers/apps-shared.router.ts
@@ -2,11 +2,18 @@
 //
 // Mounted at `trpc.apps.shared.*` (block-token authed) + `trpc.apps.mod.*`
 // (session moderatorProcedure). This is the FIRST App Blocks surface that opens
-// the per-app datastore to PUBLIC cross-user writes — today per-user KV is
-// reachable only by mods + app-dev-testers (apps.router `assertViewerIsAppDeveloper`).
-// Every control here exists because a community app serves GENERAL users; see the
-// hardened design (`shared-storage-design.md`, "HARDENED per design security
-// review"). Read that before touching auth/counter/trust logic.
+// the per-app datastore to PUBLIC cross-user writes. The per-user KV path
+// (apps.router) is scoped by every query to the writer's OWN
+// (block_instance_id, user_id) rows, and is gated on the RUN capability
+// (`app-blocks-enabled`, via apps.router's `assertAppBlocksEnabledForTokenUser`)
+// — i.e. whoever may open the app at all. It is NO LONGER limited to app
+// authors: `assertViewerIsAppDeveloper` left that path when per-user storage was
+// re-gated on the run capability, and now guards only the mod review-preview
+// ("run for real") branch. Here, by contrast, a write is readable, votable and
+// reportable by OTHER users of the app, which is what every control below
+// (min-trust, per-user row cap, rate limits, revocation, content safety) is
+// answering. See the hardened design (`shared-storage-design.md`, "HARDENED per
+// design security review"). Read that before touching auth/counter/trust logic.
 //
 // Data model (per-app schema `app_<slug>`, provisioned by AppStorageProvisioner):
 //   - shared_kv(key ULID PK [SERVER-generated], author_user_id, value jsonb, …)

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -35,9 +35,26 @@ import { appsSharedRouter, appsModRouter } from '~/server/routers/apps-shared.ro
  * block-token authed — the viewer is resolved from the JWT subject, not
  * `ctx.user`. Re-assert the resolved viewer is an app AUTHOR here (mod OR the
  * app-dev-testers cohort, via the appBlocksAuthor capability) — defense-in-depth
- * per call. Mirrors blocks.router's assertViewerIsAppDeveloper.
- * Fail-closed: an unhydratable subject → undefined → mod-floor misses +
- * Flipt eval can't match → FORBIDDEN. Throws FORBIDDEN otherwise.
+ * per call. Same capability and same refusal message as blocks.router's
+ * `assertViewerIsAppDeveloper`, but NOT the same function: this one additionally
+ * null-guards the subject (see below), takes `op`, and counts every refusal on
+ * `appStorageOpsCounter`. Keep those three when reconciling the two.
+ *
+ * FAIL-CLOSED ON AN UNHYDRATABLE SUBJECT IS STRUCTURAL HERE, the same shape
+ * `assertAppBlocksEnabledForTokenUser` below uses (different code and message —
+ * this gate throws FORBIDDEN, that one UNAUTHORIZED): a subject the session hub
+ * cannot resolve is refused BEFORE any flag evaluation. Handing
+ * `isAppBlocksAuthorEnabled` an `undefined` user instead takes its no-user
+ * branch — no moderator floor, then a contextless GLOBAL eval of
+ * `app-blocks-author` (entityId `'global'`, empty context), which is fail-closed
+ * only until a base-enabled GA flip: a plain base-`enabled: true` flag matches
+ * every entityId, the global one included. That matters on THIS gate in
+ * particular, because the review-preview branch returns before
+ * `assertAppBlocksEnabledForTokenUser` runs, so this is the only subject check
+ * that branch makes.
+ *
+ * Otherwise: a hydrated subject holding neither the moderator floor nor the
+ * author cohort → FORBIDDEN.
  *
  * SCOPE: this is the AUTHORING capability, so it belongs ONLY on paths that are
  * genuinely an author/reviewer action — today just the mod review-preview
@@ -53,7 +70,17 @@ import { appsSharedRouter, appsModRouter } from '~/server/routers/apps-shared.ro
  */
 async function assertViewerIsAppDeveloper(userId: number, op: StorageOp): Promise<void> {
   const user = (await sessionClient.getSessionUserById(userId)) as SessionUser | null;
-  if (!(await isAppBlocksAuthorEnabled({ user: user ?? undefined }))) {
+  // Structural fail-closed: refuse an unhydratable subject outright, before the
+  // capability is evaluated. Distinct message from the capability refusal below
+  // AND from the run gate's, so all three stay separable in a log and in a test.
+  if (!user) {
+    appStorageOpsCounter.inc({ op, outcome: 'unauthorized' });
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'review token subject could not be resolved',
+    });
+  }
+  if (!(await isAppBlocksAuthorEnabled({ user }))) {
     appStorageOpsCounter.inc({ op, outcome: 'unauthorized' });
     throw new TRPCError({
       code: 'FORBIDDEN',
@@ -80,8 +107,11 @@ async function assertViewerIsAppDeveloper(userId: number, op: StorageOp): Promis
  * segment match cannot be spoofed.
  *
  * FAIL-CLOSED HERE IS STRUCTURAL, NOT INHERITED FROM THE FLAG'S BASE STATE — and
- * that is the one way this gate does NOT mirror blocks.router's. A subject that
- * cannot be hydrated (deleted account, transient session-hub miss) is refused
+ * it is NOT the only way this gate departs from blocks.router's same-named
+ * helper. It also takes `op` and increments `appStorageOpsCounter` on both of its
+ * refusals, where blocks.router's `assertAppBlocksEnabledForTokenUser` takes only
+ * a userId and counts nothing. Keep all three when reconciling the two. A subject
+ * that cannot be hydrated (deleted account, transient session-hub miss) is refused
  * BEFORE any flag evaluation, rather than being passed to `isAppBlocksEnabled` as
  * `undefined`. That overload takes the no-user branch — a GLOBAL eval
  * (entityId `'global'`, empty context; see `isAppBlocksEnabled` in

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -45,10 +45,16 @@ import { appsSharedRouter, appsModRouter } from '~/server/routers/apps-shared.ro
  * The ordinary per-user storage path must NOT use it: reading and writing your
  * own saved data inside an app you are allowed to RUN is a CONSUMER capability
  * (see assertAppBlocksEnabledForTokenUser below).
+ *
+ * Takes `op` only to label the refusal counter — every OTHER refusal in
+ * `resolveStorageContext` is counted, and a capability refusal that is not
+ * leaves the "valid token, refused anyway" case visible only in a raw request
+ * log (audit 🟡-4).
  */
-async function assertViewerIsAppDeveloper(userId: number): Promise<void> {
+async function assertViewerIsAppDeveloper(userId: number, op: StorageOp): Promise<void> {
   const user = (await sessionClient.getSessionUserById(userId)) as SessionUser | null;
   if (!(await isAppBlocksAuthorEnabled({ user: user ?? undefined }))) {
+    appStorageOpsCounter.inc({ op, outcome: 'unauthorized' });
     throw new TRPCError({
       code: 'FORBIDDEN',
       message: 'Apps authoring is not enabled for this account',
@@ -67,13 +73,27 @@ async function assertViewerIsAppDeveloper(userId: number): Promise<void> {
  * no-session call). The kill-switch has to bind that subject too, or the
  * per-subject half of the gate does not exist.
  *
- * Mirrors `assertAppBlocksEnabledForTokenUser` in blocks.router: hydrate the FULL
+ * The subject is hydrated the same way blocks.router's gate hydrates it: the FULL
  * server-side SessionUser via `sessionClient.getSessionUserById` (the
  * authoritative hub-backed resolver, never a client-supplied value) so
  * `buildFliptContext` sees the subject's real `isModerator`/`tier` and the
- * segment match cannot be spoofed. Fail-closed: a vanished/unhydratable subject
- * → `undefined` → global eval → a base-false flag can never match a segment →
- * refused.
+ * segment match cannot be spoofed.
+ *
+ * FAIL-CLOSED HERE IS STRUCTURAL, NOT INHERITED FROM THE FLAG'S BASE STATE — and
+ * that is the one way this gate does NOT mirror blocks.router's. A subject that
+ * cannot be hydrated (deleted account, transient session-hub miss) is refused
+ * BEFORE any flag evaluation, rather than being passed to `isAppBlocksEnabled` as
+ * `undefined`. That overload takes the no-user branch — a GLOBAL eval
+ * (entityId `'global'`, empty context; see `isAppBlocksEnabled` in
+ * app-blocks-flag.ts) — which refuses today only because `app-blocks-enabled` is
+ * base-`false`, so no segment can match. A plain base-`enabled: true` flag (the
+ * documented GA shape) matches EVERY entityId, the contextless global one
+ * included; on that config the `undefined` path would ADMIT an unresolvable
+ * subject and `set` would write rows on its behalf for the rest of the token's
+ * lifetime. The explicit null check removes that dependency: the refusal holds
+ * on every flag configuration. `resolveSharedContext` in apps-shared.router.ts
+ * takes the same approach on its write path (`if (userId == null) throw`, and
+ * `assertSharedWriteTrust` opens with `if (!user) return deny(...)`).
  *
  * This is the RUN capability, NOT the authoring one: per-user storage is a
  * consumer surface (your own saved data, in an app you are allowed to open), so
@@ -81,10 +101,23 @@ async function assertViewerIsAppDeveloper(userId: number): Promise<void> {
  * app. Same reasoning the shared-storage resolver already applies — see
  * `resolveSharedContext` in apps-shared.router.ts, which deliberately does not
  * reuse the author gate.
+ *
+ * `op` labels the refusal counter — see assertViewerIsAppDeveloper above.
  */
-async function assertAppBlocksEnabledForTokenUser(userId: number): Promise<void> {
+async function assertAppBlocksEnabledForTokenUser(userId: number, op: StorageOp): Promise<void> {
   const user = (await sessionClient.getSessionUserById(userId)) as SessionUser | null;
-  if (!(await isAppBlocksEnabled({ user: user ?? undefined }))) {
+  // Structural fail-closed: refuse an unhydratable subject outright. Distinct
+  // message so the two refusals below are separable in a log AND in a test —
+  // they are different conditions, not one gate spelled twice.
+  if (!user) {
+    appStorageOpsCounter.inc({ op, outcome: 'unauthorized' });
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'block token subject could not be resolved',
+    });
+  }
+  if (!(await isAppBlocksEnabled({ user }))) {
+    appStorageOpsCounter.inc({ op, outcome: 'unauthorized' });
     throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Apps are not enabled' });
   }
 }
@@ -186,7 +219,7 @@ async function resolveStorageContext(blockToken: string, op: StorageOp): Promise
     // Self-bound: reads/writes land in the reviewing MOD's own rows. A non-mod
     // subject can't hold a review token (mint is mod-gated); assert developer.
     if (userId != null) {
-      await assertViewerIsAppDeveloper(userId);
+      await assertViewerIsAppDeveloper(userId, op);
     }
     // The preview namespace is keyed on the publishRequestId (the token's
     // `appBlockId` claim = `pubreq_<ULID>`), so it is isolated per pending app AND
@@ -266,7 +299,7 @@ async function resolveStorageContext(blockToken: string, op: StorageOp): Promise
   // Anon subjects (userId === null) fall through to each op's existing
   // anon-handling (clean-null for reads, UNAUTHORIZED for writes).
   if (userId != null) {
-    await assertAppBlocksEnabledForTokenUser(userId);
+    await assertAppBlocksEnabledForTokenUser(userId, op);
   }
   return {
     userId,

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -35,10 +35,16 @@ import { appsSharedRouter, appsModRouter } from '~/server/routers/apps-shared.ro
  * block-token authed — the viewer is resolved from the JWT subject, not
  * `ctx.user`. Re-assert the resolved viewer is an app AUTHOR here (mod OR the
  * app-dev-testers cohort, via the appBlocksAuthor capability) — defense-in-depth
- * per call (mint is also author-gated). Mirrors blocks.router's
- * assertViewerIsAppDeveloper so a KV-using block works for the whole author
- * loop. Fail-closed: an unhydratable subject → undefined → mod-floor misses +
+ * per call. Mirrors blocks.router's assertViewerIsAppDeveloper.
+ * Fail-closed: an unhydratable subject → undefined → mod-floor misses +
  * Flipt eval can't match → FORBIDDEN. Throws FORBIDDEN otherwise.
+ *
+ * SCOPE: this is the AUTHORING capability, so it belongs ONLY on paths that are
+ * genuinely an author/reviewer action — today just the mod review-preview
+ * ("run for real") branch, whose rows land in the reviewing MOD's own namespace.
+ * The ordinary per-user storage path must NOT use it: reading and writing your
+ * own saved data inside an app you are allowed to RUN is a CONSUMER capability
+ * (see assertAppBlocksEnabledForTokenUser below).
  */
 async function assertViewerIsAppDeveloper(userId: number): Promise<void> {
   const user = (await sessionClient.getSessionUserById(userId)) as SessionUser | null;
@@ -47,6 +53,39 @@ async function assertViewerIsAppDeveloper(userId: number): Promise<void> {
       code: 'FORBIDDEN',
       message: 'Apps authoring is not enabled for this account',
     });
+  }
+}
+
+/**
+ * App Blocks RUN gate, evaluated against the BLOCK TOKEN'S SUBJECT.
+ *
+ * WHY THIS EXISTS — the `enforceAppBlocksFlag` middleware below evaluates
+ * `app-blocks-enabled` against `ctx.user`, the request's SESSION user. These
+ * procedures are `publicProcedure` authenticated by a block JWT, so the identity
+ * that actually owns the rows being read/written is the TOKEN SUBJECT, which the
+ * middleware never looks at (and which is absent entirely from `ctx` on a
+ * no-session call). The kill-switch has to bind that subject too, or the
+ * per-subject half of the gate does not exist.
+ *
+ * Mirrors `assertAppBlocksEnabledForTokenUser` in blocks.router: hydrate the FULL
+ * server-side SessionUser via `sessionClient.getSessionUserById` (the
+ * authoritative hub-backed resolver, never a client-supplied value) so
+ * `buildFliptContext` sees the subject's real `isModerator`/`tier` and the
+ * segment match cannot be spoofed. Fail-closed: a vanished/unhydratable subject
+ * → `undefined` → global eval → a base-false flag can never match a segment →
+ * refused.
+ *
+ * This is the RUN capability, NOT the authoring one: per-user storage is a
+ * consumer surface (your own saved data, in an app you are allowed to open), so
+ * gating it on `app-blocks-author` locked every non-author out of every stateful
+ * app. Same reasoning the shared-storage resolver already applies — see
+ * `resolveSharedContext` in apps-shared.router.ts, which deliberately does not
+ * reuse the author gate.
+ */
+async function assertAppBlocksEnabledForTokenUser(userId: number): Promise<void> {
+  const user = (await sessionClient.getSessionUserById(userId)) as SessionUser | null;
+  if (!(await isAppBlocksEnabled({ user: user ?? undefined }))) {
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Apps are not enabled' });
   }
 }
 
@@ -212,12 +251,22 @@ async function resolveStorageContext(blockToken: string, op: StorageOp): Promise
   }
 
   const userId = parseSubjectUserId(claims.sub);
-  // Phase 2: moderator-only until GA. A non-null subject must be a moderator;
-  // anon subjects (userId === null) fall through to each op's existing
-  // anon-handling (clean-null for reads, UNAUTHORIZED for writes) — block-token
-  // minting is itself mod-gated so an anon mod token can't be minted anyway.
+  // Per-subject kill-switch. A non-null subject must hold the RUN capability
+  // (`app-blocks-enabled`) — the same capability the block-token mint gates on
+  // (`getFeatureFlags({ user }).appBlocks`), so anyone who could legitimately
+  // open this app can also read and write their OWN storage in it.
+  //
+  // This used to assert the AUTHORING capability (`app-blocks-author`), left over
+  // from the pre-GA phase when the two cohorts were the same people. Once the run
+  // cohort widened past the author cohort, every non-author with a perfectly valid
+  // token got a 403 on all five storage ops, which makes any stateful app
+  // unusable — both saving new state and reading back what was already saved.
+  // Per-user storage is a consumer capability, not an authoring one.
+  //
+  // Anon subjects (userId === null) fall through to each op's existing
+  // anon-handling (clean-null for reads, UNAUTHORIZED for writes).
   if (userId != null) {
-    await assertViewerIsAppDeveloper(userId);
+    await assertAppBlocksEnabledForTokenUser(userId);
   }
   return {
     userId,


### PR DESCRIPTION
## The defect

A user who can open an on-site app at `/apps/run/<slug>` cannot read or write that app's per-user storage. Every `apps.storage.*` call comes back:

```
403 FORBIDDEN — "Apps authoring is not enabled for this account"
```

Because the gate sits in the shared context resolver it covers all five ops (`get` / `set` / `delete` / `list` / `getQuota`), so a stateful app can neither save new state nor read back state it had already saved. In practice that makes any stateful app unusable for anyone who isn't an app author.

## Cause

`resolveStorageContext` in `src/server/routers/apps.router.ts` asserted the **authoring** capability (`app-blocks-author`, via `assertViewerIsAppDeveloper`) against the block token's subject.

That was correct only while the run cohort and the author cohort were the same people. Block tokens are minted against the **run** capability — `getFeatureFlags({ user }).appBlocks` → `app-blocks-enabled` — so once the run cohort widened past the author cohort, users holding entirely valid tokens started hitting an authoring gate on a consumer surface.

Reading and writing your own saved data inside an app you are allowed to open is a consumer capability, not an authoring one. The sibling shared-storage resolver already reached that conclusion and says so in a comment — `resolveSharedContext` deliberately does **not** reuse `resolveStorageContext` / `assertViewerIsAppDeveloper` because "that gates to app-authors only; copying it would FORBID all general users." That reasoning was never back-ported to per-user storage.

## The change

The ordinary app path now asserts `app-blocks-enabled` against the token subject, through a new `assertAppBlocksEnabledForTokenUser` that mirrors the same-named helper in `blocks.router.ts`.

**The assertion is not dropped.** The subject is still hydrated with `sessionClient.getSessionUserById` (the authoritative resolver, never a client-supplied value) and the flag is still evaluated against that real subject, so the kill-switch keeps binding per-subject and keeps failing closed on a vanished/unhydratable subject. That is load-bearing: the `enforceAppBlocksFlag` middleware only ever evaluates `ctx.user`, the **session** identity — a different identity from the token subject, and absent entirely on a no-session call. Without a per-subject assertion the subject half of the gate would not exist at all.

Denials on this path now surface as `UNAUTHORIZED` / "Apps are not enabled", matching both the middleware in this file and `blocks.router`'s helper for the same flag. The host bridge surfaces the message and does not branch on the code.

### Deliberately unchanged

- **The mod review-preview ("run for real") branch keeps the authoring gate.** Its reads and writes land in the reviewing moderator's own namespace, so it is genuinely a reviewer action. A new invariant guard pins this.
- The declared-scope gate (`apps:storage:read` / `:write`), the approved-status gate, and anon handling.
- The author-gated generation/Buzz procedures in `blocks.router.ts` (`submitWorkflow`, `estimateWorkflow`, `getMyBuzzBalance`, …) — a separate product decision, out of scope here.

## Tests

`src/server/routers/__tests__/apps.router.storage.test.ts` now models the run capability as a per-user cohort, so the middleware's evaluation (session user) and the resolver's evaluation (token subject) can disagree. This matters: both refuse with the **same code and the same message**, so any test that leaves the two identities equal would pass even with the per-subject assertion deleted outright.

Added / updated:

- a non-author subject holding the run capability can `get` its own storage;
- …and can `set` it (reaching the real INSERT);
- a subject **without** the run capability is refused even though the session user has it — asserted on the specific code *and* message, plus proof the resolver was reached (token verified, subject hydrated) so the refusal cannot be the middleware's;
- the *same* subject is admitted once it holds the capability (positive control — the only variable that moved is cohort membership);
- an unhydratable subject fails closed;
- invariant guard: review-preview still requires authoring, so widening the ordinary path did not widen that one.

### Verification

| check | result |
|---|---|
| new tests at the base commit `db5ef312` | **6 red** (all the new/changed cases) |
| same tests at this branch's HEAD | **43 passed** |
| `apps.router.storage` + `apps-shared.router` + `blocks.router.workflow` | 520 passed |
| `pnpm typecheck` | 0 type errors |
| `pnpm test:lint-rules` | 36 files / 501 passed |

Two mutation checks, to show the guards are not vacuous:

- delete the per-subject run assertion on the normal path → exactly the 3 kill-switch tests fail (so they are not passing via the middleware);
- swap the review-preview branch onto the run gate → exactly the review-preview invariant guard fails.

Both files were already not Prettier-clean at the base commit; the added lines are, and the pre-existing formatting is left alone rather than reformatting the whole file.
