### PR TITLE
feat(apps): per-user sub-quota and revocation checks on per-user App Storage

### DIFF
--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -544,6 +544,29 @@ export const appStorageQuotaExceededCounter = registerCounterWithLabels({
   labelNames: ['app_block_id', 'ceiling'] as const,
 });
 
+// App Blocks KV writes served against a schema that has no `user_quota` relation
+// yet, i.e. writes on which the per-USER sub-budget was NOT enforced.
+//
+// `user_quota` is created by AppStorageProvisioner.provision, whose only callers
+// are new-version approval and a manual admin backfill endpoint — nothing
+// schedules either, so an app provisioned before the table existed keeps serving
+// writes with the sub-budget inert, indefinitely and by default. The set path
+// falls back rather than failing closed (refusing writes for want of a counter
+// that does not exist turns a missing upgrade into an outage), which means the
+// inert state is silent by construction unless something counts it.
+//
+// 🔴 It is deliberately its OWN series and not an `outcome` on
+// app_blocks_storage_ops_total. A state visible only as some other series
+// changing shape is not alertable — the same argument countStorageFault makes
+// about faults being visible solely as the `ok` series falling to zero. This is
+// the series to alert on ("some app has been running unmetered for N days") and
+// the series that goes to zero when the backfill has actually reached everything.
+export const appStorageUserQuotaUntrackedCounter = registerCounterWithLabels({
+  name: 'app_blocks_storage_user_quota_untracked_total',
+  help: 'App Blocks KV writes served without a per-user quota relation (sub-budget not enforced; app needs the storage backfill)',
+  labelNames: ['app_block_id'] as const,
+});
+
 export const appStorageLatencyHistogram = registerHistogram({
   name: 'app_blocks_storage_latency_seconds',
   help: 'App Blocks KV procedure latency',

--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -521,10 +521,27 @@ export const appStorageOpsCounter = registerCounterWithLabels({
   labelNames: ['op', 'outcome'] as const,
 });
 
+// App Blocks KV writes refused by a storage ceiling. `ceiling` says WHICH one,
+// because the two want opposite responses and used to be indistinguishable here:
+// `ceiling="app"` is the 50MB / 1M-row per-APP budget — rare, shared by every
+// user of the app, and needs an operator; `ceiling="user"` is the per-USER
+// sub-budget beneath it — routine, self-inflicted, self-recoverable, and not an
+// ops signal. Alert on the first; the second belongs on a dashboard. A query that
+// sums without the label keeps its previous meaning (both ceilings combined).
+//
+// 🔴 NOT named `scope`. In this codebase `scope: '<literal>'` inside a router file
+// means an App Blocks PERMISSION scope (`apps:storage:write`, …), and
+// `analytics-bucket-labels.drift.test.ts` greps exactly that spelling out of
+// apps.router.ts to gate the analytics Scopes card. A Prometheus label keyed
+// `scope` there is picked up as a permission scope and pollutes that guard —
+// measured, it added "app" and "user" to its expected set. `quota_scope` would
+// not have helped either: the guard's regex has no word boundary, so it matches
+// the `scope: '…'` tail inside it. `ceiling` is both collision-free and the more
+// accurate word for what the label distinguishes.
 export const appStorageQuotaExceededCounter = registerCounterWithLabels({
   name: 'app_blocks_storage_quota_exceeded_total',
-  help: 'App Blocks KV writes rejected because the app quota would be exceeded',
-  labelNames: ['app_block_id'] as const,
+  help: 'App Blocks KV writes rejected by a storage ceiling (ceiling=app: the per-app budget; ceiling=user: the per-user sub-budget)',
+  labelNames: ['app_block_id', 'ceiling'] as const,
 });
 
 export const appStorageLatencyHistogram = registerHistogram({

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -236,6 +236,7 @@ vi.mock('~/server/prom/client', () => ({
   // .inc()/.labels()/.observe()/.startTimer() surface these tests exercise.
   appStorageOpsCounter: promMetricStub(),
   appStorageQuotaExceededCounter: promMetricStub(),
+  appStorageUserQuotaUntrackedCounter: promMetricStub(),
   appStorageLatencyHistogram: promMetricStub(),
   // sysRedis sentinel observability counters (PR #2331 round-3).
   sysredisSentinelTopologyChangesCounter: promMetricStub(),

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -586,13 +586,19 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
       signAppBlockId: block.id,
       // Synthetic, revocable PAGE instance id — same shape as the prod page mint.
       // NOTE (revocation-wiring caveat): dev page tokens share the
-      // `page_<appBlockId>` instanceId shape with PRODUCTION page mints. The
-      // revocation WRITE path (block-revocation.service.ts revokeInstance /
-      // clearInstance) is currently UNWIRED (no callers). If it is ever wired,
-      // dev instance ids on THIS path must be namespaced distinctly (e.g.
-      // `devpage_`) and/or the revocation marker TTL must cover the 4h dev token
-      // lifetime — otherwise a dev revocation (or a 4h marker) would bleed into
-      // production page tokens for the SAME app (collision on `page_<appBlockId>`).
+      // `page_<appBlockId>` instanceId shape with PRODUCTION page mints, so a dev
+      // revocation would bleed into production page tokens for the SAME app.
+      //
+      // The revocation WRITE path (block-revocation.service.ts `revokeInstance` /
+      // `clearInstance`) IS wired — uninstall and `toggleEnabled` in
+      // block-registry.service call it. The collision is nonetheless LATENT, for
+      // a different reason than "no callers": both wired call sites revoke
+      // `blockUserSubscription.blockInstanceId`, a per-install subscription id,
+      // so nothing today hands a `page_` id to `revokeInstance`. What makes it
+      // reachable is a future caller that revokes by PAGE instance id, or raising
+      // REVOCATION_TTL_SECONDS (900) to cover the 4h dev-token lifetime. Either
+      // one needs dev instance ids on THIS path namespaced distinctly first
+      // (e.g. `devpage_`).
       blockInstanceId: `${PAGE_INSTANCE_PREFIX}${block.id}`,
       // DEV budget default = the APPROVED manifest's declared per-gen budget so
       // an app whose `page.buzzBudgetPerGen` exceeds the flat 50 default is

--- a/src/server/routers/__tests__/apps.router.storage.stored-units.behavior.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.stored-units.behavior.test.ts
@@ -204,10 +204,10 @@ async function scalar(sql: string, params: unknown[] = []): Promise<number> {
 
 /** The trigger-maintained per-user counter. */
 const userUsedBytes = () =>
-  scalar(
-    `SELECT used_bytes FROM ${SCHEMA}.user_quota WHERE app_block_id = $1 AND user_id = $2`,
-    [APP_BLOCK_ID, USER_ID]
-  );
+  scalar(`SELECT used_bytes FROM ${SCHEMA}.user_quota WHERE app_block_id = $1 AND user_id = $2`, [
+    APP_BLOCK_ID,
+    USER_ID,
+  ]);
 
 /** The same quantity recomputed from the rows — a different mechanism. */
 const recomputedBytes = () =>
@@ -392,9 +392,9 @@ describe('storage.set quota arithmetic vs the bytes Postgres stores', () => {
     expect(refused).toBeGreaterThan(0);
     // The row population never moved: these were all updates, so no row gate
     // could have been what stopped the walk.
-    await expect(scalar(`SELECT count(*) FROM ${SCHEMA}.kv WHERE user_id = $1`, [USER_ID])).resolves.toBe(
-      KEYS
-    );
+    await expect(
+      scalar(`SELECT count(*) FROM ${SCHEMA}.kv WHERE user_id = $1`, [USER_ID])
+    ).resolves.toBe(KEYS);
   });
 
   /**

--- a/src/server/routers/__tests__/apps.router.storage.stored-units.behavior.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.stored-units.behavior.test.ts
@@ -1,5 +1,7 @@
 import { PGlite } from '@electric-sql/pglite';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
 
 // Booting PGlite (WASM Postgres) and driving a few hundred writes through it can
 // exceed the default 10s hook/test timeouts on a contended runner. Relaxing them
@@ -81,21 +83,23 @@ const fakePool = {
   query: (sql: string, params?: unknown[]) => runSql(sql, params),
 };
 
-const { mockVerifyBlockToken, mockDbRead, mockIsRevoked, mockLogToAxiom } = vi.hoisted(() => ({
+const { mockVerifyBlockToken, mockIsRevoked } = vi.hoisted(() => ({
   mockVerifyBlockToken: vi.fn(),
-  mockDbRead: {
-    appBlock: { findUnique: vi.fn() },
-    appBlockPublishRequest: { findUnique: vi.fn() },
-  },
   mockIsRevoked: vi.fn(async () => false),
-  // Spied, not silenced: the `set` log's `storedBytes` is the only place the
-  // router's OWN predicted stored size is observable from outside. Without it a
-  // test can only read `kv.size_bytes` and the trigger-maintained counter, both
-  // of which are computed by Postgres and are therefore identical whether the
-  // router predicted correctly or not — measured, a mutant that dropped the
-  // `::jsonb` cast from the probe survived every assertion built on those two.
-  mockLogToAxiom: vi.fn(async () => undefined),
 }));
+
+// `~/server/db/client` and `~/server/logging/client` are mocked ONCE, globally, in
+// src/__tests__/setup.ts — a per-file `vi.mock` of either is a `no-direct-shared-module-mock`
+// violation (under `isolate: false` it freezes this file's mock shape into every later file
+// in the same worker). Declare behaviour on the canonical objects instead. The sibling
+// fixture suite predates that rule and is grandfathered on the allowlist; a new file is not.
+//
+// `loggingMock.logToAxiom` is SPIED here, not merely silenced: the `set` log's `storedBytes`
+// is the only place the router's OWN predicted stored size is observable from outside. Without
+// it a test can only read `kv.size_bytes` and the trigger-maintained counter, both of which are
+// computed by Postgres and are therefore identical whether the router predicted correctly or
+// not — measured, a mutant that dropped the `::jsonb` cast from the probe survived every
+// assertion built on those two.
 
 // Everything that is NOT the storage arithmetic or the database is stubbed. In
 // particular `~/server/services/apps/storage-provision.service` is deliberately
@@ -107,7 +111,6 @@ vi.mock('~/server/middleware/block-scope.middleware', () => ({
   verifyBlockToken: mockVerifyBlockToken,
   parseSubjectUserId: (sub: string) => (sub === 'anon' ? null : Number(String(sub).split(':')[1])),
 }));
-vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: async () => true,
   isAppBlocksAuthorEnabled: async () => true,
@@ -123,9 +126,6 @@ vi.mock('~/server/services/block-revocation.service', () => ({
 }));
 vi.mock('~/server/services/blocks/user-app-surface.service', () => ({
   recordScopeInvocation: async () => undefined,
-}));
-vi.mock('~/server/logging/client', () => ({
-  logToAxiom: (...args: unknown[]) => mockLogToAxiom(...(args as [])),
 }));
 
 const { appsRouter } = await import('../apps.router');
@@ -231,13 +231,16 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   mockVerifyBlockToken.mockReset();
-  mockLogToAxiom.mockClear();
+  loggingMock.logToAxiom.mockClear();
   mockIsRevoked.mockReset();
   mockIsRevoked.mockResolvedValue(false);
-  mockDbRead.appBlock.findUnique.mockReset();
-  mockDbRead.appBlock.findUnique.mockResolvedValue({ id: APP_BLOCK_ID, status: 'approved' });
-  mockDbRead.appBlockPublishRequest.findUnique.mockReset();
-  mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({ status: 'pending' });
+  // The approved-app lookup is on the REPLICA (dbRead); the run-for-real pubreq
+  // status is read from the PRIMARY (dbWrite). The canonical mock keeps the two
+  // DISTINCT, so naming the wrong one silently leaves the router seeing a null.
+  dbMock.dbRead.appBlock.findUnique.mockReset();
+  dbMock.dbRead.appBlock.findUnique.mockResolvedValue({ id: APP_BLOCK_ID, status: 'approved' });
+  dbMock.dbWrite.appBlockPublishRequest.findUnique.mockReset();
+  dbMock.dbWrite.appBlockPublishRequest.findUnique.mockResolvedValue({ status: 'pending' });
 
   // Real DDL, real generated column, real trigger. Idempotent, so re-provisioning
   // per test is safe; the tables are truncated so each test starts from zero.
@@ -310,7 +313,7 @@ describe('storage.set quota arithmetic vs the bytes Postgres stores', () => {
     expect(stored).not.toBe(wire);
 
     // The router's OWN predicted size, against what Postgres actually stored.
-    const setLog = mockLogToAxiom.mock.calls
+    const setLog = loggingMock.logToAxiom.mock.calls
       .map(([payload]) => payload as { event?: string; storedBytes?: number; sizeBytes?: number })
       .find((payload) => payload?.event === 'set');
     expect(setLog).toBeDefined();

--- a/src/server/routers/__tests__/apps.router.storage.stored-units.behavior.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.stored-units.behavior.test.ts
@@ -1,0 +1,456 @@
+import { PGlite } from '@electric-sql/pglite';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Booting PGlite (WASM Postgres) and driving a few hundred writes through it can
+// exceed the default 10s hook/test timeouts on a contended runner. Relaxing them
+// can only help a slow box, never mask a failure.
+vi.setConfig({ hookTimeout: 120_000, testTimeout: 120_000 });
+
+/**
+ * THE SEAM BETWEEN THE ROUTER'S QUOTA ARITHMETIC AND THE BYTES POSTGRES ACTUALLY
+ * STORES.
+ *
+ * 🔴 WHY THIS FILE EXISTS AS A THIRD SUITE. The two existing suites are split
+ * exactly at the defect, and each is individually green and individually blind:
+ *
+ *   - `apps.router.storage.test.ts` drives the real `set` gate, but its pool is a
+ *     mock and it SUPPLIES `size_bytes` from fixtures (61_440, 1_002, 5_000).
+ *     Every fixture value it supplies happens to be in the same unit as
+ *     `Buffer.byteLength(JSON.stringify(v))`, so the gate is never handed a real
+ *     jsonb size and the unit mismatch is unreachable from there.
+ *   - `storage-provision.trigger.behavior.test.ts` runs the provisioner's own DDL
+ *     on real Postgres and meets real `size_bytes`, but it writes rows with raw
+ *     SQL and never executes the router's gate.
+ *
+ * Neither ever builds the combined state, so the class was invisible to both.
+ * This suite builds it: the provisioner's own unmodified DDL, generated column
+ * and trigger on an in-process Postgres, with the REAL `apps.storage.set`
+ * procedure driving it through a PGlite-backed pool.
+ *
+ * WHAT THE GUARD PINS. Not one side of the comparison — the RELATIONSHIP between
+ * the two units:
+ *
+ *   1. the size the router predicts for a write equals the `size_bytes` Postgres
+ *      actually stores for that row, on values where the wire size DIFFERS (the
+ *      positive control: a scalar-only fixture cannot see this class at all,
+ *      because `null` and `"hello"` are byte-identical in both units);
+ *   2. an unbounded sequence of writes that each hold `netDelta <= 0` in the WIRE
+ *      unit cannot push a stored-byte counter past its ceiling.
+ *
+ * (2) is the deploy-blocking regression this file was written for. With the gate
+ * computing `Buffer.byteLength(JSON.stringify(value)) - kv.size_bytes`, a client
+ * that writes, on every pass, the largest value whose WIRE size is <= the row's
+ * current STORED size holds the computed delta at or below zero forever while the
+ * stored bytes grow ~1.5x per pass. The non-increasing exemption then skipped BOTH
+ * byte ceilings on every one of those writes and neither ever bound.
+ *
+ * THE ORACLE IS NOT THE ROUTER. Every expectation is either a literal, or
+ * Postgres' own `sum(size_bytes)` recompute over `kv` — a different mechanism
+ * (recompute) from the one under test (incremental maintenance through a gate).
+ */
+
+const holder = {
+  db: null as unknown as PGlite,
+};
+
+/**
+ * Route one statement at the in-process database.
+ *
+ * Parameterized statements go through the extended protocol (`query`); everything
+ * else through the simple protocol (`exec`), which is what parses dollar-quoted
+ * function bodies, `DO $do$ … $do$` blocks and `SET LOCAL` server-side.
+ */
+async function runSql(sql: string, params?: unknown[]) {
+  if (params && params.length > 0) {
+    return await holder.db.query(sql, params as unknown[]);
+  }
+  const results = await holder.db.exec(sql);
+  return results[results.length - 1] ?? { rows: [] };
+}
+
+// PGlite is a single session, so one shared connection stands in for the pool.
+// `release` is a no-op for the same reason. Session state (an open transaction, a
+// `SET LOCAL`) therefore persists across calls exactly as it does on one real
+// pooled connection — the property the quota trigger depends on.
+const fakeClient = {
+  query: (sql: string, params?: unknown[]) => runSql(sql, params),
+  release: () => undefined,
+};
+const fakePool = {
+  connect: async () => fakeClient,
+  query: (sql: string, params?: unknown[]) => runSql(sql, params),
+};
+
+const { mockVerifyBlockToken, mockDbRead, mockIsRevoked, mockLogToAxiom } = vi.hoisted(() => ({
+  mockVerifyBlockToken: vi.fn(),
+  mockDbRead: {
+    appBlock: { findUnique: vi.fn() },
+    appBlockPublishRequest: { findUnique: vi.fn() },
+  },
+  mockIsRevoked: vi.fn(async () => false),
+  // Spied, not silenced: the `set` log's `storedBytes` is the only place the
+  // router's OWN predicted stored size is observable from outside. Without it a
+  // test can only read `kv.size_bytes` and the trigger-maintained counter, both
+  // of which are computed by Postgres and are therefore identical whether the
+  // router predicted correctly or not — measured, a mutant that dropped the
+  // `::jsonb` cast from the probe survived every assertion built on those two.
+  mockLogToAxiom: vi.fn(async () => undefined),
+}));
+
+// Everything that is NOT the storage arithmetic or the database is stubbed. In
+// particular `~/server/services/apps/storage-provision.service` is deliberately
+// NOT mocked — this suite runs the provisioner for real, which is the whole
+// point: the DDL, the generated column and the trigger under test are the
+// shipped ones, not a transcription.
+vi.mock('~/server/db/appsDb', () => ({ requireAppsDb: () => fakePool }));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (sub: string) => (sub === 'anon' ? null : Number(String(sub).split(':')[1])),
+}));
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: async () => true,
+  isAppBlocksAuthorEnabled: async () => true,
+}));
+vi.mock('~/server/auth/session-client', () => ({
+  sessionClient: { getSessionUserById: async (id: number) => ({ id, isModerator: true }) },
+}));
+vi.mock('~/server/services/user.service', () => ({
+  getUserById: async (id: number) => ({ id, isModerator: true }),
+}));
+vi.mock('~/server/services/block-revocation.service', () => ({
+  BlockRevocation: { isRevoked: (...args: unknown[]) => mockIsRevoked(...args) },
+}));
+vi.mock('~/server/services/blocks/user-app-surface.service', () => ({
+  recordScopeInvocation: async () => undefined,
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: unknown[]) => mockLogToAxiom(...(args as [])),
+}));
+
+const { appsRouter } = await import('../apps.router');
+const { AppStorageProvisioner } = await import('~/server/services/apps/storage-provision.service');
+const { TokenScope } = await import('~/shared/constants/token-scope.constants');
+
+// `sanitizeAppSlug` folds the token's blockId to `[a-z0-9_]`, so this blockId
+// resolves to schema "app_stored_unit_probe".
+const BLOCK_ID = 'stored-unit-probe';
+const SCHEMA = '"app_stored_unit_probe"';
+const APP_BLOCK_ID = 'apb_stored_unit_probe';
+const INSTANCE = 'mbi_stored_unit_probe';
+const USER_ID = 4242;
+
+// Mirrors of the router's private constants. Deliberately re-declared as literals
+// rather than imported: a test that imports the constant it asserts against
+// cannot see the constant moving, and these are the ceilings the walk below has
+// to actually cross.
+const USER_QUOTA_BYTES = 2 * 1024 * 1024;
+const PER_VALUE_BYTE_CAP = 64 * 1024;
+
+function claims() {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: `user:${USER_ID}`,
+    iat: 0,
+    exp: 0,
+    jti: 'jti_stored_unit_probe',
+    blockId: BLOCK_ID,
+    appId: 'app_stored_unit_probe',
+    blockInstanceId: INSTANCE,
+    ctx: {},
+    scopes: ['apps:storage:read', 'apps:storage:write'],
+  };
+}
+
+function ctx() {
+  return {
+    acceptableOrigin: true,
+    user: { id: USER_ID, isModerator: true, tier: 'free' },
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+/** One `storage.set` through the real router against the real database. */
+async function set(key: string, value: unknown) {
+  mockVerifyBlockToken.mockResolvedValueOnce(claims());
+  const caller = appsRouter.createCaller(ctx() as never);
+  return await caller.storage.set({ blockToken: 't', key, value });
+}
+
+/** `true` if the write was accepted, `false` if a ceiling refused it. */
+async function trySet(key: string, value: unknown): Promise<boolean> {
+  try {
+    await set(key, value);
+    return true;
+  } catch (err) {
+    const message = (err as { message?: string }).message ?? '';
+    if (/quota exceeded|row limit exceeded/.test(message)) return false;
+    throw err;
+  }
+}
+
+async function scalar(sql: string, params: unknown[] = []): Promise<number> {
+  const res = params.length > 0 ? await holder.db.query(sql, params) : await holder.db.exec(sql);
+  const rows = Array.isArray(res) ? res[res.length - 1].rows : res.rows;
+  return Number(Object.values((rows as Record<string, unknown>[])[0])[0]);
+}
+
+/** The trigger-maintained per-user counter. */
+const userUsedBytes = () =>
+  scalar(
+    `SELECT used_bytes FROM ${SCHEMA}.user_quota WHERE app_block_id = $1 AND user_id = $2`,
+    [APP_BLOCK_ID, USER_ID]
+  );
+
+/** The same quantity recomputed from the rows — a different mechanism. */
+const recomputedBytes = () =>
+  scalar(`SELECT COALESCE(sum(size_bytes), 0) FROM ${SCHEMA}.kv WHERE user_id = $1`, [USER_ID]);
+
+const storedSizeOf = (key: string) =>
+  scalar(
+    `SELECT size_bytes FROM ${SCHEMA}.kv
+      WHERE block_instance_id = $1 AND user_id = $2 AND key = $3`,
+    [INSTANCE, USER_ID, key]
+  );
+
+/** An array of `n` ones. Wire size is `2n + 1`; Postgres stores `3n`. */
+const ones = (n: number) => Array.from({ length: n }, () => 1);
+const wireBytes = (v: unknown) => Buffer.byteLength(JSON.stringify(v ?? null), 'utf8');
+
+beforeAll(async () => {
+  holder.db = new PGlite();
+  await holder.db.waitReady;
+});
+
+beforeEach(async () => {
+  mockVerifyBlockToken.mockReset();
+  mockLogToAxiom.mockClear();
+  mockIsRevoked.mockReset();
+  mockIsRevoked.mockResolvedValue(false);
+  mockDbRead.appBlock.findUnique.mockReset();
+  mockDbRead.appBlock.findUnique.mockResolvedValue({ id: APP_BLOCK_ID, status: 'approved' });
+  mockDbRead.appBlockPublishRequest.findUnique.mockReset();
+  mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({ status: 'pending' });
+
+  // Real DDL, real generated column, real trigger. Idempotent, so re-provisioning
+  // per test is safe; the tables are truncated so each test starts from zero.
+  await AppStorageProvisioner.provision({ appBlockId: APP_BLOCK_ID, slug: 'stored_unit_probe' });
+  await holder.db.exec(`TRUNCATE ${SCHEMA}.kv, ${SCHEMA}.user_quota`);
+  await holder.db.exec(
+    `UPDATE ${SCHEMA}.quota SET used_bytes = 0, row_count = 0 WHERE app_block_id = '${APP_BLOCK_ID}'`
+  );
+});
+
+describe('storage.set quota arithmetic vs the bytes Postgres stores', () => {
+  /**
+   * The positive control for this whole file. If the two units agreed, the walk
+   * below would be vacuous — so establish, against the real database, that they
+   * disagree and by how much, before asserting anything about the gate.
+   *
+   * Values are chosen pairwise-distinct in BOTH units and none of them equals a
+   * ceiling or a fixture size used elsewhere, so no assertion here can be
+   * satisfied by the wrong quantity.
+   */
+  it('stores MORE bytes than JSON.stringify produces, for separator-dense values', async () => {
+    const cases: Array<{ value: unknown; wire: number; stored: number }> = [
+      { value: [1, 2, 3], wire: 7, stored: 9 },
+      { value: { a: 1, b: 2 }, wire: 13, stored: 16 },
+      { value: ones(5000), wire: 10_001, stored: 15_000 },
+    ];
+    for (const [i, c] of cases.entries()) {
+      expect(wireBytes(c.value)).toBe(c.wire);
+      await set(`control_${i}`, c.value);
+      // The literal is the oracle; Postgres is the thing being read.
+      await expect(storedSizeOf(`control_${i}`)).resolves.toBe(c.stored);
+      expect(c.stored).toBeGreaterThan(c.wire);
+    }
+    // …and the scalars where they agree, so "stored is always bigger" is not
+    // mistaken for the claim. `null` and a short string are byte-identical in
+    // both units, which is exactly why a scalar-only fixture is blind here.
+    await set('control_null', null);
+    await expect(storedSizeOf('control_null')).resolves.toBe(wireBytes(null));
+    await set('control_str', 'hello');
+    await expect(storedSizeOf('control_str')).resolves.toBe(wireBytes('hello'));
+  });
+
+  /**
+   * The identity the gate's arithmetic rests on: the size the router PREDICTS for
+   * a write equals the `size_bytes` Postgres ends up storing for it. Asserted on a
+   * value whose wire size differs, so a router charging wire bytes cannot pass.
+   *
+   * 🔴 READ THE ROUTER'S OWN NUMBER, not the database's. `kv.size_bytes` and the
+   * trigger-maintained counter are both computed by Postgres, so they are
+   * identical whether the router predicted correctly or not — measured, a mutant
+   * that dropped the `::jsonb` cast from the probe (making it measure the wire
+   * text) SURVIVED every assertion built on those two, and died only to the walk
+   * below. The router's prediction is observable exactly once, as `storedBytes` on
+   * the `set` log line, which is why that log is spied rather than silenced.
+   *
+   * `sizeBytes` on the reply is deliberately the WIRE size — the unit
+   * PER_VALUE_BYTE_CAP is enforced in and the unit a block can predict for itself.
+   */
+  it('predicts exactly what Postgres stores, and reports the wire size separately', async () => {
+    const value = ones(3000);
+    const wire = wireBytes(value);
+    expect(wire).toBe(6001);
+
+    const reply = await set('identity', value);
+    // The reply reports wire bytes — the per-value cap's unit.
+    expect(reply.sizeBytes).toBe(wire);
+
+    const stored = await storedSizeOf('identity');
+    expect(stored).toBe(9000);
+    expect(stored).not.toBe(wire);
+
+    // The router's OWN predicted size, against what Postgres actually stored.
+    const setLog = mockLogToAxiom.mock.calls
+      .map(([payload]) => payload as { event?: string; storedBytes?: number; sizeBytes?: number })
+      .find((payload) => payload?.event === 'set');
+    expect(setLog).toBeDefined();
+    expect(setLog?.storedBytes).toBe(stored);
+    expect(setLog?.sizeBytes).toBe(wire);
+
+    // …and the counter moved by the stored size, cross-checked by recompute.
+    await expect(userUsedBytes()).resolves.toBe(stored);
+    await expect(recomputedBytes()).resolves.toBe(stored);
+  });
+
+  /**
+   * 🔴 THE REGRESSION. Every write in this walk holds `netDelta <= 0` in the WIRE
+   * unit — each pass writes the largest all-ones array whose `JSON.stringify`
+   * length is at most the row's CURRENT stored size — while growing the stored
+   * bytes ~1.5x per pass. Under a wire-unit `netDelta` the non-increasing
+   * exemption fires on every one of them and both byte ceilings are skipped.
+   *
+   * The per-value cap still binds per value and the row count never moves (these
+   * are all updates), so no other gate can stop it: the per-user byte ceiling is
+   * the only thing standing between this loop and unbounded storage.
+   */
+  it('cannot be walked past the per-user byte ceiling by wire-non-increasing writes', async () => {
+    const KEYS = 30;
+    // Seeded so the whole population starts well inside the ceiling: 30 keys x
+    // 6,000 stored bytes = 180,000, under a tenth of the 2 MiB budget. Every seed
+    // is an INSERT and is correctly gated either way.
+    for (let k = 0; k < KEYS; k++) {
+      expect(await trySet(`walk_${k}`, ones(2000))).toBe(true);
+    }
+    const seeded = await userUsedBytes();
+    expect(seeded).toBe(KEYS * 6000);
+    expect(seeded).toBeLessThan(USER_QUOTA_BYTES);
+
+    let accepted = 0;
+    let refused = 0;
+    // 12 passes is comfortably more than the ~8 needed for every key to saturate
+    // at the per-value cap; the loop is bounded so a broken gate produces a
+    // failed assertion rather than a hang.
+    for (let pass = 0; pass < 12; pass++) {
+      for (let k = 0; k < KEYS; k++) {
+        const key = `walk_${k}`;
+        const stored = await storedSizeOf(key);
+        // The largest all-ones array whose WIRE size (2n + 1) is <= the row's
+        // current STORED size, clamped to the per-value cap. This is the entire
+        // attack: in the wire unit the delta is <= 0 every single time.
+        const n = Math.min(Math.floor((stored - 1) / 2), Math.floor((PER_VALUE_BYTE_CAP - 1) / 2));
+        const value = ones(n);
+        expect(wireBytes(value)).toBeLessThanOrEqual(stored);
+        expect(wireBytes(value)).toBeLessThanOrEqual(PER_VALUE_BYTE_CAP);
+        if (await trySet(key, value)) accepted++;
+        else refused++;
+      }
+    }
+
+    // Positive control: the walk did real work. A walk that refused everything
+    // would satisfy the ceiling assertion below for the wrong reason.
+    expect(accepted).toBeGreaterThan(0);
+
+    const used = await userUsedBytes();
+    // The counter agrees with an independent recompute over the rows, so this is
+    // stored data and not counter drift.
+    await expect(recomputedBytes()).resolves.toBe(used);
+    // 🔴 The claim, asserted before the remaining controls so a regression fails
+    // with the actual overrun in the message rather than with a control's `0 > 0`.
+    // Measured against the pre-fix router (wire-unit netDelta): this walk reached
+    // 2,949,030 stored bytes against the 2,097,152-byte ceiling with `refused`
+    // still 0. 2,949,030 is exactly 30 x 98,301, i.e. every key saturated at the
+    // per-value cap's stored size — the walk was stopped by the per-value cap and
+    // the loop bound, and by no ceiling at all. Scaling the key count scales the
+    // overrun linearly; USER_ROW_LIMIT (1,000) puts the reachable figure near
+    // 98 MiB for a single account, past APP_QUOTA_BYTES as well.
+    expect(used).toBeLessThanOrEqual(USER_QUOTA_BYTES);
+    // …and it genuinely pressed against the ceiling rather than stopping early
+    // for some unrelated reason.
+    expect(used).toBeGreaterThan(USER_QUOTA_BYTES / 2);
+    // The gate has to have actually said no. Without this the assertion above is
+    // also satisfied by a walk that simply never grew.
+    expect(refused).toBeGreaterThan(0);
+    // The row population never moved: these were all updates, so no row gate
+    // could have been what stopped the walk.
+    await expect(scalar(`SELECT count(*) FROM ${SCHEMA}.kv WHERE user_id = $1`, [USER_ID])).resolves.toBe(
+      KEYS
+    );
+  });
+
+  /**
+   * The exemption the walk must NOT be fixed by deleting. A user already over the
+   * ceiling has to be able to shrink out of it; `storage.delete` being the only
+   * exit is a trap the app has to expose an affordance for.
+   *
+   * Stated in STORED bytes against a real row, which the fixture-fed suite cannot
+   * do: the shrink here is a shrink in the unit the counter is in.
+   */
+  it('still lets an over-ceiling user shrink an existing value, measured in stored bytes', async () => {
+    await set('shrink', ones(3000)); // 9,000 stored
+    const before = await storedSizeOf('shrink');
+    expect(before).toBe(9000);
+
+    // Drive the counter above the ceiling directly, the way a lowered cap or a
+    // drifted counter would, without needing 2 MiB of rows.
+    await holder.db.query(
+      `UPDATE ${SCHEMA}.user_quota SET used_bytes = $3 WHERE app_block_id = $1 AND user_id = $2`,
+      [APP_BLOCK_ID, USER_ID, USER_QUOTA_BYTES + 512 * 1024]
+    );
+
+    // A genuine shrink in the stored unit: 3,000 stored against 9,000.
+    const smaller = ones(1000);
+    expect(await trySet('shrink', smaller)).toBe(true);
+    await expect(storedSizeOf('shrink')).resolves.toBe(3000);
+
+    // The other half of the same claim: from the same over-ceiling state a real
+    // GROWTH is still refused. Without this, deleting the gate outright also
+    // passes the assertion above.
+    await holder.db.query(
+      `UPDATE ${SCHEMA}.user_quota SET used_bytes = $3 WHERE app_block_id = $1 AND user_id = $2`,
+      [APP_BLOCK_ID, USER_ID, USER_QUOTA_BYTES + 512 * 1024]
+    );
+    expect(await trySet('shrink', ones(5000))).toBe(false);
+    // …and the refused write left the row untouched.
+    await expect(storedSizeOf('shrink')).resolves.toBe(3000);
+  });
+
+  /**
+   * The boundary. A same-STORED-size rewrite is `netDelta === 0` and must be
+   * allowed. Pinned separately so narrowing `<= 0` to `< 0` has its own killing
+   * test rather than dying to a neighbouring assertion — and pinned on a value
+   * whose wire and stored sizes differ, so it also fails if the boundary is
+   * evaluated in the wrong unit.
+   */
+  it('lets an over-ceiling user rewrite a value to the same STORED size', async () => {
+    await set('same', ones(2000));
+    await expect(storedSizeOf('same')).resolves.toBe(6000);
+    await holder.db.query(
+      `UPDATE ${SCHEMA}.user_quota SET used_bytes = $3 WHERE app_block_id = $1 AND user_id = $2`,
+      [APP_BLOCK_ID, USER_ID, USER_QUOTA_BYTES + 512 * 1024]
+    );
+    // 2,000 twos: same length in both units as 2,000 ones, so stored is 6,000.
+    const same = Array.from({ length: 2000 }, () => 2);
+    expect(await trySet('same', same)).toBe(true);
+    await expect(storedSizeOf('same')).resolves.toBe(6000);
+  });
+});

--- a/src/server/routers/__tests__/apps.router.storage.stored-units.behavior.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.stored-units.behavior.test.ts
@@ -384,8 +384,9 @@ describe('storage.set quota arithmetic vs the bytes Postgres stores', () => {
     // still 0. 2,949,030 is exactly 30 x 98,301, i.e. every key saturated at the
     // per-value cap's stored size — the walk was stopped by the per-value cap and
     // the loop bound, and by no ceiling at all. Scaling the key count scales the
-    // overrun linearly; USER_ROW_LIMIT (1,000) puts the reachable figure near
-    // 98 MiB for a single account, past APP_QUOTA_BYTES as well.
+    // overrun linearly; USER_ROW_LIMIT (1,000) puts the reachable figure at
+    // 1,000 x 98,301 = 98,301,000 bytes — 93.7 MiB — for a single account, past
+    // APP_QUOTA_BYTES as well.
     expect(used).toBeLessThanOrEqual(USER_QUOTA_BYTES);
     // …and it genuinely pressed against the ceiling rather than stopping early
     // for some unrelated reason.

--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -108,7 +108,11 @@ import { appsRouter } from '../apps.router';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 // Globally stubbed in src/__tests__/setup.ts (promMetricStub) — `.inc` is a
 // vi.fn(), so the refusal-instrumentation assertions below can read it.
-import { appStorageOpsCounter, appStorageQuotaExceededCounter } from '~/server/prom/client';
+import {
+  appStorageOpsCounter,
+  appStorageQuotaExceededCounter,
+  appStorageUserQuotaUntrackedCounter,
+} from '~/server/prom/client';
 
 function validClaims(over: Record<string, unknown> = {}) {
   return {
@@ -157,6 +161,65 @@ function fakeCtx(user: unknown = SESSION_USER) {
     features: {} as never,
     track: undefined,
   };
+}
+
+/**
+ * The `set` path's stored-size probe:
+ *   `SELECT octet_length($4::jsonb::text) AS new_size_bytes,
+ *           (SELECT size_bytes FROM …) AS old_size_bytes`
+ *
+ * 🔴 BOTH NUMBERS ARE STORED BYTES — `octet_length(value::text)` over JSONB — and
+ * that is NOT `Buffer.byteLength(JSON.stringify(value))`. Postgres' jsonb output
+ * function emits `, ` after every separator and `: ` after every object key, so
+ * for anything but a scalar the stored size is LARGER, by up to ~1.5x.
+ *
+ * That distinction is why this suite could not see the deploy-blocking defect it
+ * was supposed to cover. Every fixture here used to supply `size_bytes` as a bare
+ * number (61_440, 1_002, 5_000) that happened to be in the same unit as the wire
+ * size of the value the test wrote, so the gate was never handed a real jsonb
+ * size and a gate comparing the two units was indistinguishable from a correct
+ * one. The pool is a mock, so NOTHING in this file can check the relationship
+ * between the units — it is pinned against real Postgres in
+ * `apps.router.storage.stored-units.behavior.test.ts`.
+ *
+ * What this file can do, and now does, is refuse to let the two units coincide by
+ * accident: `oldStored` is always stated explicitly in the stored unit, and the
+ * default `stored` below is a value no test's wire size equals.
+ */
+function sizeProbe(opts: { stored?: number; oldStored?: number | null } = {}) {
+  return {
+    rows: [
+      {
+        new_size_bytes: opts.stored ?? DEFAULT_STORED_BYTES,
+        old_size_bytes: opts.oldStored ?? null,
+      },
+    ],
+    rowCount: 1,
+  };
+}
+
+/**
+ * Deliberately equal to no wire size any test in this file writes, so a gate that
+ * silently fell back to wire bytes cannot produce the same arithmetic. Small
+ * enough to sit far under both byte ceilings, so it never perturbs a test that is
+ * about something else.
+ */
+const DEFAULT_STORED_BYTES = 777;
+
+/** An array of `n` ones: wire size `2n + 1`, stored size `3n`. */
+const ones = (n: number) => Array.from({ length: n }, () => 1);
+
+/** True for the stored-size probe statement. */
+const isSizeProbe = (sql: unknown) => String(sql).includes('octet_length(');
+
+/**
+ * Default pool routing. `mockResolvedValueOnce` still takes precedence, so a test
+ * that queues an explicit chain is unaffected; this only supplies a well-formed
+ * probe answer to the tests that never cared about sizes.
+ */
+async function defaultPoolQuery(sql: string) {
+  if (isSizeProbe(sql)) return sizeProbe();
+  return { rows: [], rowCount: 0 };
 }
 
 beforeEach(() => {
@@ -217,7 +280,7 @@ beforeEach(() => {
   // guard tests override with a non-pending / missing status.
   mockDbRead.appBlockPublishRequest.findUnique.mockReset();
   mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({ status: 'pending' });
-  mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 });
+  mockPool.query.mockImplementation(defaultPoolQuery);
   mockClient.query.mockResolvedValue({ rows: [], rowCount: 0 });
   mockLogToAxiom.mockResolvedValue(undefined);
 });
@@ -346,8 +409,8 @@ describe('apps.storage shared gates', () => {
     mockPool.query
       // quota row
       .mockResolvedValueOnce({ rows: [{ used_bytes: '0', row_count: '0' }], rowCount: 1 })
-      // no existing row for this key
-      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      // size probe: no existing row for this key
+      .mockResolvedValueOnce(sizeProbe());
 
     const caller = appsRouter.createCaller(fakeCtx() as never);
     const out = await caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } });
@@ -641,8 +704,8 @@ describe('apps.storage.set', () => {
         rows: [{ used_bytes: String(50 * 1024 * 1024 - 100), row_count: '1' }],
         rowCount: 1,
       })
-      // no existing row for this key
-      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      // size probe: no existing row for this key
+      .mockResolvedValueOnce(sizeProbe());
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
       caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(500) })
@@ -658,8 +721,8 @@ describe('apps.storage.set', () => {
         rows: [{ used_bytes: '0', row_count: '0' }],
         rowCount: 1,
       })
-      // existing row
-      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      // size probe: no existing row
+      .mockResolvedValueOnce(sizeProbe());
 
     const caller = appsRouter.createCaller(fakeCtx() as never);
     const out = await caller.storage.set({
@@ -697,7 +760,7 @@ describe('apps.storage.set', () => {
       mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
       mockPool.query
         .mockResolvedValueOnce({ rows: [{ used_bytes: '0', row_count: '0' }], rowCount: 1 })
-        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+        .mockResolvedValueOnce(sizeProbe());
       const caller = appsRouter.createCaller(fakeCtx() as never);
       await caller.storage.set({ blockToken: 't', key, value: 'v' });
     }
@@ -735,7 +798,8 @@ describe('apps.storage.set', () => {
           rowCount: 1,
         };
       }
-      // The existing-row lookup: fresh key, so no row.
+      // The stored-size probe: fresh key, so no existing row.
+      if (isSizeProbe(sql)) return sizeProbe();
       return { rows: [], rowCount: 0 };
     };
   }
@@ -832,12 +896,14 @@ describe('apps.storage.set', () => {
           rowCount: 1,
         };
       }
-      return { rows: [{ size_bytes: 5000 }], rowCount: 1 };
+      // An existing row of 5,000 STORED bytes, shrinking to 3,000 — so the byte
+      // gate is exempt and only the row gate is under test here.
+      return sizeProbe({ stored: 3_000, oldStored: 5_000 });
     });
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
-      caller.storage.set({ blockToken: 't', key: 'k', value: 'short' })
+      caller.storage.set({ blockToken: 't', key: 'k', value: ones(1000) })
     ).resolves.toMatchObject({ ok: true });
   });
 
