### PR TITLE
fix(trainer): name a published LoRA after its model, not its version

### DIFF
--- a/src/components/Resource/Wizard/ModelWizard.tsx
+++ b/src/components/Resource/Wizard/ModelWizard.tsx
@@ -30,6 +30,7 @@ import { ModelUploadType, ModelUsageControl, TrainingStatus } from '~/shared/uti
 import { showErrorNotification } from '~/utils/notifications';
 import { useS3UploadStore } from '~/store/s3-upload.store';
 import type { ModelById } from '~/types/router';
+import { resolveTrainedFileName } from '~/utils/file-display-helpers';
 import { QS } from '~/utils/qs';
 import { sanitizeDownloadFilename } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
@@ -270,7 +271,7 @@ export function TrainStepModelFileRename({
     <TextInput
       label="Download filename"
       description="The name users will see when downloading this model file"
-      placeholder={`${modelVersion.name || 'model'}.safetensors`}
+      placeholder={modelFile.name}
       value={value}
       onChange={(e) => onChange(e.currentTarget.value)}
     />
@@ -322,9 +323,17 @@ const TrainSteps = ({
     useWizardStepSave(navigateToStep);
 
   const modelFile = modelVersion.files.find((f) => f.type === 'Model');
-  const [fileName, setFileName] = useState<string>(
-    modelFile?.overrideName ?? (modelVersion.name ? `${modelVersion.name}.safetensors` : '')
-  );
+  // null means untouched; '' is a real edit that clears the override.
+  const [editedFileName, setEditedFileName] = useState<string | null>(null);
+  const fileName = modelFile
+    ? resolveTrainedFileName({
+        editedName: editedFileName,
+        overrideName: modelFile.overrideName,
+        modelName: model.name,
+        versionName: modelVersion.name,
+        fileName: modelFile.name,
+      })
+    : '';
   const updateFileMutation = trpc.modelFile.update.useMutation();
 
   const handleVersionNext = async () => {
@@ -416,7 +425,7 @@ const TrainSteps = ({
               <TrainStepModelFileRename
                 modelVersion={modelVersion}
                 value={fileName}
-                onChange={setFileName}
+                onChange={setEditedFileName}
               />
             }
           >

--- a/src/utils/__tests__/trained-file-default-name.test.ts
+++ b/src/utils/__tests__/trained-file-default-name.test.ts
@@ -50,7 +50,11 @@ describe('getTrainedFileDefaultName', () => {
 
   it('falls back to the stored name when the model name leaves nothing behind', () => {
     expect(
-      getTrainedFileDefaultName({ modelName: 'キュアスパークル', versionName: 'V1', fileName: jobIdFile })
+      getTrainedFileDefaultName({
+        modelName: 'キュアスパークル',
+        versionName: 'V1',
+        fileName: jobIdFile,
+      })
     ).toBe(jobIdFile);
   });
 
@@ -90,7 +94,11 @@ describe('resolveTrainedFileName', () => {
 
   it('leaves a name the creator saved earlier alone', () => {
     expect(
-      resolveTrainedFileName({ ...trained, editedName: null, overrideName: 'MyOwnName.safetensors' })
+      resolveTrainedFileName({
+        ...trained,
+        editedName: null,
+        overrideName: 'MyOwnName.safetensors',
+      })
     ).toBe('MyOwnName.safetensors');
   });
 

--- a/src/utils/__tests__/trained-file-default-name.test.ts
+++ b/src/utils/__tests__/trained-file-default-name.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTrainedFileDefaultName, resolveTrainedFileName } from '~/utils/file-display-helpers';
+
+const jobIdFile = 'X40F7C8WA9TN0XW80MTTCT2TT0.safetensors';
+
+describe('getTrainedFileDefaultName', () => {
+  it('names the file after the model, not the version', () => {
+    expect(
+      getTrainedFileDefaultName({
+        modelName: 'BB Bunny',
+        versionName: 'V1',
+        fileName: jobIdFile,
+      })
+    ).toBe('bbBunny_v1.safetensors');
+  });
+
+  it('keeps the version detail that distinguishes two downloads of one model', () => {
+    expect(
+      getTrainedFileDefaultName({
+        modelName: 'ginger anima photoreal male',
+        versionName: 'V1 (from epoch 10)',
+        fileName: jobIdFile,
+      })
+    ).toBe('gingerAnimaPhotoreal_v1FromEpoch10.safetensors');
+  });
+
+  it('drops the version segment when it only repeats the model name', () => {
+    expect(
+      getTrainedFileDefaultName({ modelName: 'Grace', versionName: 'Grace', fileName: jobIdFile })
+    ).toBe('grace.safetensors');
+    expect(
+      getTrainedFileDefaultName({
+        modelName: 'Beet Cookie',
+        versionName: 'Beet Cookie',
+        fileName: jobIdFile,
+      })
+    ).toBe('beetCookie.safetensors');
+  });
+
+  it('strips characters filenamize cannot represent', () => {
+    expect(
+      getTrainedFileDefaultName({
+        modelName: 'Cure Sparkle/キュアスパークル(プリキュア)',
+        versionName: 'V1',
+        fileName: jobIdFile,
+      })
+    ).toBe('cureSparkle_v1.safetensors');
+  });
+
+  it('falls back to the stored name when the model name leaves nothing behind', () => {
+    expect(
+      getTrainedFileDefaultName({ modelName: 'キュアスパークル', versionName: 'V1', fileName: jobIdFile })
+    ).toBe(jobIdFile);
+  });
+
+  it('preserves the stored extension', () => {
+    expect(
+      getTrainedFileDefaultName({
+        modelName: 'BB Bunny',
+        versionName: 'V1',
+        fileName: 'X40F7C8WA9TN0XW80MTTCT2TT0.ckpt',
+      })
+    ).toBe('bbBunny_v1.ckpt');
+  });
+
+  it('defaults the extension when the stored name has none', () => {
+    expect(
+      getTrainedFileDefaultName({
+        modelName: 'BB Bunny',
+        versionName: 'V1',
+        fileName: 'X40F7C8WA9TN0XW80MTTCT2TT0',
+      })
+    ).toBe('bbBunny_v1.safetensors');
+  });
+});
+
+describe('resolveTrainedFileName', () => {
+  const trained = {
+    modelName: 'BB Bunny',
+    versionName: 'V1',
+    fileName: jobIdFile,
+  };
+
+  it('shows the computed default on a fresh trainer import', () => {
+    expect(resolveTrainedFileName({ ...trained, editedName: null, overrideName: null })).toBe(
+      'bbBunny_v1.safetensors'
+    );
+  });
+
+  it('leaves a name the creator saved earlier alone', () => {
+    expect(
+      resolveTrainedFileName({ ...trained, editedName: null, overrideName: 'MyOwnName.safetensors' })
+    ).toBe('MyOwnName.safetensors');
+  });
+
+  it('lets the current edit win over both', () => {
+    expect(
+      resolveTrainedFileName({
+        ...trained,
+        editedName: 'typing.safetensors',
+        overrideName: 'MyOwnName.safetensors',
+      })
+    ).toBe('typing.safetensors');
+  });
+
+  it('treats a cleared field as an edit rather than falling back', () => {
+    expect(
+      resolveTrainedFileName({ ...trained, editedName: '', overrideName: 'MyOwnName.safetensors' })
+    ).toBe('');
+  });
+});

--- a/src/utils/file-display-helpers.ts
+++ b/src/utils/file-display-helpers.ts
@@ -5,7 +5,7 @@
 
 import type { ModelFileType } from '~/server/common/constants';
 import type { ModelType } from '~/shared/utils/prisma/enums';
-import { getFileExtension } from '~/utils/string-helpers';
+import { filenamize, getFileExtension, replaceInsensitive } from '~/utils/string-helpers';
 
 /**
  * Metadata shape expected for file display functions
@@ -268,4 +268,48 @@ export const primaryModelFileTypes: readonly ModelFileType[] = [
 export function getPrimaryFileTypes(modelType?: ModelType | null): readonly ModelFileType[] {
   if (!modelType) return primaryModelFileTypes;
   return primaryFileTypesByModelType[modelType] ?? primaryModelFileTypes;
+}
+
+/**
+ * Default download name for a trainer import, whose stored name is the opaque training
+ * job id. Falls back to that stored name when `filenamize` leaves nothing of the model
+ * name — opaque-but-unique beats a version name that collides across a whole catalogue.
+ */
+export function getTrainedFileDefaultName({
+  modelName,
+  versionName,
+  fileName,
+}: {
+  modelName: string;
+  versionName: string;
+  fileName: string;
+}) {
+  const model = filenamize(modelName);
+  if (!model) return fileName;
+
+  const version = filenamize(replaceInsensitive(versionName, model, ''));
+  const base = version && version !== model ? `${model}_${version}` : model;
+  return `${base}.${getFileExtension(fileName) || 'safetensors'}`;
+}
+
+/**
+ * A name the creator typed wins, then one they saved on an earlier pass, then the
+ * computed default. Writing that default over a saved name is what this ordering stops.
+ */
+export function resolveTrainedFileName({
+  editedName,
+  overrideName,
+  modelName,
+  versionName,
+  fileName,
+}: {
+  editedName: string | null;
+  overrideName: string | null | undefined;
+  modelName: string;
+  versionName: string;
+  fileName: string;
+}) {
+  return (
+    editedName ?? overrideName ?? getTrainedFileDefaultName({ modelName, versionName, fileName })
+  );
 }


### PR DESCRIPTION
Fixes the trainer-import filename bug reported in Freshdesk #70707 (and #69350 before it, which was closed as a feature suggestion).

## The bug

The trained-model wizard pre-filled "Download filename" with `${modelVersion.name}.safetensors` and persisted it on **Next** whenever it differed from the stored override. On a fresh trainer import `overrideName` is `null`, so the untouched default always differed — and got written. Creators who never touched the field got their download named after the version.

Reproduced end-to-end on a local dev server before changing anything: model `2908896` / file `3174963`, stored name `X40F7C8WA9TN0XW80MTTCT2TT0.safetensors`, `overrideName` `NULL` → opened wizard step 3, clicked Next without focusing the field → `overrideName` became `V1.safetensors`.

The field renders the default as a real `value`, not a placeholder, which is why the write fires.

## Scale

Prod, trained-model files (`trainingStatus IS NOT NULL`, `type='Model'`), last 90 days:

- **8,956** carry an `overrideName` exactly equal to the version-name default; **8,916** of those differ from the stored name
- **7,833** are literally `V1.safetensors` — so a creator's downloads folder collides with itself
- newest affected rows are from the day this was written

Monthly, showing the cause — #2737 merged 2026-07-08, and the reporter independently said "seems to have started between July 7th and 9th":

| Month | Trained files | With override | Override == version default |
|---|---|---|---|
| May 2026 | 8,928 | 52 | 0 |
| Jun 2026 | 6,942 | 121 | 35 |
| **Jul 2026** | 7,333 | 5,077 | **3,203** |
| Aug 2026 | 10,258 | 7,562 | 4,592 |
| Sep 2026 (partial) | 2,550 | 1,809 | 1,130 |

## The fix

The default is now `<model>_<version>`, the shape `getDownloadFilename` already gives every other model type:

```
BB Bunny                              V1     →  bbBunny_v1.safetensors
Keiko Konan(Robotic Alchemic Drive)   V1     →  keikoKonanRobotic_v1.safetensors
Cure Sparkle/キュアスパークル(プリキュア)         V1     →  cureSparkle_v1.safetensors
ginger anima photoreal male   V1 (from epoch 10) → gingerAnimaPhotoreal_v1FromEpoch10.safetensors
```

Two edge cases the production data forced, both measured over the 8,960 affected rows:

- **96** models have names with no `[A-Za-z0-9]` at all, so `filenamize` returns empty. Those fall back to the stored job id — opaque but unique beats a bare `v1` that collides across a creator's whole catalogue.
- **194** have version name equal to model name, which would give `grace_.safetensors` or `beetCookie_beetCookie.safetensors`. The version segment is dropped when it only repeats the model.

Precedence — the creator's current edit, then a name they saved on an earlier pass, then the computed default — moved into `resolveTrainedFileName` so the clobber it prevents is covered by tests rather than living as an inline `??` chain. The wizard's value is derived per render instead of seeded into `useState`, and the state is `string | null` so a cleared field reads as a deliberate clear rather than "untouched".

The placeholder now shows the stored filename, which is what you actually get if you clear the field.

## Verification

Unit tests cover both helpers (11 cases). Beyond those, each path was walked in the running app against the dev database:

| Case | Result |
|---|---|
| Fresh import | Field shows `rimuruAndLuminous_v1.safetensors`; same value written on Next |
| `overrideName` already set to `CreatorPickedThis.safetensors` | Shown as-is, **unchanged** after Next |
| Field cleared | Stays empty, writes `null` |

`pnpm run typecheck` — 0 errors. All dev rows restored afterwards.

## Not in this PR

- **The ~8,900 existing rows.** Clearing their `overrideName` makes things worse: 81% of them have a job-id stored name underneath, so they'd fall back to a ULID. The useful backfill rewrites them to the computed default, which retroactively changes download names on published models — worth deciding separately.
- **The name is still pinned at publish time.** We persist `overrideName`, so a later model rename leaves the download name stale. The alternative is to write nothing and teach `getDownloadFilename` to compute this for job-id-named LoRA files, which stays in sync and needs no backfill — but it touches the download path for every LoRA.

Separately: renaming the version *in the form* doesn't move the filename until it's saved, because `modelVersion` comes from the query rather than react-hook-form state. Pre-existing and cosmetic; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cF671xyK2TwjFmfbYRExG
