### PR TITLE
fix(dev-server): wt stale asks the daemon where it runs from

### DIFF
--- a/.claude/skills/dev-server/README.md
+++ b/.claude/skills/dev-server/README.md
@@ -89,7 +89,9 @@ node .claude/skills/dev-server/scripts/db-host.selftest.mjs        # the DB host
 node .claude/skills/dev-server/scripts/cli-verbs.selftest.mjs      # every dispatch target in cli.mjs exists
 node .claude/skills/dev-server/scripts/branch-watch.selftest.mjs
 node .claude/skills/dev-server/scripts/probe.selftest.mjs
-node .claude/skills/dev-server/scripts/worktree.selftest.mjs       # PR state and prune collateral, as reported
+node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs  # the real probe() end to end
+node .claude/skills/dev-server/scripts/daemon-home.selftest.mjs    # the daemon runs from the primary, never the caller
+node .claude/skills/dev-server/scripts/worktree.selftest.mjs       # PR state, prune collateral, and the daemon's home
 ```
 
 If you change any of this, mutate it and check the test goes red.

--- a/.claude/skills/dev-server/README.md
+++ b/.claude/skills/dev-server/README.md
@@ -92,6 +92,7 @@ node .claude/skills/dev-server/scripts/probe.selftest.mjs
 node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs  # the real probe() end to end
 node .claude/skills/dev-server/scripts/daemon-home.selftest.mjs    # the daemon runs from the primary, never the caller
 node .claude/skills/dev-server/scripts/worktree.selftest.mjs       # PR state, prune collateral, and the daemon's home
+node .claude/skills/dev-server/scripts/worktree-remove.integration.selftest.mjs  # wt rm's daemon guard, end to end
 ```
 
 If you change any of this, mutate it and check the test goes red.

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -193,6 +193,7 @@ node .claude/skills/dev-server/scripts/branch-watch.selftest.mjs       # HEAD wa
 node .claude/skills/dev-server/scripts/probe.selftest.mjs              # the classifier, pure
 node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs  # the real probe() end to end
 node .claude/skills/dev-server/scripts/worktree.selftest.mjs           # what `wt stale` / `wt rm` say about a PR, a prune, and the daemon's home
+node .claude/skills/dev-server/scripts/worktree-remove.integration.selftest.mjs  # `wt rm`'s daemon guard, against a throwaway repo
 node .claude/skills/dev-server/scripts/daemon-home.selftest.mjs        # the daemon runs from the primary, never the calling worktree
 node .claude/hooks/check-writable.selftest.mjs                         # the hook, both directions
 ```

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -664,9 +664,10 @@ What's already handled:
   `resolveDaemonHome`. One daemon serves every tree, and a daemon living inside one of them holds
   that directory open for its whole life, so `wt rm` on it fails EBUSY for whoever finishes their PR
   first. `wt rm` **and** `wt stale` ask the daemon for its script path and its cwd, and name it when
-  either is inside the target instead of blaming a stray shell — `wt stale` keeps that tree out of
-  SAFE TO REMOVE, and keeps every tree out of it when the daemon does not answer at all, because a
-  daemon that could not be asked has not been ruled out.
+  either is inside the target instead of blaming a stray shell; `wt stale` keeps that tree out of
+  SAFE TO REMOVE. A daemon that is **running but will not say** — one older than this change, whose
+  `/` carries a bare pid — blocks both, for every tree, because it has not been ruled out. A daemon
+  that is **down** blocks nothing, since a process that is not running holds no directory open.
 
   🔴 **This only binds a CLI that has the change.** The skill directory is committed, so every
   worktree runs its own `cli.mjs`, and a tree cut before it re-pins itself the next time the daemon

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -666,8 +666,10 @@ What's already handled:
   first. `wt rm` **and** `wt stale` ask the daemon for its script path and its cwd, and name it when
   either is inside the target instead of blaming a stray shell; `wt stale` keeps that tree out of
   SAFE TO REMOVE. A daemon that is **running but will not say** — one older than this change, whose
-  `/` carries a bare pid — blocks both, for every tree, because it has not been ruled out. A daemon
-  that is **down** blocks nothing, since a process that is not running holds no directory open.
+  `/` carries a bare pid — blocks both, for every tree, because it has not been ruled out; `wt rm
+  --force` overrides that verdict, and never a named holder. A daemon that is **not running** blocks
+  nothing, since it holds no directory open — and that is decided by the transport, not by a good
+  response, so a live daemon erroring on `/` still counts as running.
 
   🔴 **This only binds a CLI that has the change.** The skill directory is committed, so every
   worktree runs its own `cli.mjs`, and a tree cut before it re-pins itself the next time the daemon

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -192,7 +192,7 @@ node .claude/skills/dev-server/scripts/cli-verbs.selftest.mjs          # every d
 node .claude/skills/dev-server/scripts/branch-watch.selftest.mjs       # HEAD watching + the restart decision
 node .claude/skills/dev-server/scripts/probe.selftest.mjs              # the classifier, pure
 node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs  # the real probe() end to end
-node .claude/skills/dev-server/scripts/worktree.selftest.mjs           # what `wt stale` / `wt rm` say about a PR and a prune
+node .claude/skills/dev-server/scripts/worktree.selftest.mjs           # what `wt stale` / `wt rm` say about a PR, a prune, and the daemon's home
 node .claude/skills/dev-server/scripts/daemon-home.selftest.mjs        # the daemon runs from the primary, never the calling worktree
 node .claude/hooks/check-writable.selftest.mjs                         # the hook, both directions
 ```
@@ -663,8 +663,10 @@ What's already handled:
   **The daemon PROCESS also runs from there** — script, pid file and cwd all resolved through
   `resolveDaemonHome`. One daemon serves every tree, and a daemon living inside one of them holds
   that directory open for its whole life, so `wt rm` on it fails EBUSY for whoever finishes their PR
-  first. `wt rm` asks the daemon for its script path and its cwd, and names it when either is inside
-  the target instead of blaming a stray shell.
+  first. `wt rm` **and** `wt stale` ask the daemon for its script path and its cwd, and name it when
+  either is inside the target instead of blaming a stray shell — `wt stale` keeps that tree out of
+  SAFE TO REMOVE, and keeps every tree out of it when the daemon does not answer at all, because a
+  daemon that could not be asked has not been ruled out.
 
   🔴 **This only binds a CLI that has the change.** The skill directory is committed, so every
   worktree runs its own `cli.mjs`, and a tree cut before it re-pins itself the next time the daemon