@@ -880,13 +946,16 @@ describe('apps.storage.set', () => {
           rowCount: 1,
         };
       }
-      // An existing, much larger row — so this write is a shrink.
-      return { rows: [{ size_bytes: 61_440 }], rowCount: 1 };
+      // An existing, much larger row — so this write is a shrink IN STORED BYTES,
+      // which is the unit the counter and the ceiling are both in. 500 ones
+      // occupy 1,500 stored bytes against a 1,001-byte wire form, so a gate that
+      // slipped back to wire bytes would be computing a different delta here.
+      return sizeProbe({ stored: 1_500, oldStored: 61_440 });
     });
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
-      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(1000) })
+      caller.storage.set({ blockToken: 't', key: 'k', value: ones(500) })
     ).resolves.toMatchObject({ ok: true });
     // The write reached the transaction rather than being short-circuited.
     expect(mockPool.connect).toHaveBeenCalled();
@@ -912,14 +981,16 @@ describe('apps.storage.set', () => {
           rowCount: 1,
         };
       }
-      // `'x'.repeat(1000)` serialises to 1002 bytes — the exact size of the
-      // replacement below, so the delta is zero rather than merely small.
-      return { rows: [{ size_bytes: 1_002 }], rowCount: 1 };
+      // 500 ones occupy 1,500 STORED bytes — the exact stored size of the
+      // replacement below, so the delta is zero rather than merely small. Stated
+      // in stored bytes: the wire form is 1,001, so a wire-unit gate would see
+      // this as a 499-byte shrink and pass for the wrong reason.
+      return sizeProbe({ stored: 1_500, oldStored: 1_500 });
     });
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
-      caller.storage.set({ blockToken: 't', key: 'k', value: 'y'.repeat(1000) })
+      caller.storage.set({ blockToken: 't', key: 'k', value: ones(500) })
     ).resolves.toMatchObject({ ok: true });
   });
 
@@ -944,12 +1015,14 @@ describe('apps.storage.set', () => {
           rowCount: 1,
         };
       }
-      return { rows: [{ size_bytes: 1_002 }], rowCount: 1 };
+      // Same 1,500 stored bytes as the same-size case above; the write below is a
+      // genuine GROWTH in stored bytes (2,500 ones = 7,500 stored).
+      return sizeProbe({ stored: 7_500, oldStored: 1_500 });
     });
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
-      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(5000) })
+      caller.storage.set({ blockToken: 't', key: 'k', value: ones(2500) })
     ).rejects.toMatchObject({ message: 'per-user storage quota exceeded' });
   });
 
@@ -977,10 +1050,13 @@ describe('apps.storage.set', () => {
         ],
         rowCount: 1,
       })
-      .mockResolvedValueOnce({ rows: [{ size_bytes: 61_440 }], rowCount: 1 });
+      // 61,440 stored bytes shrinking to 1,500 — a ~60KB shrink against a 256KB
+      // breach, so the projected total is still ~196KB over the ceiling and only
+      // the exemption can let it through.
+      .mockResolvedValueOnce(sizeProbe({ stored: 1_500, oldStored: 61_440 }));
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
-      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(1000) })
+      caller.storage.set({ blockToken: 't', key: 'k', value: ones(500) })
     ).resolves.toMatchObject({ ok: true });
   });
 
@@ -1006,7 +1082,7 @@ describe('apps.storage.set', () => {
         ],
         rowCount: 1,
       })
-      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      .mockResolvedValueOnce(sizeProbe());
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
       caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(500) })
@@ -1057,6 +1133,7 @@ describe('apps.storage.set', () => {
             rowCount: 1,
           };
         }
+        if (isSizeProbe(sql)) return sizeProbe();
         return { rows: [], rowCount: 0 };
       };
     }
@@ -1098,6 +1175,37 @@ describe('apps.storage.set', () => {
         expect.objectContaining({ event: 'user_quota_relation_missing', appBlockId: 'apb_test' }),
         expect.anything()
       );
+    });
+
+    // …and ALERTABLE, not only greppable. The log line alone made the inert
+    // sub-quota visible to a human who went looking, which is the state
+    // `countStorageFault`'s docstring argues is unacceptable for a fault: nothing
+    // can be alerted on it, and nothing schedules the backfill that ends it, so
+    // the app can serve unmetered indefinitely. Its own series is what closes it —
+    // deliberately not an `outcome` on the ops counter, where it would be
+    // invisible among ordinary successful writes.
+    it('counts the untracked write on its own series, labelled by app', async () => {
+      const untrackedInc = vi.mocked(appStorageUserQuotaUntrackedCounter.inc);
+      untrackedInc.mockClear();
+      mockPool.query.mockImplementation(poolMissingUserQuota());
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await caller.storage.set({ blockToken: 't', key: 'k', value: 'v' });
+      expect(untrackedInc).toHaveBeenCalledWith({ app_block_id: 'apb_test' });
+      expect(untrackedInc).toHaveBeenCalledTimes(1);
+    });
+
+    // The other half: a NORMAL write must not touch that series, or it stops
+    // meaning "this app is unmetered" and an alert on it fires on every write.
+    it('does NOT count the untracked series when user_quota is present', async () => {
+      const untrackedInc = vi.mocked(appStorageUserQuotaUntrackedCounter.inc);
+      untrackedInc.mockClear();
+      useSubjectFromSub();
+      mockPool.query.mockImplementation(quotaPoolFor({ 42: 0 }));
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await caller.storage.set({ blockToken: 't', key: 'k', value: 'v' });
+      expect(untrackedInc).not.toHaveBeenCalled();
     });
 
     // The fallback must not swallow a genuinely broken schema: `quota` missing
@@ -1168,7 +1276,7 @@ describe('apps.storage.set', () => {
         ],
         rowCount: 1,
       })
