### PR TITLE
fix(apps): stop the permissions tab instructing a revoke that does not revoke

### DIFF
--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.browser.test.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.browser.test.tsx
@@ -134,12 +134,7 @@ describe('AppPermissionsActivityDrawer (Part B — per-app permissions & activit
     ];
 
     renderWithProviders(
-      <AppPermissionsActivityDrawer
-        appBlockId="ab-1"
-        appName="My App"
-        opened
-        onClose={() => {}}
-      />
+      <AppPermissionsActivityDrawer appBlockId="ab-1" appName="My App" opened onClose={() => {}} />
     );
 
     // Granted scope for ab-1 shows (via BlockScopeList); ab-2's scope must NOT leak.
@@ -149,18 +144,14 @@ describe('AppPermissionsActivityDrawer (Part B — per-app permissions & activit
     // Activity timeline: the scope-invocation row (workflow submit) humanises to
     // "Generated an image" and the Buzz row to "Spent Buzz on a per-model install".
     await expect.element(page.getByText('Generated an image')).toBeInTheDocument();
-    await expect
-      .element(page.getByText('Spent Buzz on a per-model install'))
-      .toBeInTheDocument();
+    await expect.element(page.getByText('Spent Buzz on a per-model install')).toBeInTheDocument();
   });
 
   test('BOTH activity queries (Buzz + scope-invocations) are server-filtered by the current appBlockId', async () => {
     renderWithProviders(
       <AppPermissionsActivityDrawer appBlockId="ab-42" appName="Scoped" opened onClose={() => {}} />
     );
-    await expect
-      .element(page.getByTestId('app-permissions-activity-drawer'))
-      .toBeInTheDocument();
+    await expect.element(page.getByTestId('app-permissions-activity-drawer')).toBeInTheDocument();
     // Scope-invocation audit — server-filtered.
     expect(m.scopeSpy).toHaveBeenCalledWith(
       expect.objectContaining({ appBlockId: 'ab-42' }),
@@ -194,8 +185,17 @@ describe('AppPermissionsActivityDrawer (Part B — per-app permissions & activit
     renderWithProviders(
       <AppPermissionsActivityDrawer appBlockId="ab-1" appName="My App" opened onClose={() => {}} />
     );
+    // 🔴 PINNED AS THE WHOLE NORMALISED STRING, NOT A KEYWORD. The claim under test is
+    // that this label does NOT assert "you granted this app nothing" — a defect a
+    // `/permissions/` substring match would walk straight past, since the false wording
+    // contained that word too. The two load-bearing halves are the qualifier
+    // ("from an install") and the pointer to Recent activity.
     await expect
-      .element(page.getByText("You haven't granted this app any permissions yet."))
+      .element(
+        page.getByText(
+          'No permissions recorded from an install of this app — which is not the same as no access. Anything it has actually done on your account is listed under Recent activity below.'
+        )
+      )
       .toBeInTheDocument();
     await expect.element(page.getByText(/No activity yet\./)).toBeInTheDocument();
   });

--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
@@ -80,14 +80,17 @@ function DrawerBody({ appBlockId, appName }: { appBlockId: string; appName?: str
     <Stack gap="lg">
       {appName && (
         <Text size="sm" c="dimmed">
-          What <strong>{appName}</strong> can do on your behalf, and what it has done recently.
-          Only you can see this.
+          The permissions <strong>{appName}</strong> carries through your own installs, and what it
+          has done recently. Only you can see this.
         </Text>
       )}
 
       <Stack gap="xs">
+        {/* "…from your installs", not "Granted permissions" — the section's only source is
+            install-backed, so the wider heading was the same overstatement as the empty
+            label it sits above. */}
         <Text fw={600} size="sm">
-          Granted permissions
+          Permissions from your installs
         </Text>
         {!isAuthed ? (
           <Text size="xs" c="dimmed" fs="italic">
@@ -98,9 +101,19 @@ function DrawerBody({ appBlockId, appName }: { appBlockId: string; appName?: str
             <Loader size="sm" />
           </Center>
         ) : (
+          /* 🔴 THE EMPTY LABEL IS NOT "no permissions granted", AND THE PANEL BELOW IS WHY.
+             `grant` is `grants.find(g => g.appBlockId === appBlockId)` over
+             `listMyScopeGrants`, whose only source is the viewer's OWN
+             `block_user_subscriptions` rows. A full-page app has no install, so that lookup
+             is `undefined` for every such app — and the drawer then claimed the viewer had
+             granted it nothing WHILE `AppActivityPanel` a few lines down listed the
+             scope-gated calls that same app had just made, possibly minutes after they
+             accepted its consent modal. Two halves of one drawer contradicting each other.
+             Absence of an install-backed row is not absence of granted permission; the label
+             says which of the two it is and sends the reader to the half that knows. */
           <BlockScopeList
             scopes={grant?.scopes ?? []}
-            emptyLabel="You haven't granted this app any permissions yet."
+            emptyLabel="No permissions recorded from an install of this app — which is not the same as no access. Anything it has actually done on your account is listed under Recent activity below."
           />
         )}
       </Stack>

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -311,10 +311,10 @@ describe('🔴 the INSTALL-ONLY tabs are gated on the SLOT flag', () => {
     expect(pageTab('Hidden'), 'the Hidden tab must be hidden without appBlocks').toBeUndefined();
     // 🔴 `Apps & permissions` IS GATED TOO, and its DATA SOURCE is the reason. The panel's
     // only read is `blocks.listMyScopeGrants`, whose `enforceAppBlocksFlag` middleware
-    // returns `[]` for exactly this viewer — so ungated the tab showed them the "No apps
-    // installed or subscribed yet." empty state, always. There was no cohort for whom it
-    // held content. (An earlier revision of this file argued the opposite; that premise
-    // was false at the data layer and is retracted.)
+    // returns `[]` for exactly this viewer — so ungated the tab showed them its installs
+    // empty state, always. There was no cohort for whom it held content. (An earlier
+    // revision of this file argued the opposite; that premise was false at the data layer
+    // and is retracted.)
     expect(
       pageTab('Apps & permissions'),
       'the permissions tab must be hidden without appBlocks — its own query refuses'
@@ -598,5 +598,66 @@ describe('Apps & permissions — the per-app daily Buzz limit', () => {
     await input.clear();
     await input.fill('5');
     await expect.element(page.getByTestId('app-budget-low-warning')).toBeInTheDocument();
+  });
+});
+
+/**
+ * 🔴 THE PERMISSIONS TAB MUST NOT INSTRUCT AN ACTION THAT DOES NOT DO WHAT IT SAYS.
+ *
+ * The retracted copy read: "This is a reflection of the current state — to revoke access,
+ * remove the install or subscription on the Installs tab." Removing an install does NOT
+ * revoke the scope grant. `BlockRegistry.deleteSubscription` deletes the
+ * `block_user_subscriptions` row and nothing else; `uninstallFromModel` additionally
+ * revokes the block INSTANCE token, which invalidates already-minted tokens but leaves the
+ * consent row intact. The grant lives in `app_user_scope_grants`, whose only writes in the
+ * entire repo are the two in `~/server/services/blocks/scope-grant.service.ts`, both
+ * setting `revokedAt: null`. Nothing writes a non-null `revoked_at`; nothing deletes a row.
+ * So the scopes survive the uninstall and the next mint carries them with no fresh prompt.
+ *
+ * 🔴 PINNED AS THE WHOLE NORMALISED STRING, DELIBERATELY. The artifact under test is
+ * PROSE, so a guard on keywords is walkable by rewording — a future edit could reintroduce
+ * "remove the install to revoke" without tripping any `/revoke/`-shaped matcher, because
+ * the honest copy contains that word too. Pinning the whole sentence means a cosmetic
+ * reword fails this test; that cost is the price of a machine-readable claim about what
+ * the page tells users. If you are here because you reworded it, re-read the paragraph
+ * above and confirm your new wording is still TRUE before updating the literal.
+ */
+describe('🔴 the revoke instruction is retracted, not reworded', () => {
+  const PERMISSIONS_TAB_COPY =
+    "The apps you've installed or subscribed to, the permissions each one declares it may " +
+    'use, and where you have it. Removing an install on the Installs tab takes the app off ' +
+    'that surface, but it does not withdraw a permission you have already granted — ' +
+    'withdrawing one is not possible yet. Recent activity is the full record of what apps ' +
+    'have actually done on your account.';
+
+  test('the panel states plainly that withdrawing a permission is not possible', async () => {
+    // `Tabs.Panel` is `keepMounted` by default, so the permissions panel's copy is in the
+    // DOM without a click — the same property the marketplace-anchor count above relies on.
+    mocks.flags = { appBlocks: true, appBlocksPages: true, appListings: true };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByText(PERMISSIONS_TAB_COPY)).toBeInTheDocument();
+  });
+
+  test('🔴 …and the retracted sentence is nowhere on the page', async () => {
+    // A second, cheaper tripwire aimed at a LITERAL revert (a `git revert`, a bad merge
+    // resolution) rather than at a reword — the pin above is what covers rewording. Kept
+    // because the two fail with very different messages, and this one names the defect.
+    mocks.flags = { appBlocks: true, appBlocksPages: true, appListings: true };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByText(PERMISSIONS_TAB_COPY)).toBeInTheDocument();
+    expect(
+      document.body.textContent ?? '',
+      'the copy instructs an uninstall as a way to revoke access, which it is not'
+    ).not.toContain('to revoke access, remove the install');
+  });
+
+  test('🔴 POSITIVE CONTROL: the body text really is readable from here', async () => {
+    // Without this, the `not.toContain` above passes for a page that rendered nothing at
+    // all — the reassuring-zero shape. Assert a string the page MUST carry, taken from a
+    // different panel so it cannot be satisfied by the copy under test.
+    mocks.flags = { appBlocks: true, appBlocksPages: true, appListings: true };
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByText(PERMISSIONS_TAB_COPY)).toBeInTheDocument();
+    expect(document.body.textContent ?? '').toContain('Recent actions apps have taken');
   });
 });

--- a/src/components/Apps/appsActivityTabs.ts
+++ b/src/components/Apps/appsActivityTabs.ts
@@ -49,10 +49,10 @@ export function isActivityTab(value: unknown): value is ActivityTab {
  *   · `permissions` reads `blocks.listMyScopeGrants` and NOTHING else — one `useQuery`
  *     with no `enabled:`. That procedure runs `enforceAppBlocksFlag`, which evaluates the
  *     `app-blocks-enabled` Flipt key (exactly `features.appBlocks`) and short-circuits to
- *     `[]` for anyone without it. So the panel rendered "No apps installed or subscribed
- *     yet." for every slotless viewer, ALWAYS — there was no cohort for whom the ungated
- *     tab showed anything. Gating it loses nothing that was ever displayed, and it closes
- *     the #3899 / #4668 class: a tab offered whose own gate refuses its content.
+ *     `[]` for anyone without it. So the panel rendered its installs empty state for every
+ *     slotless viewer, ALWAYS — there was no cohort for whom the ungated tab showed
+ *     anything. Gating it loses nothing that was ever displayed, and it closes the
+ *     #3899 / #4668 class: a tab offered whose own gate refuses its content.
  *
  * 🔴 `permissions` USED TO BE EXCLUDED ON THE PREMISE THAT A PAGE-FLAG-ONLY VIEWER HAS
  * GRANTS TO READ. That premise is false at the data layer (above), and it was ALREADY

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -338,7 +338,10 @@ function EmptyState({ label }: { label: string }) {
     <Center py="md">
       <Stack align="center" gap="xs">
         <IconPlugConnected size={28} opacity={0.5} />
-        <Text size="sm" c="dimmed">
+        {/* `ta`/`maw` so a two-sentence label wraps as a centred block rather than one
+            page-wide line — the labels here now name what the tab covers, not just what
+            is absent. Mirrors `HiddenBlocksPanel`'s own empty state. */}
+        <Text size="sm" c="dimmed" ta="center" maw={460}>
           {label}
         </Text>
         {canSeeStore && (
@@ -543,7 +546,14 @@ function ScopeGrantsPanel() {
     );
   }
   if (!grants || grants.length === 0) {
-    return <EmptyState label="No apps installed or subscribed yet." />;
+    /* 🔴 NOT "no app has any access to your account" — that is the claim this string used
+       to make, and it was false. `listMyScopeGrants` reads `block_user_subscriptions`
+       ONLY, so an empty result means "no install or subscription of your own", which is
+       silent about full-page apps and about blocks other people installed. Naming the
+       tab's actual population and pointing at the feed is what keeps the sentence true. */
+    return (
+      <EmptyState label="No apps installed or subscribed yet. This tab covers your own installs — Recent activity is the full record of what apps have done on your account." />
+    );
   }
   return (
     <AppsCardGrid testId="apps-installed-grants-grid">
@@ -737,7 +747,7 @@ export default function AppActivityPage() {
       <Meta title="App activity — Civitai" deIndex />
       <AppsPageLayout
         title="Your app activity"
-        subtitle="What Civitai Apps have done on your behalf, what they can access, and where they show up."
+        subtitle="What Civitai Apps have done on your account, what the apps you've installed declare they can access, and where they show up."
       >
         {/* 🔴 CONTROLLED, NOT `defaultValue` — that is what puts the selection in the
             URL. `replace` + `shallow`: no re-run of `getServerSideProps`, and no history
@@ -808,16 +818,33 @@ export default function AppActivityPage() {
 
           {/* 🔴 GATED, AND ITS OWN DATA SOURCE IS WHY. `ScopeGrantsPanel`'s only read is
               `blocks.listMyScopeGrants`, whose `enforceAppBlocksFlag` middleware returns
-              `[]` for a viewer without the `appBlocks` slot flag — so ungated this showed
-              the "No apps installed or subscribed yet." empty state to every such viewer,
-              always. Gating it displays nothing that was ever displayed. */}
+              `[]` for a viewer without the slot flag — so ungated this showed the installs
+              empty state to every such viewer, always. Gating it displays nothing that was
+              ever displayed.
+
+              🔴 THE COPY BELOW USED TO INSTRUCT AN ACTION THAT DOES NOT DO WHAT THE SENTENCE
+              SAID: "to revoke access, remove the install or subscription on the Installs
+              tab". Neither uninstall path touches the consent row.
+              `BlockRegistry.deleteSubscription` deletes the `block_user_subscriptions` row
+              and nothing else; `uninstallFromModel` additionally revokes the block INSTANCE
+              token, which kills tokens already minted but leaves the grant standing. The
+              grant lives in `app_user_scope_grants`, and the only writes to it anywhere in
+              the repo are in `~/server/services/blocks/scope-grant.service.ts`, both of
+              which set `revokedAt: null` — nothing writes a non-null `revoked_at` and
+              nothing deletes a row. So `getGrantedScopes` keeps returning the same scopes
+              afterwards and the next mint carries them with no fresh prompt. Withdrawing
+              consent is genuinely not implemented; the copy says so rather than pointing at
+              a control that does not do it. Do not soften this back into an instruction
+              until a real revoke path exists. */}
           {isActivityTabVisible('permissions', visibility) && (
             <Tabs.Panel value="permissions" pt="md">
               <Stack gap="sm">
                 <Text size="sm" c="dimmed">
-                  What each app you've installed can request, and where you have it. This is a
-                  reflection of the current state — to revoke access, remove the install or
-                  subscription on the Installs tab.
+                  The apps you've installed or subscribed to, the permissions each one declares it
+                  may use, and where you have it. Removing an install on the Installs tab takes the
+                  app off that surface, but it does not withdraw a permission you have already
+                  granted — withdrawing one is not possible yet. Recent activity is the full record
+                  of what apps have actually done on your account.
                 </Text>
                 <ScopeGrantsPanel />
               </Stack>


### PR DESCRIPTION
Copy-correction half of clawgate #532. **Copy only** — no query widened, no revoke path added, no service or schema touched. The query-widening half stays blocked on the grant-revocation gap this PR documents (clawgate #188).

## The defect

The "Apps & permissions" tab told users how to revoke access, and the instruction does not work:

> This is a reflection of the current state — to revoke access, remove the install or subscription on the Installs tab.

Verified from source, not reported:

- `BlockRegistry.deleteSubscription` (`src/server/services/block-registry.service.ts:2962`) deletes the `block_user_subscriptions` row and nothing else.
- `BlockRegistry.uninstallFromModel` (`:2327`) additionally calls `BlockRevocation.revokeInstance`, which invalidates tokens **already minted** but leaves the consent row standing.
- The grant lives in `app_user_scope_grants`. The only writes to that table anywhere in the repo are the two in `src/server/services/blocks/scope-grant.service.ts` (`:79`, `:107`), **both of which set `revokedAt: null`**. Nothing writes a non-null `revoked_at`; nothing deletes a row.

So `getGrantedScopes` keeps returning the same scopes after an uninstall, and the next mint carries them with no fresh prompt. The page instructed an action that does not do what the sentence says — for installed apps, not just an edge cohort.

## The wider overstatement

`listMyScopeGrants` (`src/server/services/blocks/user-app-surface.service.ts:70`) reads `block_user_subscriptions` for the current user and nothing else, and its `scopes` field is the app's **manifest-declared** scopes. So every string below described the viewer's own installs while reading as a claim about account-wide access.

| File:line | Before | After |
|---|---|---|
| `src/pages/apps/activity.tsx:573` (subtitle) | "…what they can access…" | "…what the apps you've installed declare they can access…" |
| `src/pages/apps/activity.tsx:666` (tab copy) | "…to revoke access, remove the install or subscription on the Installs tab." | Narrowed to installs; states plainly that withdrawing a permission is not possible yet; points at Recent activity as the full record. |
| `src/pages/apps/activity.tsx:392` (empty state) | "No apps installed or subscribed yet." | Names the tab's population and points at Recent activity. |
| `src/components/AppBlocks/AppPermissionsActivityDrawer.tsx:116` (empty label) | "You haven't granted this app any permissions yet." | "No permissions recorded from an install of this app — which is not the same as no access. Anything it has actually done on your account is listed under Recent activity below." |
| `src/components/AppBlocks/AppPermissionsActivityDrawer.tsx:90` (heading) | "Granted permissions" | "Permissions from your installs" |
| `src/components/AppBlocks/AppPermissionsActivityDrawer.tsx:82` (intro) | "What *App* can do on your behalf…" | "The permissions *App* carries through your own installs…" |

The drawer label was the worst of them. For a full-page app with no install, `grants.find(g => g.appBlockId === appBlockId)` is **always** `undefined`, so it claimed the viewer had granted the app nothing **while `AppActivityPanel` directly beneath it listed the scope-gated calls that same app had just made** — possibly minutes after the user accepted its consent modal. Two halves of one drawer contradicting each other.

## Sweep

`grep -rn "revoke access\|installed or subscribed\|granted this app any permissions" src/` (run with GNU grep over an explicit `find`, since the shell's `grep -r` is gitignore-blind). Every remaining hit is accounted for:

- `src/components/Account/ConnectedAppsCard.tsx:74` — the **OAuth connected-apps** feature, a different mechanism with a real `oauthConsent` revoke mutation that deletes tokens. Correct as written; left alone.
- `src/static-content/creator-program-v2-tos.md:17` — unrelated.
- Remaining hits in `activity.tsx` and `AppActivityPage.browser.test.tsx` are the deliberate documentation of the retracted claim.

Comments in `appsActivityTabs.ts:52` and `AppActivityPage.browser.test.tsx` that quoted the old empty-state string verbatim were updated too, so no retracted wording survives in an un-swept place.

A wider pass over `src/components/Apps`, `src/components/AppBlocks` and `src/pages/apps` for `revoke|revocation|withdraw` and for uninstall-implies-access-removal phrasing found nothing else user-facing.

## Guards

Three new cases in `AppActivityPage.browser.test.tsx` pin the permissions copy as the **whole normalised string**. The artifact under test is prose, so a keyword guard is walkable by rewording — and the honest copy contains the word "revoke" too, so a `/revoke/`-shaped matcher would pass over the defect. A cosmetic reword now fails the test; that is the price of a machine-readable claim. Alongside it: a literal-revert tripwire (`not.toContain('to revoke access, remove the install')`) and a positive control that `document.body.textContent` is readable at all, so the `not.toContain` cannot pass over a page that rendered nothing.

**Red/green matrix**, measured by restoring only `activity.tsx` and `AppPermissionsActivityDrawer.tsx` to `origin/main` with the new tests in place:

- base: `4 failed | 24 passed (28)` — exactly the four cases pinning the new copy
- HEAD: `28 passed (28)`

## Verification (base `af73e14b56`, both figures derived this session)

| Check | Base | HEAD |
|---|---|---|
| `node scripts/typecheck.mjs` | 13 errors | 13 errors — diff of the error lines **IDENTICAL** |
| `… -p tsconfig.tests.json` | 1205 errors | 1205 errors — no changed file named |
| `npx eslint` (5 files) | 8 problems | 8 problems — zero delta |
| `npx prettier --check` | — | all matched files clean |
| browser `component` tier, 9 related specs | — | **129 passed** |
| unit tier: `appsStoreAccessCallSites` + `appsActivityTabs` + `appsWideLayout` | — | **75 passed** |

The 13 and 1205 are pre-existing and structural (unbuilt workspace packages in a worktree); both are non-zero, which is the positive control that the runs actually checked something rather than OOM-ing at `rc=134` with `0 errors`.

ESLint delta is zero including the 5 pre-existing `react/no-unescaped-entities` in `activity.tsx` — held at exactly 5 by keeping a raw apostrophe in the rewritten sentence rather than folding a lint fix into a copy PR.

`appsStoreAccessCallSites.test.ts` requires every `features.appBlocks` in `activity.tsx` to survive `maskNonCode`; the new comments say "the slot flag" and never spell the flag literally, and that guard is green.

## Not done here

- No revoke path. Withdrawing consent is genuinely unimplemented, and the copy now says so instead of implying otherwise.
- `listMyScopeGrants` is untouched. The under-reported cohort — viewers who hold the slot flag but used full-page apps, or blocks *other people* installed, where the subscription row's `user_id` is the publisher while the activity feeds key on the actor — is still under-reported. This PR does not write copy presuming that widening has happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ybx7CGR6KbH9ZR192KnmKm
