### PR TITLE
fix(flipt): key the eval-context ledger on file+flag, not file:line

### DIFF
--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -107,7 +107,31 @@ function splitArgs(src: string, open: number): string[] | null {
   return null;
 }
 
-type EvalCall = { site: string; key: string; fn: string; argc: number };
+type EvalCall = { site: string; key: string; enclosing: string; fn: string; argc: number };
+
+/**
+ * The top-level declaration a call sits inside — what a ledger row NAMES.
+ *
+ * Deliberately crude: nearest preceding declaration anchored at column 0, so a nested arrow or an
+ * object property cannot claim a site. `src/server/services/blocks/__tests__/` has a careful
+ * brace-depth version of this; it is not exported, and neither copying 60 lines nor extracting a
+ * shared test helper belongs in a change about a ledger key. What makes a crude parser safe here is
+ * that every name it produces is PINNED in the ledger below, so drift fails loudly by name instead
+ * of quietly widening what a row forgives.
+ *
+ * 🔴 `<unattributed>` is a FAILURE, never a forgiveness — see the assertion that rejects it. A row
+ * that covered a site the parser could not name would be the cardinality bug again with more steps.
+ */
+const DECLARATION =
+  /^(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+([\w$]+)|^(?:export\s+)?(?:const|let|var)\s+([\w$]+)\s*=|^(?:export\s+)?(?:abstract\s+)?class\s+([\w$]+)/gm;
+
+function enclosingDeclaration(before: string): string {
+  DECLARATION.lastIndex = 0;
+  let last: RegExpExecArray | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = DECLARATION.exec(before))) last = m;
+  return last ? last[1] || last[2] || last[3] : '<unattributed>';
+}
 
 /**
  * What a ledger row is addressed by: the file, and the flag expression as written.
@@ -148,6 +172,7 @@ function scanEvalCalls(): { calls: EvalCall[]; scanned: number } {
       calls.push({
         site: `${rel}:${line}`,
         key: ledgerKey(rel, args[0] ?? '(no argument)'),
+        enclosing: enclosingDeclaration(src.slice(0, m.index)),
         fn: m[1],
         argc: args.length,
       });
@@ -168,14 +193,27 @@ function scanEvalCalls(): { calls: EvalCall[]; scanned: number } {
  * deliberately hoisted out of per-flag work, and the dispute helper has a bare
  * `userId` and no `SessionUser` to build a truthful context from.
  */