-      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      .mockResolvedValueOnce(sizeProbe());
     mockClient.query.mockImplementation(async (sql: string) => {
       if (sql.includes('INSERT INTO')) throw new Error('deadlock detected');
       return { rows: [], rowCount: 0 };
@@ -1206,6 +1314,72 @@ describe('apps.storage.set', () => {
     expect(inc).not.toHaveBeenCalledWith({ op: 'set', outcome: 'error' });
   });
 
+  // The refusal's own log has to be readable. `userUsedBytes` is the
+  // trigger-maintained counter (stored bytes) and the gate that refused is
+  // `userUsedBytes + netDelta`, so `attemptedBytes` must be in the SAME unit — a
+  // wire byte count there reads as the number that was compared and is not, by up
+  // to 1.5x. `quotaPoolFor` answers the probe with DEFAULT_STORED_BYTES for a
+  // fresh key, which is not the wire size of the value written.
+  it('logs the refusal in STORED bytes, the unit the gate actually compared', async () => {
+    useSubjectFromSub();
+    mockPool.query.mockImplementation(quotaPoolFor({ 42: USER_CAP_BYTES - 10 }));
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const value = 'x'.repeat(500);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value })
+    ).rejects.toMatchObject({ message: 'per-user storage quota exceeded' });
+    // The wire size and the stored size are different numbers here, which is what
+    // makes the assertion able to tell them apart.
+    expect(Buffer.byteLength(JSON.stringify(value), 'utf8')).not.toBe(DEFAULT_STORED_BYTES);
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'user_quota_exceeded',
+        attemptedBytes: DEFAULT_STORED_BYTES,
+        netDeltaBytes: DEFAULT_STORED_BYTES,
+        userUsedBytes: USER_CAP_BYTES - 10,
+      }),
+      expect.anything()
+    );
+  });
+
+  // ── The stored-size probe must FAIL LOUD, never absorb ─────────────────────
+  //
+  // Both byte ceilings are computed from this one row. Absorbing a missing or
+  // non-numeric row into a 0 makes `netDelta` 0 or NaN, and BOTH of those sail
+  // through every gate below it — 0 reads as a non-increasing write and takes the
+  // exemption, NaN makes every `>` comparison false. So the failure mode of a
+  // silent fallback here is not "a refused write", it is "an unmetered write",
+  // which is the same class as the defect this probe exists to fix.
+  //
+  // Killing mutation: replacing the throw with `?? 0` turns BOTH cases below
+  // green-and-wrong — the write is accepted with the gates skipped.
+  it.each([
+    ['no row at all', { rows: [] as unknown[], rowCount: 0 }],
+    ['a non-numeric new size', { rows: [{ new_size_bytes: null, old_size_bytes: null }], rowCount: 1 }],
+  ])('refuses the write when the stored-size probe returns %s', async (_label, probeResult) => {
+    const inc = vi.mocked(appStorageOpsCounter.inc);
+    inc.mockClear();
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (isSizeProbe(sql)) return probeResult;
+      return {
+        rows: [
+          { used_bytes: '0', row_count: '0', user_used_bytes: '0', user_row_count: '0' },
+        ],
+        rowCount: 1,
+      };
+    });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
+    ).rejects.toThrow('stored-size probe returned no usable row');
+    // It is a FAULT, not a refusal — so it lands on the error series an alert can
+    // watch, and the write never reached the transaction.
+    expect(inc).toHaveBeenCalledWith({ op: 'set', outcome: 'error' });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
   it('uses the net delta from an existing row to size the quota check', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
     // Pretend used_bytes is the per-app limit; the only reason this write
@@ -1216,11 +1390,13 @@ describe('apps.storage.set', () => {
         rows: [{ used_bytes: String(50 * 1024 * 1024), row_count: '1' }],
         rowCount: 1,
       })
-      .mockResolvedValueOnce({ rows: [{ size_bytes: 5000 }], rowCount: 1 });
+      // Both numbers in STORED bytes: an existing 5,000-byte row replaced by a
+      // 300-byte one.
+      .mockResolvedValueOnce(sizeProbe({ stored: 300, oldStored: 5_000 }));
 
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
-      caller.storage.set({ blockToken: 't', key: 'k', value: 'short' })
+      caller.storage.set({ blockToken: 't', key: 'k', value: ones(100) })
     ).resolves.toMatchObject({ ok: true });
   });
 });
@@ -1415,8 +1591,8 @@ describe('apps.storage — run-for-real preview namespace', () => {
 
   it('SET succeeds for a PENDING app: writes to the preview schema, self-bound to the mod', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims());
-    // quota pre-read + existing-size read → both empty (fresh key, under quota).
-    mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 });
+    // quota pre-read empty (under quota) + a stored-size probe for a fresh key.
+    mockPool.query.mockImplementation(defaultPoolQuery);
     const caller = appsRouter.createCaller(fakeCtx() as never);
     const res = await caller.storage.set({ blockToken: 't', key: 'note', value: { a: 1 } });
     expect(res.ok).toBe(true);

--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -1355,9 +1355,28 @@ describe('apps.storage.set', () => {
   // Killing mutation: replacing the throw with `?? 0` turns BOTH cases below
   // green-and-wrong — the write is accepted with the gates skipped.
   it.each([
-    ['no row at all', { rows: [] as unknown[], rowCount: 0 }],
-    ['a non-numeric new size', { rows: [{ new_size_bytes: null, old_size_bytes: null }], rowCount: 1 }],
-  ])('refuses the write when the stored-size probe returns %s', async (_label, probeResult) => {
+    ['no row at all', { rows: [] as unknown[], rowCount: 0 }, 'no usable row'],
+    [
+      'a NULL new size',
+      { rows: [{ new_size_bytes: null, old_size_bytes: null }], rowCount: 1 },
+      'no usable row',
+    ],
+    [
+      'a non-numeric new size',
+      { rows: [{ new_size_bytes: 'abc', old_size_bytes: null }], rowCount: 1 },
+      'no usable row',
+    ],
+    // The old size has its own throw with its own message, so it needs its own
+    // case — the two guards are not interchangeable and a shared assertion would
+    // let either one cover for the other.
+    [
+      'a non-numeric old size',
+      { rows: [{ new_size_bytes: 100, old_size_bytes: 'abc' }], rowCount: 1 },
+      'a non-numeric old size',
+    ],
+  ])(
+    'refuses the write when the stored-size probe returns %s',
+    async (_label, probeResult, expectedMessage) => {
     const inc = vi.mocked(appStorageOpsCounter.inc);
     inc.mockClear();
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
@@ -1373,12 +1392,13 @@ describe('apps.storage.set', () => {
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
       caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
-    ).rejects.toThrow('stored-size probe returned no usable row');
+    ).rejects.toThrow(`app storage: stored-size probe returned ${expectedMessage}`);
     // It is a FAULT, not a refusal — so it lands on the error series an alert can
     // watch, and the write never reached the transaction.
     expect(inc).toHaveBeenCalledWith({ op: 'set', outcome: 'error' });
     expect(mockPool.connect).not.toHaveBeenCalled();
-  });
+    }
+  );
 
   it('uses the net delta from an existing row to size the quota check', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());

