### PR TITLE
fix(mentions): stop the @mention popup claiming "No results" mid-type

### DIFF
--- a/src/components/RichTextEditor/MentionList.tsx
+++ b/src/components/RichTextEditor/MentionList.tsx
@@ -2,6 +2,7 @@ import { Button, Center, Group, Loader, Paper, Stack, Text } from '@mantine/core
 import { useDebouncedValue } from '@mantine/hooks';
 import type { ReactRendererOptions } from '@tiptap/react';
 import type { SuggestionProps } from '@tiptap/suggestion';
+import { keepPreviousData } from '@tanstack/react-query';
 import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import { trpc } from '~/utils/trpc';
 import { removeDuplicates } from '~/utils/array-helpers';
@@ -12,17 +13,30 @@ export const MentionList = forwardRef<MentionListRef, Props>((props, ref) => {
 
   const {
     data = [],
-    isLoading,
-    isRefetching,
-  } = trpc.user.getAll.useQuery({ query: debouncedQuery, limit: 5 }, { enabled: !!debouncedQuery });
+    isFetching,
+    isError,
+  } = trpc.user.getAll.useQuery(
+    { query: debouncedQuery, limit: 5 },
+    { enabled: !!debouncedQuery, placeholderData: keepPreviousData }
+  );
+
+  // A disabled query reports isFetching: false, so without counting the debounce
+  // window as loading the popup shows a settled "No results" (~1s at typing speed).
+  const awaitingDebounce = props.query !== debouncedQuery;
+  const loading = !!props.query && (awaitingDebounce || isFetching);
 
   const items = useMemo(
     () =>
       removeDuplicates(
-        [...props.items, ...data.map((item) => ({ id: item.id, label: item.username }))],
+        [
+          ...props.items,
+          // keepPreviousData would otherwise keep the last query's hits on screen after
+          // the user deletes back to a bare `@`, hiding the default suggestions.
+          ...(debouncedQuery ? data.map((item) => ({ id: item.id, label: item.username })) : []),
+        ],
         'id'
       ),
-    [data, props.items]
+    [data, debouncedQuery, props.items]
   );
 
   const selectItem = (index: number) => {
@@ -84,7 +98,7 @@ export const MentionList = forwardRef<MentionListRef, Props>((props, ref) => {
               </Button>
             ))
           : null}
-        {(isLoading && debouncedQuery) || isRefetching ? (
+        {loading ? (
           <Center p="sm">
             <Group gap="sm" wrap="nowrap">
               <Loader size="sm" />
@@ -92,6 +106,12 @@ export const MentionList = forwardRef<MentionListRef, Props>((props, ref) => {
                 Fetching...
               </Text>
             </Group>
+          </Center>
+        ) : isError && items.length === 0 ? (
+          <Center p="sm">
+            <Text size="sm" c="dimmed">
+              Search unavailable — try again
+            </Text>
           </Center>
         ) : items.length === 0 ? (
           <Center p="sm">

--- a/src/components/RichTextEditor/__tests__/MentionList.browser.test.tsx
+++ b/src/components/RichTextEditor/__tests__/MentionList.browser.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { page } from 'vitest/browser';
+import type * as TrpcModule from '~/utils/trpc';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+
+/**
+ * A DISABLED React Query reports `isFetching: false`, so before the fix the whole 300ms
+ * debounce window fell through to the empty-state branch — ~1.0s of "No results" for text
+ * nobody had searched yet.
+ */
+type Hit = { id: number; username: string };
+
+const queryCalls: Array<{ input: { query: string }; opts: Record<string, unknown> }> = [];
+let nextResult: { data?: Array<Hit>; isError?: boolean } = {};
+let lastData: Array<Hit> | undefined;
+
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
+  return {
+    ...actual,
+    trpc: {
+      user: {
+        getAll: {
+          useQuery: (input: { query: string }, opts: Record<string, unknown>) => {
+            queryCalls.push({ input, opts });
+            // placeholderData applies to any PENDING query, disabled included, so the previous
+            // payload survives a key change. Without it the "bare @" test passes vacuously.
+            const carried = opts.placeholderData ? lastData : undefined;
+            // Disabled: no fetch, and NOT reported as fetching — the trap this file exists for.
+            if (!opts.enabled) return { data: carried, isFetching: false, isError: false };
+            // An errored query has no placeholder — placeholderData covers pending only.
+            if (nextResult.isError) return { data: undefined, isFetching: false, isError: true };
+            if (!nextResult.data) return { data: carried, isFetching: true, isError: false };
+            lastData = nextResult.data;
+            return { data: nextResult.data, isFetching: false, isError: false };
+          },
+        },
+      },
+    },
+  };
+});
+
+const { MentionList } = await import('~/components/RichTextEditor/MentionList');
+
+type ListProps = React.ComponentProps<typeof MentionList>;
+
+const props = (query: string, items: Array<{ id: number; label: string }> = []) =>
+  ({ query, items, command: vi.fn(), editor: null } as unknown as ListProps);
+
+const shownText = (container: HTMLElement) => container.textContent ?? '';
+
+beforeEach(() => {
+  queryCalls.length = 0;
+  nextResult = {};
+  lastData = undefined;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('MentionList', () => {
+  test('🔴 does not claim "No results" during the debounce window', async () => {
+    // Fake timers hold the debounce open, so the asserted state cannot delete itself
+    // mid-assertion; a real 300ms timer would be green locally and red on a busy box.
+    vi.useFakeTimers();
+
+    // Mounting straight to 'nof' seeds useDebouncedValue's initial state with it and skips
+    // the gap entirely — the test would then pass against the bug.
+    const { rerender, container } = await renderWithProviders(<MentionList {...props('')} />);
+    await rerender(<MentionList {...props('nof')} />);
+
+    // Control: without this the assertions below could pass for a reason unrelated to the gap.
+    expect(queryCalls.at(-1)?.opts.enabled).toBe(false);
+
+    const shown = shownText(container);
+    expect(shown).not.toContain('No results');
+    expect(shown).toContain('Fetching');
+  });
+
+  test('says "No results" once the query has actually settled empty', async () => {
+    const { rerender } = await renderWithProviders(<MentionList {...props('')} />);
+    nextResult = { data: [] };
+    await rerender(<MentionList {...props('zzzznobody')} />);
+
+    await expect.element(page.getByText('No results')).toBeInTheDocument();
+  });
+
+  test('renders results once they arrive', async () => {
+    const { rerender, container } = await renderWithProviders(<MentionList {...props('')} />);
+    nextResult = { data: [{ id: 9178756, username: 'nofmegan895' }] };
+    await rerender(<MentionList {...props('nofmegan895')} />);
+
+    await expect.element(page.getByText('nofmegan895')).toBeInTheDocument();
+    expect(shownText(container)).not.toContain('No results');
+  });
+
+  test('a failed search reads as unavailable, not as an absent user', async () => {
+    const { rerender, container } = await renderWithProviders(<MentionList {...props('')} />);
+    nextResult = { isError: true };
+    await rerender(<MentionList {...props('nofmegan895')} />);
+
+    await expect.element(page.getByText(/Search unavailable/)).toBeInTheDocument();
+    expect(shownText(container)).not.toContain('No results');
+  });
+
+  test('asks for keepPreviousData so the list does not blank between keystrokes', async () => {
+    const { rerender } = await renderWithProviders(<MentionList {...props('')} />);
+    nextResult = { data: [{ id: 1, username: 'nofear' }] };
+    await rerender(<MentionList {...props('nof')} />);
+
+    await expect.element(page.getByText('nofear')).toBeInTheDocument();
+    // Without it every key change resets `data` to undefined and the list blanks mid-type.
+    expect(queryCalls.at(-1)?.opts.placeholderData).toBeTypeOf('function');
+  });
+
+  test('drops server hits when the user deletes back to a bare @', async () => {
+    nextResult = { data: [{ id: 1, username: 'nofear' }] };
+    const { rerender } = await renderWithProviders(<MentionList {...props('')} />);
+    await rerender(<MentionList {...props('nof')} />);
+    await expect.element(page.getByText('nofear')).toBeInTheDocument();
+
+    // Polled, not read synchronously: `debouncedQuery` trails back to '' on the same
+    // 300ms timer, so the hits are still on screen at the moment of the rerender.
+    await rerender(<MentionList {...props('', [{ id: 42, label: 'ThreadParticipant' }])} />);
+    await expect.element(page.getByText('ThreadParticipant')).toBeInTheDocument();
+    await expect.element(page.getByText('nofear')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

The `@mention` autocomplete answered **"No results"** for text nobody had searched yet.

The query is `enabled: !!debouncedQuery`, and a **disabled React Query reports `isFetching: false`** — so the entire 300ms debounce window fell straight through to the empty-state branch.

Measured in a real editor, typing `@nofmegan895` at 80ms/char:

```
BEFORE  +110ms   No results     <-- 1.0s of this, mid-type
        +1200ms  Fetching...
        +2000ms  nofmegan895

AFTER   +112ms   Fetching...
        +1552ms  nofmegan895    "No results" never appears
```

Users read that as broken, deleted, retyped, and hit the same window again — which is what *"returns no results until many retries"* was.

A second failure mode at deliberate typing speed (450ms/char): every character fired its own request and the popup collapsed to a bare spinner in between, flickering through unrelated names from Meilisearch's typo tolerance.

## Changes

`src/components/RichTextEditor/MentionList.tsx`:

1. **Count the debounce window as loading** (`props.query !== debouncedQuery`) — kills the false "No results".
2. **`placeholderData: keepPreviousData`** — the list no longer blanks between keystrokes.
3. **An error branch.** A failed search also rendered as "No results", which reads as *"that user doesn't exist"*. It now says the search is unavailable.

## What this is *not*

The reporter suggested adding a debounce. **One was already there** (300ms, `useDebouncedValue`, since 2025). The defect was what the UI showed *while* it ran.

Server-side search was healthy throughout — every prefix of the reported username returned correct hits sub-second, and Axiom shows **0** `User search is temporarily overloaded` in prod over 7 days. No server change.

## Testing

New `MentionList.browser.test.tsx`, 6 tests. Each guard was **mutation-checked individually**:

| Reverted | Result |
|---|---|
| the loading fix | fails in **3.3s** on a readable assertion |
| `keepPreviousData` | fails |
| the error branch | fails |
| the bare-`@` guard on carried hits | fails |

One test was **vacuous on first write** — the fake didn't emulate `keepPreviousData`, so the guard it claimed to protect passed under mutation. The fake now encodes React Query's real disabled + placeholder contract, and the mutation is caught.

Also green: 34 sibling browser tests + 27 unit tests in `RichTextEditor/`, eslint, prettier, tsserver diagnostics.

## How to check in preview

Open any comment box (article, image, bounty entry), type `@` plus a username **at normal speed**. The popup should go straight to a spinner and then results — it should never flash "No results" while you're still typing.

Reported via Freshdesk #70848 · ClickUp [868m2ay0c](https://app.clickup.com/t/868m2ay0c)

The same ticket's second claim — bounty-entry authors not notified on comments — was checked and is **already shipped**: `new-bounty-entry-comment` has delivered 875 notifications, first on 2026-08-07, most recent today. Nothing to do there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9HNnyjhWgMy13DJLdXW7t