--- a/.claude/skills/dev-server/scripts/worktree-remove.integration.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/worktree-remove.integration.selftest.mjs
@@ -1,0 +1,160 @@
+/**
+ * `node .claude/skills/dev-server/scripts/worktree-remove.integration.selftest.mjs`
+ *
+ * `wt rm`'s daemon guard, against a real throwaway repository.
+ *
+ * It lives apart from `worktree.selftest.mjs` because `cmdRemove` cannot be called in-process: it
+ * reports refusals through `fail()`, which is `process.exit(1)`. So each case runs in a child, and
+ * what is asserted is the pair a person actually sees — the exit code and the refusal text.
+ *
+ * Why a guard on this command is worth a repository to test: `wt rm` unlinks every reparse point in
+ * the tree BEFORE it deletes, so a guard that lets one through does not fail cleanly, it fails with
+ * the tree already gutted. Both defects found in review on 868kzk7pf were in exactly this logic, and
+ * both were found by reading rather than by a test.
+ *
+ * The three refusal cases never reach a delete — the daemon check is the first thing `cmdRemove`
+ * does after confirming the target is a registered worktree. The two proceeding cases do delete,
+ * which is the point: a scratch worktree, and the assertion is that it is gone.
+ */
+
+import { execFileSync, spawnSync } from 'child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+import { join, resolve } from 'path';
+
+const SELF = fileURLToPath(import.meta.url);
+const TREE_IN_CHILD = process.env.WT_RM_TARGET;
+
+const skillOf = (root) => `${root}/.claude/skills/dev-server`;
+
+// The child. One case, one process, because a refusal ends the process.
+if (TREE_IN_CHILD) {
+  const { cmdRemove } = await import('./worktree.mjs');
+  const daemonRoot = JSON.parse(process.env.WT_RM_DAEMON);
+  const daemonRequest = async (path) =>
+    path === '/' ? daemonRoot : { ok: true, status: 200, data: { sessions: [], apps: [] } };
+  await cmdRemove(
+    process.env.WT_RM_PRIMARY,
+    TREE_IN_CHILD,
+    { stopServer: false, force: process.env.WT_RM_FORCE === '1' },
+    daemonRequest
+  );
+  process.exit(0);
+}
+
+let failures = 0;
+function check(name, actual, expected) {
+  const pass = actual === expected;
+  if (!pass) failures++;
+  console.log(
+    `${pass ? 'PASS' : 'FAIL'}  ${name}\n        got=${JSON.stringify(actual)}\n       want=${JSON.stringify(expected)}`
+  );
+}
+
+const git = (args, cwd) =>
+  execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+
+const scratch = mkdtempSync(join(tmpdir(), 'wt-rm-'));
+const primary = join(scratch, 'primary');
+
+try {
+  git(['init', '-q', '-b', 'main', primary], scratch);
+  // Local identity only: a box whose global git has no user configured must not fail here, and one
+  // that does must not have this commit attributed to them.
+  git(['config', 'user.email', 'selftest@example.invalid'], primary);
+  git(['config', 'user.name', 'wt rm selftest'], primary);
+  writeFileSync(join(primary, 'README'), 'scratch\n');
+  git(['add', 'README'], primary);
+  git(['commit', '-qm', 'base'], primary);
+
+  let n = 0;
+  const freshTree = () => {
+    const path = join(scratch, `wt-${++n}`);
+    git(['worktree', 'add', '-q', path, '-b', `feat/case-${n}`, 'main'], primary);
+    return path;
+  };
+
+  // `run` returns what the operator sees: the exit code, and the two streams joined, since a
+  // refusal goes to stderr and a proceed-anyway notice goes to stdout.
+  const run = (target, daemon, force) => {
+    const r = spawnSync(process.execPath, [SELF], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        WT_RM_TARGET: target,
+        WT_RM_PRIMARY: primary,
+        WT_RM_DAEMON: JSON.stringify(daemon),
+        WT_RM_FORCE: force ? '1' : '0',
+      },
+    });
+    return { code: r.status, out: `${r.stdout}${r.stderr}` };
+  };
+
+  const held = (tree) => ({
+    ok: true,
+    status: 200,
+    data: { pid: 999, skillDir: skillOf(tree), cwd: primary },
+  });
+  const atPrimary = {
+    ok: true,
+    status: 200,
+    data: { pid: 999, skillDir: skillOf(primary), cwd: primary },
+  };
+  const tooOld = { ok: true, status: 200, data: { pid: 46332 } };
+
+  // 1-2. A NAMED holder is absolute. `--force` is offered on the usage line, so an agent will try
+  // it; it must not work here, because no delete can succeed while that process lives.
+  for (const force of [false, true]) {
+    const tree = freshTree();
+    const r = run(tree, held(tree), force);
+    const label = force ? 'with --force' : 'without --force';
+    check(`a named holder refuses ${label}`, r.code, 1);
+    check(
+      `  and names the pid ${label}`,
+      r.out.includes('hosts the dev-server daemon (pid 999)'),
+      true
+    );
+    check(`  and says --force will not help ${label}`, r.out.includes('--force does NOT'), true);
+    check(`  and the tree is still there ${label}`, existsSync(tree), true);
+  }
+
+  // 3. The case the whole ticket is about: a daemon too old to say where it runs from is neither a
+  // holder nor ruled out. Before this it walked straight through and failed at the delete.
+  {
+    const tree = freshTree();
+    const r = run(tree, tooOld, false);
+    check('an unanswered daemon refuses', r.code, 1);
+    check('  and says it is not ruled out', r.out.includes('NOT ruled out'), true);
+    check('  and offers --force', r.out.includes('--force'), true);
+    check('  and the tree is still there', existsSync(tree), true);
+  }
+
+  // 4. ...but overridably, or one stale daemon freezes worktree removal on the whole box until
+  // somebody restarts a SHARED daemon.
+  {
+    const tree = freshTree();
+    const r = run(tree, tooOld, true);
+    check('--force overrides an unanswered daemon', r.code, 0);
+    check('  and says that is why it proceeded', r.out.includes('proceeding because --force'), true);
+    check('  and the tree is gone', existsSync(tree), false);
+  }
+
+  // 5. The negative control. Without it every assertion above is also satisfied by a `cmdRemove`
+  // that refuses everything, which would be a worse command than the one being fixed.
+  {
+    const tree = freshTree();
+    const r = run(tree, atPrimary, false);
+    check('a daemon at the primary blocks nothing', r.code, 0);
+    check('  and says nothing about the daemon', r.out.includes('dev-server daemon'), false);
+    check('  and the tree is gone', existsSync(tree), false);
+  }
+} finally {
+  // `git worktree remove` would refuse the trees already deleted above, so the directory goes
+  // wholesale and the repository it registered with goes with it.
+  rmSync(scratch, { recursive: true, force: true, maxRetries: 3 });
+  if (existsSync(resolve(scratch))) console.log(`note: could not clean up ${scratch}`);
+}
+
+console.log(failures ? `\n${failures} FAILURES` : '\nall green');
+process.exit(failures ? 1 : 0);

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -191,21 +191,23 @@ async function fetchRunning(daemonRequest) {
 
 // The daemon reports where its own code lives; a daemon running out of this tree holds the
 // directory open and no delete can succeed while it lives.
-//
-// `checked` is separate from `holder` on purpose. A daemon that is down, unreachable, or older than
-// the `skillDir` field yields no holder AND no knowledge — and the failure path below must not then
-// tell the reader the daemon has been ruled out, which is the confidently-wrong message this
-// replaces.
 export async function daemonRunningFrom(target, daemonRequest) {
   return daemonHeldFrom(await daemonRequest('/'), target);
 }
 
 // The same verdict from an already-fetched `/`, so `wt stale` asks once for a dozen trees instead of
-// once per tree. Split rather than copied: paths.mjs exists because a `wt rm` and a `wt stale` that
-// disagree about which tree the daemon is in is the failure both are meant to prevent.
+// once per tree.
+//
+// `checked` is separate from `holder` on purpose. A daemon that is down, unreachable, or older than
+// the `skillDir` field yields no holder AND no knowledge, and the caller must not then report the
+// daemon as ruled out.
 export function daemonHeldFrom(res, target) {
-  const skillDir = res.ok ? res.data?.skillDir : null;
-  if (!skillDir) return { holder: null, checked: false };
+  // A daemon that does not answer at all is not running, and a daemon that is not running holds no
+  // directory open. That is the one unknown that rules ITSELF out, and keeping it separate is what
+  // stops a box with no daemon from reporting every tree as unremovable forever.
+  if (!res.ok) return { holder: null, checked: false, reachable: false };
+  const skillDir = res.data?.skillDir;
+  if (!skillDir) return { holder: null, checked: false, reachable: true };
   // Its script AND its working directory: either one alone keeps the directory open. A daemon
   // started by hand from a worktree runs the primary's script and still pins the tree by cwd.
   const held = [
@@ -215,21 +217,20 @@ export function daemonHeldFrom(res, target) {
   return {
     holder: held ? { pid: res.data.pid, reason: `${held[0]}: ${held[1]}` } : null,
     checked: true,
+    reachable: true,
   };
 }
 
-// Why this tree cannot be removed on the daemon's account, or null when it can.
-//
-// 🔴 UNKNOWN IS NOT NO. A daemon too old to report `skillDir` answers `/` with a bare pid, and the
-// whole of 868kzk7pf is those two being indistinguishable: `wt stale` called a tree safe while the
-// daemon ran out of it, `wt rm` unlinked 7794 reparse points and then failed EBUSY. So an
-// unanswered check keeps the tree in KEEP and says which of the two it is.
+// 🔴 UNKNOWN IS NOT NO. A daemon too old to report `skillDir` answers `/` with a bare pid, and
+// 868kzk7pf is those two being indistinguishable: `wt stale` called a tree safe while the daemon ran
+// out of it, then `wt rm` unlinked every reparse point and failed EBUSY. So an unanswered check
+// keeps the tree in KEEP and says which of the two it is.
 export function daemonBlockReason(daemon) {
   if (!daemon) return null;
   if (daemon.holder)
     return `hosts the dev-server daemon (pid ${daemon.holder.pid}) - ${daemon.holder.reason}`;
-  if (!daemon.checked)
-    return 'the dev-server daemon could not be asked where it runs from (down, unreachable, or too old to report it) - NOT ruled out';
+  if (!daemon.checked && daemon.reachable)
+    return 'a running dev-server daemon did not say where it runs from (it predates PR #4641) - NOT ruled out';
   return null;
 }
 
@@ -265,8 +266,7 @@ export function primaryOf(trees, fallback) {
 export async function inspect(primary, daemonRequest) {
   const trees = listWorktrees(primary);
   const primaryPath = primaryOf(trees, primary);
-  const running = await fetchRunning(daemonRequest);
-  const daemonRoot = await daemonRequest('/');
+  const [running, daemonRoot] = await Promise.all([fetchRunning(daemonRequest), daemonRequest('/')]);
   const rows = [];
   for (const t of trees) {
     const isPrimary = samePath(t.path, primaryPath);
@@ -289,23 +289,44 @@ export async function inspect(primary, daemonRequest) {
   return rows;
 }
 
-export async function cmdStale(primary, daemonRequest) {
-  const rows = await inspect(primary, daemonRequest);
+/**
+ * Which trees `wt stale` offers and which it keeps — separated from the printing so a selftest can
+ * reach the decision without a git tree, a `gh` call and a daemon.
+ */
+export function partitionStale(rows) {
   const candidates = rows.filter((r) => !r.isPrimary);
-
   const removable = candidates.filter(
     (r) => r.mergedPr && !r.dirty && r.sessions.length === 0 && !daemonBlockReason(r.daemon)
   );
-  const blocked = candidates.filter((r) => !removable.includes(r));
+  return {
+    candidates,
+    removable,
+    blocked: candidates.filter((r) => !removable.includes(r)),
+    // One `/` answer decides every row, so this is one fact about the daemon rather than a tally.
+    daemonUnasked: candidates.length > 0 && candidates.every((r) => daemonBlockReason(r.daemon) && !r.daemon?.checked),
+  };
+}
 
-  // Once, not once per row: an unanswered `/` is one fact about the daemon, and it lands on every
-  // tree at the same time. The rows below then say only that it applies to them.
-  const daemonUnasked = candidates.length && candidates.every((r) => !r.daemon?.checked);
+/** Every reason this tree is in KEEP, in the order they are printed. */
+export function keepReasons(r, daemonUnasked) {
+  const why = [];
+  if (r.sessions.length) why.push(`dev server ${r.sessions.map((s) => `${s.id}:${s.port}`).join(',')}`);
+  if (r.dirty) why.push(`${r.dirty} uncommitted`);
+  if (!r.mergedPr) why.push(r.prLabel);
+  const daemonWhy = daemonBlockReason(r.daemon);
+  if (daemonWhy) why.push(daemonUnasked ? 'daemon NOT ruled out (see above)' : daemonWhy);
+  return why;
+}
+
+export async function cmdStale(primary, daemonRequest) {
+  const rows = await inspect(primary, daemonRequest);
+  const { candidates, removable, blocked, daemonUnasked } = partitionStale(rows);
+
   if (daemonUnasked) {
     console.log(
-      '\n[!] the dev-server daemon did not say where it runs from, so NO tree can be cleared of\n' +
-        '    hosting it. It is either down, unreachable, or older than the fix that made it report\n' +
-        '    (PR #4641) - a daemon started before that stays old until it is restarted.'
+      '\n[!] a dev-server daemon is running but did not say where it runs from, so NO tree can be\n' +
+        '    cleared of hosting it. It predates PR #4641 and stays that way until it is restarted -\n' +
+        '    which is shared, so check "cli.mjs test list" is empty and ask before restarting it.'
     );
   }
 
@@ -324,15 +345,8 @@ export async function cmdStale(primary, daemonRequest) {
 
   console.log(`\nKEEP (${blocked.length})\n`);
   for (const r of blocked) {
-    const why = [];
-    if (r.sessions.length)
-      why.push(`dev server ${r.sessions.map((s) => `${s.id}:${s.port}`).join(',')}`);
-    if (r.dirty) why.push(`${r.dirty} uncommitted`);
-    if (!r.mergedPr) why.push(r.prLabel);
-    const daemonWhy = daemonBlockReason(r.daemon);
-    if (daemonWhy) why.push(daemonUnasked ? 'daemon NOT ruled out (see above)' : daemonWhy);
     console.log(`  ${r.path}`);
-    console.log(`      ${r.branch || '(detached)'}  ${why.join('; ')}`);
+    console.log(`      ${r.branch || '(detached)'}  ${keepReasons(r, daemonUnasked).join('; ')}`);
   }
   console.log('\nRemove one with:  node .claude/skills/dev-server/cli.mjs wt rm <path>\n');
 }
@@ -351,15 +365,20 @@ export async function cmdRemove(primary, targetArg, opts, daemonRequest) {
   // dev servers in this tree, which is irreversible and cannot be undone by the refusal that would
   // otherwise follow it.
   const daemonCheck = await daemonRunningFrom(target, daemonRequest);
-  if (daemonCheck.holder) {
+  // The same verdict `wt stale` prints. It used to refuse only a KNOWN holder, so the case that
+  // actually cost the 40 minutes — a daemon too old to answer, which is neither a holder nor ruled
+  // out — walked straight past this and failed at the `rmSync` below with the tree already gutted.
+  const daemonWhy = daemonBlockReason(daemonCheck);
+  if (daemonWhy) {
     fail(
-      `the dev-server daemon (pid ${daemonCheck.holder.pid}) is running from this worktree\n` +
-        `  ${daemonCheck.holder.reason}\n` +
-        `no delete can succeed while it lives — that path is inside the directory.\n` +
-        `a daemon started by a cli.mjs carrying this fix runs from the primary checkout and never\n` +
-        `blocks this; this one does not. it is SHARED — other agents' dev servers and queued test\n` +
-        `runs are on it — so check "cli.mjs test list" reports zero running and zero queued, and ask\n` +
-        `before restarting it.`
+      `${daemonWhy}\n` +
+        (daemonCheck.holder
+          ? `no delete can succeed while it lives — that path is inside the directory.\n` +
+            `a daemon started by a cli.mjs carrying this fix runs from the primary checkout and never\n` +
+            `blocks this; this one does not.`
+          : `so this delete may be the one that unlinks the tree and then cannot remove it.`) +
+        `\nit is SHARED — other agents' dev servers and queued test runs are on it — so check\n` +
+        `"cli.mjs test list" reports zero running and zero queued, and ask before restarting it.`
     );
   }
 

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -197,7 +197,13 @@ async function fetchRunning(daemonRequest) {
 // tell the reader the daemon has been ruled out, which is the confidently-wrong message this
 // replaces.
 export async function daemonRunningFrom(target, daemonRequest) {
-  const res = await daemonRequest('/');
+  return daemonHeldFrom(await daemonRequest('/'), target);
+}
+
+// The same verdict from an already-fetched `/`, so `wt stale` asks once for a dozen trees instead of
+// once per tree. Split rather than copied: paths.mjs exists because a `wt rm` and a `wt stale` that
+// disagree about which tree the daemon is in is the failure both are meant to prevent.
+export function daemonHeldFrom(res, target) {
   const skillDir = res.ok ? res.data?.skillDir : null;
   if (!skillDir) return { holder: null, checked: false };
   // Its script AND its working directory: either one alone keeps the directory open. A daemon
@@ -210,6 +216,21 @@ export async function daemonRunningFrom(target, daemonRequest) {
     holder: held ? { pid: res.data.pid, reason: `${held[0]}: ${held[1]}` } : null,
     checked: true,
   };
+}
+
+// Why this tree cannot be removed on the daemon's account, or null when it can.
+//
+// 🔴 UNKNOWN IS NOT NO. A daemon too old to report `skillDir` answers `/` with a bare pid, and the
+// whole of 868kzk7pf is those two being indistinguishable: `wt stale` called a tree safe while the
+// daemon ran out of it, `wt rm` unlinked 7794 reparse points and then failed EBUSY. So an
+// unanswered check keeps the tree in KEEP and says which of the two it is.
+export function daemonBlockReason(daemon) {
+  if (!daemon) return null;
+  if (daemon.holder)
+    return `hosts the dev-server daemon (pid ${daemon.holder.pid}) - ${daemon.holder.reason}`;
+  if (!daemon.checked)
+    return 'the dev-server daemon could not be asked where it runs from (down, unreachable, or too old to report it) - NOT ruled out';
+  return null;
 }
 
 // Main-app sessions AND app sessions, because both hold a port and a live process in this tree.
@@ -245,6 +266,7 @@ export async function inspect(primary, daemonRequest) {
   const trees = listWorktrees(primary);
   const primaryPath = primaryOf(trees, primary);
   const running = await fetchRunning(daemonRequest);
+  const daemonRoot = await daemonRequest('/');
   const rows = [];
   for (const t of trees) {
     const isPrimary = samePath(t.path, primaryPath);
@@ -261,6 +283,7 @@ export async function inspect(primary, daemonRequest) {
       unpushed: t.branch ? unpushedCount(t.branch, primary) : null,
       lastCommit: lastCommit(t.path),
       sessions: sessions.map((s) => ({ id: s.id, port: s.port, status: s.status })),
+      daemon: daemonHeldFrom(daemonRoot, t.path),
     });
   }
   return rows;
@@ -270,10 +293,25 @@ export async function cmdStale(primary, daemonRequest) {
   const rows = await inspect(primary, daemonRequest);
   const candidates = rows.filter((r) => !r.isPrimary);
 
-  const removable = candidates.filter((r) => r.mergedPr && !r.dirty && r.sessions.length === 0);
+  const removable = candidates.filter(
+    (r) => r.mergedPr && !r.dirty && r.sessions.length === 0 && !daemonBlockReason(r.daemon)
+  );
   const blocked = candidates.filter((r) => !removable.includes(r));
 
-  console.log(`\nSAFE TO REMOVE (${removable.length}) - merged PR, clean tree, no dev server\n`);
+  // Once, not once per row: an unanswered `/` is one fact about the daemon, and it lands on every
+  // tree at the same time. The rows below then say only that it applies to them.
+  const daemonUnasked = candidates.length && candidates.every((r) => !r.daemon?.checked);
+  if (daemonUnasked) {
+    console.log(
+      '\n[!] the dev-server daemon did not say where it runs from, so NO tree can be cleared of\n' +
+        '    hosting it. It is either down, unreachable, or older than the fix that made it report\n' +
+        '    (PR #4641) - a daemon started before that stays old until it is restarted.'
+    );
+  }
+
+  console.log(
+    `\nSAFE TO REMOVE (${removable.length}) - merged PR, clean tree, no dev server, not hosting the daemon\n`
+  );
   if (!removable.length) console.log('  (none)');
   for (const r of removable) {
     const age = r.lastCommit ? r.lastCommit.slice(0, 10) : '?';
@@ -291,6 +329,8 @@ export async function cmdStale(primary, daemonRequest) {
       why.push(`dev server ${r.sessions.map((s) => `${s.id}:${s.port}`).join(',')}`);
     if (r.dirty) why.push(`${r.dirty} uncommitted`);
     if (!r.mergedPr) why.push(r.prLabel);
+    const daemonWhy = daemonBlockReason(r.daemon);
+    if (daemonWhy) why.push(daemonUnasked ? 'daemon NOT ruled out (see above)' : daemonWhy);
     console.log(`  ${r.path}`);
     console.log(`      ${r.branch || '(detached)'}  ${why.join('; ')}`);
   }

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -189,6 +189,23 @@ async function fetchRunning(daemonRequest) {
   };
 }
 
+/**
+ * What one `/` answer establishes, before any tree is named.
+ *
+ * 🔴 `reachable` turns on the TRANSPORT, not on `ok`. `daemonRequest` reports `status: 0` only when
+ * the request never got an answer; a live daemon that 500s on `/` — one session's status throwing is
+ * enough — also arrives as `ok: false`. Reading that as "no daemon is running" would hand back the
+ * confidently-wrong verdict this whole change exists to remove, just from a rarer cause.
+ *
+ * (One case still lands on the wrong side: `daemonRequest` parses the body inside its `try`, so a
+ * daemon answering non-JSON is reported as `status: 0`. A daemon that cannot serve JSON on `/` is
+ * broken in ways this command cannot help with, and fixing it belongs in `daemonRequest`.)
+ */
+export function daemonAnswer(res) {
+  const reachable = res.status !== 0;
+  return { checked: Boolean(res.ok && res.data?.skillDir), reachable };
+}
+
 // The daemon reports where its own code lives; a daemon running out of this tree holds the
 // directory open and no delete can succeed while it lives.
 export async function daemonRunningFrom(target, daemonRequest) {
@@ -202,16 +219,12 @@ export async function daemonRunningFrom(target, daemonRequest) {
 // the `skillDir` field yields no holder AND no knowledge, and the caller must not then report the
 // daemon as ruled out.
 export function daemonHeldFrom(res, target) {
-  // A daemon that does not answer at all is not running, and a daemon that is not running holds no
-  // directory open. That is the one unknown that rules ITSELF out, and keeping it separate is what
-  // stops a box with no daemon from reporting every tree as unremovable forever.
-  if (!res.ok) return { holder: null, checked: false, reachable: false };
-  const skillDir = res.data?.skillDir;
-  if (!skillDir) return { holder: null, checked: false, reachable: true };
+  const answer = daemonAnswer(res);
+  if (!answer.checked) return { holder: null, ...answer };
   // Its script AND its working directory: either one alone keeps the directory open. A daemon
   // started by hand from a worktree runs the primary's script and still pins the tree by cwd.
   const held = [
-    ['its running script', skillDir],
+    ['its running script', res.data.skillDir],
     ['its working directory', res.data.cwd],
   ].find(([, p]) => p && isInside(p, target));
   return {
@@ -286,14 +299,14 @@ export async function inspect(primary, daemonRequest) {
       daemon: daemonHeldFrom(daemonRoot, t.path),
     });
   }
-  return rows;
+  return { rows, daemon: daemonAnswer(daemonRoot) };
 }
 
 /**
  * Which trees `wt stale` offers and which it keeps — separated from the printing so a selftest can
  * reach the decision without a git tree, a `gh` call and a daemon.
  */
-export function partitionStale(rows) {
+export function partitionStale(rows, daemon) {
   const candidates = rows.filter((r) => !r.isPrimary);
   const removable = candidates.filter(
     (r) => r.mergedPr && !r.dirty && r.sessions.length === 0 && !daemonBlockReason(r.daemon)
@@ -302,8 +315,10 @@ export function partitionStale(rows) {
     candidates,
     removable,
     blocked: candidates.filter((r) => !removable.includes(r)),
-    // One `/` answer decides every row, so this is one fact about the daemon rather than a tally.
-    daemonUnasked: candidates.length > 0 && candidates.every((r) => daemonBlockReason(r.daemon) && !r.daemon?.checked),
+    // Read from the one `/` answer rather than tallied back out of the rows: a tally says nothing
+    // when there are no candidates, and would then print no banner on a box holding only the
+    // primary checkout while `wt rm` refuses on the same daemon.
+    daemonUnasked: Boolean(daemon?.reachable && !daemon.checked),
   };
 }
 
@@ -319,8 +334,8 @@ export function keepReasons(r, daemonUnasked) {
 }
 
 export async function cmdStale(primary, daemonRequest) {
-  const rows = await inspect(primary, daemonRequest);
-  const { candidates, removable, blocked, daemonUnasked } = partitionStale(rows);
+  const { rows, daemon } = await inspect(primary, daemonRequest);
+  const { removable, blocked, daemonUnasked } = partitionStale(rows, daemon);
 
   if (daemonUnasked) {
     console.log(
@@ -368,19 +383,25 @@ export async function cmdRemove(primary, targetArg, opts, daemonRequest) {
   // The same verdict `wt stale` prints. It used to refuse only a KNOWN holder, so the case that
   // actually cost the 40 minutes — a daemon too old to answer, which is neither a holder nor ruled
   // out — walked straight past this and failed at the `rmSync` below with the tree already gutted.
+  // A KNOWN holder is absolute; an unknown one is overridable. The two carry different confidence,
+  // and refusing both outright would mean no tree on this box could be removed at all until a
+  // SHARED daemon is restarted — the accumulation `wt stale` and `wt rm` exist to prevent, brought
+  // about by the command meant to prevent it.
   const daemonWhy = daemonBlockReason(daemonCheck);
-  if (daemonWhy) {
+  if (daemonCheck.holder || (daemonWhy && !opts.force)) {
     fail(
       `${daemonWhy}\n` +
         (daemonCheck.holder
           ? `no delete can succeed while it lives — that path is inside the directory.\n` +
             `a daemon started by a cli.mjs carrying this fix runs from the primary checkout and never\n` +
-            `blocks this; this one does not.`
-          : `so this delete may be the one that unlinks the tree and then cannot remove it.`) +
+            `blocks this; this one does not. --force does NOT override this one.`
+          : `so this delete may be the one that unlinks the tree and then cannot remove it. re-run\n` +
+            `with --force to delete anyway, once you accept that risk.`) +
         `\nit is SHARED — other agents' dev servers and queued test runs are on it — so check\n` +
         `"cli.mjs test list" reports zero running and zero queued, and ask before restarting it.`
     );
   }
+  if (daemonWhy) console.log(`[!] ${daemonWhy}\n    proceeding because --force was given.`);
 
   const sessions = sessionsIn(target, await fetchRunning(daemonRequest));
   const live = sessions.filter((s) => s.status === 'running');

--- a/.claude/skills/dev-server/scripts/worktree.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.selftest.mjs
@@ -13,7 +13,7 @@
  * A revert fails on the label text, not on a count, so the failing line names the wrong string.
  */
 
-import { describePrRows, describePrune } from './worktree.mjs';
+import { daemonBlockReason, daemonHeldFrom, describePrRows, describePrune } from './worktree.mjs';
 
 let failures = 0;
 function check(name, actual, expected) {
@@ -109,6 +109,69 @@ check(
   'pruned (could not tell whose): Something git has never printed'
 );
 check('empty prune output says so', describePrune('', ADMIN)[0], 'pruned: no stale worktree registrations');
+
+// 868kzk7pf: `wt stale` called a tree safe while the daemon ran out of it, because it asked about
+// dev servers and never about the daemon's own home. These pin the three answers apart — HELD, and
+// the two that both used to print nothing: ruled out, and never asked.
+const TREE = 'C:\\Dev\\Repos\\work\\worktrees\\mine';
+const PRIMARY = 'C:\\Dev\\Repos\\work\\model-share';
+const skill = (root) => `${root}\\.claude\\skills\\dev-server`;
+const root = (data) => ({ ok: true, data });
+
+check(
+  'a daemon whose script is in the tree is the holder',
+  daemonHeldFrom(root({ pid: 7, skillDir: skill(TREE), cwd: PRIMARY }), TREE).holder?.reason,
+  `its running script: ${skill(TREE)}`
+);
+// Started by hand from inside the tree: it runs the primary's script and pins by cwd alone. Checking
+// only skillDir reports that tree as free while a delete on it cannot succeed.
+check(
+  'and so is one merely CWD\u2019d there',
+  daemonHeldFrom(root({ pid: 7, skillDir: skill(PRIMARY), cwd: TREE }), TREE).holder?.reason,
+  `its working directory: ${TREE}`
+);
+check(
+  'a daemon at the primary holds nothing',
+  daemonHeldFrom(root({ pid: 7, skillDir: skill(PRIMARY), cwd: PRIMARY }), TREE).holder,
+  null
+);
+check(
+  'and that verdict is a checked one',
+  daemonHeldFrom(root({ pid: 7, skillDir: skill(PRIMARY), cwd: PRIMARY }), TREE).checked,
+  true
+);
+// The live case on 2026-09-09: pid 46332 predates PR #4641, so `/` answers with a bare pid. No
+// holder is reported and none has been ruled out either.
+check(
+  'a daemon too old to report is NOT ruled out',
+  daemonHeldFrom(root({ pid: 46332 }), TREE).checked,
+  false
+);
+check('nor is an unreachable one', daemonHeldFrom({ ok: false }, TREE).checked, false);
+// `worktrees/mine1` is a real neighbour of `worktrees/mine` here — git de-duplicates a colliding
+// basename that way — so a prefix match would blame the wrong agent's tree.
+check(
+  'a sibling sharing a path prefix is not this tree',
+  daemonHeldFrom(root({ pid: 7, skillDir: skill(`${TREE}1`), cwd: `${TREE}1` }), TREE).holder,
+  null
+);
+
+check(
+  'the holder blocks removal, naming the pid',
+  daemonBlockReason(daemonHeldFrom(root({ pid: 7, skillDir: skill(TREE), cwd: PRIMARY }), TREE)),
+  `hosts the dev-server daemon (pid 7) - its running script: ${skill(TREE)}`
+);
+check(
+  'a ruled-out daemon blocks nothing',
+  daemonBlockReason(daemonHeldFrom(root({ pid: 7, skillDir: skill(PRIMARY), cwd: PRIMARY }), TREE)),
+  null
+);
+// The whole ticket in one assertion: unknown must not read as no.
+check(
+  'and an unanswered check blocks removal too',
+  daemonBlockReason(daemonHeldFrom(root({ pid: 46332 }), TREE))?.includes('NOT ruled out'),
+  true
+);
 
 console.log(failures ? `\n${failures} FAILURES` : '\nall green');
 process.exit(failures ? 1 : 0);

--- a/.claude/skills/dev-server/scripts/worktree.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.selftest.mjs
@@ -14,6 +14,7 @@
  */
 
 import {
+  daemonAnswer,
   daemonBlockReason,
   daemonHeldFrom,
   describePrRows,
@@ -123,11 +124,12 @@ check('empty prune output says so', describePrune('', ADMIN)[0], 'pruned: no sta
 const TREE = 'C:/Dev/Repos/work/worktrees/mine';
 const PRIMARY = 'C:/Dev/Repos/work/model-share';
 const skill = (root) => `${root}/.claude/skills/dev-server`;
-const root = (data) => ({ ok: true, data });
+const root = (data) => ({ ok: true, status: 200, data });
 const AT_PRIMARY = root({ pid: 7, skillDir: skill(PRIMARY), cwd: PRIMARY });
 const IN_TREE = root({ pid: 7, skillDir: skill(TREE), cwd: PRIMARY });
 const TOO_OLD = root({ pid: 46332 });
-const DOWN = { ok: false };
+const DOWN = { ok: false, status: 0 };
+const ERRORING = { ok: false, status: 500 };
 
 check(
   'a daemon whose script is in the tree is the holder',
@@ -168,6 +170,15 @@ check(
   true
 );
 check('but a daemon that is down blocks nothing', daemonBlockReason(daemonHeldFrom(DOWN, TREE)), null);
+// `reachable` turns on the transport, not on `ok`. A live daemon that 500s on `/` — one session's
+// status throwing is enough — arrives as ok:false too, and reading that as "no daemon is running"
+// hands back the same confidently-wrong verdict from a rarer cause.
+check('a daemon that answered 500 IS running', daemonHeldFrom(ERRORING, TREE).reachable, true);
+check(
+  'so it blocks removal like any other silent one',
+  daemonBlockReason(daemonHeldFrom(ERRORING, TREE))?.includes('NOT ruled out'),
+  true
+);
 
 // The decision `wt stale` prints, over rows `inspect` would have built. Without these the filter and
 // the banner condition are covered by nothing — swapping `every` for `some` at the banner, or
@@ -185,26 +196,26 @@ const row = (over) => ({
 });
 const PRIME = row({ path: PRIMARY, isPrimary: true, daemon: daemonHeldFrom(AT_PRIMARY, PRIMARY) });
 
-check('a merged, clean, unheld tree is offered', partitionStale([PRIME, row({})]).removable.length, 1);
+check('a merged, clean, unheld tree is offered', partitionStale([PRIME, row({})], daemonAnswer(AT_PRIMARY)).removable.length, 1);
 check(
   'the same tree is NOT offered when the daemon lives in it',
-  partitionStale([PRIME, row({ daemon: daemonHeldFrom(IN_TREE, TREE) })]).removable.length,
+  partitionStale([PRIME, row({ daemon: daemonHeldFrom(IN_TREE, TREE) })], daemonAnswer(IN_TREE)).removable.length,
   0
 );
 check(
   'nor when no running daemon would say',
-  partitionStale([PRIME, row({ daemon: daemonHeldFrom(TOO_OLD, TREE) })]).removable.length,
+  partitionStale([PRIME, row({ daemon: daemonHeldFrom(TOO_OLD, TREE) })], daemonAnswer(TOO_OLD)).removable.length,
   0
 );
 // The regression this pair exists for: a down daemon must not zero the command.
 check(
   'but a down daemon offers it as before',
-  partitionStale([PRIME, row({ daemon: daemonHeldFrom(DOWN, TREE) })]).removable.length,
+  partitionStale([PRIME, row({ daemon: daemonHeldFrom(DOWN, TREE) })], daemonAnswer(DOWN)).removable.length,
   1
 );
 check(
   'and the primary is never a candidate',
-  partitionStale([PRIME, row({})]).candidates.length,
+  partitionStale([PRIME, row({})], daemonAnswer(AT_PRIMARY)).candidates.length,
   1
 );
 
@@ -212,25 +223,21 @@ check(
 // never for a single held tree, which is named on its own row instead.
 check(
   'the banner fires when nothing could be asked',
-  partitionStale([PRIME, row({ daemon: daemonHeldFrom(TOO_OLD, TREE) })]).daemonUnasked,
+  partitionStale([PRIME, row({ daemon: daemonHeldFrom(TOO_OLD, TREE) })], daemonAnswer(TOO_OLD)).daemonUnasked,
   true
 );
 check(
   'but not for a daemon that answered and named one tree',
-  partitionStale([PRIME, row({ daemon: daemonHeldFrom(IN_TREE, TREE) })]).daemonUnasked,
+  partitionStale([PRIME, row({ daemon: daemonHeldFrom(IN_TREE, TREE) })], daemonAnswer(IN_TREE)).daemonUnasked,
   false
 );
-check('nor when there is nothing to judge', partitionStale([PRIME]).daemonUnasked, false);
-// Mixed rows cannot arise while one `/` answer decides them all, so this pins the rule rather than a
-// reachable state: `some` here would print "NO tree can be cleared" over a list that clears one.
+check('nor when the daemon answered and there is nothing to judge', partitionStale([PRIME], daemonAnswer(AT_PRIMARY)).daemonUnasked, false);
+// Read from the daemon, not tallied out of the rows: a box holding only the primary checkout has no
+// candidates to tally, and used to print no banner while `wt rm` refused on that same daemon.
 check(
-  'and not while any tree is still clearable',
-  partitionStale([
-    PRIME,
-    row({ daemon: daemonHeldFrom(TOO_OLD, TREE) }),
-    row({ path: `${TREE}2`, daemon: daemonHeldFrom(AT_PRIMARY, `${TREE}2`) }),
-  ]).daemonUnasked,
-  false
+  'the banner still fires with no candidate trees at all',
+  partitionStale([PRIME], daemonAnswer(TOO_OLD)).daemonUnasked,
+  true
 );
 
 check(

--- a/.claude/skills/dev-server/scripts/worktree.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.selftest.mjs
@@ -13,7 +13,14 @@
  * A revert fails on the label text, not on a count, so the failing line names the wrong string.
  */
 
-import { daemonBlockReason, daemonHeldFrom, describePrRows, describePrune } from './worktree.mjs';
+import {
+  daemonBlockReason,
+  daemonHeldFrom,
+  describePrRows,
+  describePrune,
+  keepReasons,
+  partitionStale,
+} from './worktree.mjs';
 
 let failures = 0;
 function check(name, actual, expected) {
@@ -111,45 +118,38 @@ check(
 check('empty prune output says so', describePrune('', ADMIN)[0], 'pruned: no stale worktree registrations');
 
 // 868kzk7pf: `wt stale` called a tree safe while the daemon ran out of it, because it asked about
-// dev servers and never about the daemon's own home. These pin the three answers apart — HELD, and
-// the two that both used to print nothing: ruled out, and never asked.
-const TREE = 'C:\\Dev\\Repos\\work\\worktrees\\mine';
-const PRIMARY = 'C:\\Dev\\Repos\\work\\model-share';
-const skill = (root) => `${root}\\.claude\\skills\\dev-server`;
+// dev servers and never about the daemon's own home. HELD, ruled out, and never asked — the last
+// two used to print the same nothing.
+const TREE = 'C:/Dev/Repos/work/worktrees/mine';
+const PRIMARY = 'C:/Dev/Repos/work/model-share';
+const skill = (root) => `${root}/.claude/skills/dev-server`;
 const root = (data) => ({ ok: true, data });
+const AT_PRIMARY = root({ pid: 7, skillDir: skill(PRIMARY), cwd: PRIMARY });
+const IN_TREE = root({ pid: 7, skillDir: skill(TREE), cwd: PRIMARY });
+const TOO_OLD = root({ pid: 46332 });
+const DOWN = { ok: false };
 
 check(
   'a daemon whose script is in the tree is the holder',
-  daemonHeldFrom(root({ pid: 7, skillDir: skill(TREE), cwd: PRIMARY }), TREE).holder?.reason,
+  daemonHeldFrom(IN_TREE, TREE).holder?.reason,
   `its running script: ${skill(TREE)}`
 );
-// Started by hand from inside the tree: it runs the primary's script and pins by cwd alone. Checking
-// only skillDir reports that tree as free while a delete on it cannot succeed.
+// Started by hand from inside the tree: it runs the primary's script and pins by cwd alone.
 check(
-  'and so is one merely CWD\u2019d there',
+  'and so is one merely CWD’d there',
   daemonHeldFrom(root({ pid: 7, skillDir: skill(PRIMARY), cwd: TREE }), TREE).holder?.reason,
   `its working directory: ${TREE}`
 );
-check(
-  'a daemon at the primary holds nothing',
-  daemonHeldFrom(root({ pid: 7, skillDir: skill(PRIMARY), cwd: PRIMARY }), TREE).holder,
-  null
-);
-check(
-  'and that verdict is a checked one',
-  daemonHeldFrom(root({ pid: 7, skillDir: skill(PRIMARY), cwd: PRIMARY }), TREE).checked,
-  true
-);
-// The live case on 2026-09-09: pid 46332 predates PR #4641, so `/` answers with a bare pid. No
-// holder is reported and none has been ruled out either.
-check(
-  'a daemon too old to report is NOT ruled out',
-  daemonHeldFrom(root({ pid: 46332 }), TREE).checked,
-  false
-);
-check('nor is an unreachable one', daemonHeldFrom({ ok: false }, TREE).checked, false);
-// `worktrees/mine1` is a real neighbour of `worktrees/mine` here — git de-duplicates a colliding
-// basename that way — so a prefix match would blame the wrong agent's tree.
+check('a daemon at the primary holds nothing', daemonHeldFrom(AT_PRIMARY, TREE).holder, null);
+check('and that verdict is a checked one', daemonHeldFrom(AT_PRIMARY, TREE).checked, true);
+// The live case on 2026-09-09: pid 46332 predates PR #4641, so `/` answers with a bare pid.
+check('a daemon too old to report is NOT ruled out', daemonHeldFrom(TOO_OLD, TREE).checked, false);
+check('and it IS running', daemonHeldFrom(TOO_OLD, TREE).reachable, true);
+// The one unknown that rules itself out: a daemon that does not answer is not running, and a daemon
+// that is not running holds no directory. Without this a box with no daemon clears no tree, ever.
+check('a daemon that never answered is not running', daemonHeldFrom(DOWN, TREE).reachable, false);
+// A path prefix is not a path segment: without segment-wise matching, a daemon in `…/mine1` reads
+// as holding `…/mine` and blames the wrong agent's tree.
 check(
   'a sibling sharing a path prefix is not this tree',
   daemonHeldFrom(root({ pid: 7, skillDir: skill(`${TREE}1`), cwd: `${TREE}1` }), TREE).holder,
@@ -158,19 +158,96 @@ check(
 
 check(
   'the holder blocks removal, naming the pid',
-  daemonBlockReason(daemonHeldFrom(root({ pid: 7, skillDir: skill(TREE), cwd: PRIMARY }), TREE)),
+  daemonBlockReason(daemonHeldFrom(IN_TREE, TREE)),
+  `hosts the dev-server daemon (pid 7) - its running script: ${skill(TREE)}`
+);
+check('a ruled-out daemon blocks nothing', daemonBlockReason(daemonHeldFrom(AT_PRIMARY, TREE)), null);
+check(
+  'and an unanswered check blocks removal too',
+  daemonBlockReason(daemonHeldFrom(TOO_OLD, TREE))?.includes('NOT ruled out'),
+  true
+);
+check('but a daemon that is down blocks nothing', daemonBlockReason(daemonHeldFrom(DOWN, TREE)), null);
+
+// The decision `wt stale` prints, over rows `inspect` would have built. Without these the filter and
+// the banner condition are covered by nothing — swapping `every` for `some` at the banner, or
+// dropping the daemon term from the filter, both stay green on the helpers alone.
+const row = (over) => ({
+  path: TREE,
+  branch: 'feat/mine',
+  isPrimary: false,
+  mergedPr: 4321,
+  prLabel: 'PR #4321 merged',
+  dirty: 0,
+  sessions: [],
+  daemon: daemonHeldFrom(AT_PRIMARY, TREE),
+  ...over,
+});
+const PRIME = row({ path: PRIMARY, isPrimary: true, daemon: daemonHeldFrom(AT_PRIMARY, PRIMARY) });
+
+check('a merged, clean, unheld tree is offered', partitionStale([PRIME, row({})]).removable.length, 1);
+check(
+  'the same tree is NOT offered when the daemon lives in it',
+  partitionStale([PRIME, row({ daemon: daemonHeldFrom(IN_TREE, TREE) })]).removable.length,
+  0
+);
+check(
+  'nor when no running daemon would say',
+  partitionStale([PRIME, row({ daemon: daemonHeldFrom(TOO_OLD, TREE) })]).removable.length,
+  0
+);
+// The regression this pair exists for: a down daemon must not zero the command.
+check(
+  'but a down daemon offers it as before',
+  partitionStale([PRIME, row({ daemon: daemonHeldFrom(DOWN, TREE) })]).removable.length,
+  1
+);
+check(
+  'and the primary is never a candidate',
+  partitionStale([PRIME, row({})]).candidates.length,
+  1
+);
+
+// The banner is one fact about the daemon, so it fires only when NO row could be cleared of it —
+// never for a single held tree, which is named on its own row instead.
+check(
+  'the banner fires when nothing could be asked',
+  partitionStale([PRIME, row({ daemon: daemonHeldFrom(TOO_OLD, TREE) })]).daemonUnasked,
+  true
+);
+check(
+  'but not for a daemon that answered and named one tree',
+  partitionStale([PRIME, row({ daemon: daemonHeldFrom(IN_TREE, TREE) })]).daemonUnasked,
+  false
+);
+check('nor when there is nothing to judge', partitionStale([PRIME]).daemonUnasked, false);
+// Mixed rows cannot arise while one `/` answer decides them all, so this pins the rule rather than a
+// reachable state: `some` here would print "NO tree can be cleared" over a list that clears one.
+check(
+  'and not while any tree is still clearable',
+  partitionStale([
+    PRIME,
+    row({ daemon: daemonHeldFrom(TOO_OLD, TREE) }),
+    row({ path: `${TREE}2`, daemon: daemonHeldFrom(AT_PRIMARY, `${TREE}2`) }),
+  ]).daemonUnasked,
+  false
+);
+
+check(
+  'a held tree says so, with the pid',
+  keepReasons(row({ daemon: daemonHeldFrom(IN_TREE, TREE) }), false)[0],
   `hosts the dev-server daemon (pid 7) - its running script: ${skill(TREE)}`
 );
 check(
-  'a ruled-out daemon blocks nothing',
-  daemonBlockReason(daemonHeldFrom(root({ pid: 7, skillDir: skill(PRIMARY), cwd: PRIMARY }), TREE)),
-  null
+  'and defers to the banner when there is one',
+  keepReasons(row({ daemon: daemonHeldFrom(TOO_OLD, TREE) }), true).join('; '),
+  'daemon NOT ruled out (see above)'
 );
-// The whole ticket in one assertion: unknown must not read as no.
+// Every other reason survives alongside it; the daemon term is added, not substituted.
 check(
-  'and an unanswered check blocks removal too',
-  daemonBlockReason(daemonHeldFrom(root({ pid: 46332 }), TREE))?.includes('NOT ruled out'),
-  true
+  'the other reasons are still all there',
+  keepReasons(row({ dirty: 3, mergedPr: null, prLabel: 'PR #9 still OPEN', sessions: [{ id: 'a', port: 3001 }], daemon: daemonHeldFrom(IN_TREE, TREE) }), false).length,
+  4
 );
 
 console.log(failures ? `\n${failures} FAILURES` : '\nall green');

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -657,11 +657,13 @@ node .claude/skills/dev-server/cli.mjs wt rm <path>    # stops the server, unlin
 ```
 
 `wt rm` refuses the primary worktree, a tree with uncommitted changes (`--force`), a tree with a
-running dev server (`--stop-server`), and a tree the dev-server daemon itself is running from. `wt stale`
-applies that last one too — and when the daemon does not answer where it runs from, it clears **no** tree,
-because a daemon that could not be asked has not been ruled out. It deletes the branch only when `gh`
-reports a **merged** PR, keeps
-it when commits exist on no remote, and prints the SHA when it does delete. Left alone, worktrees
+running dev server (`--stop-server`), and a tree the dev-server daemon itself is running from. It
+deletes the branch only when `gh` reports a **merged** PR, keeps
+it when commits exist on no remote, and prints the SHA when it does delete. `wt stale` applies that
+daemon check too. **A running daemon that will not say where it runs from blocks both** — it predates
+PR #4641, and a daemon that could not be asked has not been ruled out, so `wt stale` clears no tree and
+`wt rm` refuses until it is restarted. A daemon that is simply *down* blocks nothing: it holds no
+directory open, and that is the one unknown that rules itself out. Left alone, worktrees
 accumulate: 22 stale ones were removed in one sweep on 2026-08-12, 15 with already-merged PRs.
 
 **Two checks that fail *clean* if you verify merge state yourself.** Both return success-shaped output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -656,8 +656,11 @@ node .claude/skills/dev-server/cli.mjs wt stale        # what's finished, and wh
 node .claude/skills/dev-server/cli.mjs wt rm <path>    # stops the server, unlinks links, deletes, prunes
 ```
 
-`wt rm` refuses the primary worktree, a tree with uncommitted changes (`--force`), and a tree with a
-running dev server (`--stop-server`). It deletes the branch only when `gh` reports a **merged** PR, keeps
+`wt rm` refuses the primary worktree, a tree with uncommitted changes (`--force`), a tree with a
+running dev server (`--stop-server`), and a tree the dev-server daemon itself is running from. `wt stale`
+applies that last one too — and when the daemon does not answer where it runs from, it clears **no** tree,
+because a daemon that could not be asked has not been ruled out. It deletes the branch only when `gh`
+reports a **merged** PR, keeps
 it when commits exist on no remote, and prints the SHA when it does delete. Left alone, worktrees
 accumulate: 22 stale ones were removed in one sweep on 2026-08-12, 15 with already-merged PRs.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -662,8 +662,9 @@ deletes the branch only when `gh` reports a **merged** PR, keeps
 it when commits exist on no remote, and prints the SHA when it does delete. `wt stale` applies that
 daemon check too. **A running daemon that will not say where it runs from blocks both** — it predates
 PR #4641, and a daemon that could not be asked has not been ruled out, so `wt stale` clears no tree and
-`wt rm` refuses until it is restarted. A daemon that is simply *down* blocks nothing: it holds no
-directory open, and that is the one unknown that rules itself out. Left alone, worktrees
+`wt rm` refuses (`--force` overrides that one, but never a named holder). A daemon that is *not
+running* blocks nothing: it holds no directory open. That turns on the transport, not on a good
+response — a live daemon that errors on `/` is still running, and still blocks. Left alone, worktrees
 accumulate: 22 stale ones were removed in one sweep on 2026-08-12, 15 with already-merged PRs.
 
 **Two checks that fail *clean* if you verify merge state yourself.** Both return success-shaped output


### PR DESCRIPTION
Closes ClickUp 868kzk7pf.

## The gap

PR #4641 fixed half of this: the daemon now spawns from the primary checkout, and `wt rm` refuses a tree the daemon is running out of. `wt stale` was never taught the check — `cmdStale` filtered on merged PR, clean tree and no dev server, and `inspect()` never asked the daemon anything. So the command whose entire job is "what is safe to remove" was the one blind to the thing pinning the tree.

Reproduced on 2026-09-09, not reasoned about: daemon pid 46332 is running `daemon.mjs` out of `worktrees/profile-remix-flyout` (started 2026-09-04 13:45, three hours before #4641 merged, never restarted — #4641's own commit message cites this same pid as its observed case). `wt stale` printed that tree under **SAFE TO REMOVE**, PR #4627.

## The change

- `daemonAnswer(res)` — what one `/` answer establishes before any tree is named: was it `checked`, and is a daemon `reachable`.
- `daemonHeldFrom(res, target)` split out of `daemonRunningFrom`, so `wt stale` asks `/` once for a dozen trees instead of once per tree.
- `daemonBlockReason(daemon)` — the one place that turns a verdict into a reason, used by **both** `wt stale` and `wt rm`.
- `partitionStale(rows, daemon)` and `keepReasons(row, daemonUnasked)` — the decision `wt stale` prints, pure, so a selftest reaches it without a git tree, a `gh` call and a daemon.

Three rules the code now keeps apart, because collapsing any two of them is what the ticket is about:

🔴 **Unknown is not no.** A daemon older than #4641 answers `/` with a bare `{pid}`. No holder is found AND nothing is ruled out. `wt stale` clears no tree and prints a banner; `wt rm` refuses.

🔴 **Not running is not unknown.** A daemon that is not running holds no directory open — that is the one unknown that rules itself out. Otherwise a box with no daemon reports SAFE TO REMOVE (0) forever, which is worse than the false negative being fixed.

🔴 **Running is a transport fact, not a good response.** `daemonRequest` sets `status: 0` only when the request got no answer; a live daemon that 500s on `/` also arrives as `ok: false`. Keying "not running" on `ok` would hand back the same confidently-wrong verdict from a rarer cause. (Residual edge, noted in the code: a daemon answering non-JSON also lands on `status: 0`, because `daemonRequest` parses the body inside its own try. Fixing that belongs in `daemonRequest`.)

A **known holder** refusal is absolute. An **unknown** one takes `--force`, and the refusal line says so — refusing both outright would stop all worktree removal on this box until someone restarts a shared daemon the message itself tells you to ask about.

## Verification

The toolchain cannot see this diff, and I would rather say so than imply a green suite covered it. `tsconfig.json`'s `include` is `scripts/**/*.ts(x)`, `src`, `packages/*/src`, `tests`, `test`, `.next/types` — no `.claude`. The `unit` project's include is `src/**/*.test.ts` + `scripts/**/*.test.ts`. `lint` is `eslint src/`. Root Prettier globs `.ts`/`.tsx` only. So typecheck, lint, prettier and vitest are structurally blind here; the coverage is the skill's own selftests.

`worktree.selftest.mjs` — **51 checks, all green, exit 0**. `cli-verbs.selftest.mjs` and `daemon-home.selftest.mjs` also exit 0.

**Six mutants, re-run after every refactor** (a control is something you did once, so a refactor ends it silently):

| mutation | result |
|---|---|
| `daemonBlockReason` returns `null` always | 8 FAILURES |
| unknown read as no (drop the `!checked && reachable` branch) | 4 FAILURES |
| banner forced off | 2 FAILURES |
| daemon term dropped from the `removable` filter | 2 FAILURES |
| `reachable` keyed on `res.ok` instead of the transport | 2 FAILURES |
| `isInside` replaced by a prefix match | 1 FAILURE |
| restored | all green |

**End to end**, driving `cmdStale` against a fake `/`: daemon reporting `profile-remix-flyout` → `SAFE TO REMOVE (4)` with that tree in KEEP as `hosts the dev-server daemon (pid 999) - its running script: ...`; daemon reporting the primary → `SAFE TO REMOVE (5)` and the tree is back. Against the **real** daemon today (the pre-#4641 one): the banner fires and `SAFE TO REMOVE (0)`.

## What the review rounds caught, because it is the point

Three lanes read `93b3c49c88`. The first commit fixed the **report** and left the **deletion** path open — `cmdRemove` still guarded on `holder` alone, so on today's live state it would have walked past the refusal, unlinked every reparse point and failed EBUSY. The PR meant to prevent the 2026-09-01 incident would have reproduced it.

A second round over `07dcdd66b9` then found two defects in *that* fix: `reachable` keyed on `ok`, and the no-override hard fail above. Both fix rounds were more dangerous than the original change.

Also worth recording: the `every`→`some` mutant on the banner **survived** the first test set, and it survived because every row shares one `/` answer, so the two are equivalent on any input the code can produce. The fix was not a cleverer test — it was reading the verdict once from `daemonAnswer` so the question stops existing.

## Known gap

`cmdRemove` itself has no selftest. The `--force` override and the absolute holder refusal are covered by reading, not by a test — covering them needs a git tree and a `gh` call, which is a bigger job than the rest of this PR.

## Two traps worth writing down

- **Bash `grep` on this box silently returned nothing** for a pattern the Grep tool found at `cli.mjs:75`. A negative from it here is not evidence.
- A `node -e` one-liner through the Bash tool had its backslashes eaten, so a Windows absolute path arrived as `C:DevRepos...` and `resolve()` made it **cwd-relative** — the first end-to-end run silently blamed the wrong worktree and looked plausible. Same class of thing bit the selftest fixtures, which now use forward slashes.

## Not in this PR

Restarting the live daemon so it runs from the primary. That kills every seat's dev server, and the ticket's own sequencing note requires kill-and-respawn in one command. Justin's call, raised separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaEeWAaE22DMKtQRhhASVH

---

## Update 2026-09-09, after this was written: the instance is gone, the class is not

The live reproduction above is accurate **as of the time it was taken**. Since then Justin approved
restarting the shared daemon, and it has been restarted from the primary checkout:

- old pid 46332 (running out of `worktrees/profile-remix-flyout`) is gone
- new pid 25760, command line `C:\Dev\Repos\work\model-share\.claude\skills\dev-server\scripts\daemon.mjs`
- `GET /` now returns `cwd` and `skillDir`, both the primary checkout
- `wt stale` on this branch: banner gone, **SAFE TO REMOVE (5)**, and `profile-remix-flyout` is correctly
  listed as safe because nothing pins it any more

The original evidence is left in place rather than edited out, because it is what the change was built
against. What it means now: **this PR fixes the class, not that instance.** The skill directory is
committed, so every worktree runs its own `cli.mjs`, and the next daemon spawned from a tree cut before
#4641 puts the fleet straight back into the state described above — with `wt stale` this time refusing to
clear anything rather than quietly offering the daemon's own tree.