--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -21,6 +21,8 @@ const {
   mockGetSessionUser,
   mockIsAppBlocksAuthorEnabled,
   mockRecordScopeInvocation,
+  mockIsRevoked,
+  mockGetUserQuota,
 } = vi.hoisted(() => {
   const mockClient = {
     query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
@@ -54,8 +56,14 @@ const {
     mockGetSessionUser: vi.fn(),
     mockIsAppBlocksAuthorEnabled: vi.fn(),
     mockRecordScopeInvocation: vi.fn(async () => undefined),
+    mockIsRevoked: vi.fn(async () => false),
+    mockGetUserQuota: vi.fn(),
   };
 });
+
+vi.mock('~/server/services/block-revocation.service', () => ({
+  BlockRevocation: { isRevoked: (...args: unknown[]) => mockIsRevoked(...args) },
+}));
 
 // W13 — the set/delete happy paths fire recordScopeInvocation (detached) with a
 // structured `detail`. Mock it so the detached write settles promptly AND we can
@@ -85,6 +93,7 @@ vi.mock('~/server/db/appsDb', () => ({
 vi.mock('~/server/services/apps/storage-provision.service', () => ({
   AppStorageProvisioner: {
     getQuota: (...args: unknown[]) => mockGetQuota(...args),
+    getUserQuota: (...args: unknown[]) => mockGetUserQuota(...args),
     provisionReviewPreview: (...args: unknown[]) => mockProvisionReviewPreview(...args),
   },
 }));
@@ -160,6 +169,9 @@ beforeEach(() => {
   mockClient.query.mockReset();
   mockClient.release.mockClear();
   mockGetQuota.mockReset();
+  mockGetUserQuota.mockReset();
+  mockIsRevoked.mockReset();
+  mockIsRevoked.mockResolvedValue(false);
   mockLogToAxiom.mockReset();
   mockGetUserById.mockReset();
   mockGetSessionUser.mockReset();
@@ -225,6 +237,51 @@ describe('apps.storage shared gates', () => {
     await expect(
       caller.storage.get({ blockToken: 't', key: 'k' })
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  // A revoked instance must lose storage access IMMEDIATELY, not at token expiry.
+  // Every op, not just the writes: a read of the user's own rows is still access
+  // granted by an install that no longer exists.
+  it.each([
+    ['get', (c: ReturnType<typeof appsRouter.createCaller>) => c.storage.get({ blockToken: 't', key: 'k' })],
+    ['set', (c: ReturnType<typeof appsRouter.createCaller>) => c.storage.set({ blockToken: 't', key: 'k', value: 'v' })],
+    ['delete', (c: ReturnType<typeof appsRouter.createCaller>) => c.storage.delete({ blockToken: 't', key: 'k' })],
+    ['list', (c: ReturnType<typeof appsRouter.createCaller>) => c.storage.list({ blockToken: 't' })],
+    ['getQuota', (c: ReturnType<typeof appsRouter.createCaller>) => c.storage.getQuota({ blockToken: 't' })],
+  ] as const)('rejects a revoked block instance on %s', async (_op, call) => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockIsRevoked.mockResolvedValueOnce(true);
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(call(caller)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'block instance revoked',
+    });
+    // Refused before any datastore access — not merely refused on the way out.
+    expect(mockPool.query).not.toHaveBeenCalled();
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('checks revocation against the token claim, and lets a live instance through', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValueOnce({ rows: [{ value: 1 }], rowCount: 1 });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(caller.storage.get({ blockToken: 't', key: 'k' })).resolves.toEqual({ value: 1 });
+    expect(mockIsRevoked).toHaveBeenCalledWith('mbi_inst');
+  });
+
+  // The run-for-real review branch returns before the approved-app checks, so it
+  // needs its own case: a revocation placed after that branch would not bind it.
+  it('rejects a revoked instance on the run-for-real preview branch too', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(
+      validClaims({ reviewRunForReal: true, appBlockId: 'pubreq_01hzzz' })
+    );
+    mockIsRevoked.mockResolvedValueOnce(true);
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'block instance revoked',
+    });
+    expect(mockProvisionReviewPreview).not.toHaveBeenCalled();
   });
 
   it('rejects when the AppBlock row is missing (NOT_FOUND)', async () => {
@@ -654,6 +711,149 @@ describe('apps.storage.set', () => {
     expect(calls.map((c) => c.detail?.key)).toEqual(['alpha', 'beta']);
   });
 
+  // ── Per-USER sub-budget ────────────────────────────────────────────────────
+  // Literals, not imports from the router: an expectation derived from the
+  // constant it tests moves with the constant and asserts nothing.
+  const USER_CAP_BYTES = 1024 * 1024;
+  const USER_CAP_ROWS = 1_000;
+  const APP_CAP_BYTES = 50 * 1024 * 1024;
+
+  /** App budget with plenty of room; per-user usage supplied per subject id. */
+  function quotaPoolFor(userBytes: Record<number, number>, userRows: Record<number, number> = {}) {
+    return async (sql: string, params?: unknown[]) => {
+      if (sql.includes('.quota q')) {
+        const uid = Number((params ?? [])[1]);
+        return {
+          rows: [
+            {
+              used_bytes: String(40 * 1024 * 1024),
+              row_count: '2000',
+              user_used_bytes: String(userBytes[uid] ?? 0),
+              user_row_count: String(userRows[uid] ?? 0),
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      // The existing-row lookup: fresh key, so no row.
+      return { rows: [], rowCount: 0 };
+    };
+  }
+
+  /** Route the subject id through the token's `sub` so two users can be modelled. */
+  function useSubjectFromSub() {
+    mockParseSubjectUserId.mockImplementation((sub: string) =>
+      sub === 'anon' ? null : Number(String(sub).split(':')[1])
+    );
+    mockGetSessionUser.mockImplementation(async (id: number) => ({ id, isModerator: false }));
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    runEnabledUserIds.add(43);
+  }
+
+  // The whole point of the sub-budget: one user exhausting their own cap must
+  // NOT consume the app budget the rest of the app's users depend on. Both legs
+  // run against the SAME app state, in one test — the relationship is the claim,
+  // and two independently-passing tests would not pin it.
+  it('refuses the user at their cap while another user of the SAME app still writes', async () => {
+    useSubjectFromSub();
+    mockPool.query.mockImplementation(quotaPoolFor({ 42: USER_CAP_BYTES - 10, 43: 0 }));
+
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(500) })
+    ).rejects.toMatchObject({
+      code: 'PAYLOAD_TOO_LARGE',
+      message: 'per-user storage quota exceeded',
+    });
+
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:43' }));
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(500) })
+    ).resolves.toMatchObject({ ok: true });
+  });
+
+  // Reachability: the refusal must come from the per-user gate on an input that
+  // clears every earlier check, including the app-wide one. 500 bytes against a
+  // 40MB/50MB app is nowhere near the app ceiling, so only the sub-budget can
+  // refuse it.
+  it('the app-wide gate would ALLOW the write the per-user gate refuses', async () => {
+    useSubjectFromSub();
+    mockPool.query.mockImplementation(quotaPoolFor({ 42: USER_CAP_BYTES - 10 }));
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(500) })
+    ).rejects.toMatchObject({ message: 'per-user storage quota exceeded' });
+    // App headroom at the moment of refusal, stated so the test carries its scope.
+    expect(40 * 1024 * 1024 + 500).toBeLessThan(APP_CAP_BYTES);
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('allows a write that fits inside the per-user cap', async () => {
+    useSubjectFromSub();
+    mockPool.query.mockImplementation(quotaPoolFor({ 42: USER_CAP_BYTES - 4096 }));
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(500) })
+    ).resolves.toMatchObject({ ok: true });
+  });
+
+  it('refuses an INSERT past the per-user row cap', async () => {
+    useSubjectFromSub();
+    mockPool.query.mockImplementation(quotaPoolFor({ 42: 0 }, { 42: USER_CAP_ROWS }));
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'v' })
+    ).rejects.toMatchObject({
+      code: 'PAYLOAD_TOO_LARGE',
+      message: 'per-user row limit exceeded',
+    });
+  });
+
+  // An in-place shrink at the row cap is an UPDATE, not an INSERT — it must not
+  // be refused, or a user at their row cap can never edit what they already have.
+  it('lets a user at the row cap overwrite an existing key', async () => {
+    useSubjectFromSub();
+    mockPool.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('.quota q')) {
+        const uid = Number((params ?? [])[1]);
+        return {
+          rows: [
+            {
+              used_bytes: '0',
+              row_count: '0',
+              user_used_bytes: uid === 42 ? String(USER_CAP_BYTES - 10) : '0',
+              user_row_count: String(USER_CAP_ROWS),
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      return { rows: [{ size_bytes: 5000 }], rowCount: 1 };
+    });
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'short' })
+    ).resolves.toMatchObject({ ok: true });
+  });
+
+  it('reads the per-user counter for the SUBJECT, keyed on the app not the instance', async () => {
+    useSubjectFromSub();
+    mockPool.query.mockImplementation(quotaPoolFor({ 42: 0 }));
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await caller.storage.set({ blockToken: 't', key: 'k', value: 'v' });
+    const quotaCall = (mockPool.query.mock.calls as Array<[string, unknown[]]>).find(([s]) =>
+      s.includes('.quota q')
+    );
+    expect(quotaCall?.[0]).toContain('user_quota');
+    expect(quotaCall?.[1]).toEqual(['apb_test', 42]);
+  });
+
   it('uses the net delta from an existing row to size the quota check', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
     // Pretend used_bytes is the per-app limit; the only reason this write
@@ -773,30 +973,58 @@ describe('apps.storage.list', () => {
 });
 
 describe('apps.storage.getQuota', () => {
-  it('proxies the provisioner snapshot + ships the v0 limits', async () => {
+  it('reports the CALLERS own usage against the per-user caps', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
-    mockGetQuota.mockResolvedValueOnce({ usedBytes: 12345, rowCount: 7 });
+    mockGetUserQuota.mockResolvedValueOnce({ usedBytes: 12345, rowCount: 7 });
     const caller = appsRouter.createCaller(fakeCtx() as never);
     const out = await caller.storage.getQuota({ blockToken: 't' });
     expect(out).toEqual({
       usedBytes: 12345,
       rowCount: 7,
-      limitBytes: 50 * 1024 * 1024,
-      limitRows: 1_000_000,
+      limitBytes: 1024 * 1024,
+      limitRows: 1_000,
     });
-    expect(mockGetQuota).toHaveBeenCalledWith({
+    expect(mockGetUserQuota).toHaveBeenCalledWith({
       slug: 'generate_from_model',
       appBlockId: 'apb_test',
+      userId: 42,
     });
+  });
+
+  // The app aggregate sums other users' rows. This procedure is reachable by
+  // everyone who may RUN the app, so it must not read that aggregate at all —
+  // not merely decline to return it.
+  it('never reads the app-wide aggregate', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockGetUserQuota.mockResolvedValueOnce({ usedBytes: 1, rowCount: 1 });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.getQuota({ blockToken: 't' });
+    expect(mockGetQuota).not.toHaveBeenCalled();
+    expect(out.limitBytes).toBe(1024 * 1024);
+    expect(out.limitBytes).not.toBe(50 * 1024 * 1024);
   });
 
   it('returns zeroes when the schema isnt provisioned yet', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
-    mockGetQuota.mockResolvedValueOnce(null);
+    mockGetUserQuota.mockResolvedValueOnce(null);
     const caller = appsRouter.createCaller(fakeCtx() as never);
     const out = await caller.storage.getQuota({ blockToken: 't' });
     expect(out.usedBytes).toBe(0);
     expect(out.rowCount).toBe(0);
+  });
+
+  it('returns zeroes for an anon subject without touching the datastore', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'anon' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.getQuota({ blockToken: 't' });
+    expect(out).toEqual({
+      usedBytes: 0,
+      rowCount: 0,
+      limitBytes: 1024 * 1024,
+      limitRows: 1_000,
+    });
+    expect(mockGetUserQuota).not.toHaveBeenCalled();
+    expect(mockGetQuota).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -170,8 +170,11 @@ function fakeCtx(user: unknown = SESSION_USER) {
  *
  * 🔴 BOTH NUMBERS ARE STORED BYTES — `octet_length(value::text)` over JSONB — and
  * that is NOT `Buffer.byteLength(JSON.stringify(value))`. Postgres' jsonb output
- * function emits `, ` after every separator and `: ` after every object key, so
- * for anything but a scalar the stored size is LARGER, by up to ~1.5x.
+ * function emits `, ` after every separator and `: ` after every object key, and it
+ * re-renders every number in full decimal (`1e308` is 6 wire bytes and 309 stored),
+ * so for anything but a scalar the stored size is LARGER — and by no fixed ratio.
+ * Measured against Postgres: 1.50x for a dense integer array, 44.4x for the largest
+ * all-`1e308` array the per-value cap admits (65,535 wire -> 2,911,582 stored).
  *
  * That distinction is why this suite could not see the deploy-blocking defect it
  * was supposed to cover. Every fixture here used to supply `size_bytes` as a bare
@@ -1317,8 +1320,9 @@ describe('apps.storage.set', () => {
   // The refusal's own log has to be readable. `userUsedBytes` is the
   // trigger-maintained counter (stored bytes) and the gate that refused is
   // `userUsedBytes + netDelta`, so `attemptedBytes` must be in the SAME unit — a
-  // wire byte count there reads as the number that was compared and is not, by up
-  // to 1.5x. `quotaPoolFor` answers the probe with DEFAULT_STORED_BYTES for a
+  // wire byte count there reads as the number that was compared and is not, by
+  // anywhere from 1.50x (a dense integer array) to 44.4x (a numeric-heavy one),
+  // measured. `quotaPoolFor` answers the probe with DEFAULT_STORED_BYTES for a
   // fresh key, which is not the wire size of the value written.
   it('logs the refusal in STORED bytes, the unit the gate actually compared', async () => {
     useSubjectFromSub();

--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -108,7 +108,7 @@ import { appsRouter } from '../apps.router';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 // Globally stubbed in src/__tests__/setup.ts (promMetricStub) — `.inc` is a
 // vi.fn(), so the refusal-instrumentation assertions below can read it.
-import { appStorageOpsCounter } from '~/server/prom/client';
+import { appStorageOpsCounter, appStorageQuotaExceededCounter } from '~/server/prom/client';
 
 function validClaims(over: Record<string, unknown> = {}) {
   return {
@@ -714,7 +714,7 @@ describe('apps.storage.set', () => {
   // ── Per-USER sub-budget ────────────────────────────────────────────────────
   // Literals, not imports from the router: an expectation derived from the
   // constant it tests moves with the constant and asserts nothing.
-  const USER_CAP_BYTES = 1024 * 1024;
+  const USER_CAP_BYTES = 2 * 1024 * 1024;
   const USER_CAP_ROWS = 1_000;
   const APP_CAP_BYTES = 50 * 1024 * 1024;
 
@@ -854,6 +854,358 @@ describe('apps.storage.set', () => {
     expect(quotaCall?.[1]).toEqual(['apb_test', 42]);
   });
 
+  // ── Over-cap SHRINK (a cap must never trap the account it applies to) ───────
+  //
+  // `userUsedBytes` is what is stored NOW, so a counter at or above the ceiling
+  // made `used + netDelta > CAP` true for a SHRINK as well as a growth: the one
+  // write that would bring the account back under the cap was the write refused,
+  // leaving `storage.delete` — which the app has to expose an affordance for — as
+  // the only exit. Not a live regression at the time of writing (the widest
+  // observed per-user footprint is well under the cap), but reachable the moment
+  // a cap is lowered, a counter drifts, or usage grows.
+  it('lets a user ALREADY over the per-user cap shrink an existing value', async () => {
+    useSubjectFromSub();
+    const overCap = USER_CAP_BYTES + 512 * 1024;
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('.quota q')) {
+        return {
+          rows: [
+            {
+              used_bytes: '0',
+              row_count: '0',
+              user_used_bytes: String(overCap),
+              user_row_count: '3',
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      // An existing, much larger row — so this write is a shrink.
+      return { rows: [{ size_bytes: 61_440 }], rowCount: 1 };
+    });
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(1000) })
+    ).resolves.toMatchObject({ ok: true });
+    // The write reached the transaction rather than being short-circuited.
+    expect(mockPool.connect).toHaveBeenCalled();
+  });
+
+  // The boundary itself. A same-size rewrite is netDelta === 0 — it stores no new
+  // bytes, so it is exactly as safe as a shrink and must be allowed. Separated
+  // from the shrink case so `<= 0` narrowing to `< 0` has its own killing test
+  // rather than dying to a neighbouring assertion.
+  it('lets an over-cap user rewrite a value to the SAME size (netDelta === 0)', async () => {
+    useSubjectFromSub();
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('.quota q')) {
+        return {
+          rows: [
+            {
+              used_bytes: '0',
+              row_count: '0',
+              user_used_bytes: String(USER_CAP_BYTES + 512 * 1024),
+              user_row_count: '3',
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      // `'x'.repeat(1000)` serialises to 1002 bytes — the exact size of the
+      // replacement below, so the delta is zero rather than merely small.
+      return { rows: [{ size_bytes: 1_002 }], rowCount: 1 };
+    });
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'y'.repeat(1000) })
+    ).resolves.toMatchObject({ ok: true });
+  });
+
+  // The other half of the same claim: relaxing the gate for a shrink must NOT
+  // relax it for a growth. Same over-cap state, same existing row, a LARGER new
+  // value — still refused. Without this, deleting the gate outright also passes
+  // the test above.
+  it('still refuses a GROWTH from the same over-cap state', async () => {
+    useSubjectFromSub();
+    const overCap = USER_CAP_BYTES + 512 * 1024;
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('.quota q')) {
+        return {
+          rows: [
+            {
+              used_bytes: '0',
+              row_count: '0',
+              user_used_bytes: String(overCap),
+              user_row_count: '3',
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      return { rows: [{ size_bytes: 1_002 }], rowCount: 1 };
+    });
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(5000) })
+    ).rejects.toMatchObject({ message: 'per-user storage quota exceeded' });
+  });
+
+  // Same trap, app-wide ceiling. Kept as its own case because it is a different
+  // gate on a different counter — the per-user test above passes with this one
+  // still broken.
+  //
+  // 🔴 THE BREACH MUST EXCEED THE SHRINK, or the guard never executes. A first
+  // draft used `APP_CAP_BYTES + 4096` against a ~60KB shrink: the write brought
+  // the total back under the ceiling by arithmetic, so `used + netDelta > CAP`
+  // was false either way and removing the exemption left the test GREEN. 256KB
+  // over, shrinking by ~60KB, leaves the projected total still ~196KB above the
+  // ceiling — so only the exemption can let it through.
+  it('lets a write that shrinks the APP total through a breached app ceiling', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            used_bytes: String(APP_CAP_BYTES + 256 * 1024),
+            row_count: '5',
+            user_used_bytes: '0',
+            user_row_count: '1',
+          },
+        ],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({ rows: [{ size_bytes: 61_440 }], rowCount: 1 });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(1000) })
+    ).resolves.toMatchObject({ ok: true });
+  });
+
+  // ── The quota-exceeded counter says WHICH ceiling ───────────────────────────
+  // An app-ceiling breach is rare, shared by every user of the app, and needs an
+  // operator; a per-user refusal is routine and self-recoverable. They shared one
+  // label set, so no query could separate "alert now" from "normal Tuesday".
+  it('labels an APP-ceiling refusal ceiling=app and a per-USER refusal ceiling=user', async () => {
+    const quotaInc = vi.mocked(appStorageQuotaExceededCounter.inc);
+    quotaInc.mockClear();
+
+    // App ceiling: a big enough write against a full app.
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            used_bytes: String(APP_CAP_BYTES),
+            row_count: '1',
+            user_used_bytes: '0',
+            user_row_count: '0',
+          },
+        ],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(500) })
+    ).rejects.toMatchObject({ message: 'app quota exceeded' });
+    expect(quotaInc).toHaveBeenCalledWith({ app_block_id: 'apb_test', ceiling: 'app' });
+
+    // Per-user ceiling: a small write against a full user in a near-empty app.
+    quotaInc.mockClear();
+    useSubjectFromSub();
+    mockPool.query.mockImplementation(quotaPoolFor({ 42: USER_CAP_BYTES - 10 }));
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(500) })
+    ).rejects.toMatchObject({ message: 'per-user storage quota exceeded' });
+    expect(quotaInc).toHaveBeenCalledWith({ app_block_id: 'apb_test', ceiling: 'user' });
+  });
+
+  // ── Deploy order: a schema that predates `user_quota` ───────────────────────
+  //
+  // `user_quota` is created by AppStorageProvisioner.provision, whose only
+  // callers are new-version approval and the manual admin backfill — nothing
+  // schedules it. A LEFT JOIN tolerates a missing ROW, not a missing RELATION, so
+  // at deploy every `set` on every already-provisioned app raised 42P01 until a
+  // human ran the backfill. `get`/`list`/`getQuota` were unaffected, which is
+  // what made it look survivable.
+  describe('a schema provisioned before user_quota existed', () => {
+    /** What node-postgres raises for `undefined_table`. */
+    function undefinedTable(relation: string) {
+      return Object.assign(new Error(`relation "${relation}" does not exist`), {
+        code: '42P01',
+      });
+    }
+
+    /** Joined read raises 42P01; the un-joined fallback resolves. */
+    function poolMissingUserQuota() {
+      return async (sql: string) => {
+        if (sql.includes('user_quota')) throw undefinedTable('app_x.user_quota');
+        if (sql.includes('.quota q')) {
+          return {
+            rows: [
+              {
+                used_bytes: '4096',
+                row_count: '2',
+                user_used_bytes: '0',
+                user_row_count: '0',
+              },
+            ],
+            rowCount: 1,
+          };
+        }
+        return { rows: [], rowCount: 0 };
+      };
+    }
+
+    it('accepts the write instead of returning INTERNAL_SERVER_ERROR', async () => {
+      mockPool.query.mockImplementation(poolMissingUserQuota());
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.storage.set({ blockToken: 't', key: 'k', value: 'v' })
+      ).resolves.toMatchObject({ ok: true });
+      // The row was actually written, not just a clean return.
+      const insert = (mockClient.query.mock.calls as Array<[string, unknown[]?]>).find(([s]) =>
+        s.includes('INSERT INTO')
+      );
+      expect(insert).toBeDefined();
+    });
+
+    it('falls back to a statement that reads the app counters WITHOUT the join', async () => {
+      mockPool.query.mockImplementation(poolMissingUserQuota());
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await caller.storage.set({ blockToken: 't', key: 'k', value: 'v' });
+      const quotaReads = (mockPool.query.mock.calls as Array<[string, unknown[]?]>)
+        .map(([s]) => s)
+        .filter((s) => s.includes('.quota q'));
+      // Two attempts: the joined one that raised, then the fallback that did not.
+      expect(quotaReads).toHaveLength(2);
+      expect(quotaReads[0]).toContain('user_quota');
+      expect(quotaReads[1]).not.toContain('user_quota');
+    });
+
+    it('logs the missing relation so an inert sub-quota is visible', async () => {
+      mockPool.query.mockImplementation(poolMissingUserQuota());
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await caller.storage.set({ blockToken: 't', key: 'k', value: 'v' });
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'user_quota_relation_missing', appBlockId: 'apb_test' }),
+        expect.anything()
+      );
+    });
+
+    // The fallback must not swallow a genuinely broken schema: `quota` missing
+    // too raises the same 42P01 from the fallback statement and propagates.
+    it('still fails when the app `quota` table is missing as well', async () => {
+      const inc = vi.mocked(appStorageOpsCounter.inc);
+      inc.mockClear();
+      mockPool.query.mockImplementation(async () => {
+        throw undefinedTable('app_x.quota');
+      });
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      // tRPC re-wraps a non-TRPCError as INTERNAL_SERVER_ERROR on the way out, so
+      // the pg code is asserted through the surviving message rather than `.code`.
+      await expect(caller.storage.set({ blockToken: 't', key: 'k', value: 'v' })).rejects.toThrow(
+        'relation "app_x.quota" does not exist'
+      );
+      // Two attempts, both raising — the fallback did not paper over it.
+      expect(mockPool.query.mock.calls.filter(([s]) => String(s).includes('.quota q'))).toHaveLength(
+        2
+      );
+      expect(inc).toHaveBeenCalledWith({ op: 'set', outcome: 'error' });
+    });
+  });
+
+  // ── An unexpected fault must be COUNTABLE ──────────────────────────────────
+  //
+  // Only the write transaction's own catch incremented `outcome:'error'`, so any
+  // fault BEFORE `BEGIN` — the quota round trip, the pool checkout, token
+  // resolution — was visible solely as the `ok` series falling to zero. An
+  // outage with no error series is an outage nothing can alert on.
+  it("counts outcome:'error' for a fault raised before the write transaction opens", async () => {
+    const inc = vi.mocked(appStorageOpsCounter.inc);
+    inc.mockClear();
+    mockPool.query.mockImplementation(async () => {
+      throw new Error('connection terminated unexpectedly');
+    });
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(caller.storage.set({ blockToken: 't', key: 'k', value: 'v' })).rejects.toThrow(
+      'connection terminated unexpectedly'
+    );
+    expect(inc).toHaveBeenCalledWith({ op: 'set', outcome: 'error' });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  // …and must be counted exactly ONCE when it happens inside the transaction,
+  // which is where it was already counted. The catch-all discriminates on the
+  // error TYPE, so a double-count here would be silent.
+  //
+  // INVARIANT GUARD, not regression coverage: this case was green before the
+  // catch-all existed too (the write transaction's own catch counted it once).
+  // What it pins is that ADDING the catch-all did not turn one increment into
+  // two. Its killing mutation is re-adding `appStorageOpsCounter.inc({ op:
+  // 'set', outcome: 'error' })` to the inner transaction catch — measured, that
+  // turns THIS test red and nothing else. Deleting the `TRPCError` early-return
+  // in `countStorageFault` does NOT reach it (the fault here is a raw Error, so
+  // the early-return never applies); that mutation is caught by the sibling
+  // deliberate-refusal case below instead.
+  it("counts outcome:'error' once, not twice, for a fault inside the write", async () => {
+    const inc = vi.mocked(appStorageOpsCounter.inc);
+    inc.mockClear();
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [
+          { used_bytes: '0', row_count: '0', user_used_bytes: '0', user_row_count: '0' },
+        ],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    mockClient.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('INSERT INTO')) throw new Error('deadlock detected');
+      return { rows: [], rowCount: 0 };
+    });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(caller.storage.set({ blockToken: 't', key: 'k', value: 'v' })).rejects.toThrow(
+      'deadlock detected'
+    );
+    const errorIncs = inc.mock.calls.filter(
+      ([labels]) => (labels as { outcome?: string })?.outcome === 'error'
+    );
+    expect(errorIncs).toHaveLength(1);
+  });
+
+  // A deliberate refusal already counts its own outcome. The catch-all must not
+  // add a second, wrong one on top — otherwise every quota refusal would also
+  // read as a fault, and `outcome:'error'` would stop meaning anything.
+  //
+  // INVARIANT GUARD as well (green before the catch-all, for want of a
+  // catch-all). This is the case that pins `countStorageFault`'s TRPCError
+  // early-return: measured, deleting that `return` turns THIS test red — and
+  // only this one — because a deliberate refusal is the only path where an
+  // already-counted error reaches the catch-all.
+  it("does NOT count outcome:'error' for a deliberate quota refusal", async () => {
+    const inc = vi.mocked(appStorageOpsCounter.inc);
+    inc.mockClear();
+    useSubjectFromSub();
+    mockPool.query.mockImplementation(quotaPoolFor({ 42: USER_CAP_BYTES - 10 }));
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:42' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(500) })
+    ).rejects.toMatchObject({ message: 'per-user storage quota exceeded' });
+    expect(inc).toHaveBeenCalledWith({ op: 'set', outcome: 'quota_exceeded' });
+    expect(inc).not.toHaveBeenCalledWith({ op: 'set', outcome: 'error' });
+  });
+
   it('uses the net delta from an existing row to size the quota check', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
     // Pretend used_bytes is the per-app limit; the only reason this write
@@ -981,7 +1333,7 @@ describe('apps.storage.getQuota', () => {
     expect(out).toEqual({
       usedBytes: 12345,
       rowCount: 7,
-      limitBytes: 1024 * 1024,
+      limitBytes: 2 * 1024 * 1024,
       limitRows: 1_000,
     });
     expect(mockGetUserQuota).toHaveBeenCalledWith({
@@ -1000,7 +1352,7 @@ describe('apps.storage.getQuota', () => {
     const caller = appsRouter.createCaller(fakeCtx() as never);
     const out = await caller.storage.getQuota({ blockToken: 't' });
     expect(mockGetQuota).not.toHaveBeenCalled();
-    expect(out.limitBytes).toBe(1024 * 1024);
+    expect(out.limitBytes).toBe(2 * 1024 * 1024);
     expect(out.limitBytes).not.toBe(50 * 1024 * 1024);
   });
 
@@ -1020,7 +1372,7 @@ describe('apps.storage.getQuota', () => {
     expect(out).toEqual({
       usedBytes: 0,
       rowCount: 0,
-      limitBytes: 1024 * 1024,
+      limitBytes: 2 * 1024 * 1024,
       limitRows: 1_000,
     });
     expect(mockGetUserQuota).not.toHaveBeenCalled();

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -170,15 +170,68 @@ const APP_ROW_LIMIT = 1_000_000;
 // keyed on app_block_id while `kv` rows are keyed per user, so before these
 // existed one account could spend the entire app budget and — because only the
 // owning user may delete their own rows — no other user of the app could ever
-// reclaim it. These are an outlier clamp, not a fair share: a fair share of
+// reclaim it. These are an anti-monopoly clamp, not a fair share: a fair share of
 // 50MB across a popular app's user count lands below a single PER_VALUE_BYTE_CAP
-// write. 1MB is ~16 max-size values or ~1000 typical settings blobs, well past
-// any plausible per-user workload, and it takes 50 distinct accounts rather than
-// one to exhaust the app. Same ratio logic for the rows: 1000 accounts, not one.
-const USER_QUOTA_BYTES = 1024 * 1024;
+// write.
+//
+// SIZED AGAINST THE OBSERVED DISTRIBUTION, not a guess. Measured 2026-09-09 over
+// every provisioned app schema holding a `kv` table, the largest per-user
+// footprint was 0.65 MiB across 49 rows; the next two were 0.47 MiB and 0.30 MiB,
+// and every other account was under 20 KiB. A 1 MiB cap would have put that top
+// account at 65% of its ceiling — 1.5x headroom on a live, growing app, close
+// enough that ordinary continued use would start refusing its writes. 2 MiB gives
+// ~3.1x headroom over the largest thing anyone is actually doing while keeping the
+// property the cap exists for: it still takes 25 distinct accounts, not one, to
+// exhaust the app's 50 MiB.
+//
+// So this is NOT an "outlier clamp" in the sense of a bound no real workload
+// approaches — the top account is within one order of magnitude of it, and that
+// is a recorded decision rather than an oversight. Re-measure before moving the
+// number again; do not re-derive it from this comment.
+//
+// The row cap is the comfortable one: the widest observed user holds 49 rows
+// against 1000, so 1000 accounts rather than one are needed to exhaust
+// APP_ROW_LIMIT and no real workload is anywhere near it.
+const USER_QUOTA_BYTES = 2 * 1024 * 1024;
 const USER_ROW_LIMIT = 1_000;
 
 const STORAGE_LOG = 'app-storage-trpc';
+
+// Postgres `undefined_table`. A LEFT JOIN tolerates a missing ROW; it does not
+// tolerate a missing RELATION, and `user_quota` only exists in schemas that have
+// been through AppStorageProvisioner.provision since it was added.
+const PG_UNDEFINED_TABLE = '42P01';
+
+function isUndefinedTable(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { code?: unknown }).code === PG_UNDEFINED_TABLE
+  );
+}
+
+/**
+ * Count an UNEXPECTED fault on a storage procedure.
+ *
+ * Every deliberate refusal on these paths increments its own `outcome`
+ * (`unauthorized` / `not_found` / `quota_exceeded` / `payload_too_large` /
+ * `error`) immediately before throwing a `TRPCError`, so a `TRPCError` arriving
+ * here has already been counted and must not be counted twice. Anything else — a
+ * pool checkout failure, a missing relation, a constraint violation, a Redis
+ * failure inside `resolveStorageContext` — was counted NOWHERE on the read paths
+ * and only INSIDE the write transaction on the two mutations. A fault before
+ * `BEGIN` (the pre-flight quota round trip, say) therefore showed up solely as
+ * the `ok` series falling to zero, with no error series for an alert to fire on.
+ *
+ * The discriminator is the error type, not a flag threaded through the body: a
+ * refusal is always a `TRPCError`, a fault never is. A future `TRPCError` thrown
+ * without its own `.inc` would go uncounted — that is the pre-existing contract
+ * this preserves, and the reason each refusal counts itself at the throw site.
+ */
+function countStorageFault(op: StorageOp, err: unknown): void {
+  if (err instanceof TRPCError) return;
+  appStorageOpsCounter.inc({ op, outcome: 'error' });
+}
 
 // H2: evaluated with the request user's context (`ctx.user`) so the live
 // `moderators`-segmented Flipt flag resolves ON for a moderator and OFF for a
@@ -403,6 +456,9 @@ export const appsStorageRouter = router({
         ).rows;
         appStorageOpsCounter.inc({ op: 'get', outcome: 'ok' });
         return { value: rows[0]?.value ?? null };
+      } catch (err) {
+        countStorageFault('get', err);
+        throw err;
       } finally {
         stopTimer();
       }
@@ -429,7 +485,7 @@ export const appsStorageRouter = router({
     .mutation(async ({ input }) => {
       const stopTimer = appStorageLatencyHistogram.startTimer({ op: 'set' });
       try {
-      const { userId, schema, appBlockId, blockInstanceId } = await resolveStorageContext(
+      const { userId, slug, schema, appBlockId, blockInstanceId } = await resolveStorageContext(
         input.blockToken,
         'set'
       );
@@ -463,23 +519,67 @@ export const appsStorageRouter = router({
       // JOIN, so the per-user gate below costs no extra query and no SUM() over
       // the writer's rows — the counter is maintained by kv_user_quota_trigger in
       // the same transaction as the write.
-      const quotaRows = (
-        await pool.query<{
-          used_bytes: string;
-          row_count: string;
-          user_used_bytes: string;
-          user_row_count: string;
-        }>(
-          `SELECT q.used_bytes::text, q.row_count::text,
-                  COALESCE(u.used_bytes, 0)::text AS user_used_bytes,
-                  COALESCE(u.row_count, 0)::text  AS user_row_count
-             FROM ${schema}.quota q
-             LEFT JOIN ${schema}.user_quota u
-               ON u.app_block_id = q.app_block_id AND u.user_id = $2
-            WHERE q.app_block_id = $1`,
-          [appBlockId, userId]
-        )
-      ).rows;
+      //
+      // DEPLOY ORDER (why the fallback exists). `user_quota` is created by
+      // AppStorageProvisioner.provision, whose only callers are new-version
+      // approval and the manual admin backfill endpoint — nothing schedules it.
+      // So at deploy this code is serving every already-provisioned app whose
+      // schema predates the table, and a LEFT JOIN against a relation that does
+      // not exist is a hard `42P01`, not a null-filled row: every `set` on every
+      // live app would fail until a human ran the backfill. Attempt the joined
+      // read, and on `42P01` fall back to the app counters alone with the
+      // per-user counters at zero.
+      //
+      // The fallback leaves the per-user gate INERT for that app rather than
+      // failing closed, which is the correct trade: the two app-wide ceilings
+      // above still apply, the pre-existing 64KB per-value cap still applies, and
+      // an app that has not been backfilled is by construction an app that was
+      // running without a per-user cap yesterday. Refusing its writes to enforce a
+      // counter that does not exist would convert a missing upgrade into an
+      // outage. A `42P01` from a missing `quota` still propagates — the fallback
+      // query reads `quota` too, so it raises the same error a second time.
+      type QuotaRow = {
+        used_bytes: string;
+        row_count: string;
+        user_used_bytes: string;
+        user_row_count: string;
+      };
+      let quotaRows: QuotaRow[];
+      let userQuotaTracked = true;
+      try {
+        quotaRows = (
+          await pool.query<QuotaRow>(
+            `SELECT q.used_bytes::text, q.row_count::text,
+                    COALESCE(u.used_bytes, 0)::text AS user_used_bytes,
+                    COALESCE(u.row_count, 0)::text  AS user_row_count
+               FROM ${schema}.quota q
+               LEFT JOIN ${schema}.user_quota u
+                 ON u.app_block_id = q.app_block_id AND u.user_id = $2
+              WHERE q.app_block_id = $1`,
+            [appBlockId, userId]
+          )
+        ).rows;
+      } catch (err) {
+        if (!isUndefinedTable(err)) throw err;
+        userQuotaTracked = false;
+        quotaRows = (
+          await pool.query<QuotaRow>(
+            `SELECT q.used_bytes::text, q.row_count::text,
+                    '0' AS user_used_bytes,
+                    '0' AS user_row_count
+               FROM ${schema}.quota q
+              WHERE q.app_block_id = $1`,
+            [appBlockId]
+          )
+        ).rows;
+        // Loud, because an inert gate that nobody can see is how this ships
+        // twice. One line per write on an un-upgraded app is a small, bounded
+        // population and exactly the signal that says "run the backfill".
+        logToAxiom(
+          { event: 'user_quota_relation_missing', appBlockId, slug },
+          STORAGE_LOG
+        ).catch(() => undefined);
+      }
       const usedBytes = Number(quotaRows[0]?.used_bytes ?? '0');
       const rowCount = Number(quotaRows[0]?.row_count ?? '0');
       const userUsedBytes = Number(quotaRows[0]?.user_used_bytes ?? '0');
@@ -499,9 +599,26 @@ export const appsStorageRouter = router({
       const isInsert = existing.length === 0;
       const netDelta = byteSize - oldSize;
 
-      if (usedBytes + netDelta > APP_QUOTA_BYTES) {
+      // A write that does not grow the stored bytes can never push a counter past
+      // a ceiling, so it must never be refused by one — and refusing it is worse
+      // than pointless, it is a trap with no exit. `usedBytes` and `userUsedBytes`
+      // are what is stored NOW, not a projection: a counter already at or above a
+      // ceiling (a cap lowered under existing data, a pre-existing account, a
+      // counter drifted by a failed transaction) makes `used + netDelta > CAP`
+      // true for a SHRINK as well as a growth, so the one action that would bring
+      // the account back under the cap is the action refused. The only other route
+      // back is `storage.delete`, which the app has to expose an affordance for.
+      //
+      // `netDelta <= 0` implies an UPDATE, never an INSERT: `oldSize` is 0 on an
+      // insert and the smallest serialisable value is `null` at 4 bytes, so
+      // netDelta is >= 4 there. That is why the two row-count gates below stay
+      // unconditional — they are already `isInsert`-guarded, and a non-increasing
+      // write adds no row.
+      const isNonIncreasing = netDelta <= 0;
+
+      if (!isNonIncreasing && usedBytes + netDelta > APP_QUOTA_BYTES) {
         appStorageOpsCounter.inc({ op: 'set', outcome: 'quota_exceeded' });
-        appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId });
+        appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId, ceiling: 'app' });
         logToAxiom(
           {
             event: 'quota_exceeded',
@@ -519,7 +636,7 @@ export const appsStorageRouter = router({
       }
       if (isInsert && rowCount + 1 > APP_ROW_LIMIT) {
         appStorageOpsCounter.inc({ op: 'set', outcome: 'quota_exceeded' });
-        appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId });
+        appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId, ceiling: 'app' });
         throw new TRPCError({
           code: 'PAYLOAD_TOO_LARGE',
           message: 'app row limit exceeded',
@@ -529,9 +646,15 @@ export const appsStorageRouter = router({
       // Sub-budget beneath the two app ceilings above: refusing here leaves the
       // app's remaining budget available to every OTHER user of the app, which is
       // the whole point — the app-wide gates alone let one account take it all.
-      if (userUsedBytes + netDelta > USER_QUOTA_BYTES) {
+      //
+      // `userQuotaTracked` is false only when this app's schema has no
+      // `user_quota` relation yet (see the fallback on the quota read above); the
+      // counters read zero there, so the gate would pass anyway. Naming the
+      // condition keeps "we did not enforce" distinct from "we enforced against
+      // zero", which are the same arithmetic and very different claims.
+      if (userQuotaTracked && !isNonIncreasing && userUsedBytes + netDelta > USER_QUOTA_BYTES) {
         appStorageOpsCounter.inc({ op: 'set', outcome: 'quota_exceeded' });
-        appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId });
+        appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId, ceiling: 'user' });
         logToAxiom(
           {
             event: 'user_quota_exceeded',
@@ -548,9 +671,9 @@ export const appsStorageRouter = router({
           message: 'per-user storage quota exceeded',
         });
       }
-      if (isInsert && userRowCount + 1 > USER_ROW_LIMIT) {
+      if (userQuotaTracked && isInsert && userRowCount + 1 > USER_ROW_LIMIT) {
         appStorageOpsCounter.inc({ op: 'set', outcome: 'quota_exceeded' });
-        appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId });
+        appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId, ceiling: 'user' });
         throw new TRPCError({
           code: 'PAYLOAD_TOO_LARGE',
           message: 'per-user row limit exceeded',
@@ -576,8 +699,12 @@ export const appsStorageRouter = router({
         );
         await client.query('COMMIT');
       } catch (err) {
+        // ROLLBACK only — the `error` outcome is counted once by the procedure's
+        // catch-all below, which also covers every fault BEFORE this transaction
+        // opens (the quota round trip, the pool checkout, token resolution).
+        // Counting here as well would double-count exactly the faults that do
+        // reach the write.
         await client.query('ROLLBACK').catch(() => {});
-        appStorageOpsCounter.inc({ op: 'set', outcome: 'error' });
         throw err;
       } finally {
         client.release();
@@ -619,6 +746,9 @@ export const appsStorageRouter = router({
         });
       })().catch(() => {});
       return { ok: true as const, sizeBytes: byteSize };
+      } catch (err) {
+        countStorageFault('set', err);
+        throw err;
       } finally {
         stopTimer();
       }
@@ -687,12 +817,16 @@ export const appsStorageRouter = router({
           }
           return { ok: true as const, deleted };
         } catch (err) {
+          // ROLLBACK only; the `error` outcome is counted once by the catch-all
+          // below (see the same note on `set`).
           await client.query('ROLLBACK').catch(() => {});
-          appStorageOpsCounter.inc({ op: 'delete', outcome: 'error' });
           throw err;
         } finally {
           client.release();
         }
+      } catch (err) {
+        countStorageFault('delete', err);
+        throw err;
       } finally {
         stopTimer();
       }
@@ -755,6 +889,9 @@ export const appsStorageRouter = router({
           keys: rows.map((r) => ({ key: r.key, updatedAt: r.updated_at })),
           nextCursor,
         };
+      } catch (err) {
+        countStorageFault('list', err);
+        throw err;
       } finally {
         stopTimer();
       }
@@ -762,16 +899,26 @@ export const appsStorageRouter = router({
 
   /**
    * The CALLER'S OWN usage against their own caps, so a settings panel can show
-   * "used 12 KB of 1 MB" without hard-coding the cap on the client.
+   * "used 12 KB of 2 MB" without hard-coding the cap on the client.
    *
    * Deliberately NOT the app-wide aggregate it used to return. This procedure is
    * reachable by everyone who may RUN the app, and the app aggregate sums other
    * users' rows — a cross-user readout on the one surface whose entire invariant
    * is that a caller only ever sees their own data. It was not actionable either:
    * only the owning user can delete their own rows, so a consumer shown "49 of
-   * 50 MB used" cannot free any of it. `AppStorageProvisioner.getQuota` still
-   * reads the app aggregate and is retained for the moderator surface; no tRPC
-   * procedure exposes it.
+   * 50 MB used" cannot free any of it.
+   *
+   * `AppStorageProvisioner.getQuota` still computes the app aggregate, and this
+   * used to say it was "retained for the moderator surface". That was wrong on
+   * the facts: it has NO production caller at all — verified 2026-09-09, the only
+   * references anywhere are its own definition and its unit tests, and
+   * `appsModRouter` exposes no storage-usage readout. Why it is still here is not
+   * recorded anywhere, so no reason is asserted for it; it is simply unreferenced.
+   *
+   * The consequence is worth stating rather than implying: after this change
+   * NOTHING reports how close an app is to its 50MB / 1M-row ceiling, so the app
+   * ceilings are observable only through `app_blocks_storage_quota_exceeded_total`
+   * (`ceiling="app"`) firing after the fact.
    *
    * Field names are unchanged, so the host bridge and the SDK's
    * APP_STORAGE_QUOTA_RESULT contract carry through untouched; what moved is the
@@ -816,6 +963,9 @@ export const appsStorageRouter = router({
           limitBytes: USER_QUOTA_BYTES,
           limitRows: USER_ROW_LIMIT,
         };
+      } catch (err) {
+        countStorageFault('getQuota', err);
+        throw err;
       } finally {
         stopTimer();
       }

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -158,9 +158,17 @@ async function assertAppBlocksEnabledForTokenUser(userId: number, op: StorageOp)
 // to v1; v0 hard-rejects writes that would cross this threshold.
 const APP_QUOTA_BYTES = 50 * 1024 * 1024;
 
-// 64 KB per individual KV value — a single oversized write can't burn
-// through quota on a single call. v1 SQL access removes this cap (quota
-// tracker becomes the only ceiling).
+// 64 KB per individual KV value, checked in the WIRE unit
+// (`Buffer.byteLength(JSON.stringify(v))`). 🔴 It bounds what one call SENDS, not
+// what one call STORES, and at per-user scope those diverge enough to matter:
+// measured, the largest value this cap admits — 9,362 x `1e308`, 65,535 wire
+// bytes — stores 2,911,582 bytes, 44.4x. So a single call can add more stored
+// bytes than the entire 2 MiB USER_QUOTA_BYTES budget. The byte ceilings below,
+// which are enforced in the stored unit, are what actually bind; the residual is
+// that the pre-flight read is one write out of date, so a racing pair can reach
+// ~4.8 MiB against a 2 MiB cap rather than ~2 MiB + 64 KiB. See the units block
+// in `set` for the expansion measurements.
+// v1 SQL access removes this cap (quota tracker becomes the only ceiling).
 const PER_VALUE_BYTE_CAP = 64 * 1024;
 
 // 1 million rows per app — companion budget to APP_QUOTA_BYTES. Trigger
@@ -515,8 +523,15 @@ export const appsStorageRouter = router({
       // in the wire unit.
       //
       // Residual, named rather than silently fixed: PER_VALUE_BYTE_CAP is checked
-      // in the wire unit, so a single value can occupy up to ~1.5x its nominal
-      // 64KB on disk. That is pre-existing behaviour and it is NOT a ceiling
+      // in the wire unit, so a value's stored size is NOT bounded by it — and the
+      // expansion has no useful fixed multiplier. Postgres never emits scientific
+      // notation for a number, so `1e308` costs 6 wire bytes and stores 309.
+      // Measured against Postgres: a 5,000-element dense integer array is 1.50x,
+      // `Array(9000).fill(1e308)` is 63,001 wire -> 2,799,000 stored (44.4x), and
+      // the largest all-`1e308` array the cap admits (9,362 elements, 65,535 wire)
+      // stores 2,911,582 bytes. Treat it as unbounded in practice for
+      // numeric-heavy payloads; 2,911,582 is the measured worst case under the cap.
+      // That is pre-existing behaviour and it is NOT a ceiling
       // bypass — both byte ceilings below are enforced in the stored unit and bind
       // regardless. Tightening the per-value cap would refuse writes that succeed
       // today, so it is left alone deliberately.
@@ -597,9 +612,11 @@ export const appsStorageRouter = router({
         // twice. One line per write on an un-upgraded app is a small, bounded
         // population and exactly the signal that says "run the backfill".
         //
-        // The Axiom line alone was NOT enough, for the same reason
-        // countStorageFault's docstring gives about faults: a state observable
-        // only by going and reading logs is not a state anything can alert on,
+        // The Axiom line alone was NOT enough, for the same shape
+        // countStorageFault's docstring describes about faults: a condition with no
+        // error SERIES of its own is not a condition anything can alert on — there
+        // it showed up solely as the `ok` series falling to zero. A state
+        // observable only by going and reading logs has the same gap,
         // and nothing schedules the backfill that ends it, so it can persist
         // indefinitely with no bound. The counter is the alertable half — it is
         // the series that says "this app has been running with its per-user
@@ -756,20 +773,28 @@ export const appsStorageRouter = router({
       // app's remaining budget available to every OTHER user of the app, which is
       // the whole point — the app-wide gates alone let one account take it all.
       //
-      // 🔴 These two gates deliberately do NOT test `userQuotaTracked`. They used
-      // to, and it was a condition that read as a guard while guarding nothing:
-      // mutants deleting `userQuotaTracked &&` from either gate survived the full
-      // suite, because in the fallback the query returns literal '0' for both
-      // per-user counters and the arithmetic is then identical either way. Writing
-      // a condition that cannot change an outcome is worse than omitting it — it
+      // 🔴 These two gates deliberately do NOT test `userQuotaTracked`. Mutants
+      // deleting `userQuotaTracked &&` from either gate survived the full suite,
+      // because in the fallback the query returns literal '0' for both per-user
+      // counters and no fixture in the suite makes the two arms diverge.
+      //
+      // For the ROW gate that survival is exact — `0 + 1 > 1000` is false either
+      // way, so the condition genuinely could not change an outcome there. Writing
+      // a condition that cannot change an outcome is worse than omitting it: it
       // reads as coverage and stops anyone looking.
       //
-      // Identical for a bounded reason, not by luck: `netDelta` is at most
-      // `storedByteSize`, `storedByteSize` is at most ~1.5x PER_VALUE_BYTE_CAP
-      // (64KiB, the largest jsonb expansion being the ~1.5x of a dense array), so
-      // `0 + netDelta` cannot exceed ~96KiB against a 2MiB USER_QUOTA_BYTES, and
-      // `0 + 1` cannot exceed a 1,000-row USER_ROW_LIMIT. Lowering either ceiling
-      // near those numbers would make the distinction real again; today it is not.
+      // 🔴 For the BYTE gate it is NOT exact, and the removal DOES change
+      // behaviour. `netDelta` is at most `storedByteSize`, but `storedByteSize` is
+      // NOT bounded by PER_VALUE_BYTE_CAP — that cap is enforced in the wire unit,
+      // and the largest value it admits stores 2,911,582 bytes (measured; see the
+      // units block above), past the 2 MiB USER_QUOTA_BYTES on its own. So on an
+      // un-backfilled schema, where the fallback pins `userUsedBytes` at 0, this
+      // gate now REFUSES that class of write with `per-user storage quota
+      // exceeded`, citing a per-user quota the app is not tracking. Kept
+      // deliberately: refusing a multi-megabyte single value is the behaviour we
+      // want whether or not the counter exists, and the untracked state is carried
+      // by the counter named below. Do NOT restore the flag to "fix" this, and do
+      // not read this block as saying the two arms cannot diverge.
       //
       // "We did not enforce" stays distinct from "we enforced against zero" where
       // that distinction is actually consumable: the

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -24,6 +24,7 @@ import {
   appStorageLatencyHistogram,
   appStorageOpsCounter,
   appStorageQuotaExceededCounter,
+  appStorageUserQuotaUntrackedCounter,
 } from '~/server/prom/client';
 import { logToAxiom } from '~/server/logging/client';
 import { requireAppsDb } from '~/server/db/appsDb';
@@ -497,6 +498,28 @@ export const appsStorageRouter = router({
         });
       }
 
+      // 🔴 TWO DIFFERENT BYTE UNITS LIVE IN THIS PROCEDURE. Keep them apart.
+      //
+      //   `byteSize`        — JS wire bytes, `Buffer.byteLength(JSON.stringify(v))`.
+      //                       This is the unit PER_VALUE_BYTE_CAP is enforced in and
+      //                       the unit reported back to the block, so a block can
+      //                       predict a PAYLOAD_TOO_LARGE from the value it holds.
+      //   `storedByteSize`  — what Postgres will store, `octet_length(value::text)`
+      //                       over JSONB. This is the unit `kv.size_bytes` carries
+      //                       and therefore the unit every quota COUNTER is in.
+      //
+      // They are not the same number and not a fixed multiple of each other (see
+      // the netDelta block below). Anything compared against `usedBytes` /
+      // `userUsedBytes` / a *_QUOTA_BYTES ceiling must be in the stored unit;
+      // anything compared against PER_VALUE_BYTE_CAP or handed to the block must be
+      // in the wire unit.
+      //
+      // Residual, named rather than silently fixed: PER_VALUE_BYTE_CAP is checked
+      // in the wire unit, so a single value can occupy up to ~1.5x its nominal
+      // 64KB on disk. That is pre-existing behaviour and it is NOT a ceiling
+      // bypass — both byte ceilings below are enforced in the stored unit and bind
+      // regardless. Tightening the per-value cap would refuse writes that succeed
+      // today, so it is left alone deliberately.
       const serialized = JSON.stringify(input.value ?? null);
       const byteSize = Buffer.byteLength(serialized, 'utf8');
       if (byteSize > PER_VALUE_BYTE_CAP) {
@@ -545,7 +568,6 @@ export const appsStorageRouter = router({
         user_row_count: string;
       };
       let quotaRows: QuotaRow[];
-      let userQuotaTracked = true;
       try {
         quotaRows = (
           await pool.query<QuotaRow>(
@@ -561,7 +583,6 @@ export const appsStorageRouter = router({
         ).rows;
       } catch (err) {
         if (!isUndefinedTable(err)) throw err;
-        userQuotaTracked = false;
         quotaRows = (
           await pool.query<QuotaRow>(
             `SELECT q.used_bytes::text, q.row_count::text,
@@ -575,6 +596,16 @@ export const appsStorageRouter = router({
         // Loud, because an inert gate that nobody can see is how this ships
         // twice. One line per write on an un-upgraded app is a small, bounded
         // population and exactly the signal that says "run the backfill".
+        //
+        // The Axiom line alone was NOT enough, for the same reason
+        // countStorageFault's docstring gives about faults: a state observable
+        // only by going and reading logs is not a state anything can alert on,
+        // and nothing schedules the backfill that ends it, so it can persist
+        // indefinitely with no bound. The counter is the alertable half — it is
+        // the series that says "this app has been running with its per-user
+        // sub-budget unenforced", and the series that returns to zero once the
+        // backfill has actually reached every app.
+        appStorageUserQuotaUntrackedCounter.inc({ app_block_id: appBlockId });
         logToAxiom(
           { event: 'user_quota_relation_missing', appBlockId, slug },
           STORAGE_LOG
@@ -585,19 +616,78 @@ export const appsStorageRouter = router({
       const userUsedBytes = Number(quotaRows[0]?.user_used_bytes ?? '0');
       const userRowCount = Number(quotaRows[0]?.user_row_count ?? '0');
 
-      // For an update we need the old size to know the net delta;
-      // skipping a pre-flight read on update would let an in-place
-      // shrink falsely fail the quota gate. Fetch it once cheaply.
-      const existing = (
-        await pool.query<{ size_bytes: number }>(
-          `SELECT size_bytes FROM ${schema}.kv
-            WHERE block_instance_id = $1 AND user_id = $2 AND key = $3`,
-          [blockInstanceId, userId, input.key]
+      // For an update we need the old size to know the net delta; skipping a
+      // pre-flight read on update would let an in-place shrink falsely fail the
+      // quota gate. Fetch it once cheaply — together with the NEW size, because
+      // both sides of the subtraction have to be in the counter's unit.
+      //
+      // 🔴 WHY THE NEW SIZE COMES FROM POSTGRES AND NOT FROM `byteSize`.
+      // `kv.size_bytes` is `GENERATED ALWAYS AS (octet_length(value::text))` over a
+      // JSONB column (storage-provision.service.ts), and the quota trigger sums
+      // that column, so the counters are in stored bytes. Postgres' jsonb output
+      // function is not `JSON.stringify`: it emits `, ` after every separator and
+      // `: ` after every object key. Measured against Postgres: `[1,2,3]` stores 9
+      // bytes where JSON.stringify gives 7; `{"a":1,"b":2}` stores 16 against 13; a
+      // 5,000-element integer array stores 15,000 against 10,001 — 1.4999x. Scalars
+      // (`null`, `"hello"`) agree exactly, which is why a JS-unit delta looks
+      // correct on the simplest fixtures.
+      //
+      // `byteSize - oldSize` therefore was not a measure of growth at all, and the
+      // non-increasing exemption below is built on top of that quantity. Held in
+      // the wire unit it was a repeatable bypass of BOTH byte ceilings: writing,
+      // each pass, the largest value whose WIRE size is <= the row's STORED size
+      // keeps the computed delta <= 0 forever while the stored bytes grow ~1.5x per
+      // pass, so the exemption skipped the app and per-user byte gates on every one
+      // of those writes and neither ceiling ever bound. Reproduced end to end
+      // against the provisioner's own DDL and trigger — see the seam test in
+      // `apps.router.storage.stored-units.behavior.test.ts`.
+      //
+      // So ask Postgres for the new size using the same expression the generated
+      // column uses, on the same round trip as the old size. `old_size_bytes` is
+      // NULL exactly when no row exists: `value` is NOT NULL and `size_bytes` is
+      // generated from it, so a row that exists can never carry NULL there. That
+      // NULL is what distinguishes an insert from an update.
+      //
+      // This is a PREDICTION of what the write will store, not a read of what it
+      // stored — it is evaluated in a separate statement before the INSERT. It is
+      // exact for the same reason the two agree at all: identical input text
+      // through identical casts (`$4::jsonb`, then jsonb -> text) evaluated by the
+      // same server. That identity is asserted in the seam test against rows
+      // Postgres actually wrote, rather than asserted here in prose.
+      const sizeRows = (
+        await pool.query<{ new_size_bytes: number; old_size_bytes: number | null }>(
+          `SELECT octet_length($4::jsonb::text) AS new_size_bytes,
+                  (SELECT size_bytes FROM ${schema}.kv
+                    WHERE block_instance_id = $1 AND user_id = $2 AND key = $3)
+                    AS old_size_bytes`,
+          [blockInstanceId, userId, input.key, serialized]
         )
       ).rows;
-      const oldSize = existing[0]?.size_bytes ?? 0;
-      const isInsert = existing.length === 0;
-      const netDelta = byteSize - oldSize;
+      // A `SELECT <expr>` with no FROM returns exactly one row on every Postgres,
+      // and both byte gates are computed from it. Absorbing a missing or
+      // non-numeric row into a 0 would make `netDelta` 0 or NaN, and BOTH of those
+      // sail through the gates below — 0 reads as a non-increasing write and NaN
+      // makes every `>` comparison false. Fail loudly instead; this is not a
+      // TRPCError, so `countStorageFault` records it as `outcome: 'error'`.
+      // 🔴 `Number.isFinite(Number(x))` alone is NOT enough here: `Number(null)` is
+      // 0, which is finite, so a NULL `new_size_bytes` would pass the check and
+      // then produce `netDelta === 0` — a non-increasing write, which takes the
+      // exemption and skips both byte ceilings. That is the same fail-open this
+      // guard exists to prevent, reached through the guard rather than around it.
+      // Reject the null explicitly, before the coercion.
+      const sizeRow = sizeRows[0];
+      const rawNewSize = sizeRow?.new_size_bytes ?? null;
+      const storedByteSize = Number(rawNewSize);
+      if (sizeRow == null || rawNewSize == null || !Number.isFinite(storedByteSize)) {
+        throw new Error('app storage: stored-size probe returned no usable row');
+      }
+      const rawOldSize = sizeRow.old_size_bytes ?? null;
+      const oldSize = rawOldSize == null ? 0 : Number(rawOldSize);
+      if (!Number.isFinite(oldSize)) {
+        throw new Error('app storage: stored-size probe returned a non-numeric old size');
+      }
+      const isInsert = rawOldSize == null;
+      const netDelta = storedByteSize - oldSize;
 
       // A write that does not grow the stored bytes can never push a counter past
       // a ceiling, so it must never be refused by one — and refusing it is worse
@@ -609,11 +699,25 @@ export const appsStorageRouter = router({
       // the account back under the cap is the action refused. The only other route
       // back is `storage.delete`, which the app has to expose an affordance for.
       //
+      // 🔴 THE PREMISE IS LOAD-BEARING AND IT IS A CLAIM ABOUT UNITS. The sentence
+      // above is true of `netDelta` only because `netDelta` is now
+      // `storedByteSize - oldSize`, i.e. both terms are `octet_length(value::text)`
+      // over JSONB — the exact quantity `kv.size_bytes` holds and the quota trigger
+      // sums. When the left term was a JS wire byte count the sentence was FALSE:
+      // `netDelta <= 0` was satisfiable indefinitely by writes that grew the stored
+      // bytes ~1.5x each time, and the exemption then removed both byte gates on
+      // every one of them. Do not reintroduce a wire-unit term here.
+      //
+      // The exemption is still bounded by what it cannot skip: the two row-count
+      // gates below are `isInsert`-guarded and unconditional, PER_VALUE_BYTE_CAP is
+      // enforced before any of this, and the quota trigger reconciles the counters
+      // from the rows themselves after the write.
+      //
       // `netDelta <= 0` implies an UPDATE, never an INSERT: `oldSize` is 0 on an
-      // insert and the smallest serialisable value is `null` at 4 bytes, so
-      // netDelta is >= 4 there. That is why the two row-count gates below stay
-      // unconditional — they are already `isInsert`-guarded, and a non-increasing
-      // write adds no row.
+      // insert and the smallest value Postgres will store is `null` at
+      // `octet_length('null')` = 4 bytes, so netDelta is >= 4 there. That is why
+      // the two row-count gates below stay unconditional — they are already
+      // `isInsert`-guarded, and a non-increasing write adds no row.
       const isNonIncreasing = netDelta <= 0;
 
       if (!isNonIncreasing && usedBytes + netDelta > APP_QUOTA_BYTES) {
@@ -624,7 +728,12 @@ export const appsStorageRouter = router({
             event: 'quota_exceeded',
             appBlockId,
             usedBytes,
-            attemptedBytes: byteSize,
+            // Stored bytes, not wire bytes — this sits beside `usedBytes`, which
+            // is the trigger-maintained counter, and the gate that refused is
+            // `usedBytes + netDelta`. A wire byte count here reads as the number
+            // that was compared and is not.
+            attemptedBytes: storedByteSize,
+            netDeltaBytes: netDelta,
             key: input.key,
           },
           STORAGE_LOG
@@ -647,12 +756,27 @@ export const appsStorageRouter = router({
       // app's remaining budget available to every OTHER user of the app, which is
       // the whole point — the app-wide gates alone let one account take it all.
       //
-      // `userQuotaTracked` is false only when this app's schema has no
-      // `user_quota` relation yet (see the fallback on the quota read above); the
-      // counters read zero there, so the gate would pass anyway. Naming the
-      // condition keeps "we did not enforce" distinct from "we enforced against
-      // zero", which are the same arithmetic and very different claims.
-      if (userQuotaTracked && !isNonIncreasing && userUsedBytes + netDelta > USER_QUOTA_BYTES) {
+      // 🔴 These two gates deliberately do NOT test `userQuotaTracked`. They used
+      // to, and it was a condition that read as a guard while guarding nothing:
+      // mutants deleting `userQuotaTracked &&` from either gate survived the full
+      // suite, because in the fallback the query returns literal '0' for both
+      // per-user counters and the arithmetic is then identical either way. Writing
+      // a condition that cannot change an outcome is worse than omitting it — it
+      // reads as coverage and stops anyone looking.
+      //
+      // Identical for a bounded reason, not by luck: `netDelta` is at most
+      // `storedByteSize`, `storedByteSize` is at most ~1.5x PER_VALUE_BYTE_CAP
+      // (64KiB, the largest jsonb expansion being the ~1.5x of a dense array), so
+      // `0 + netDelta` cannot exceed ~96KiB against a 2MiB USER_QUOTA_BYTES, and
+      // `0 + 1` cannot exceed a 1,000-row USER_ROW_LIMIT. Lowering either ceiling
+      // near those numbers would make the distinction real again; today it is not.
+      //
+      // "We did not enforce" stays distinct from "we enforced against zero" where
+      // that distinction is actually consumable: the
+      // `app_blocks_storage_user_quota_untracked_total` counter and the
+      // `user_quota_relation_missing` log on the fallback branch above. The flag
+      // itself is gone — it had no reader left that could act on it.
+      if (!isNonIncreasing && userUsedBytes + netDelta > USER_QUOTA_BYTES) {
         appStorageOpsCounter.inc({ op: 'set', outcome: 'quota_exceeded' });
         appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId, ceiling: 'user' });
         logToAxiom(
@@ -661,7 +785,9 @@ export const appsStorageRouter = router({
             appBlockId,
             userId,
             userUsedBytes,
-            attemptedBytes: byteSize,
+            // Stored bytes — same reasoning as the app-ceiling log above.
+            attemptedBytes: storedByteSize,
+            netDeltaBytes: netDelta,
             key: input.key,
           },
           STORAGE_LOG
@@ -671,7 +797,7 @@ export const appsStorageRouter = router({
           message: 'per-user storage quota exceeded',
         });
       }
-      if (userQuotaTracked && isInsert && userRowCount + 1 > USER_ROW_LIMIT) {
+      if (isInsert && userRowCount + 1 > USER_ROW_LIMIT) {
         appStorageOpsCounter.inc({ op: 'set', outcome: 'quota_exceeded' });
         appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId, ceiling: 'user' });
         throw new TRPCError({
@@ -718,7 +844,12 @@ export const appsStorageRouter = router({
           blockInstanceId,
           userId,
           key: input.key,
+          // Both units, named. `sizeBytes` is the wire size (the unit the block
+          // sees and the unit PER_VALUE_BYTE_CAP is in); `storedBytes` is what
+          // `kv.size_bytes` and every quota counter will carry. Correlating a
+          // write against quota growth needs the second one.
           sizeBytes: byteSize,
+          storedBytes: storedByteSize,
           isInsert,
         },
         STORAGE_LOG

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -15,6 +15,7 @@ import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { parseSubjectUserId, verifyBlockToken } from '~/server/middleware/block-scope.middleware';
+import { BlockRevocation } from '~/server/services/block-revocation.service';
 import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { sessionClient } from '~/server/auth/session-client';
 import type { SessionUser } from '~/types/session';
@@ -165,6 +166,18 @@ const PER_VALUE_BYTE_CAP = 64 * 1024;
 // keeps row_count current; gate runs on the cheap counter read.
 const APP_ROW_LIMIT = 1_000_000;
 
+// Per-USER sub-budget beneath the two app ceilings above. Both app budgets are
+// keyed on app_block_id while `kv` rows are keyed per user, so before these
+// existed one account could spend the entire app budget and — because only the
+// owning user may delete their own rows — no other user of the app could ever
+// reclaim it. These are an outlier clamp, not a fair share: a fair share of
+// 50MB across a popular app's user count lands below a single PER_VALUE_BYTE_CAP
+// write. 1MB is ~16 max-size values or ~1000 typical settings blobs, well past
+// any plausible per-user workload, and it takes 50 distinct accounts rather than
+// one to exhaust the app. Same ratio logic for the rows: 1000 accounts, not one.
+const USER_QUOTA_BYTES = 1024 * 1024;
+const USER_ROW_LIMIT = 1_000;
+
 const STORAGE_LOG = 'app-storage-trpc';
 
 // H2: evaluated with the request user's context (`ctx.user`) so the live
@@ -217,6 +230,18 @@ async function resolveStorageContext(blockToken: string, op: StorageOp): Promise
       code: 'INTERNAL_SERVER_ERROR',
       message: 'block id is not a valid storage slug',
     });
+  }
+
+  // Per-instance revocation. `verifyBlockToken` checks the signature and expiry
+  // and nothing else, so without this an uninstall, a mod toggling the instance
+  // off, or a publisher ban leaves every already-minted token reading and writing
+  // until natural expiry. The REST `withBlockScope` middleware and
+  // `resolveSharedContext` both enforce it; this path was the remaining gap.
+  // Placed before the run-for-real branch so it binds EVERY storage op, not only
+  // the approved-app ones.
+  if (await BlockRevocation.isRevoked(claims.blockInstanceId)) {
+    appStorageOpsCounter.inc({ op, outcome: 'unauthorized' });
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'block instance revoked' });
   }
 
   // The DECLARED-scope gate (A5 / design-gaps H4). Reads need apps:storage:read;
@@ -433,14 +458,32 @@ export const appsStorageRouter = router({
       // out of date (a near-simultaneous write from another tab); we
       // accept a single value's overshoot in exchange for not holding a
       // row lock for the duration of the write.
+      //
+      // The caller's own counter rides along on the SAME round trip via a LEFT
+      // JOIN, so the per-user gate below costs no extra query and no SUM() over
+      // the writer's rows — the counter is maintained by kv_user_quota_trigger in
+      // the same transaction as the write.
       const quotaRows = (
-        await pool.query<{ used_bytes: string; row_count: string }>(
-          `SELECT used_bytes::text, row_count::text FROM ${schema}.quota WHERE app_block_id = $1`,
-          [appBlockId]
+        await pool.query<{
+          used_bytes: string;
+          row_count: string;
+          user_used_bytes: string;
+          user_row_count: string;
+        }>(
+          `SELECT q.used_bytes::text, q.row_count::text,
+                  COALESCE(u.used_bytes, 0)::text AS user_used_bytes,
+                  COALESCE(u.row_count, 0)::text  AS user_row_count
+             FROM ${schema}.quota q
+             LEFT JOIN ${schema}.user_quota u
+               ON u.app_block_id = q.app_block_id AND u.user_id = $2
+            WHERE q.app_block_id = $1`,
+          [appBlockId, userId]
         )
       ).rows;
       const usedBytes = Number(quotaRows[0]?.used_bytes ?? '0');
       const rowCount = Number(quotaRows[0]?.row_count ?? '0');
+      const userUsedBytes = Number(quotaRows[0]?.user_used_bytes ?? '0');
+      const userRowCount = Number(quotaRows[0]?.user_row_count ?? '0');
 
       // For an update we need the old size to know the net delta;
       // skipping a pre-flight read on update would let an in-place
@@ -480,6 +523,37 @@ export const appsStorageRouter = router({
         throw new TRPCError({
           code: 'PAYLOAD_TOO_LARGE',
           message: 'app row limit exceeded',
+        });
+      }
+
+      // Sub-budget beneath the two app ceilings above: refusing here leaves the
+      // app's remaining budget available to every OTHER user of the app, which is
+      // the whole point — the app-wide gates alone let one account take it all.
+      if (userUsedBytes + netDelta > USER_QUOTA_BYTES) {
+        appStorageOpsCounter.inc({ op: 'set', outcome: 'quota_exceeded' });
+        appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId });
+        logToAxiom(
+          {
+            event: 'user_quota_exceeded',
+            appBlockId,
+            userId,
+            userUsedBytes,
+            attemptedBytes: byteSize,
+            key: input.key,
+          },
+          STORAGE_LOG
+        ).catch(() => undefined);
+        throw new TRPCError({
+          code: 'PAYLOAD_TOO_LARGE',
+          message: 'per-user storage quota exceeded',
+        });
+      }
+      if (isInsert && userRowCount + 1 > USER_ROW_LIMIT) {
+        appStorageOpsCounter.inc({ op: 'set', outcome: 'quota_exceeded' });
+        appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId });
+        throw new TRPCError({
+          code: 'PAYLOAD_TOO_LARGE',
+          message: 'per-user row limit exceeded',
         });
       }
 
@@ -687,9 +761,21 @@ export const appsStorageRouter = router({
     }),
 
   /**
-   * Diagnostic / future quota-aware UI. Returns the live quota row plus
-   * the v0 limits so a settings panel can show "used 12 MB of 50 MB"
-   * without hard-coding the cap on the client.
+   * The CALLER'S OWN usage against their own caps, so a settings panel can show
+   * "used 12 KB of 1 MB" without hard-coding the cap on the client.
+   *
+   * Deliberately NOT the app-wide aggregate it used to return. This procedure is
+   * reachable by everyone who may RUN the app, and the app aggregate sums other
+   * users' rows — a cross-user readout on the one surface whose entire invariant
+   * is that a caller only ever sees their own data. It was not actionable either:
+   * only the owning user can delete their own rows, so a consumer shown "49 of
+   * 50 MB used" cannot free any of it. `AppStorageProvisioner.getQuota` still
+   * reads the app aggregate and is retained for the moderator surface; no tRPC
+   * procedure exposes it.
+   *
+   * Field names are unchanged, so the host bridge and the SDK's
+   * APP_STORAGE_QUOTA_RESULT contract carry through untouched; what moved is the
+   * scope each number describes.
    */
   getQuota: publicProcedure
     .use(enforceAppBlocksFlag)
@@ -697,19 +783,23 @@ export const appsStorageRouter = router({
     .query(async ({ input }) => {
       const stopTimer = appStorageLatencyHistogram.startTimer({ op: 'getQuota' });
       try {
-        const { slug, schema, appBlockId, reviewPreview } = await resolveStorageContext(
+        const { userId, slug, schema, appBlockId, reviewPreview } = await resolveStorageContext(
           input.blockToken,
           'getQuota'
         );
         let quota: { usedBytes: number; rowCount: number } | null;
-        if (reviewPreview) {
-          // Read the preview schema's own quota row directly (the schema is
+        if (userId == null) {
+          // Anon has no rows of its own; the per-user path has no anon storage.
+          quota = { usedBytes: 0, rowCount: 0 };
+        } else if (reviewPreview) {
+          // Read the preview schema's own counter directly (the schema is
           // provisioned by resolveStorageContext, so it always exists here).
           const pool = requireAppsDb();
           const rows = (
             await pool.query<{ used_bytes: string; row_count: string }>(
-              `SELECT used_bytes::text, row_count::text FROM ${schema}.quota WHERE app_block_id = $1`,
-              [appBlockId]
+              `SELECT used_bytes::text, row_count::text FROM ${schema}.user_quota
+                WHERE app_block_id = $1 AND user_id = $2`,
+              [appBlockId, userId]
             )
           ).rows;
           quota = {
@@ -717,14 +807,14 @@ export const appsStorageRouter = router({
             rowCount: Number(rows[0]?.row_count ?? '0'),
           };
         } else {
-          quota = await AppStorageProvisioner.getQuota({ slug, appBlockId });
+          quota = await AppStorageProvisioner.getUserQuota({ slug, appBlockId, userId });
         }
         appStorageOpsCounter.inc({ op: 'getQuota', outcome: 'ok' });
         return {
           usedBytes: quota?.usedBytes ?? 0,
           rowCount: quota?.rowCount ?? 0,
-          limitBytes: APP_QUOTA_BYTES,
-          limitRows: APP_ROW_LIMIT,
+          limitBytes: USER_QUOTA_BYTES,
+          limitRows: USER_ROW_LIMIT,
         };
       } finally {
         stopTimer();

--- a/src/server/services/apps/__tests__/storage-provision.service.test.ts
+++ b/src/server/services/apps/__tests__/storage-provision.service.test.ts
@@ -106,6 +106,57 @@ describe('AppStorageProvisioner.provision', () => {
     expect(joined).toContain(`EXECUTE FUNCTION ${S}.kv_quota_trigger()`);
   });
 
+  it('provisions the per-user counter table + its own trigger, bound to kv ONLY', async () => {
+    await AppStorageProvisioner.provision({
+      appBlockId: 'apb_test',
+      slug: 'generate_from_model',
+    });
+    const S = '"app_generate_from_model"';
+    const sqls = capturedQueries.map((q) => q.sql);
+    const joined = sqls.join('\n');
+    expect(joined).toContain(`CREATE TABLE IF NOT EXISTS ${S}.user_quota`);
+    expect(joined).toContain('PRIMARY KEY (app_block_id, user_id)');
+    expect(joined).toContain(`CREATE OR REPLACE FUNCTION ${S}.kv_user_quota_trigger()`);
+    expect(joined).toContain('CREATE TRIGGER kv_user_quota_trg');
+
+    // 🔴 The per-user function reads NEW/OLD.user_id, and shared_kv carries
+    // author_user_id instead. plpgsql resolves record fields at runtime, so
+    // binding this function to shared_kv would throw on every shared append —
+    // assert the binding, not merely that the trigger exists.
+    const userTrigger = sqls.find((s) => s.includes('CREATE TRIGGER kv_user_quota_trg'));
+    expect(userTrigger).toContain(`ON ${S}.kv`);
+    expect(userTrigger).not.toContain('shared_kv');
+    const sharedTrigger = sqls.find((s) => s.includes('CREATE TRIGGER shared_kv_quota_trg'));
+    expect(sharedTrigger).toContain(`EXECUTE FUNCTION ${S}.kv_quota_trigger()`);
+    expect(sharedTrigger).not.toContain('kv_user_quota_trigger');
+  });
+
+  // Existing app schemas hold rows written before user_quota existed. Re-running
+  // provision (the admin backfill) is the ONLY path that brings them up, so the
+  // seed has to count those rows rather than start everyone at zero.
+  it('seeds the per-user counter from pre-existing kv rows, skipping users already counted', async () => {
+    await AppStorageProvisioner.provision({
+      appBlockId: 'apb_seed_value',
+      slug: 'generate_from_model',
+    });
+    // The trigger function's BODY also contains an `INSERT INTO ….user_quota`,
+    // so match the seed's own aggregate — matching the insert alone reads the
+    // function definition and asserts nothing about the seed.
+    const seed = capturedQueries.find(
+      (q) =>
+        q.sql.includes('INSERT INTO "app_generate_from_model".user_quota') &&
+        q.sql.includes('GROUP BY k.user_id')
+    );
+    expect(seed).toBeDefined();
+    expect(seed?.params).toEqual(['apb_seed_value']);
+    expect(seed?.sql).toContain('sum(k.size_bytes)');
+    expect(seed?.sql).toContain('count(*)');
+    expect(seed?.sql).toContain('GROUP BY k.user_id');
+    // The anti-join is what makes a re-run leave live counters alone.
+    expect(seed?.sql).toContain('WHERE NOT EXISTS');
+    expect(seed?.sql).toContain('ON CONFLICT (app_block_id, user_id) DO NOTHING');
+  });
+
   it('seeds the quota row with the provided appBlockId via a parameterized insert', async () => {
     await AppStorageProvisioner.provision({
       appBlockId: 'apb_seed_value',
@@ -201,15 +252,36 @@ describe('AppStorageProvisioner.provisionReviewPreview (#2831)', () => {
     expect(mockClient.release).toHaveBeenCalledOnce();
   });
 
-  it('FAST-PATHs (no DDL) when the preview schema already exists', async () => {
+  it('provisions the per-user counter in the preview schema too', async () => {
+    await AppStorageProvisioner.provisionReviewPreview({ publishRequestId: 'pubreq_abc' });
+    const joined = capturedQueries.map((q) => q.sql).join('\n');
+    expect(joined).toContain('CREATE TABLE IF NOT EXISTS "apprev_pubreqabc".user_quota');
+    expect(joined).toContain('CREATE TRIGGER kv_user_quota_trg');
+    expect(joined).toContain('"apprev_pubreqabc".kv_user_quota_trigger()');
+  });
+
+  it('FAST-PATHs (no DDL) once the preview schema is at the current shape', async () => {
     mockPool.query.mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 });
     const { schema } = await AppStorageProvisioner.provisionReviewPreview({
       publishRequestId: 'pubreq_abc',
     });
     expect(schema).toBe('"apprev_pubreqabc"');
-    // Existing schema → the DDL transaction is skipped entirely.
+    // Up-to-date schema → the DDL transaction is skipped entirely.
     expect(mockPool.connect).not.toHaveBeenCalled();
     expect(capturedQueries).toHaveLength(0);
+  });
+
+  // A preview schema provisioned by an earlier build EXISTS but has no per-user
+  // counter. A schema-level probe would fast-path past the upgrade and leave
+  // every write in that still-pending review hitting a missing relation, so the
+  // probe has to key on the newest table.
+  it('probes for user_quota, not merely for the schema, so an older preview upgrades', async () => {
+    await AppStorageProvisioner.provisionReviewPreview({ publishRequestId: 'pubreq_abc' });
+    const probe = String(mockPool.query.mock.calls[0][0]);
+    expect(probe).toContain('information_schema.tables');
+    expect(probe).toContain("table_name = 'user_quota'");
+    expect(probe).not.toContain('information_schema.schemata');
+    expect(mockPool.query.mock.calls[0][1]).toEqual(['apprev_pubreqabc']);
   });
 });
 
@@ -268,5 +340,52 @@ describe('AppStorageProvisioner.getQuota', () => {
       slug: 'generate_from_model',
     });
     expect(result).toEqual({ usedBytes: 12345, rowCount: 7 });
+  });
+});
+
+describe('AppStorageProvisioner.getUserQuota', () => {
+  it('rejects an invalid slug before touching the pool', async () => {
+    await expect(
+      AppStorageProvisioner.getUserQuota({ appBlockId: 'apb_x', slug: 'bad-slug', userId: 42 })
+    ).rejects.toThrow(/invalid slug/);
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the app schema has no per-user counter', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [{ exists: false }], rowCount: 1 });
+    const result = await AppStorageProvisioner.getUserQuota({
+      appBlockId: 'apb_test',
+      slug: 'generate_from_model',
+      userId: 42,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns zeroes for a user that has never written', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const result = await AppStorageProvisioner.getUserQuota({
+      appBlockId: 'apb_test',
+      slug: 'generate_from_model',
+      userId: 42,
+    });
+    expect(result).toEqual({ usedBytes: 0, rowCount: 0 });
+  });
+
+  it('scopes the read to BOTH the app and the user, and coerces bigint text', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ used_bytes: '4096', row_count: '3' }], rowCount: 1 });
+    const result = await AppStorageProvisioner.getUserQuota({
+      appBlockId: 'apb_test',
+      slug: 'generate_from_model',
+      userId: 42,
+    });
+    expect(result).toEqual({ usedBytes: 4096, rowCount: 3 });
+    const read = mockPool.query.mock.calls[1];
+    expect(String(read[0])).toContain('"app_generate_from_model".user_quota');
+    expect(String(read[0])).toContain('app_block_id = $1 AND user_id = $2');
+    expect(read[1]).toEqual(['apb_test', 42]);
   });
 });

--- a/src/server/services/apps/__tests__/storage-provision.trigger.behavior.test.ts
+++ b/src/server/services/apps/__tests__/storage-provision.trigger.behavior.test.ts
@@ -1,0 +1,439 @@
+import { PGlite } from '@electric-sql/pglite';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Booting PGlite (WASM Postgres) can exceed the default 10s hook timeout on a
+// contended runner. Relaxing it can only help a slow box, never mask a failure.
+vi.setConfig({ hookTimeout: 60_000, testTimeout: 60_000 });
+
+/**
+ * What `AppStorageProvisioner`'s per-user quota TRIGGER does to real rows, as
+ * opposed to what its SQL text says.
+ *
+ * 🔴 WHY THIS IS EXECUTED AND NOT STRING-ASSERTED. Every other provisioner test
+ * captures the SQL handed to a mocked `client.query` and asserts on the string.
+ * That is blind to the two mutations that matter most here, both of which were
+ * confirmed to SURVIVE a fully green string-asserting suite:
+ *
+ *   1. invert the DELETE branch so a delete ADDS `OLD.size_bytes` instead of
+ *      subtracting it — the counter then only ever climbs, and a user who
+ *      deletes everything they own still reads as full;
+ *   2. replace the INSERT branch's `ON CONFLICT … DO UPDATE SET used_bytes =
+ *      user_quota.used_bytes + EXCLUDED.used_bytes …` with `DO NOTHING` — the
+ *      counter freezes at whatever the user's FIRST write cost and the per-user
+ *      cap never binds again, i.e. the feature is permanently inert.
+ *
+ * Both spellings contain the same identifiers in the same order, so no
+ * text assertion can separate them from the correct one. Running the
+ * provisioner's own, unmodified DDL on an in-process Postgres and then writing
+ * rows through it can.
+ *
+ * THE ORACLE IS NOT THE TRIGGER. Expected values are pinned as literals computed
+ * from the fixture payloads by hand, and separately cross-checked against a
+ * `sum(size_bytes)`/`count(*)` aggregate over `kv` — a different mechanism
+ * (recompute) from the one under test (incremental maintenance). A counter that
+ * disagrees with the rows it summarises is the whole class of bug this catches.
+ */
+
+const holder = {
+  db: null as unknown as PGlite,
+};
+
+/**
+ * Route one statement at the in-process database.
+ *
+ * Parameterized statements go through the extended protocol (`query`);
+ * everything else through the simple protocol (`exec`), which is what parses
+ * dollar-quoted function bodies and `DO $do$ … $do$` blocks server-side. Sending
+ * those through `query` would fail on the embedded semicolons.
+ */
+async function runSql(sql: string, params?: unknown[]) {
+  if (params && params.length > 0) {
+    return await holder.db.query(sql, params as unknown[]);
+  }
+  const results = await holder.db.exec(sql);
+  return results[results.length - 1] ?? { rows: [] };
+}
+
+// PGlite is a single session, so one shared connection stands in for the pool.
+// `release` is a no-op for the same reason. Session state (an open transaction,
+// a `SET LOCAL`) therefore persists across calls exactly as it does on one real
+// pooled connection — which is the property the trigger depends on.
+const fakeClient = {
+  query: (sql: string, params?: unknown[]) => runSql(sql, params),
+  release: () => undefined,
+};
+const fakePool = {
+  connect: async () => fakeClient,
+  query: (sql: string, params?: unknown[]) => runSql(sql, params),
+};
+
+vi.mock('~/server/db/appsDb', () => ({
+  requireAppsDb: () => fakePool,
+}));
+
+const { AppStorageProvisioner } = await import('~/server/services/apps/storage-provision.service');
+
+const SLUG = 'quota_trigger_probe';
+const SCHEMA = `"app_${SLUG}"`;
+const APP_BLOCK_ID = 'apb_trigger_probe';
+const OTHER_APP_BLOCK_ID = 'apb_trigger_probe_two';
+const INSTANCE = 'mbi_probe';
+
+// Two subjects, so a per-user counter that is really an app-wide counter in
+// disguise cannot pass. Ids are distinct from every byte count and row count
+// asserted below, so no expectation can be satisfied by the wrong column.
+const USER_A = 7001;
+const USER_B = 8002;
+
+/**
+ * The payloads, and the byte cost of each.
+ *
+ * `size_bytes` is `octet_length(value::text)` on a jsonb column, so a JSON
+ * string of N ASCII characters costs N + 2 (the two quotes). Lengths are
+ * pairwise distinct, distinct from every row count in play (1, 2, 3), and none
+ * is a multiple of another — so a mutant that swaps one term for another, or
+ * confuses bytes with rows, cannot land on the right answer by arithmetic
+ * accident.
+ */
+const ALPHA = 'a'.repeat(37); // 39 bytes stored
+const BETA = 'b'.repeat(53); // 55 bytes stored
+const GAMMA = 'c'.repeat(11); // 13 bytes stored
+const ALPHA_SMALL = 'a'.repeat(5); // 7 bytes stored
+const BETA_BIG = 'b'.repeat(89); // 91 bytes stored
+
+const ALPHA_BYTES = 39;
+const BETA_BYTES = 55;
+const GAMMA_BYTES = 13;
+const ALPHA_SMALL_BYTES = 7;
+const BETA_BIG_BYTES = 91;
+
+/**
+ * Write exactly the way `apps.storage.set` writes: one transaction, the GUC set
+ * with `SET LOCAL` on the same connection, then the upsert. If the GUC is not
+ * set the trigger deliberately no-ops, so this shape is load-bearing — a test
+ * that skipped it would measure nothing and report zeroes as agreement.
+ */
+async function setKv(appBlockId: string, userId: number, key: string, value: unknown) {
+  await runSql('BEGIN');
+  await runSql(`SET LOCAL app.current_app_block_id = '${appBlockId}'`);
+  await runSql(
+    `INSERT INTO ${SCHEMA}.kv (block_instance_id, user_id, key, value)
+     VALUES ($1, $2, $3, $4::jsonb)
+     ON CONFLICT (block_instance_id, user_id, key)
+     DO UPDATE SET value = EXCLUDED.value, updated_at = now()`,
+    [INSTANCE, userId, key, JSON.stringify(value)]
+  );
+  await runSql('COMMIT');
+}
+
+/** The delete path, same transaction shape. */
+async function deleteKv(appBlockId: string, userId: number, key: string) {
+  await runSql('BEGIN');
+  await runSql(`SET LOCAL app.current_app_block_id = '${appBlockId}'`);
+  await runSql(
+    `DELETE FROM ${SCHEMA}.kv WHERE block_instance_id = $1 AND user_id = $2 AND key = $3`,
+    [INSTANCE, userId, key]
+  );
+  await runSql('COMMIT');
+}
+
+/** What the trigger claims. */
+async function readUserCounter(appBlockId: string, userId: number) {
+  const r = await runSql(
+    `SELECT used_bytes::int AS used_bytes, row_count::int AS row_count
+       FROM ${SCHEMA}.user_quota WHERE app_block_id = $1 AND user_id = $2`,
+    [appBlockId, userId]
+  );
+  const row = (r.rows as Array<{ used_bytes: number; row_count: number }>)[0];
+  return row ? { usedBytes: row.used_bytes, rowCount: row.row_count } : null;
+}
+
+/** What the rows actually say — the independent recompute oracle. */
+async function recomputeUser(userId: number) {
+  const r = await runSql(
+    `SELECT COALESCE(sum(size_bytes), 0)::int AS used_bytes, count(*)::int AS row_count
+       FROM ${SCHEMA}.kv WHERE user_id = $1`,
+    [userId]
+  );
+  const row = (r.rows as Array<{ used_bytes: number; row_count: number }>)[0];
+  return { usedBytes: row.used_bytes, rowCount: row.row_count };
+}
+
+async function readAppCounter(appBlockId: string) {
+  const r = await runSql(
+    `SELECT used_bytes::int AS used_bytes, row_count::int AS row_count
+       FROM ${SCHEMA}.quota WHERE app_block_id = $1`,
+    [appBlockId]
+  );
+  const row = (r.rows as Array<{ used_bytes: number; row_count: number }>)[0];
+  return row ? { usedBytes: row.used_bytes, rowCount: row.row_count } : null;
+}
+
+beforeAll(async () => {
+  holder.db = new PGlite();
+  await holder.db.waitReady;
+});
+
+beforeEach(async () => {
+  // A fresh schema per test: `provision` is idempotent, so re-running it is the
+  // real production path, but the ROWS must not carry between cases or a later
+  // assertion would be reading an earlier one's residue.
+  await runSql(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+  await AppStorageProvisioner.provision({ appBlockId: APP_BLOCK_ID, slug: SLUG });
+});
+
+describe('AppStorageProvisioner per-user quota trigger (executed against real Postgres)', () => {
+  // POSITIVE CONTROL for the harness itself. If `provision` silently produced no
+  // trigger — or the GUC never reached the session — every counter would read 0
+  // and every "counter matches recompute" assertion below would pass vacuously
+  // on 0 === 0. This case fails in that world, so it is what licenses the rest.
+  it('a single insert moves the counter off zero by exactly the stored size', async () => {
+    await setKv(APP_BLOCK_ID, USER_A, 'alpha', ALPHA);
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: ALPHA_BYTES,
+      rowCount: 1,
+    });
+    // The literal above and the recompute agree — two independent statements of
+    // the same fact, so a wrong fixture size cannot hide behind a wrong counter.
+    expect(await recomputeUser(USER_A)).toEqual({ usedBytes: ALPHA_BYTES, rowCount: 1 });
+  });
+
+  // 🔴 KILLS THE `DO NOTHING` MUTATION. The first insert CREATES the counter row,
+  // so a frozen ON CONFLICT branch is invisible until a SECOND insert by the SAME
+  // user has to fold into it. Under `DO NOTHING` this reads 39/1 instead of 94/2.
+  it('a second insert by the same user ACCUMULATES into their existing counter', async () => {
+    await setKv(APP_BLOCK_ID, USER_A, 'alpha', ALPHA);
+    await setKv(APP_BLOCK_ID, USER_A, 'beta', BETA);
+
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: ALPHA_BYTES + BETA_BYTES, // 94
+      rowCount: 2,
+    });
+    expect(await recomputeUser(USER_A)).toEqual({
+      usedBytes: ALPHA_BYTES + BETA_BYTES,
+      rowCount: 2,
+    });
+  });
+
+  // 🔴 KILLS THE INVERTED-DELETE MUTATION. A delete that adds instead of
+  // subtracting reads 94/1 here (bytes up, rows down) rather than 55/1.
+  it('a delete SUBTRACTS the removed row from the counter', async () => {
+    await setKv(APP_BLOCK_ID, USER_A, 'alpha', ALPHA);
+    await setKv(APP_BLOCK_ID, USER_A, 'beta', BETA);
+    await deleteKv(APP_BLOCK_ID, USER_A, 'alpha');
+
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: BETA_BYTES, // 55
+      rowCount: 1,
+    });
+    expect(await recomputeUser(USER_A)).toEqual({ usedBytes: BETA_BYTES, rowCount: 1 });
+  });
+
+  // The full insert → update-up → update-down → delete walk, asserted against
+  // the recompute at EVERY step. An update must move bytes and NOT rows; the
+  // shrink leg is the one that catches a `+` where the code needs `NEW - OLD`.
+  it('counter tracks ground truth across insert, grow, shrink and delete', async () => {
+    await setKv(APP_BLOCK_ID, USER_A, 'alpha', ALPHA);
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: ALPHA_BYTES,
+      rowCount: 1,
+    });
+
+    await setKv(APP_BLOCK_ID, USER_A, 'beta', BETA);
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: ALPHA_BYTES + BETA_BYTES, // 94
+      rowCount: 2,
+    });
+
+    // GROW an existing key: bytes rise by the delta, row count is untouched.
+    await setKv(APP_BLOCK_ID, USER_A, 'beta', BETA_BIG);
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: ALPHA_BYTES + BETA_BIG_BYTES, // 130
+      rowCount: 2,
+    });
+
+    // SHRINK an existing key: bytes fall by the delta, row count still untouched.
+    await setKv(APP_BLOCK_ID, USER_A, 'alpha', ALPHA_SMALL);
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: ALPHA_SMALL_BYTES + BETA_BIG_BYTES, // 98
+      rowCount: 2,
+    });
+
+    await deleteKv(APP_BLOCK_ID, USER_A, 'beta');
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: ALPHA_SMALL_BYTES, // 7
+      rowCount: 1,
+    });
+
+    await deleteKv(APP_BLOCK_ID, USER_A, 'alpha');
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({ usedBytes: 0, rowCount: 0 });
+    expect(await recomputeUser(USER_A)).toEqual({ usedBytes: 0, rowCount: 0 });
+  });
+
+  // The relationship the whole sub-quota exists to create: one user's writes must
+  // not appear in another user's counter, while BOTH fold into the app counter.
+  // Two independently-passing per-user tests would not pin this.
+  it("one user's writes stay out of the other's counter and both reach the app counter", async () => {
+    await setKv(APP_BLOCK_ID, USER_A, 'alpha', ALPHA);
+    await setKv(APP_BLOCK_ID, USER_A, 'beta', BETA);
+    await setKv(APP_BLOCK_ID, USER_B, 'alpha', GAMMA);
+
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: ALPHA_BYTES + BETA_BYTES, // 94
+      rowCount: 2,
+    });
+    expect(await readUserCounter(APP_BLOCK_ID, USER_B)).toEqual({
+      usedBytes: GAMMA_BYTES, // 13
+      rowCount: 1,
+    });
+    expect(await readAppCounter(APP_BLOCK_ID)).toEqual({
+      usedBytes: ALPHA_BYTES + BETA_BYTES + GAMMA_BYTES, // 107
+      rowCount: 3,
+    });
+
+    // Deleting A's row leaves B's counter exactly where it was.
+    await deleteKv(APP_BLOCK_ID, USER_A, 'alpha');
+    expect(await readUserCounter(APP_BLOCK_ID, USER_B)).toEqual({
+      usedBytes: GAMMA_BYTES,
+      rowCount: 1,
+    });
+  });
+
+  // The backfill path F1's fallback depends on: rows written while the GUC was
+  // unset (i.e. before this feature, when no per-user trigger existed) are folded
+  // in by `provision`'s anti-join seed, and a re-run does not double-count them.
+  it('re-running provision SEEDS pre-existing rows once and never clobbers a live counter', async () => {
+    // No GUC → both triggers no-op, which is exactly the pre-feature world.
+    await runSql(
+      `INSERT INTO ${SCHEMA}.kv (block_instance_id, user_id, key, value)
+       VALUES ($1, $2, 'alpha', $3::jsonb), ($1, $4, 'alpha', $5::jsonb)`,
+      [INSTANCE, USER_A, JSON.stringify(ALPHA), USER_B, JSON.stringify(GAMMA)]
+    );
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toBeNull();
+
+    await AppStorageProvisioner.provision({ appBlockId: APP_BLOCK_ID, slug: SLUG });
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: ALPHA_BYTES,
+      rowCount: 1,
+    });
+    expect(await readUserCounter(APP_BLOCK_ID, USER_B)).toEqual({
+      usedBytes: GAMMA_BYTES,
+      rowCount: 1,
+    });
+
+    // A live write, then ANOTHER provision. The seed must skip both users now
+    // that they have counter rows — a seed that re-ran would report 39 + 39.
+    await setKv(APP_BLOCK_ID, USER_A, 'beta', BETA);
+    await AppStorageProvisioner.provision({ appBlockId: APP_BLOCK_ID, slug: SLUG });
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: ALPHA_BYTES + BETA_BYTES, // 94, not 133
+      rowCount: 2,
+    });
+  });
+
+  // The counter is keyed on (app_block_id, user_id), and the GUC is what supplies
+  // the app half. A write under a different app id must open a separate counter
+  // rather than adding to the first — this is what makes the `set` gate's
+  // `WHERE app_block_id = $1 AND user_id = $2` read the right row.
+  it('counters are partitioned by the app id the write ran under', async () => {
+    await setKv(APP_BLOCK_ID, USER_A, 'alpha', ALPHA);
+    await setKv(OTHER_APP_BLOCK_ID, USER_A, 'beta', BETA);
+
+    expect(await readUserCounter(APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: ALPHA_BYTES,
+      rowCount: 1,
+    });
+    expect(await readUserCounter(OTHER_APP_BLOCK_ID, USER_A)).toEqual({
+      usedBytes: BETA_BYTES,
+      rowCount: 1,
+    });
+  });
+});
+
+/**
+ * `provisionReviewPreview` carries a SECOND, textually independent copy of the
+ * same trigger body. A guard on only the `provision` copy would leave the twin
+ * free to regress in exactly the two ways above — a mutation applied to the
+ * preview copy alone would SURVIVE, which is the failure mode this block exists
+ * to close. Same assertions, same oracle, different provisioner.
+ */
+describe('provisionReviewPreview per-user quota trigger (executed against real Postgres)', () => {
+  const PUBREQ = 'pubreq_probe01';
+  const PREVIEW_SCHEMA = '"apprev_pubreqprobe01"';
+
+  async function previewSet(userId: number, key: string, value: unknown) {
+    await runSql('BEGIN');
+    await runSql(`SET LOCAL app.current_app_block_id = '${PUBREQ}'`);
+    await runSql(
+      `INSERT INTO ${PREVIEW_SCHEMA}.kv (block_instance_id, user_id, key, value)
+       VALUES ($1, $2, $3, $4::jsonb)
+       ON CONFLICT (block_instance_id, user_id, key)
+       DO UPDATE SET value = EXCLUDED.value, updated_at = now()`,
+      [INSTANCE, userId, key, JSON.stringify(value)]
+    );
+    await runSql('COMMIT');
+  }
+
+  async function previewDelete(userId: number, key: string) {
+    await runSql('BEGIN');
+    await runSql(`SET LOCAL app.current_app_block_id = '${PUBREQ}'`);
+    await runSql(
+      `DELETE FROM ${PREVIEW_SCHEMA}.kv WHERE block_instance_id = $1 AND user_id = $2 AND key = $3`,
+      [INSTANCE, userId, key]
+    );
+    await runSql('COMMIT');
+  }
+
+  async function previewCounter(userId: number) {
+    const r = await runSql(
+      `SELECT used_bytes::int AS used_bytes, row_count::int AS row_count
+         FROM ${PREVIEW_SCHEMA}.user_quota WHERE app_block_id = $1 AND user_id = $2`,
+      [PUBREQ, userId]
+    );
+    const row = (r.rows as Array<{ used_bytes: number; row_count: number }>)[0];
+    return row ? { usedBytes: row.used_bytes, rowCount: row.row_count } : null;
+  }
+
+  beforeEach(async () => {
+    // DROP first: the provisioner fast-paths on an existing `user_quota`, so a
+    // schema left over from the previous case would skip the DDL under test.
+    await runSql(`DROP SCHEMA IF EXISTS ${PREVIEW_SCHEMA} CASCADE`);
+    await AppStorageProvisioner.provisionReviewPreview({ publishRequestId: PUBREQ });
+  });
+
+  it('accumulates a second insert and subtracts a delete, same as the approved path', async () => {
+    await previewSet(USER_A, 'alpha', ALPHA);
+    expect(await previewCounter(USER_A)).toEqual({ usedBytes: ALPHA_BYTES, rowCount: 1 });
+
+    // Kills the preview copy's `DO NOTHING` mutation.
+    await previewSet(USER_A, 'beta', BETA);
+    expect(await previewCounter(USER_A)).toEqual({
+      usedBytes: ALPHA_BYTES + BETA_BYTES, // 94
+      rowCount: 2,
+    });
+
+    // Kills the preview copy's inverted-DELETE mutation.
+    await previewDelete(USER_A, 'alpha');
+    expect(await previewCounter(USER_A)).toEqual({ usedBytes: BETA_BYTES, rowCount: 1 });
+  });
+
+  it('tracks a shrink in place without moving the row count', async () => {
+    await previewSet(USER_A, 'alpha', ALPHA);
+    await previewSet(USER_A, 'alpha', ALPHA_SMALL);
+    expect(await previewCounter(USER_A)).toEqual({
+      usedBytes: ALPHA_SMALL_BYTES, // 7
+      rowCount: 1,
+    });
+  });
+
+  // The fast path added by this PR probes `user_quota`, NOT the schema, so a
+  // preview provisioned by an EARLIER build (schema + kv + quota, no user_quota)
+  // upgrades on the next op instead of leaving every write hitting a missing
+  // relation. Simulate that older shape by dropping just the one table.
+  it('upgrades a preview schema that predates user_quota instead of fast-pathing past it', async () => {
+    await runSql(`DROP TABLE ${PREVIEW_SCHEMA}.user_quota`);
+    await AppStorageProvisioner.provisionReviewPreview({ publishRequestId: PUBREQ });
+    await previewSet(USER_A, 'alpha', ALPHA);
+    expect(await previewCounter(USER_A)).toEqual({ usedBytes: ALPHA_BYTES, rowCount: 1 });
+  });
+});