-type LedgerRow = { count: number; reason: string };
+type LedgerRow = { fns: string[]; reason: string };
 
 /**
- * 🔴 `count` IS LOAD-BEARING. A row forgives the sites it names and no more: keying on file+flag
- * alone would mean a FOURTH uncontexted evaluation of an already-ledgered flag, in an
- * already-ledgered file, arrives pre-forgiven — the gate going silent for exactly the violation it
- * exists to catch. The count assertion below fails when the number moves, in either direction, and
- * names the lines it found.
+ * 🔴 `fns` IS LOAD-BEARING, and it is why a row is not just `file#flag`. A row forgives the sites it
+ * NAMES and no more. Keying on file+flag alone would mean a further uncontexted evaluation of an
+ * already-ledgered flag, in an already-ledgered file, arrives pre-forgiven — the gate going silent
+ * for exactly the violation it exists to catch. A bare COUNT is not enough either: swapping one
+ * ledgered site for a genuinely new one keeps the number and forgives a site nobody reviewed.
+ *
+ * So each row lists the enclosing declarations it covers, and the assertion below compares that set
+ * both ways. `<file>::<enclosing function>` is how the ledgers in
+ * `src/server/services/blocks/__tests__/` already address their sites; this is that, with the flag
+ * kept in the key.
+ *
+ * 🔴 RAISING A ROW IS NOT A FORMALITY. Adding a name means the existing `reason` now speaks for that
+ * site too — so check it applies to the new one verbatim, not merely that the flag still has no
+ * segment rollout. That judgement is the whole value of the row.
+ *
+ * ⚠️ The trade this makes: renaming one of these functions renames its row, and that is a conflict.
+ * It is a rare, loud breakage in place of a frequent silent one — the line-number scheme was
+ * renumbered 19 times in three weeks, and a 20th time while this was being written.
  */
 const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, LedgerRow> = {
   // flag `article-rating-dispute`: enabled=true, 0 rules, 0 rollouts → answers
@@ -183,19 +221,23 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, LedgerRow> = {
   // with only `pending.userId` in hand; building a real context would cost a
   // user fetch. Revisit the moment this flag gains a rollout.
   'server/services/article-rating-review.helpers.ts#FLIPT_FEATURE_FLAGS.ARTICLE_RATING_DISPUTE': {
-    count: 1,
+    fns: ['maybeAutoResolveDisputeAfterScan'],
     reason: 'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   },
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
   'server/services/image.service.ts#FLIPT_FEATURE_FLAGS.FEED_POST_FILTER': {
-    count: 1,
+    fns: ['searchImages'],
     reason: 'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   },
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites,
-  // same reason at each — which is why they share a row, and why the count is
-  // the thing that notices a fourth.
+  // same reason at each — which is why they share a row, and why the row names
+  // all three rather than counting them.
   'server/services/image.service.ts#FLIPT_FEATURE_FLAGS.FEED_IMAGE_EXISTENCE': {
-    count: 3,
+    fns: [
+      'getImagesFromFeedSearch',
+      'getImagesFromSearchPreFilter',
+      'getImagesFromSearchPostFilter',
+    ],
     reason: 'feed-image-existence has no segment rollouts; hot feed path',
   },
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
@@ -213,13 +255,13 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, LedgerRow> = {
   // The caveat above still applies with force: if either flag ever gains a SEGMENT
   // rollout it will silently match nothing here. A percentage rollout is fine.
   'server/services/model-moderation.adapter.ts#FLIPT_FEATURE_FLAGS.MODEL_TEXT_MODERATION_XGUARD': {
-    count: 1,
+    fns: ['submitEnabled'],
     reason:
       'model-text-moderation-xguard has no segment rollouts; entityId is a MODEL id (no user segment can describe it) and the rollout is threshold-keyed; webhook path with no SessionUser',
   },
   'server/services/model-moderation.adapter.ts#FLIPT_FEATURE_FLAGS.MODEL_TEXT_MODERATION_XGUARD_APPLY':
     {
-      count: 1,
+      fns: ['recordForensics'],
       reason:
         'model-text-moderation-xguard-apply has no segment rollouts; entityId is a MODEL id (no user segment can describe it) and the rollout is threshold-keyed; webhook path with no SessionUser',
     },
@@ -235,7 +277,7 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, LedgerRow> = {
   // matches nothing here and looks exactly like "blurbs are off". The full warning is on
   // FLIPT_FEATURE_FLAGS.TEXT_BLURBS, which is where someone running the ramp will look.
   'server/services/blurb-materialize.service.ts#FLIPT_FEATURE_FLAGS.TEXT_BLURBS': {
-    count: 1,
+    fns: ['expandBlurbs'],
     reason:
       'text-blurbs has no segment rollouts; entityId is the CONTENT OWNER (not the actor) so the intended threshold rollout is sticky per creator; no SessionUser for the owner exists on either the moderator-edit path or the fan-out job',
   },
@@ -273,6 +315,22 @@ describe('flipt evaluation context — source gate', () => {
     ).toBe(2);
   });
 
+  it('still addresses sites as file#flag, by an enclosing declaration it can name', () => {
+    // Named separately from the pair above because a scanner emitting a constant or undefined key
+    // fails THAT test with `expected undefined to be 3` — a message about argument counts, which
+    // sends the reader nowhere near the key. This one says what actually broke.
+    const byKey = new Map(calls.map((c) => [c.key, c]));
+    expect(
+      byKey.has('server/services/image.service.ts#FLIPT_FEATURE_FLAGS.FEED_POST_FILTER'),
+      'ledgerKey no longer produces `file#flag`, so every row in the ledger addresses nothing.'
+    ).toBe(true);
+    expect(
+      byKey.get('server/services/image.service.ts#FLIPT_FEATURE_FLAGS.FEED_POST_FILTER')?.enclosing,
+      'the enclosing-declaration parser no longer names this site, so every ledger row that ' +
+        'names a function is addressing nothing.'
+    ).toBe('searchImages');
+  });
+
   it('adds no Flipt evaluation that names an entity but passes no context', () => {
     const unledgered = calls
       .filter((c) => c.argc === 2 && !(c.key in ENTITY_WITHOUT_CONTEXT_LEDGER))
@@ -287,46 +345,114 @@ describe('flipt evaluation context — source gate', () => {
         '"the subject is not in the segment". Pass `buildFliptContext(user)`, or the ' +
         'properties you actually know; if the flag genuinely has no segment rollout, add ' +
         'the site to ENTITY_WITHOUT_CONTEXT_LEDGER with the reason you checked, keyed by ' +
-        'file#flag and with its count.'
+        'file#flag and naming the enclosing function.'
     ).toEqual([]);
   });
 
-  it('keeps the ledger honest — a fixed or moved site must be removed from it', () => {
+  it('keeps the ledger honest — a fixed or deleted site must be removed from it', () => {
     // The direction that gets left out. Without it the ledger silently becomes a
-    // list of line numbers that stopped meaning anything, and the next reviewer
-    // reads five accepted exceptions that are no longer there.
+    // list of exceptions that are no longer there, and the next reviewer reads
+    // six accepted judgements that describe nothing.
     const bare = new Set(calls.filter((c) => c.argc === 2).map((c) => c.key));
     const stale = Object.keys(ENTITY_WITHOUT_CONTEXT_LEDGER)
       .filter((key) => !bare.has(key))
       .sort();
     expect(
       stale,
-      'A ledgered file+flag no longer passes an entityId without a context — it was fixed ' +
-        'or deleted. Drop its row. (A line number moving is no longer this test’s business.)'
+      'A ledgered file+flag no longer passes an entityId without a context. Either it was ' +
+        'fixed or deleted — drop its row — or the flag expression was respelled, or the file ' +
+        'was moved or split, in which case re-key the row. (A line number moving is no longer ' +
+        'this test’s business.)'
     ).toEqual([]);
   });
 
-  it('counts the sites in each ledgered row, so a NEW one is not pre-forgiven', () => {
-    // Without this, a row keyed on file+flag forgives every site in that file that
-    // evaluates that flag — including the fourth one somebody adds next month. The
-    // gate would go silent for exactly the violation it exists to catch.
-    const bareByKey = new Map<string, string[]>();
+  it('forgives only the declarations a row NAMES, so a new or swapped site is not pre-forgiven', () => {
+    // A row keyed on file+flag would otherwise forgive every site in that file evaluating that
+    // flag, including ones nobody reviewed. A cardinality would not be enough either: swapping one
+    // ledgered site for a new one keeps the number. So the row names the declarations, and this
+    // compares that set both ways.
+    const bareByKey = new Map<string, EvalCall[]>();
     for (const c of calls.filter((c) => c.argc === 2)) {
-      bareByKey.set(c.key, [...(bareByKey.get(c.key) ?? []), c.site]);
+      bareByKey.set(c.key, [...(bareByKey.get(c.key) ?? []), c]);
     }
+    const describeFound = (found: EvalCall[]) =>
+      found.map((c) => `${c.enclosing} (${c.site})`).join(', ') || '(none)';
     const wrong = Object.entries(ENTITY_WITHOUT_CONTEXT_LEDGER)
-      .map(([key, row]) => ({ key, row, sites: bareByKey.get(key) ?? [] }))
-      .filter(({ row, sites }) => sites.length !== row.count)
+      .map(([key, row]) => ({ key, row, found: bareByKey.get(key) ?? [] }))
+      .filter(
+        ({ row, found }) =>
+          [...row.fns].sort().join('|') !==
+          found
+            .map((c) => c.enclosing)
+            .sort()
+            .join('|')
+      )
       .map(
-        ({ key, row, sites }) =>
-          `${key}: ledger says ${row.count}, found ${sites.length} at ${sites.join(', ')}`
+        ({ key, row, found }) =>
+          `${key}: ledger names ${[...row.fns].sort().join(', ')}; found ${describeFound(found)}`
       )
       .sort();
     expect(
       wrong,
-      'The number of context-less evaluations in a ledgered file+flag has changed. If a NEW ' +
-        'one was added, it is NOT covered by the existing reason — check the flag still has no ' +
-        'segment rollout, then raise the count. If one was removed or fixed, lower it.'
+      'The context-less evaluations in a ledgered file+flag are no longer the ones its row ' +
+        'names. A NEW or MOVED site is NOT covered by the existing reason — check the flag still ' +
+        'has no segment rollout AND that the reason applies to this site verbatim, then add its ' +
+        'declaration. If one was fixed or removed, drop its name.'
+    ).toEqual([]);
+  });
+
+  it('refuses to forgive a site whose enclosing declaration it could not name', () => {
+    // 🔴 `<unattributed>` must FAIL, never forgive. A row covering a site the parser could not
+    // name is the cardinality bug again with more steps — the ledger would say which functions it
+    // reviewed while silently standing for one it cannot point at.
+    //
+    // A call nested inside a closure is attributed to the top-level declaration containing it,
+    // which is what a row should name; this fires for a call with no declaration before it at all.
+    const unnamed = calls
+      .filter((c) => c.argc === 2 && c.enclosing === '<unattributed>')
+      .map((c) => c.site)
+      .sort();
+    expect(
+      unnamed,
+      'A context-less Flipt evaluation has no top-level declaration before it — it sits at ' +
+        'module scope, or in a shape the parser does not handle. It CANNOT be ledgered as-is: ' +
+        'move the call under a named declaration, or teach the parser that shape. Do not widen ' +
+        'a row to swallow it.'
+    ).toEqual([]);
+  });
+
+  it('ledgers only a real flag constant or a literal, never a computed key', () => {
+    // A computed first argument (`isFlipt(flagFor(area), id)`) is ONE key standing for N runtime
+    // flags, and the set can grow with no source change here at all — so no assertion in this file
+    // could notice. Reading the enum from source rather than importing it keeps this a source gate
+    // with no module side effects, and catches an enum member renamed out from under a row.
+    const members = new Set(
+      [
+        ...readFileSync(path.join(SRC, 'server/flipt/client.ts'), 'utf8').matchAll(
+          /^\s{2}([A-Z][A-Z0-9_]*)\s*=\s*'/gm
+        ),
+      ].map((m) => m[1])
+    );
+    expect(
+      members.size,
+      'no FLIPT_FEATURE_FLAGS members were read from client.ts — the reader broke, so the check ' +
+        'below would pass vacuously'
+    ).toBeGreaterThan(40);
+    const bad = Object.keys(ENTITY_WITHOUT_CONTEXT_LEDGER)
+      .map((key) => ({ key, expr: key.slice(key.indexOf('#') + 1) }))
+      .filter(({ expr }) => {
+        if (/^'[^']*'$/.test(expr) || /^"[^"]*"$/.test(expr)) return false;
+        const m = /^FLIPT_FEATURE_FLAGS\.([A-Z][A-Z0-9_]*)$/.exec(expr);
+        return !m || !members.has(m[1]);
+      })
+      .map(({ key }) => key)
+      .sort();
+    expect(
+      bad,
+      'A ledger row is keyed on something that is not a known FLIPT_FEATURE_FLAGS member or a ' +
+        'string literal. Either the member was renamed — re-key the row — or the site passes a ' +
+        'COMPUTED key, which cannot be ledgered, because one row would forgive every flag that ' +
+        'expression can produce and nothing here could see the set grow.'
     ).toEqual([]);
   });
 });

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -107,7 +107,26 @@ function splitArgs(src: string, open: number): string[] | null {
   return null;
 }
 
-type EvalCall = { site: string; fn: string; argc: number };
+type EvalCall = { site: string; key: string; fn: string; argc: number };
+
+/**
+ * What a ledger row is addressed by: the file, and the flag expression as written.
+ *
+ * NOT the line number. The ledger used to key on `file:line`, which made every PR touching a
+ * ledgered file collide there — 19 commits renumbered these rows between 2026-08-20 and 2026-09-08,
+ * and the conflict carried no information, because the file itself merged cleanly every time. Worse,
+ * two of the three assertions below then reported a renumbering as "a Flipt evaluation passes an
+ * entityId with no evaluation context", sending the reader after a Flipt bug that did not exist.
+ *
+ * The gate's subject is "this call site evaluates this flag without a context", and none of that is
+ * positional. The line number is still carried, as `site`, so a failure can say WHERE — it is data,
+ * not identity.
+ */
+const ledgerKey = (rel: string, flagArg: string) =>
+  // `splitArgs` accumulates from the opening paren, so the first argument arrives carrying it, and a
+  // wrapped call carries the newline and indentation after it too. Both are spelling, not identity —
+  // reflowing a call must not rename its row, or the key is a line number again by another name.
+  `${rel}#${flagArg.replace(/^\(/, '').replace(/\s+/g, ' ').trim()}`;
 
 function scanEvalCalls(): { calls: EvalCall[]; scanned: number } {
   const calls: EvalCall[] = [];
@@ -126,7 +145,12 @@ function scanEvalCalls(): { calls: EvalCall[]; scanned: number } {
       const args = splitArgs(src, open);
       if (!args) continue;
       const line = src.slice(0, m.index).split('\n').length;
-      calls.push({ site: `${rel}:${line}`, fn: m[1], argc: args.length });
+      calls.push({
+        site: `${rel}:${line}`,
+        key: ledgerKey(rel, args[0] ?? '(no argument)'),
+        fn: m[1],
+        argc: args.length,
+      });
     }
   }
   return { calls, scanned };
@@ -144,23 +168,36 @@ function scanEvalCalls(): { calls: EvalCall[]; scanned: number } {
  * deliberately hoisted out of per-flag work, and the dispute helper has a bare
  * `userId` and no `SessionUser` to build a truthful context from.
  */
-const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
+type LedgerRow = { count: number; reason: string };
+
+/**
+ * 🔴 `count` IS LOAD-BEARING. A row forgives the sites it names and no more: keying on file+flag
+ * alone would mean a FOURTH uncontexted evaluation of an already-ledgered flag, in an
+ * already-ledgered file, arrives pre-forgiven — the gate going silent for exactly the violation it
+ * exists to catch. The count assertion below fails when the number moves, in either direction, and
+ * names the lines it found.
+ */
+const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, LedgerRow> = {
   // flag `article-rating-dispute`: enabled=true, 0 rules, 0 rollouts → answers
   // true for every entity regardless of context. A background auto-resolve path
   // with only `pending.userId` in hand; building a real context would cost a
   // user fetch. Revisit the moment this flag gains a rollout.
-  'server/services/article-rating-review.helpers.ts:482':
-    'article-rating-dispute has no segment rollouts; background path with no SessionUser',
+  'server/services/article-rating-review.helpers.ts#FLIPT_FEATURE_FLAGS.ARTICLE_RATING_DISPUTE': {
+    count: 1,
+    reason: 'article-rating-dispute has no segment rollouts; background path with no SessionUser',
+  },
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:3279':
-    'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
-  // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:3323':
-    'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4092':
-    'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4902':
-    'feed-image-existence has no segment rollouts; hot feed path',
+  'server/services/image.service.ts#FLIPT_FEATURE_FLAGS.FEED_POST_FILTER': {
+    count: 1,
+    reason: 'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
+  },
+  // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites,
+  // same reason at each — which is why they share a row, and why the count is
+  // the thing that notices a fourth.
+  'server/services/image.service.ts#FLIPT_FEATURE_FLAGS.FEED_IMAGE_EXISTENCE': {
+    count: 3,
+    reason: 'feed-image-existence has no segment rollouts; hot feed path',
+  },
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
   // 2026-08-20, which returned DEFAULT_EVALUATION_REASON for both).
@@ -175,10 +212,17 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   //
   // The caveat above still applies with force: if either flag ever gains a SEGMENT
   // rollout it will silently match nothing here. A percentage rollout is fine.
-  'server/services/model-moderation.adapter.ts:123':
-    'model-text-moderation-xguard has no segment rollouts; entityId is a MODEL id (no user segment can describe it) and the rollout is threshold-keyed; webhook path with no SessionUser',
-  'server/services/model-moderation.adapter.ts:228':
-    'model-text-moderation-xguard-apply has no segment rollouts; entityId is a MODEL id (no user segment can describe it) and the rollout is threshold-keyed; webhook path with no SessionUser',
+  'server/services/model-moderation.adapter.ts#FLIPT_FEATURE_FLAGS.MODEL_TEXT_MODERATION_XGUARD': {
+    count: 1,
+    reason:
+      'model-text-moderation-xguard has no segment rollouts; entityId is a MODEL id (no user segment can describe it) and the rollout is threshold-keyed; webhook path with no SessionUser',
+  },
+  'server/services/model-moderation.adapter.ts#FLIPT_FEATURE_FLAGS.MODEL_TEXT_MODERATION_XGUARD_APPLY':
+    {
+      count: 1,
+      reason:
+        'model-text-moderation-xguard-apply has no segment rollouts; entityId is a MODEL id (no user segment can describe it) and the rollout is threshold-keyed; webhook path with no SessionUser',
+    },
   // flag `text-blurbs`: default-off, no rules and no rollouts.
   //
   // Entity-keyed on purpose. The entityId is the CONTENT OWNER's user id, not the actor's, so a
@@ -190,8 +234,11 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   // 🔴 So this flag can only be ramped by PERCENTAGE or BOOLEAN. A SEGMENT rollout silently
   // matches nothing here and looks exactly like "blurbs are off". The full warning is on
   // FLIPT_FEATURE_FLAGS.TEXT_BLURBS, which is where someone running the ramp will look.
-  'server/services/blurb-materialize.service.ts:66':
-    'text-blurbs has no segment rollouts; entityId is the CONTENT OWNER (not the actor) so the intended threshold rollout is sticky per creator; no SessionUser for the owner exists on either the moderator-edit path or the fan-out job',
+  'server/services/blurb-materialize.service.ts#FLIPT_FEATURE_FLAGS.TEXT_BLURBS': {
+    count: 1,
+    reason:
+      'text-blurbs has no segment rollouts; entityId is the CONTENT OWNER (not the actor) so the intended threshold rollout is sticky per creator; no SessionUser for the owner exists on either the moderator-edit path or the fan-out job',
+  },
 };
 
 describe('flipt evaluation context — source gate', () => {
@@ -217,16 +264,19 @@ describe('flipt evaluation context — source gate', () => {
   it('sees a known contexted site as contexted, and a known bare site as bare', () => {
     // The pair matters. A detector hardwired to "3 args" would pass the first of
     // these and fail the second, and vice versa.
-    const bySite = new Map(calls.map((c) => [c.site, c]));
-    expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:3323')?.argc).toBe(2);
+    const byKey = new Map(calls.map((c) => [c.key, c]));
+    expect(byKey.get('server/services/feedback.service.ts#feedbackAreaFlagKey(area)')?.argc).toBe(
+      3
+    );
+    expect(
+      byKey.get('server/services/image.service.ts#FLIPT_FEATURE_FLAGS.FEED_POST_FILTER')?.argc
+    ).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {
     const unledgered = calls
-      .filter((c) => c.argc === 2)
+      .filter((c) => c.argc === 2 && !(c.key in ENTITY_WITHOUT_CONTEXT_LEDGER))
       .map((c) => c.site)
-      .filter((site) => !(site in ENTITY_WITHOUT_CONTEXT_LEDGER))
       .sort();
     expect(
       unledgered,
@@ -236,7 +286,8 @@ describe('flipt evaluation context — source gate', () => {
         'any of them, and returns the flag default instead. That is indistinguishable from ' +
         '"the subject is not in the segment". Pass `buildFliptContext(user)`, or the ' +
         'properties you actually know; if the flag genuinely has no segment rollout, add ' +
-        'the site to ENTITY_WITHOUT_CONTEXT_LEDGER with the reason you checked.'
+        'the site to ENTITY_WITHOUT_CONTEXT_LEDGER with the reason you checked, keyed by ' +
+        'file#flag and with its count.'
     ).toEqual([]);
   });
 
@@ -244,14 +295,38 @@ describe('flipt evaluation context — source gate', () => {
     // The direction that gets left out. Without it the ledger silently becomes a
     // list of line numbers that stopped meaning anything, and the next reviewer
     // reads five accepted exceptions that are no longer there.
-    const bare = new Set(calls.filter((c) => c.argc === 2).map((c) => c.site));
+    const bare = new Set(calls.filter((c) => c.argc === 2).map((c) => c.key));
     const stale = Object.keys(ENTITY_WITHOUT_CONTEXT_LEDGER)
-      .filter((site) => !bare.has(site))
+      .filter((key) => !bare.has(key))
       .sort();
     expect(
       stale,
-      'A ledgered site no longer passes an entityId without a context — it was fixed, ' +
-        'deleted, or the line moved. Drop or update its row.'
+      'A ledgered file+flag no longer passes an entityId without a context — it was fixed ' +
+        'or deleted. Drop its row. (A line number moving is no longer this test’s business.)'
+    ).toEqual([]);
+  });
+
+  it('counts the sites in each ledgered row, so a NEW one is not pre-forgiven', () => {
+    // Without this, a row keyed on file+flag forgives every site in that file that
+    // evaluates that flag — including the fourth one somebody adds next month. The
+    // gate would go silent for exactly the violation it exists to catch.
+    const bareByKey = new Map<string, string[]>();
+    for (const c of calls.filter((c) => c.argc === 2)) {
+      bareByKey.set(c.key, [...(bareByKey.get(c.key) ?? []), c.site]);
+    }
+    const wrong = Object.entries(ENTITY_WITHOUT_CONTEXT_LEDGER)
+      .map(([key, row]) => ({ key, row, sites: bareByKey.get(key) ?? [] }))
+      .filter(({ row, sites }) => sites.length !== row.count)
+      .map(
+        ({ key, row, sites }) =>
+          `${key}: ledger says ${row.count}, found ${sites.length} at ${sites.join(', ')}`
+      )
+      .sort();
+    expect(
+      wrong,
+      'The number of context-less evaluations in a ledgered file+flag has changed. If a NEW ' +
+        'one was added, it is NOT covered by the existing reason — check the flag still has no ' +
+        'segment rollout, then raise the count. If one was removed or fixed, lower it.'
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes ClickUp 868kwa4w4.

## The problem, and why it is not theoretical

`ENTITY_WITHOUT_CONTEXT_LEDGER` in `flipt-eval-context.test.ts` was keyed on `file:line`. Any two PRs touching a ledgered file therefore collide in this test — and the collision carries no information, because the file itself merges cleanly every time. Both original occurrences were exactly that: `image.service.ts` auto-merged, only the ledger conflicted, because both branches renumbered the same four rows.

`git log -G'image\.service\.ts:[0-9]+'` over the test file returns **19 commits**, from the one that introduced the gate (2026-08-20) to 2026-09-08. Eight of them landed *after* the problem was written up. Control: the same query with a token that never appears in the file returns empty.

**And it happened again while this fix was being written.** The audit read the primary checkout, on `3bb6b8a300`, and found the rows at `3268 / 3312 / 4081 / 4891`. This worktree, cut from fresh `origin/main` at `d54868ebf5` a few hours later, has them at `3279 / 3323 / 4092 / 4902`. A 20th renumbering, inside the window between reading the ticket and fixing it.

(That gap is also worth stating on its own: **the primary checkout is not `origin/main`**. If line numbers were the identity, the two disagree about what the ledger says.)

The second cost is subtler than the conflicts. Of the three assertions, only the third mentioned line numbers. The other two reported a renumbering as *"A Flipt evaluation passes an entityId with no evaluation context"* — so the first reaction was to go hunting a Flipt bug that did not exist.

## The change

One file.

**Key** — `ledgerKey(rel, flagArg)` = `` `${rel}#${flagArg}` ``, built from `args[0]`, which the scanner already parses. The gate's subject is "this call site evaluates this flag without a context", and none of that is positional. `site` (with the line) survives on every `EvalCall` so a failure still says *where* — it is data now, not identity.

Normalisation matters here and is commented in place: `splitArgs` accumulates from the opening paren, so `args[0]` arrives as `"(FLIPT_FEATURE_FLAGS.FEED_IMAGE_EXISTENCE"`, and a wrapped call carries the newline and indent too. Both are spelling, not identity — otherwise reflowing a call renames its row and the key is a line number again under another name.

**A row names the declarations it forgives.** `{ fns: string[], reason }`. Keying on file+flag alone collapses the three `FEED_IMAGE_EXISTENCE` sites in `image.service.ts` into one row — which is the right grain, since their reasons are identical — but a row that forgives *the file+flag* forgives sites nobody reviewed. A per-row **count** is not enough either, and that is the substance of the review round below: a swap keeps the number.

So each row lists its enclosing declarations and the assertion compares that set both ways. `<file>::<enclosing function>` is how the ledgers in `src/server/services/blocks/__tests__/` already address their sites; this is that, with the flag kept in the key. The four `image.service.ts` sites are in four different functions (`searchImages`, `getImagesFromFeedSearch`, `getImagesFromSearchPreFilter`, `getImagesFromSearchPostFilter`), so the grain is real rather than nominal.

🔴 **`<unattributed>` fails rather than forgives**, in its own assertion. A row covering a site the parser could not name is the cardinality bug again with more steps. The parser is deliberately crude — nearest top-level declaration anchored at column 0 — and what makes that safe is that every name it produces is **pinned** in the ledger, so drift fails loudly by name instead of quietly widening what a row covers.

**A ledgered key must name a real flag.** A computed first argument (`isFlipt(flagFor(area), id)`) is one row standing for N runtime flags, and that set can grow with no source change in this repo at all — so nothing else in this file could notice. A new assertion requires every ledgered expression to be a string literal or a `FLIPT_FEATURE_FLAGS` member that exists, read out of `client.ts` rather than imported (keeping this a source gate with no module side effects). The same check catches an enum member renamed out from under a row.

**The trade, stated so it is visible rather than discovered:** renaming one of these functions renames its row, and that is a conflict. This swaps a frequent silent breakage for a rare loud one.

## Controls

Every claim below was measured. `image.service.ts` was restored after each mutation and `git diff --stat` on it is empty; `git status` shows only the test file.

| mutation | result |
|---|---|
| **the swap** — remove one ledgered site, add a bare eval of the same flag in a NEW function | **RED**, 1 failed / 15 passed. `ledger names getImagesFromFeedSearch, getImagesFromSearchPostFilter, getImagesFromSearchPreFilter; found …` |
| a plain fourth site in a new function | **RED**, 1 failed / 15 passed, same assertion |
| five blank lines inserted, so every ledgered line moves | **GREEN**, 16 passed — the whole point of the PR |
| a bare eval at module scope, before any declaration | **RED**, 2 failed — including `refuses to forgive a site whose enclosing declaration it could not name` |
| a ledger row keyed on `FLIPT_FEATURE_FLAGS.NO_SUCH_MEMBER` | **RED**, 4 failed — including `ledgers only a real flag constant or a literal` |
| restored | **GREEN**, 16 passed, exit 0 |

**The paired renumbering control**, run against both ledgers under the same five-line shift:

| ledger | result |
|---|---|
| this branch | `Tests 16 passed (16)`, exit 0 |
| `main` (file:line) | `Tests 3 failed \| 9 passed (12)`, exit 1 — including the misleading "passes an entityId with no evaluation context" |

Both arms ran and they disagree. The old ledger reproduces the ticket's second complaint verbatim under the same input the new one absorbs.

### The two lines that are the whole change

An earlier round of this PR used a per-row **count** instead of names. Same mutation, both rounds:

    count:  Tests  16 passed (16)      <- the swap is forgiven, silently
    fns:    Tests   1 failed | 15 passed (16)
            "ledger names getImagesFromFeedSearch, getImagesFromSearchPostFilter,
             getImagesFromSearchPreFilter; found getImagesFromFeedSearch (...:3323), ..."

A count is a proxy for "this row forgives these sites"; the two come apart on a swap. Three review lanes found that gap independently before the mutation was run.

### The green mutant is a PASS, not a miss

A mutant that stays green normally means a hole. This one is the ticket: under the same five-line shift, `main` gives `3 failed | 9 passed (12)` and this branch gives `16 passed (16)`. Absorbing that input is the entire point of the change.

## Verification

- `pnpm exec vitest run --project 'unit*' src/server/flipt/__tests__/flipt-eval-context.test.ts` — `Test Files 1 passed (1)`, `Tests 16 passed (16)`, exit 0
- `pnpm run typecheck` — `OK — 0 type errors`, exit 0
- `pnpm exec eslint` on the changed file — clean, exit 0. (`pnpm run lint` exits 1 with 358 errors repo-wide; that is the pre-existing baseline, and none of it is in this file.)
- `pnpm exec prettier --write` on the changed file
- **Full unit suite**: `Test Files  1 failed | 1724 passed | 3 skipped (1728)` / `Tests  1 failed | 39454 passed | 35 skipped (39490)`, exit 1. Both lines account for everything.
- `blocks.router.workflow.test.ts` collected **370 tests**, so the submodule is initialised and the run means something.

**The one failure is judged unrelated, and that judgement is inference, not measurement.** `src/server/integrations/__tests__/moderation-cache-probe.test.ts` failed on a `vi.waitFor` (`expected +0 to be 2`) under full-suite contention, and passes in isolation: `Tests 22 passed (22)`, exit 0. It failed identically on two different versions of this diff. I did **not** re-run the whole suite on a stashed base to prove it fails there too — that is another five-minute run through a shared queue.

So weigh it yourself. In favour of unrelated: it passes alone, it failed the same way before and after a substantial change to this diff, this diff imports nothing that suite touches, and contention-only failures on a full-suite run are a documented property of `main` (ClickUp 868kwa4yq, parked — "main fails 7 tests in 2 files under full-suite parallelism, and no CI runs on main"). Against: **that ticket names `user-payment-configuration.tipalti-status` and `home-block-fetch-sizing`, not `moderation-cache-probe`** — so it establishes the class, not this file.

## Known limitation, not fixed here

The scanner strips comments but **not string literals**, so `const doc = 'isFlipt(flag, id)'` counts as a call site. That is pre-existing, but this PR raises the stakes *in kind*: the ledger key is now derived from the scanned text, so under-stripping can mint a row key out of prose. The honest fix is a line-preserving variant in the shared `test/strip-comments.ts` (which already owns `stripCommentsAndStrings` for exactly this reason) — a change to a file seven other suites import, which does not belong in a PR about a ledger key. Filed as ClickUp 868m3ebw6 with a closing condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaEeWAaE22DMKtQRhhASVH