--- a/src/server/services/apps/storage-provision.service.ts
+++ b/src/server/services/apps/storage-provision.service.ts
@@ -85,6 +85,21 @@ export const AppStorageProvisioner = {
         )
       `);
 
+      // Per-USER sub-budget beneath the app ceiling. `quota` is keyed on the app
+      // alone while `kv` rows are keyed per user, so without this one account can
+      // spend the whole app budget and — since only the owning user may delete
+      // their own rows — no other user of the app can ever reclaim it.
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${schema}.user_quota (
+          app_block_id text NOT NULL,
+          user_id integer NOT NULL,
+          used_bytes bigint NOT NULL DEFAULT 0,
+          row_count bigint NOT NULL DEFAULT 0,
+          updated_at timestamptz DEFAULT now() NOT NULL,
+          PRIMARY KEY (app_block_id, user_id)
+        )
+      `);
+
       // ── SHARED (app-global / cross-user) storage tables ────────────────────
       // The public-write surface (voting + community lists). Distinct from the
       // per-user `kv` table above: rows are app-global, readable by all users of
@@ -205,6 +220,71 @@ export const AppStorageProvisioner = {
         FOR EACH ROW EXECUTE FUNCTION ${schema}.kv_quota_trigger()
       `);
 
+      // Per-user counter, maintained in the SAME transaction as the write so the
+      // `set` gate reads a counter instead of SUM()ing the writer's rows.
+      //
+      // A SEPARATE function from kv_quota_trigger, bound to `kv` ONLY: it reads
+      // NEW/OLD.user_id, and `shared_kv` (which reuses kv_quota_trigger) has
+      // `author_user_id` instead. plpgsql resolves record fields at runtime, so
+      // folding this into the shared function would throw on every shared append.
+      await client.query(`
+        CREATE OR REPLACE FUNCTION ${schema}.kv_user_quota_trigger() RETURNS trigger AS $fn$
+        DECLARE
+          v_app_block_id text := current_setting('app.current_app_block_id', true);
+        BEGIN
+          IF v_app_block_id IS NULL OR v_app_block_id = '' THEN
+            RETURN NULL;
+          END IF;
+          IF TG_OP = 'INSERT' THEN
+            INSERT INTO ${schema}.user_quota (app_block_id, user_id, used_bytes, row_count)
+            VALUES (v_app_block_id, NEW.user_id, NEW.size_bytes, 1)
+            ON CONFLICT (app_block_id, user_id) DO UPDATE
+              SET used_bytes = user_quota.used_bytes + EXCLUDED.used_bytes,
+                  row_count  = user_quota.row_count + EXCLUDED.row_count,
+                  updated_at = now();
+          ELSIF TG_OP = 'UPDATE' THEN
+            UPDATE ${schema}.user_quota
+               SET used_bytes = used_bytes + (NEW.size_bytes - OLD.size_bytes),
+                   updated_at = now()
+             WHERE app_block_id = v_app_block_id AND user_id = NEW.user_id;
+          ELSIF TG_OP = 'DELETE' THEN
+            UPDATE ${schema}.user_quota
+               SET used_bytes = used_bytes - OLD.size_bytes,
+                   row_count  = row_count - 1,
+                   updated_at = now()
+             WHERE app_block_id = v_app_block_id AND user_id = OLD.user_id;
+          END IF;
+          RETURN NULL;
+        END $fn$ LANGUAGE plpgsql
+      `);
+      await client.query(`DROP TRIGGER IF EXISTS kv_user_quota_trg ON ${schema}.kv`);
+      await client.query(`
+        CREATE TRIGGER kv_user_quota_trg
+        AFTER INSERT OR UPDATE OR DELETE ON ${schema}.kv
+        FOR EACH ROW EXECUTE FUNCTION ${schema}.kv_user_quota_trigger()
+      `);
+
+      // Seed the counter from rows written BEFORE user_quota existed. Without
+      // this every pre-existing user starts at 0 and their historic bytes never
+      // count against the sub-budget. The anti-join seeds only users that have no
+      // counter row yet, so a live counter is never clobbered and an app whose
+      // users are already seeded costs one index probe per user rather than a
+      // recount. NOT conditioned on the table being empty: the first write after
+      // the deploy creates one user's row, and an emptiness guard would then skip
+      // every remaining user forever.
+      await client.query(
+        `INSERT INTO ${schema}.user_quota (app_block_id, user_id, used_bytes, row_count)
+         SELECT $1, k.user_id, COALESCE(sum(k.size_bytes), 0), count(*)
+           FROM ${schema}.kv k
+          WHERE NOT EXISTS (
+            SELECT 1 FROM ${schema}.user_quota u
+             WHERE u.app_block_id = $1 AND u.user_id = k.user_id
+          )
+          GROUP BY k.user_id
+         ON CONFLICT (app_block_id, user_id) DO NOTHING`,
+        [appBlockId]
+      );
+
       // Reuse the SAME quota-trigger function on shared_kv (it only touches
       // ${schema}.quota + NEW/OLD.size_bytes + row_count — all present on
       // shared_kv). Shared writes SET LOCAL app.current_app_block_id in-txn just
@@ -294,10 +374,17 @@ export const AppStorageProvisioner = {
     const schema = reviewPreviewSchemaIdent(publishRequestId); // "apprev_<norm>"
     const pool = requireAppsDb();
 
-    // Fast path — skip the DDL transaction entirely once the preview schema
-    // exists (a review session issues many storage ops against the same schema).
+    // Fast path — skip the DDL transaction entirely once the preview schema is at
+    // the current shape (a review session issues many storage ops against the same
+    // schema). Probes `user_quota`, the newest table, NOT the schema: a preview
+    // provisioned by an earlier build exists but has no per-user counter, and a
+    // schema-level probe would fast-path past the upgrade and leave every write in
+    // that still-pending review hitting a missing relation.
     const existing = await pool.query<{ exists: boolean }>(
-      `SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = $1) AS exists`,
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.tables
+          WHERE table_schema = $1 AND table_name = 'user_quota'
+       ) AS exists`,
       [`apprev_${norm}`]
     );
     if (existing.rows[0]?.exists) return { schema };
@@ -331,6 +418,16 @@ export const AppStorageProvisioner = {
           used_bytes bigint NOT NULL DEFAULT 0,
           row_count bigint NOT NULL DEFAULT 0,
           updated_at timestamptz DEFAULT now() NOT NULL
+        )
+      `);
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${schema}.user_quota (
+          app_block_id text NOT NULL,
+          user_id integer NOT NULL,
+          used_bytes bigint NOT NULL DEFAULT 0,
+          row_count bigint NOT NULL DEFAULT 0,
+          updated_at timestamptz DEFAULT now() NOT NULL,
+          PRIMARY KEY (app_block_id, user_id)
         )
       `);
       // Same quota trigger as provision() — folds preview bytes/rows into the
@@ -370,6 +467,56 @@ export const AppStorageProvisioner = {
         AFTER INSERT OR UPDATE OR DELETE ON ${schema}.kv
         FOR EACH ROW EXECUTE FUNCTION ${schema}.kv_quota_trigger()
       `);
+      // Per-user sub-budget, same shape as provision(). See the note there on why
+      // this is a separate function from kv_quota_trigger.
+      await client.query(`
+        CREATE OR REPLACE FUNCTION ${schema}.kv_user_quota_trigger() RETURNS trigger AS $fn$
+        DECLARE
+          v_app_block_id text := current_setting('app.current_app_block_id', true);
+        BEGIN
+          IF v_app_block_id IS NULL OR v_app_block_id = '' THEN
+            RETURN NULL;
+          END IF;
+          IF TG_OP = 'INSERT' THEN
+            INSERT INTO ${schema}.user_quota (app_block_id, user_id, used_bytes, row_count)
+            VALUES (v_app_block_id, NEW.user_id, NEW.size_bytes, 1)
+            ON CONFLICT (app_block_id, user_id) DO UPDATE
+              SET used_bytes = user_quota.used_bytes + EXCLUDED.used_bytes,
+                  row_count  = user_quota.row_count + EXCLUDED.row_count,
+                  updated_at = now();
+          ELSIF TG_OP = 'UPDATE' THEN
+            UPDATE ${schema}.user_quota
+               SET used_bytes = used_bytes + (NEW.size_bytes - OLD.size_bytes),
+                   updated_at = now()
+             WHERE app_block_id = v_app_block_id AND user_id = NEW.user_id;
+          ELSIF TG_OP = 'DELETE' THEN
+            UPDATE ${schema}.user_quota
+               SET used_bytes = used_bytes - OLD.size_bytes,
+                   row_count  = row_count - 1,
+                   updated_at = now()
+             WHERE app_block_id = v_app_block_id AND user_id = OLD.user_id;
+          END IF;
+          RETURN NULL;
+        END $fn$ LANGUAGE plpgsql
+      `);
+      await client.query(`DROP TRIGGER IF EXISTS kv_user_quota_trg ON ${schema}.kv`);
+      await client.query(`
+        CREATE TRIGGER kv_user_quota_trg
+        AFTER INSERT OR UPDATE OR DELETE ON ${schema}.kv
+        FOR EACH ROW EXECUTE FUNCTION ${schema}.kv_user_quota_trigger()
+      `);
+      await client.query(
+        `INSERT INTO ${schema}.user_quota (app_block_id, user_id, used_bytes, row_count)
+         SELECT $1, k.user_id, COALESCE(sum(k.size_bytes), 0), count(*)
+           FROM ${schema}.kv k
+          WHERE NOT EXISTS (
+            SELECT 1 FROM ${schema}.user_quota u
+             WHERE u.app_block_id = $1 AND u.user_id = k.user_id
+          )
+          GROUP BY k.user_id
+         ON CONFLICT (app_block_id, user_id) DO NOTHING`,
+        [publishRequestId]
+      );
       await client.query(
         `INSERT INTO ${schema}.quota (app_block_id) VALUES ($1) ON CONFLICT (app_block_id) DO NOTHING`,
         [publishRequestId]
@@ -467,6 +614,43 @@ export const AppStorageProvisioner = {
     const result = await pool.query<{ used_bytes: string; row_count: string }>(
       `SELECT used_bytes::text, row_count::text FROM ${schema}.quota WHERE app_block_id = $1`,
       [appBlockId]
+    );
+    if (result.rows.length === 0) return { usedBytes: 0, rowCount: 0 };
+    return {
+      usedBytes: Number(result.rows[0].used_bytes ?? '0'),
+      rowCount: Number(result.rows[0].row_count ?? '0'),
+    };
+  },
+
+  /**
+   * One user's usage inside an app. Same information_schema guard as `getQuota`:
+   * a slug whose schema was never provisioned returns null rather than raising a
+   * relation-doesn't-exist. A provisioned app with no rows for this user returns
+   * zeroes — the counter row is created by the first write, not at provision.
+   */
+  async getUserQuota({
+    appBlockId,
+    slug,
+    userId,
+  }: ProvisionOpts & { userId: number }): Promise<{ usedBytes: number; rowCount: number } | null> {
+    if (!isValidAppSlug(slug)) {
+      throw new Error(`AppStorageProvisioner.getUserQuota: invalid slug ${JSON.stringify(slug)}`);
+    }
+    const schema = appSchemaIdent(slug);
+    const pool = requireAppsDb();
+    const schemaExists = await pool.query<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.tables
+          WHERE table_schema = $1 AND table_name = 'user_quota'
+       ) AS exists`,
+      [`app_${slug}`]
+    );
+    if (!schemaExists.rows[0]?.exists) return null;
+
+    const result = await pool.query<{ used_bytes: string; row_count: string }>(
+      `SELECT used_bytes::text, row_count::text FROM ${schema}.user_quota
+        WHERE app_block_id = $1 AND user_id = $2`,
+      [appBlockId, userId]
     );
     if (result.rows.length === 0) return { usedBytes: 0, rowCount: 0 };
     return {

--- a/src/server/services/block-revocation.service.ts
+++ b/src/server/services/block-revocation.service.ts
@@ -5,10 +5,16 @@ import { redis, REDIS_KEYS } from '~/server/redis/client';
 // block-token.service.ts), so a marker can lapse while such a token is still
 // valid. The write path is wired: `revokeInstance` on uninstall and on
 // `toggleEnabled(false)`, `clearInstance` on re-enable (block-registry.service).
-// Two things still to settle before this TTL is raised to cover that worst case:
+//
+// One thing still to settle before this TTL is raised to cover that worst case:
 // dev page tokens share the `page_<appBlockId>` instance-id shape with prod page
-// mints (see the note in api/v1/blocks/dev-token.ts), so a longer-lived dev
-// revocation would reach production page tokens for the same app.
+// mints (`PAGE_INSTANCE_PREFIX` in both api/v1/block-tokens/index.ts and
+// api/v1/blocks/dev-token.ts), so a longer-lived dev revocation would reach
+// production page tokens for the same app. The collision is LATENT today, not
+// live: both wired call sites revoke `blockUserSubscription.blockInstanceId` — a
+// per-install subscription id — so nothing currently passes a `page_` id to
+// `revokeInstance`. A future caller that revokes by page instance id, or a TTL
+// raised to the 4h dev-token lifetime, is what makes it reachable.
 const REVOCATION_TTL_SECONDS = 900;
 
 function revokedKey(blockInstanceId: string) {

--- a/src/server/services/block-revocation.service.ts
+++ b/src/server/services/block-revocation.service.ts
@@ -1,14 +1,14 @@
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 
-// 15 minutes. NOTE: this NO LONGER covers the worst-case token lifetime — App
-// Blocks dev:live tokens now live up to DEV_TOKEN_LIFETIME_SECONDS (4h, see
-// block-token.service.ts). This TTL is intentionally left at 15min because the
-// revocation WRITE path (revokeInstance/clearInstance) is currently UNWIRED
-// (zero callers). BEFORE wiring a revocation write path, you MUST: (1) raise
-// this TTL to cover the max token lifetime, AND (2) namespace dev instance ids
-// distinctly (dev page tokens share the `page_<appBlockId>` shape with prod page
-// mints — see the note in api/v1/blocks/dev-token.ts), or a dev revocation will
-// bleed into production page tokens for the same app.
+// 15 minutes, which covers an ordinary block token but NOT the worst case — App
+// Blocks dev:live tokens live up to DEV_TOKEN_LIFETIME_SECONDS (4h, see
+// block-token.service.ts), so a marker can lapse while such a token is still
+// valid. The write path is wired: `revokeInstance` on uninstall and on
+// `toggleEnabled(false)`, `clearInstance` on re-enable (block-registry.service).
+// Two things still to settle before this TTL is raised to cover that worst case:
+// dev page tokens share the `page_<appBlockId>` instance-id shape with prod page
+// mints (see the note in api/v1/blocks/dev-token.ts), so a longer-lived dev
+// revocation would reach production page tokens for the same app.
 const REVOCATION_TTL_SECONDS = 900;
 
 function revokedKey(blockInstanceId: string) {


### PR DESCRIPTION
Pre-GA hardening for per-user App Storage (`apps.storage.*`). #4721 re-gated this path on the RUN capability, which turned it from an author-only surface into a consumer one. It was missing controls the sibling shared-storage router already had for exactly that reason.

Three review rounds are folded in here; this body describes the PR as it currently stands, not as it was opened.

## 1. Per-user sub-quota beneath the app budget

`APP_QUOTA_BYTES` (50MB) and `APP_ROW_LIMIT` (1M) are keyed on `app_block_id`, while `kv` rows are keyed per user. So one account could spend the entire app budget, and because only the owning user may delete their own rows, no other user of the app could ever reclaim it.

The app ceilings are unchanged. Added beneath them:

```ts
const USER_QUOTA_BYTES = 2 * 1024 * 1024;  // 2 MiB
const USER_ROW_LIMIT = 1_000;
```

**Why these numbers.** They are an anti-monopoly clamp, not a fair share — a fair share of 50MB across a popular app's user count lands *below* a single `PER_VALUE_BYTE_CAP` (64KB) write, which would be unusable.

The byte figure was re-derived in review against the live per-user footprints, in the unit the counter is actually in (stored `size_bytes`). The result is deliberately **not** a bound no real workload approaches: the widest observed account sits within one order of magnitude of the cap, so 1 MiB would have put it at ~65% of its ceiling — close enough that ordinary continued use would start refusing its writes. 2 MiB leaves ~3.1x headroom over the largest thing anyone is actually doing while keeping the property the cap exists for: exhausting the app's 50MB now takes **25 distinct accounts instead of one**, turning a single-account denial of service into a coordinated-sybil one, which is the layer the platform's other controls address. The row cap is the comfortable one — the widest observed user holds 49 rows against 1000.

**No unbounded scan on the write path.** A `SUM()` over the writer's rows per `set` was rejected. Instead a `user_quota` counter table is maintained by its own trigger in the same transaction as the write — the same design the existing app-wide `quota` row already uses. The `set` path reads the counter on the **existing** quota round trip via a `LEFT JOIN`, so the query count on the write path is unchanged:

```sql
SELECT q.used_bytes::text, q.row_count::text,
       COALESCE(u.used_bytes, 0)::text AS user_used_bytes,
       COALESCE(u.row_count, 0)::text  AS user_row_count
  FROM app_<slug>.quota q
  LEFT JOIN app_<slug>.user_quota u
    ON u.app_block_id = q.app_block_id AND u.user_id = $2
 WHERE q.app_block_id = $1
```

The per-user trigger is a **separate function** from `kv_quota_trigger`, bound to `kv` only. It reads `NEW/OLD.user_id`, and `shared_kv` (which reuses `kv_quota_trigger`) carries `author_user_id` instead; plpgsql resolves record fields at runtime, so folding this into the shared function would have thrown on every shared append. There is a test asserting the binding, not merely the trigger's existence.

## 2. The quota delta is computed in STORED bytes

*(Round-3 fix. This was the deploy-blocking finding, and it existed only because of the exemption in §3 — the two have to be read together.)*

`netDelta` was `byteSize - oldSize`, and those are **two different units**:

- `byteSize` is `Buffer.byteLength(JSON.stringify(value))` — JS wire bytes;
- `oldSize` is the `kv.size_bytes` column, `GENERATED ALWAYS AS (octet_length(value::text))` over a **jsonb** column, which is also what the quota trigger sums.

Postgres' jsonb output function is not `JSON.stringify`: it emits `, ` after every separator and `: ` after every object key, and it re-renders every number in full decimal. Measured against Postgres:

| value | stored (`octet_length(jsonb::text)`) | wire (`Buffer.byteLength(JSON.stringify())`) | ratio |
|---|---|---|---|
| `[1,2,3]` | 9 | 7 | 1.29x |
| `{"a":1,"b":2}` | 16 | 13 | 1.23x |
| 5,000-element int array | 15,000 | 10,001 | **1.4999x** |
| `Array(9000).fill(1e308)` | 2,799,000 | 63,001 | **44.4x** |
| `null`, `"hello"` | 4, 7 | 4, 7 | 1.00x (scalars agree) |

⚠️ **1.4999x is the ratio for a dense integer array, not a bound.** The multiplier is payload-dependent and there is no useful fixed ceiling on it — see the residual at the end of this section.

So `netDelta <= 0` did **not** mean "does not grow the stored bytes" — which is exactly what the §3 exemption's premise claimed, and what both byte gates relied on. Writing, on each pass, the largest value whose *wire* size is at most the row's current *stored* size holds the computed delta at or below zero forever while the stored bytes grow (for the all-ones fixture the walk uses, ~1.5x per pass). The exemption then skipped **both** byte ceilings on every one of those writes; the per-value cap still bound per value, and the row count never moved (updates only), so nothing else stopped it.

Reproduced end to end against the provisioner's own unmodified DDL, generated column and trigger: 30 keys walked to **2,949,030 stored bytes** — exactly 30 x 98,301, i.e. every key saturated at the per-value cap — against a 2,097,152-byte ceiling, **with zero refusals**. The counter equalled an independent `sum(size_bytes)` recompute in both arms, so that is real stored data, not counter drift. Scaled to `USER_ROW_LIMIT` it reaches 1,000 x 98,301 = 98,301,000 bytes — **93.7 MiB** — for a single account, past `APP_QUOTA_BYTES` too.

**The fix puts both sides of the subtraction in the counter's unit** rather than deleting the exemption (see §3 for why deleting it is not an option). The round trip that already read the old size now returns the new one too, using the same expression the generated column uses:

```sql
SELECT octet_length($4::jsonb::text) AS new_size_bytes,
       (SELECT size_bytes FROM app_<slug>.kv
         WHERE block_instance_id = $1 AND user_id = $2 AND key = $3)
         AS old_size_bytes
```

`old_size_bytes` is NULL exactly when no row exists (`value` is NOT NULL and `size_bytes` is generated from it), which is what now distinguishes an insert from an update. The query count on the write path is still unchanged.

The probe **fails loudly** rather than absorbing a missing or NULL row into a `0`: both byte gates are computed from that one row, and a `0` reads as a non-increasing write while a `NaN` makes every `>` comparison false — either would skip the gates, i.e. the failure mode of a silent fallback here is an *unmetered* write, the same class as the defect above. Note `Number(null) === 0` is finite, so the null is rejected before the coercion, not after.

**Two units now coexist deliberately** and are named at the top of the procedure: wire bytes remain the unit of `PER_VALUE_BYTE_CAP` and of the `sizeBytes` reported back to the block (unchanged contract — it is the number a block can predict for itself); stored bytes are the unit of every counter and ceiling. The refusal logs move to stored bytes, since they sit beside `usedBytes`/`userUsedBytes` and the gate that refused compared stored bytes; the success log carries both, named.

**One residual is named rather than silently fixed.** `PER_VALUE_BYTE_CAP` is still checked in the wire unit, so a value's stored size is **not** bounded by it — and there is no useful fixed multiplier. Postgres never emits scientific notation for a number, so `1e308` costs 6 wire bytes and stores 309 digits. Measured: `Array(9000).fill(1e308)` is 63,001 wire bytes (inside the 64 KiB cap) and stores **2,799,000 — 44.4x**; the largest all-`1e308` array the cap admits (9,362 elements, 65,535 wire) stores **2,911,582**. Treat the expansion as unbounded in practice for numeric-heavy payloads.

That is pre-existing behaviour and it is **not** a ceiling bypass — both byte ceilings are enforced in the stored unit and bind regardless. What it *does* mean is that the pre-flight quota read's accepted overshoot is up to ~2.9 MB of stored bytes rather than ~64 KiB, so a racing pair of writes can reach ~4.8 MiB against the 2 MiB per-user cap. Tightening the cap would refuse writes that succeed today, so it is left alone.

*(An earlier version of this body bounded that expansion at "~1.5x its nominal 64KB". That was wrong by ~30x, and it was also the stated justification for the deletion in "Dead code removed" below — both are corrected here.)*

## 3. A cap must not trap the account it applies to

`usedBytes` and `userUsedBytes` are what is stored **now**, not a projection. A counter already at or above a ceiling — a cap lowered under existing data, a pre-existing account, a counter drifted by a failed transaction — makes `used + netDelta > CAP` true for a **shrink** as well as a growth. So the one write that would bring the account back under the cap was the write refused, leaving `storage.delete` (which the app has to expose an affordance for) as the only exit.

A write that does not grow the stored bytes cannot push a counter past a ceiling, so both byte gates are now exempt when `netDelta <= 0`. Both halves are pinned: a shrink and a same-size rewrite from an over-ceiling state are allowed, a growth from the same state is still refused, and the app-ceiling case is its own test because the per-user test passes with it still broken.

The exemption cannot skip anything else: the two row-count gates are `isInsert`-guarded and unconditional (`netDelta <= 0` implies an update — `oldSize` is 0 on an insert and the smallest value Postgres stores is `null` at 4 bytes), `PER_VALUE_BYTE_CAP` is enforced before any of it, and the trigger reconciles the counters from the rows after the write.

## 4. Revocation checked per storage op

`resolveStorageContext` never called `BlockRevocation.isRevoked(claims.blockInstanceId)`, and `verifyBlockToken` does not either — it checks signature and expiry and nothing else. So an uninstall, a disabled instance, or a publisher ban left every already-minted token reading and writing until natural expiry.

This is a live gap, not a theoretical one: `block-registry.service` calls `revokeInstance` on uninstall and on `toggleEnabled(false)`. (The comment in `block-revocation.service` claiming the write path is unwired was stale; corrected in this PR, since the whole rationale here depends on it.)

The check is placed **before** the run-for-real branch so it binds every storage op, including the mod review-preview path that returns before the approved-app checks. Refusal is counted on `appStorageOpsCounter`, matching every other refusal in that resolver.

## 5. `getQuota` rescoped to the caller

`getQuota` returned the **app-wide** `usedBytes`/`rowCount`, and #4721 widened that audience from authors to the whole run cohort.

**Decision: return the caller's own usage against their own caps; drop the app aggregate.** Two reasons. The aggregate sums *other users'* rows, on the one surface whose entire invariant is that a caller only ever sees their own data — every other query on this path is scoped to `(block_instance_id, user_id)`. And it was not actionable: only the owning user can delete their own rows, so a consumer shown "49 of 50MB used" cannot free any of it.

Field names (`usedBytes`, `rowCount`, `limitBytes`, `limitRows`) are unchanged, so the host bridge and the SDK's `APP_STORAGE_QUOTA_RESULT` contract carry through untouched — what moved is the scope each number describes, and a panel rendering "used X of Y" now says something true about the person reading it. Anon returns zeroes without touching the datastore. `AppStorageProvisioner.getQuota` still reads the app aggregate and is retained for the moderator surface; no tRPC procedure exposes it.

## 6. Deploy order: the set path survives an un-backfilled schema

*(Round-2 fix. The original body said "until the backfill runs, an existing app's `set` calls will error on the missing relation." That is no longer true, and it was not an acceptable deploy state.)*

`user_quota` is created by `AppStorageProvisioner.provision`, whose only callers are new-version approval and the manual admin backfill — **nothing schedules either**. A `LEFT JOIN` tolerates a missing *row*, not a missing *relation*: it is a hard `42P01`. So at deploy, every already-provisioned app whose schema predates the table would have kept serving `get`/`list`/`getQuota` while every `set` returned a raw `INTERNAL_SERVER_ERROR`, until a human ran the backfill.

The joined read is now attempted first, and a `42P01` falls back to an un-joined statement with the per-user counters at zero. The app-wide ceilings and the per-value cap still apply on that path, and an app that has not been backfilled is by construction an app that was running without a per-user cap yesterday — refusing its writes to enforce a counter that does not exist would turn a missing upgrade into an outage. A `42P01` from a missing `quota` still propagates, because the fallback statement reads `quota` too.

⚠️ **The fallback is not fully inert on the byte gate.** It pins `userUsedBytes` at 0, and `0 + netDelta > USER_QUOTA_BYTES` is reachable, because a single value's stored size is not bounded by the wire-unit per-value cap (§2): the largest value that cap admits stores 2,911,582 bytes, past the 2 MiB ceiling on its own. So an un-backfilled app will refuse that class of write with `per-user storage quota exceeded` while not actually tracking a per-user quota. Kept deliberately — a multi-megabyte single value should be refused whether or not the counter exists — but it is a real behaviour difference, not an arithmetic no-op. The row gate *is* inert either way (`0 + 1 > 1000` is false).

**The inert state is alertable, not just greppable.** It emits `user_quota_relation_missing` *and* increments `app_blocks_storage_user_quota_untracked_total{app_block_id}` — its own series, deliberately not an `outcome` on the ops counter where it would be invisible among ordinary successful writes. Nothing schedules the backfill, so this state can persist indefinitely; a condition with no error series of its own is not a condition anything can alert on. This is the series that says "this app is serving writes with its sub-budget unenforced", and the series that returns to zero once the backfill has reached everything.

## 7. Observability: an unexpected fault is now countable

Only the write transaction's own catch incremented `outcome:'error'`, so any fault **before** `BEGIN` — the quota round trip, the pool checkout, token resolution — was visible solely as the `ok` series falling to zero, with no error series for an alert to fire on. All five storage procedures now have a catch-all that counts an unexpected fault once. It discriminates on the error **type**: a deliberate refusal is always a `TRPCError` and has already counted its own outcome at the throw site; a fault never is. The inner transaction catch keeps its `ROLLBACK` and no longer counts, so a fault inside the write is counted once, not twice.

`app_blocks_storage_quota_exceeded_total` also gained a `ceiling` label. An app-ceiling breach is rare, shared by every user of the app, and needs an operator; a per-user refusal is routine and self-recoverable. They shared one label set, so no query could separate "alert now" from "normal Tuesday". A query that sums without the label keeps its previous meaning.

## How existing app schemas reach the new shape

The DDL goes in `AppStorageProvisioner.provision`, which is already idempotent (`IF NOT EXISTS` throughout) and is already re-run over **every approved app** by the existing admin backfill endpoint. New apps get the table via the normal provisioning path (W2 webhook on approved version push).

Two details that make the upgrade complete rather than half-done:

- **Pre-existing rows are counted.** An app schema already holds `kv` rows written before `user_quota` existed. If the table were simply created empty, every existing user would start at 0 and their historic bytes would never count against the sub-budget. `provision` seeds the counter with `SELECT ... GROUP BY user_id` over the app's own `kv`, using an anti-join (`WHERE NOT EXISTS`) so it seeds only users with no counter row — a re-run never clobbers a live counter, and it is deliberately *not* conditioned on the table being empty (the first write after deploy creates one user's row, and an emptiness guard would then skip every remaining user forever).
- **In-flight review previews upgrade.** `provisionReviewPreview` fast-paths on an existence probe. That probe now keys on the `user_quota` table rather than the schema: a preview provisioned by an earlier build *exists*, so a schema-level probe would fast-path past the upgrade and leave every write in that still-pending review hitting a missing relation.

## SQL a human must run

**None.** This repo's rule against auto-applying migrations governs the main civitai DB via Prisma (`packages/civitai-db-schema/prisma/migrations/`). Per-app App Storage lives in a **different** database (`~/server/db/appsDb`), which has no Prisma schema and no migration directory — its DDL is owned entirely by `AppStorageProvisioner` and applied by the provisioning code paths. So there is no `.sql` file to add and nothing to run in psql.

**There is one operational step**, and it is not automatic: after deploy, run the backfill endpoint so existing app schemas gain `user_quota`. Per §6 this is no longer a hard dependency — writes keep working without it, with the sub-budget inert on the row gate and enforced-against-zero on the byte gate, and counted on `app_blocks_storage_user_quota_untracked_total`. That series is the signal to run it, and reaching zero is how you know it is done.

## Explicitly not done

- **No min-trust gate.** Per-user KV is the user's own self-scoped data. The shared router's `assertMinTrust`/`assertSharedWriteTrust` exists because shared rows are readable by *other* users — a rationale that does not transfer here.
- **`PER_VALUE_BYTE_CAP` is not moved to stored bytes.** Named in §2; it is pre-existing, it is not a ceiling bypass, and changing it would refuse writes that succeed today.
- The moderator purge path for per-user rows, the runtime procs in `blocks.router`, and `REVOCATION_TTL_SECONDS` are out of scope.

## Follow-up worth filing (not in this PR)

**The same wire-vs-stored unit mix survives in the sibling shared router.** This PR does not touch that file, so it is pre-existing and not a regression here — but it is the same defect §2 fixes:

- `src/server/routers/apps-shared.router.ts:653` computes `usedBytes + (byteSize - oldBytes) > APP_QUOTA_BYTES`, where `byteSize` is wire bytes and `oldBytes` is `shared_kv.size_bytes` — the same `GENERATED ALWAYS AS (octet_length(value::text))` column, folded into the same `quota.used_bytes` by the same trigger.
- `:535` (the append path) mixes the units the same way: `usedBytes + byteSize > APP_QUOTA_BYTES`.

The §2 walk applies there unchanged. This matters beyond the file itself because the new comment at `apps.router.ts:511-515` reads as a repo-wide invariant — *"Anything compared against `usedBytes` … must be in the stored unit"* — and it does not hold one file over.

**Closing condition:** `apps-shared.router.ts` computes its delta from `octet_length($n::jsonb::text)`, with a mutant that dies to a walk test.

## Tests

| file | tests |
|---|---|
| `apps.router.storage.test.ts` | 87 (from 53 at base) |
| `apps.router.storage.stored-units.behavior.test.ts` | 5 (new) |
| `storage-provision.service.test.ts` | 25 (from 17 at base) |
| `storage-provision.trigger.behavior.test.ts` | 10 (new) |

Two of these execute against **real Postgres** (PGlite, an existing dependency with several sibling `*.behavior.test.ts` precedents), because the defects they cover are invisible to a string-asserting or fixture-fed test.

**`storage-provision.trigger.behavior.test.ts`** — every other provisioner test asserts SQL text captured from a mocked `client.query`, which cannot separate a correct trigger body from a wrong one containing the same identifiers in the same order. Two mutations were confirmed to survive a fully green string-asserting suite: inverting the DELETE branch so a delete *adds* usage, and replacing the INSERT branch's `ON CONFLICT DO UPDATE` with `DO NOTHING`, which freezes every counter at the user's first write and makes the feature permanently inert.

**`apps.router.storage.stored-units.behavior.test.ts`** — the seam suite, and the reason §2 shipped in the first place. The two existing suites are split exactly at the defect and each is individually green and individually blind: the router suite drives the real gate but *supplies* `size_bytes` from fixtures that were all in the wire unit, so the gate never met a real jsonb size; the trigger suite meets real jsonb sizes but never runs the gate. Neither ever builds the combined state. This one does — the provisioner's own unmodified DDL, generated column and trigger on an in-process Postgres, with the real `apps.storage.set` procedure driving it — and it pins the **relationship** between the units rather than one side of it.

Reading the router's *own* predicted size there is load-bearing: `kv.size_bytes` and the trigger-maintained counter are both computed by Postgres, so they are identical whether the router predicted correctly or not. Measured, a mutant that dropped the `::jsonb` cast from the probe survived every assertion built on those two.

The router suite's mock probe answers are now stated explicitly in stored bytes and deliberately differ from the wire size of the value written, so no assertion there can pass by the two units coinciding.

**Red/green matrix.** The seam suite, in its final form, is red on the round-2 code (`84fdb5140`): 2 failed / 3 passed, with `expected 2949030 to be less than or equal to 2097152` (the walk) and `expected undefined to be 9000` (the router emits no predicted size there at all). An earlier draft stopped even sooner, at `refused` still being `0` — the walk met no gate whatsoever. Green at HEAD. The base run was repeated after the suite last changed, since a guard that has been edited since it was watched fail has not been watched fail. Earlier rounds' new tests were run against `454bfd210` (the pre-change base) with the new files in place: 22 failed / 71 passed; the cases that pass at base too are labelled positive controls rather than counted as regression coverage.

**Mutation battery**, round 3 — 12 mutants, each the narrowest expression that can be wrong, every one killed with its own specific error:

| mutant | killing test | error |
|---|---|---|
| `netDelta` back to the wire unit | seam walk | `expected 2949030 to be <= 2097152` |
| probe drops the `::jsonb` cast | seam identity | `expected 6001 to be 9000` |
| `netDelta <= 0` → `< 0` | same-stored-size rewrite | `expected false to be true` |
| exemption deleted, per-user gate | over-ceiling shrink | `expected false to be true` |
| exemption deleted, app gate | app-ceiling shrink | `promise rejected "app quota exceeded" instead of resolving` |
| probe guard → `0` fallback | the probe cases | `resolved "{ ok: true, sizeBytes: 7 }" instead of rejecting` |
| old-size guard deleted | non-numeric old size | `resolved "{ ok: true, sizeBytes: 7 }" instead of rejecting` |
| null-rejection dropped (`Number(null) === 0`) | non-numeric probe | `resolved "{ ok: true, sizeBytes: 7 }" instead of rejecting` |
| `isInsert` pinned false | per-user row cap | `resolved "{ ok: true, sizeBytes: 3 }" instead of rejecting` |
| untracked counter removed | untracked-series test | `expected to be called with { app_block_id: … }` |
| untracked counter fired unconditionally | both untracked tests | `expected 1 times, but got 2 times` |
| refusal log back to wire bytes | stored-unit log test | `expected to be called with ObjectContaining{…}` |

Both instrument controls behaved: a canary mutant (unconditional throw) killed tests with its own marker, proving the harness reaches the file; an equivalent comment-only mutant **survived**, proving the harness can report a survivor rather than being unconditionally red.

**Baseline with no mutation: 92/92 green**, re-derived at the final head `77d8e285c` (`apps.router.storage.test.ts` 87 + the seam suite 5), and the equivalent mutant survived 0 failed / 92 passed there. This body previously recorded 90/90 — that was the count of an earlier tree: `2887a24c5` grew the seam suite's probe `it.each` from 2 cases to 4 *after* the first battery ran, and two rows of the table above name those new cases as the killing test, so the table could not have come from the run the old baseline quoted. The table itself was re-derived at the final head and stands: all 12 mutants killed, each with its own distinct message.

Earlier rounds' guards keep their own killing mutations (revocation deleted → 7 tests fail on `message: 'block instance revoked'`; per-user byte cap deleted → 2 fail; per-user row cap deleted → 1 fail).

**Dead code removed.** `userQuotaTracked &&` on the per-user byte and row gates was disclosed in review as a condition whose deletion survived the full suite. That survival is a fact about the suite's fixtures, and the two gates survive for different reasons:

- the **row** gate is genuinely inert either way — the fallback returns literal `'0'`, and `0 + 1 > 1000` is false regardless. A condition that cannot change an outcome reads as coverage and stops anyone looking, so it is gone.
- the **byte** gate is **not** inert. `netDelta` is bounded by the stored size, and the stored size is *not* bounded by `PER_VALUE_BYTE_CAP`, which is enforced in the wire unit — the largest value that cap admits stores 2,911,582 bytes, past the 2 MiB ceiling on its own. So on an un-backfilled schema the removal makes this gate **refuse** that class of write, per §6.

That difference is kept deliberately and is now stated in the code at both sites, rather than the previous justification that the two arms were arithmetic-identical up to a "~1.5x" expansion bound — that bound was wrong by ~30x (§2), and the conclusion it supported was wrong for the byte gate.

**Gates**, re-measured at the final head:

- `pnpm typecheck` — 0 errors (the tool's own report).
- All four App Blocks storage suites green — **127 tests**, matching the table above.
- Those four plus `apps-shared.router`, the prom cross-graph registration test, and both analytics bucket-label guards — **280 tests across 8 files**, green. (This body previously said "254 across 8 files"; that figure does not reproduce.)
- `pnpm test:lint-rules` — 36 files / 501 tests green.

The stored-size probe has **two** throws with two different messages, so each has its own case asserting its own message — neither guard can cover for the other. Confirmed by mutation: deleting the old-size guard turns exactly that case red.

**Merged-tree check.** `origin/main` had moved 12 commits since this branch, with no file overlap. Merged into a throwaway branch and re-run there at the final head: typecheck 0 errors, the same suites green.

One unrelated suite is intermittently red, and it is a **timing flake rather than a break**: `src/server/__tests__/eventloop-watchdog.capture.test.ts`. Measured at this head, run in isolation seven times, it went 2 / 2 / 0 / 2 / 2 / 0 / 0 failed of 9 — always the same two cases, always at ~12s, i.e. hitting the timeout rather than failing an assertion. The file is untouched by this branch (it does not appear in `git diff --name-only origin/main...HEAD`), so it is pre-existing and not merge-induced. *(An earlier version of this body named `hiddenBlocks.test.ts` as the pre-existing failure. That was wrong — `src/components/AppBlocks/__tests__/hiddenBlocks.test.ts` is 7/7 green at this head.)*
