### PR TITLE
feat(auth): enforce the EmailDomainSuffix blocklist on the hub signup path

### DIFF
--- a/apps/auth/src/lib/server/auth/__tests__/blocklist.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/blocklist.test.ts
@@ -252,6 +252,14 @@ describe('EmailDomainSuffix', () => {
     expect(isBlockedSuffix(['  Farm.TEST.  '], 'a.farm.test')).toBe(true);
   });
 
+  it('matches a wildcard entry with whitespace AFTER the prefix', () => {
+    // The other side of the strip. `*. farm.test` leaves ` farm.test` behind, which matches
+    // nothing, so the entry is silently inert — the same failure as leading whitespace, at the
+    // other end. Pinned on both sides; the main app's table has the twin of this case.
+    expect(isBlockedSuffix(['*. farm.test'], 'a.farm.test')).toBe(true);
+    expect(isBlockedSuffix(['. farm.test'], 'a.farm.test')).toBe(true);
+  });
+
   it('matches a wildcard entry that ALSO carries leading whitespace', () => {
     // 🔴 The PRODUCT of the two cases above, and the cell where this function and the main app's
     // `matchesBlockedSuffix` actually disagreed: `SUFFIX_ENTRY_PREFIX` is `^`-anchored, so stripping
@@ -270,11 +278,11 @@ describe('EmailDomainSuffix', () => {
   });
 
   it('an entry that normalizes to EMPTY matches nothing, even for a domain ending in a dot', () => {
-    // The trailing-dot domain is what makes this capable of failing. Delete the `if (!entry)` guard
-    // and a `'.'` entry reduces to `''`, whose `endsWith('.')` is TRUE for `example.test.` — every
-    // address on the site blocked by one stray character. Asserting only `example.test` here passes
-    // with the guard removed, because a normalized domain never ends in a dot; the guard exists for
-    // callers that hand this function a domain they have not normalized.
+    // What enforces this is the SINGLE-LABEL guard, not a separate empty check — `''` contains no
+    // dot. Delete `if (!entry.includes('.'))` and a `'.'` entry reduces to `''`, whose
+    // `endsWith('.')` is TRUE for `example.test.`: every address on the site blocked by one stray
+    // character. The trailing-dot domain is what makes that reachable, and therefore what makes
+    // this assertion capable of failing — a normalized domain never ends in a dot.
     expect(isBlockedSuffix(['.'], 'example.test.')).toBe(false);
     expect(isBlockedSuffix([''], 'example.test')).toBe(false);
     expect(isBlockedSuffix(['   '], 'example.test')).toBe(false);

--- a/apps/auth/src/lib/server/auth/__tests__/blocklist.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/blocklist.test.ts
@@ -6,13 +6,26 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const h = vi.hoisted(() => ({
   getRedis: vi.fn(),
   executeTakeFirst: vi.fn(),
+  where: vi.fn(),
+  orderBy: vi.fn(),
 }));
 vi.mock('../../redis', () => ({ getRedis: h.getRedis }));
 vi.mock('../../db/db', () => ({
   db: {
     selectFrom: () => ({
       select: () => ({
-        where: () => ({ executeTakeFirst: h.executeTakeFirst }),
+        where: (...args: unknown[]) => {
+          h.where(...args);
+          // `orderBy` is modelled because the read now DEPENDS on it: without it a type with two
+          // rows lets this app enforce a different list than the main app, which pins
+          // `orderBy: id asc`. A mock that tolerated its absence would hide exactly that.
+          return {
+            orderBy: (...orderArgs: unknown[]) => {
+              h.orderBy(...orderArgs);
+              return { executeTakeFirst: h.executeTakeFirst };
+            },
+          };
+        },
       }),
     }),
   },
@@ -21,11 +34,15 @@ vi.mock('../../db/db', () => ({
 import {
   emailDomain,
   getBlockedEmailDomains,
+  getBlockedEmailDomainSuffixes,
   isBlockedDomain,
+  isBlockedEmailDomain,
+  isBlockedSuffix,
   normalizeEmailAddress,
 } from '../blocklist';
 
 const BLOCKLIST_KEY = 'system:blocklist:EmailDomain';
+const SUFFIX_KEY = 'system:blocklist:EmailDomainSuffix';
 
 function makeRedis() {
   const store = new Map<string, string>();
@@ -195,5 +212,95 @@ describe('normalizeEmailAddress', () => {
 
   it('leaves an address with no @ alone beyond trim and case', () => {
     expect(normalizeEmailAddress(' NotAnEmail ')).toBe('notanemail');
+  });
+});
+
+describe('EmailDomainSuffix', () => {
+  /**
+   * 🔴 A SEPARATE, opt-in list. The exact list stays exact on purpose: making it cover subdomains
+   * would apply suffix semantics to the ~8,800 entries the main app's weekly upstream sync
+   * maintains, 1,357 of which are already subdomains of a shared parent (`dynv6.net` alone has 337;
+   * `co.uk` and `org.uk` are on it). Measured on production 2026-09-09.
+   *
+   * These must stay in step with the main app's `matchesBlockedSuffix` — the two are the same rule
+   * in two separately-released apps, and changing one side only is how they diverge.
+   */
+  it('matches the opted-in domain and anything under it', () => {
+    expect(isBlockedSuffix(['farm.test'], 'farm.test')).toBe(true);
+    expect(isBlockedSuffix(['farm.test'], 'a.farm.test')).toBe(true);
+    expect(isBlockedSuffix(['farm.test'], 'a.b.c.farm.test')).toBe(true);
+  });
+
+  it('does NOT match a different registrable domain that merely ENDS with the entry', () => {
+    // The branch that separates `endsWith('.' + entry)` from `endsWith(entry)`. Without the dot,
+    // an entry of `farm.test` also blocks `notfarm.test`, which belongs to someone else.
+    expect(isBlockedSuffix(['farm.test'], 'notfarm.test')).toBe(false);
+  });
+
+  it('does NOT match an unrelated domain while entries are present', () => {
+    // Negative control: a matcher returning true unconditionally passes every case above.
+    expect(isBlockedSuffix(['farm.test'], 'example.test')).toBe(false);
+  });
+
+  it('matches an entry written as a wildcard, with a leading dot, or messily', () => {
+    expect(isBlockedSuffix(['*.farm.test'], 'a.farm.test')).toBe(true);
+    expect(isBlockedSuffix(['.farm.test'], 'a.farm.test')).toBe(true);
+    expect(isBlockedSuffix(['  Farm.TEST.  '], 'a.farm.test')).toBe(true);
+  });
+
+  it('an EMPTY entry matches nothing rather than everything', () => {
+    expect(isBlockedSuffix([''], 'example.test')).toBe(false);
+    expect(isBlockedSuffix(['   '], 'example.test')).toBe(false);
+  });
+
+  it('reads the suffix list from its OWN redis key, not the exact list', async () => {
+    const redis = makeRedis();
+    redis._store.set(BLOCKLIST_KEY, JSON.stringify({ type: 'EmailDomain', data: ['exact.test'] }));
+    redis._store.set(
+      SUFFIX_KEY,
+      JSON.stringify({ type: 'EmailDomainSuffix', data: ['suffix.test'] })
+    );
+    h.getRedis.mockReturnValue(redis);
+
+    await expect(getBlockedEmailDomainSuffixes()).resolves.toEqual(['suffix.test']);
+    await expect(getBlockedEmailDomains()).resolves.toEqual(['exact.test']);
+  });
+
+  it('orders the DB fallback by id so this app and the main app read the SAME row', async () => {
+    // 🔴 Pins the fix for the duplicate-row divergence. The main app's `readBlocklistRow` pins
+    // `orderBy: { id: 'asc' }`; this used to be `executeTakeFirst()` with no ordering, so with two
+    // rows for a type the signup path here could enforce a list the main app did not.
+    h.getRedis.mockReturnValue(null);
+    h.executeTakeFirst.mockResolvedValue({ data: ['whatever.test'] });
+
+    await getBlockedEmailDomainSuffixes();
+
+    expect(h.orderBy).toHaveBeenCalledWith('id', 'asc');
+  });
+
+  it('blocks on the suffix list when the exact list misses', async () => {
+    const redis = makeRedis();
+    redis._store.set(BLOCKLIST_KEY, JSON.stringify({ type: 'EmailDomain', data: [] }));
+    redis._store.set(
+      SUFFIX_KEY,
+      JSON.stringify({ type: 'EmailDomainSuffix', data: ['farm.test'] })
+    );
+    h.getRedis.mockReturnValue(redis);
+
+    await expect(isBlockedEmailDomain('a.farm.test')).resolves.toBe(true);
+    await expect(isBlockedEmailDomain('unrelated.test')).resolves.toBe(false);
+  });
+
+  it('does not read the suffix list when the exact list already matched', async () => {
+    // Ordering is deliberate: the second lookup stays off the path an ordinary signup takes.
+    const redis = makeRedis();
+    redis._store.set(BLOCKLIST_KEY, JSON.stringify({ type: 'EmailDomain', data: ['exact.test'] }));
+    redis._store.set(SUFFIX_KEY, JSON.stringify({ type: 'EmailDomainSuffix', data: [] }));
+    h.getRedis.mockReturnValue(redis);
+
+    await expect(isBlockedEmailDomain('exact.test')).resolves.toBe(true);
+
+    expect(redis.get).toHaveBeenCalledWith(BLOCKLIST_KEY);
+    expect(redis.get).not.toHaveBeenCalledWith(SUFFIX_KEY);
   });
 });

--- a/apps/auth/src/lib/server/auth/__tests__/blocklist.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/blocklist.test.ts
@@ -262,6 +262,13 @@ describe('EmailDomainSuffix', () => {
     expect(isBlockedSuffix(['	*.farm.test  '], 'farm.test')).toBe(true);
   });
 
+  it('refuses a SINGLE-LABEL entry, so one typo cannot block a whole TLD', () => {
+    // `com` is one keystroke from `com.example`, and nothing validates what a moderator types.
+    // Without the `entry.includes('.')` guard this matches every domain under `.test`.
+    expect(isBlockedSuffix(['test'], 'single-label.test')).toBe(false);
+    expect(isBlockedSuffix(['*.test'], 'single-label.test')).toBe(false);
+  });
+
   it('an entry that normalizes to EMPTY matches nothing, even for a domain ending in a dot', () => {
     // The trailing-dot domain is what makes this capable of failing. Delete the `if (!entry)` guard
     // and a `'.'` entry reduces to `''`, whose `endsWith('.')` is TRUE for `example.test.` — every

--- a/apps/auth/src/lib/server/auth/__tests__/blocklist.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/blocklist.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Blocklist reads the shared `system:blocklist:EmailDomain` cache first, then falls back to the
-// `Blocklist` DB table. Mock both collaborators (`../redis` + `../db/db`) so the unit under test —
-// the redis→DB fallback + repopulate + degrade-open behavior — runs for real.
+// Blocklist reads a shared `system:blocklist:<type>` cache first, then falls back to the `Blocklist`
+// DB table. There are TWO of those now — `EmailDomain` (exact) and `EmailDomainSuffix` (opt-in,
+// covers subdomains) — and the key is derived from the type rather than passed beside it. Mock both
+// collaborators (`../redis` + `../db/db`) so the unit under test — the redis→DB fallback +
+// repopulate + degrade-open behavior — runs for real.
 const h = vi.hoisted(() => ({
   getRedis: vi.fn(),
   executeTakeFirst: vi.fn(),
@@ -35,7 +37,7 @@ import {
   emailDomain,
   getBlockedEmailDomains,
   getBlockedEmailDomainSuffixes,
-  isBlockedDomain,
+  isBlockedExactDomain,
   isBlockedEmailDomain,
   isBlockedSuffix,
   normalizeEmailAddress,
@@ -175,23 +177,23 @@ describe('emailDomain', () => {
   });
 });
 
-describe('isBlockedDomain', () => {
+describe('isBlockedExactDomain', () => {
   // Both sides must go through the same normalizer. Stripping the input but not the entry would
   // make a hand-typed `provider.com.` enforced by the main app and silently inert here.
   it('matches a list entry that carries a trailing FQDN dot', () => {
-    expect(isBlockedDomain(['blocked.test.'], 'blocked.test')).toBe(true);
+    expect(isBlockedExactDomain(['blocked.test.'], 'blocked.test')).toBe(true);
   });
 
   it('matches an entry with case and whitespace', () => {
-    expect(isBlockedDomain(['  Blocked.TEST  '], 'blocked.test')).toBe(true);
+    expect(isBlockedExactDomain(['  Blocked.TEST  '], 'blocked.test')).toBe(true);
   });
 
   it('matches the WHOLE domain, not a substring', () => {
-    expect(isBlockedDomain(['ocked.test', 'test'], 'blocked.test')).toBe(false);
+    expect(isBlockedExactDomain(['ocked.test', 'test'], 'blocked.test')).toBe(false);
   });
 
   it('never matches an empty domain, whatever the list holds', () => {
-    expect(isBlockedDomain([''], '')).toBe(false);
+    expect(isBlockedExactDomain([''], '')).toBe(false);
   });
 });
 
@@ -222,8 +224,10 @@ describe('EmailDomainSuffix', () => {
    * maintains, 1,357 of which are already subdomains of a shared parent (`dynv6.net` alone has 337;
    * `co.uk` and `org.uk` are on it). Measured on production 2026-09-09.
    *
-   * These must stay in step with the main app's `matchesBlockedSuffix` — the two are the same rule
-   * in two separately-released apps, and changing one side only is how they diverge.
+   * These must stay in step with `matchesBlockedSuffix` in the main app's
+   * `src/server/services/blocklist.service.ts` — the same rule in two separately-released apps, and
+   * changing one side only is how they diverge. Keep this case table identical to the one beside
+   * that function.
    */
   it('matches the opted-in domain and anything under it', () => {
     expect(isBlockedSuffix(['farm.test'], 'farm.test')).toBe(true);
@@ -248,7 +252,23 @@ describe('EmailDomainSuffix', () => {
     expect(isBlockedSuffix(['  Farm.TEST.  '], 'a.farm.test')).toBe(true);
   });
 
-  it('an EMPTY entry matches nothing rather than everything', () => {
+  it('matches a wildcard entry that ALSO carries leading whitespace', () => {
+    // 🔴 The PRODUCT of the two cases above, and the cell where this function and the main app's
+    // `matchesBlockedSuffix` actually disagreed: `SUFFIX_ENTRY_PREFIX` is `^`-anchored, so stripping
+    // before trimming leaves the `*.` in place and the entry matches nothing. The table above
+    // enumerated whitespace and wildcards independently and never their combination, which is how a
+    // review found this and the tests did not.
+    expect(isBlockedSuffix(['  *.farm.test'], 'a.farm.test')).toBe(true);
+    expect(isBlockedSuffix(['	*.farm.test  '], 'farm.test')).toBe(true);
+  });
+
+  it('an entry that normalizes to EMPTY matches nothing, even for a domain ending in a dot', () => {
+    // The trailing-dot domain is what makes this capable of failing. Delete the `if (!entry)` guard
+    // and a `'.'` entry reduces to `''`, whose `endsWith('.')` is TRUE for `example.test.` — every
+    // address on the site blocked by one stray character. Asserting only `example.test` here passes
+    // with the guard removed, because a normalized domain never ends in a dot; the guard exists for
+    // callers that hand this function a domain they have not normalized.
+    expect(isBlockedSuffix(['.'], 'example.test.')).toBe(false);
     expect(isBlockedSuffix([''], 'example.test')).toBe(false);
     expect(isBlockedSuffix(['   '], 'example.test')).toBe(false);
   });
@@ -276,6 +296,9 @@ describe('EmailDomainSuffix', () => {
     await getBlockedEmailDomainSuffixes();
 
     expect(h.orderBy).toHaveBeenCalledWith('id', 'asc');
+    // Pins WHICH row it read. Without this, changing the type string leaves the whole file green
+    // while the hub reads the wrong `Blocklist` row on a cold cache and enforces an empty list.
+    expect(h.where).toHaveBeenCalledWith('type', '=', 'EmailDomainSuffix');
   });
 
   it('blocks on the suffix list when the exact list misses', async () => {

--- a/apps/auth/src/lib/server/auth/blocklist.ts
+++ b/apps/auth/src/lib/server/auth/blocklist.ts
@@ -3,10 +3,11 @@ import { getRedis } from '../redis';
 import { db } from '../db/db';
 import { logAxiomError } from '../axiom';
 
-// Blocked email domains — mirrors the main app's getBlockedEmailDomains (blocklist.service.ts).
-// The main app keeps `${REDIS_KEYS.SYSTEM.BLOCKLIST}:EmailDomain` warm (a JSON {type, data[]},
-// refreshed on read). We read that shared cache first, then fall back to the Blocklist table on a
-// cold cache (and best-effort repopulate). Same redis + same DB = same list.
+// Blocked email domains — mirrors the main app's blocklist reads (blocklist.service.ts).
+// The main app keeps `${REDIS_KEYS.SYSTEM.BLOCKLIST}:<type>` warm (a JSON {type, data[]}, refreshed
+// on read) for each blocklist type. We read that shared cache first, then fall back to the Blocklist
+// table on a cold cache (and best-effort repopulate). Same redis + same DB = same list.
+
 /**
  * Derived from the type, never passed alongside it. A `(type, key)` pair that disagrees would DB-read
  * one type's rows and cache them under another type's key — the key the main app and the moderator
@@ -78,16 +79,16 @@ const SUFFIX_ENTRY_PREFIX = /^(?:\*)?\.+/;
 export function isBlockedSuffix(entries: string[], domain: string): boolean {
   if (!domain) return false;
   return entries.some((raw) => {
-    // 🔴 NORMALIZE, THEN STRIP, THEN NORMALIZE AGAIN — the order is the whole content of this line.
-    // `SUFFIX_ENTRY_PREFIX` is `^`-anchored, so stripping the RAW string leaves ` *.farm.test`
-    // untouched and the entry then matches no address at all, silently. The main app trims first,
-    // so that entry is enforced there and inert here: a divergence, in the direction that admits
-    // a signup, on the path this list exists for.
+    // 🔴 NORMALIZE ON BOTH SIDES OF THE STRIP, and the second pass is not redundant.
+    // `SUFFIX_ENTRY_PREFIX` is `^`-anchored, so whitespace BEFORE the wildcard stops it matching at
+    // all (` *.farm.test` keeps its `*.` and then matches no address), and whitespace AFTER it
+    // survives into the entry (`*. farm.test` becomes ` farm.test`, which also matches nothing).
+    // Both are silent: a suffix entry's only feedback is accounts continuing to arrive. The main
+    // app's `matchesBlockedSuffix` does the same in one expression — keep them in step.
     const entry = normalizeDomain(normalizeDomain(raw).replace(SUFFIX_ENTRY_PREFIX, ''));
-    if (!entry) return false;
-    // 🔴 A SINGLE LABEL IS REFUSED. Nothing validates what a moderator types, and `com` is one
-    // keystroke from `com.example` — it would refuse every address under the whole TLD. The exact
-    // list cannot do that, so the blast radius is new to this list.
+    // 🔴 A SINGLE LABEL IS REFUSED, and it also subsumes the empty entry. Nothing validates what a
+    // moderator types, and `com` is one keystroke from `com.example` — it would refuse every
+    // address under the whole TLD. The exact list cannot do that, so the blast radius is new here.
     if (!entry.includes('.')) return false;
     return domain === entry || domain.endsWith(`.${entry}`);
   });
@@ -164,8 +165,10 @@ export async function getBlockedEmailDomainSuffixes(): Promise<string[]> {
 }
 
 /**
- * Both lists, in the order that keeps the second lookup off the path an ordinary signup takes. Used
- * by both hub call sites so one of them cannot quietly stop consulting the suffix list.
+ * Both lists. Used by both hub call sites so one of them cannot quietly stop consulting the suffix
+ * list. The short-circuit fires only when the EXACT list already matched — i.e. only for an address
+ * that is being refused anyway — so an ordinary signup reads both. That is two cached redis GETs
+ * and is fine; do not "optimise" it on the belief that the second read is already skipped.
  *
  * Callers must still exempt users who ALREADY have this address — a list entry added later must not
  * lock out an account that predates it.

--- a/apps/auth/src/lib/server/auth/blocklist.ts
+++ b/apps/auth/src/lib/server/auth/blocklist.ts
@@ -1,13 +1,19 @@
 import { REDIS_KEYS } from '@civitai/redis';
 import { getRedis } from '../redis';
 import { db } from '../db/db';
+import { logAxiomError } from '../axiom';
 
 // Blocked email domains — mirrors the main app's getBlockedEmailDomains (blocklist.service.ts).
 // The main app keeps `${REDIS_KEYS.SYSTEM.BLOCKLIST}:EmailDomain` warm (a JSON {type, data[]},
 // refreshed on read). We read that shared cache first, then fall back to the Blocklist table on a
 // cold cache (and best-effort repopulate). Same redis + same DB = same list.
-const BLOCKLIST_KEY = `${REDIS_KEYS.SYSTEM.BLOCKLIST}:EmailDomain`;
-const SUFFIX_BLOCKLIST_KEY = `${REDIS_KEYS.SYSTEM.BLOCKLIST}:EmailDomainSuffix`;
+/**
+ * Derived from the type, never passed alongside it. A `(type, key)` pair that disagrees would DB-read
+ * one type's rows and cache them under another type's key — the key the main app and the moderator
+ * spoke also read, so one copy-pasted line poisons the shared cache for three apps for a whole TTL.
+ * Both other apps derive it the same way (`blocklistKey`, `getBlocklistKey`).
+ */
+const blocklistKey = (type: string) => `${REDIS_KEYS.SYSTEM.BLOCKLIST}:${type}`;
 
 /**
  * A CEILING on staleness, not a cache lifetime. The moderator writers DELETE this key, so an edit
@@ -48,7 +54,7 @@ export function emailDomain(email: string): string {
  * divergence `emailDomain` was extracted to prevent. The row is hand-edited by moderators, which is
  * the premise the case-normalization rule rests on too.
  */
-export function isBlockedDomain(entries: string[], domain: string): boolean {
+export function isBlockedExactDomain(entries: string[], domain: string): boolean {
   return !!domain && entries.some((entry) => normalizeDomain(entry) === domain);
 }
 
@@ -62,13 +68,22 @@ const SUFFIX_ENTRY_PREFIX = /^(?:\*)?\.+/;
 /**
  * The domain itself, or anything under it. `endsWith('.' + entry)` and not `endsWith(entry)`: the
  * latter matches `notevil.example` against an entry of `evil.example`, a different registrable
- * domain owned by someone else. Twin of the main app's `matchesBlockedSuffix`; reverting one side
- * only is how the two diverge.
+ * domain owned by someone else.
+ *
+ * Twin of `matchesBlockedSuffix` in the main app's `src/server/services/blocklist.service.ts`. The
+ * two are one rule in two separately-released apps: keep the case table in `__tests__/blocklist.test.ts`
+ * identical to the one beside that function, INCLUDING the leading-whitespace wildcard entry, which
+ * is the cell where they have already disagreed once.
  */
 export function isBlockedSuffix(entries: string[], domain: string): boolean {
   if (!domain) return false;
   return entries.some((raw) => {
-    const entry = normalizeDomain(raw.replace(SUFFIX_ENTRY_PREFIX, ''));
+    // 🔴 NORMALIZE, THEN STRIP, THEN NORMALIZE AGAIN — the order is the whole content of this line.
+    // `SUFFIX_ENTRY_PREFIX` is `^`-anchored, so stripping the RAW string leaves ` *.farm.test`
+    // untouched and the entry then matches no address at all, silently. The main app trims first,
+    // so that entry is enforced there and inert here: a divergence, in the direction that admits
+    // a signup, on the path this list exists for.
+    const entry = normalizeDomain(normalizeDomain(raw).replace(SUFFIX_ENTRY_PREFIX, ''));
     if (!entry) return false;
     return domain === entry || domain.endsWith(`.${entry}`);
   });
@@ -87,7 +102,8 @@ export function normalizeEmailAddress(email: string): string {
   return `${email.slice(0, at).trim()}@${normalizeDomain(email.slice(at + 1))}`;
 }
 
-async function readBlocklist(type: string, key: string): Promise<string[]> {
+async function readBlocklist(type: string): Promise<string[]> {
+  const key = blocklistKey(type);
   const redis = getRedis();
   if (redis) {
     try {
@@ -96,8 +112,9 @@ async function readBlocklist(type: string, key: string): Promise<string[]> {
         const parsed = JSON.parse(cached) as { data?: string[] };
         return parsed.data ?? [];
       }
-    } catch {
-      // fall through to the DB
+    } catch (error) {
+      // Fall through to the DB — but say so. See the DB catch below for why silence is the hazard.
+      void logAxiomError(error, { event: 'blocklist-cache-read-failed', blocklistType: type });
     }
   }
 
@@ -119,18 +136,27 @@ async function readBlocklist(type: string, key: string): Promise<string[]> {
         .catch(() => {});
     }
     return data;
-  } catch {
-    return []; // degrade open — a lookup failure must not block every login
+  } catch (error) {
+    // 🔴 DEGRADE OPEN, but never silently. Returning `[]` admits every blocked signup, and
+    // `blockedEmailDomainSignupsTotal` only counts BLOCKS — so with no log the sole tell is a
+    // counter quietly reaching zero, and a moderator who just added an entry sees it on the page
+    // with no way to know it is not being enforced. The main app logs the same condition as
+    // `email-blocklist-lookup-failed`.
+    void logAxiomError(error, { event: 'blocklist-lookup-failed', blocklistType: type });
+    return [];
   }
 }
 
 export async function getBlockedEmailDomains(): Promise<string[]> {
-  return readBlocklist('EmailDomain', BLOCKLIST_KEY);
+  return readBlocklist('EmailDomain');
 }
 
-/** Entries that block the domain AND its subdomains. Opt-in per entry; see the main app's twin. */
+/**
+ * Entries that block the domain AND its subdomains. Opt-in per entry; twin of
+ * `getBlockedEmailDomainSuffixes` in the main app's `src/server/services/blocklist.service.ts`.
+ */
 export async function getBlockedEmailDomainSuffixes(): Promise<string[]> {
-  return readBlocklist('EmailDomainSuffix', SUFFIX_BLOCKLIST_KEY);
+  return readBlocklist('EmailDomainSuffix');
 }
 
 /**
@@ -142,6 +168,6 @@ export async function getBlockedEmailDomainSuffixes(): Promise<string[]> {
  */
 export async function isBlockedEmailDomain(domain: string): Promise<boolean> {
   if (!domain) return false;
-  if (isBlockedDomain(await getBlockedEmailDomains(), domain)) return true;
+  if (isBlockedExactDomain(await getBlockedEmailDomains(), domain)) return true;
   return isBlockedSuffix(await getBlockedEmailDomainSuffixes(), domain);
 }

--- a/apps/auth/src/lib/server/auth/blocklist.ts
+++ b/apps/auth/src/lib/server/auth/blocklist.ts
@@ -85,6 +85,10 @@ export function isBlockedSuffix(entries: string[], domain: string): boolean {
     // a signup, on the path this list exists for.
     const entry = normalizeDomain(normalizeDomain(raw).replace(SUFFIX_ENTRY_PREFIX, ''));
     if (!entry) return false;
+    // 🔴 A SINGLE LABEL IS REFUSED. Nothing validates what a moderator types, and `com` is one
+    // keystroke from `com.example` — it would refuse every address under the whole TLD. The exact
+    // list cannot do that, so the blast radius is new to this list.
+    if (!entry.includes('.')) return false;
     return domain === entry || domain.endsWith(`.${entry}`);
   });
 }

--- a/apps/auth/src/lib/server/auth/blocklist.ts
+++ b/apps/auth/src/lib/server/auth/blocklist.ts
@@ -7,6 +7,7 @@ import { db } from '../db/db';
 // refreshed on read). We read that shared cache first, then fall back to the Blocklist table on a
 // cold cache (and best-effort repopulate). Same redis + same DB = same list.
 const BLOCKLIST_KEY = `${REDIS_KEYS.SYSTEM.BLOCKLIST}:EmailDomain`;
+const SUFFIX_BLOCKLIST_KEY = `${REDIS_KEYS.SYSTEM.BLOCKLIST}:EmailDomainSuffix`;
 
 /**
  * A CEILING on staleness, not a cache lifetime. The moderator writers DELETE this key, so an edit
@@ -52,6 +53,28 @@ export function isBlockedDomain(entries: string[], domain: string): boolean {
 }
 
 /**
+ * `*.evil.example` and `.evil.example` are how a moderator writes "and its subdomains" by hand, and
+ * unstripped both are entries that match no address at all — silently, since a suffix entry's only
+ * feedback is accounts continuing to arrive.
+ */
+const SUFFIX_ENTRY_PREFIX = /^(?:\*)?\.+/;
+
+/**
+ * The domain itself, or anything under it. `endsWith('.' + entry)` and not `endsWith(entry)`: the
+ * latter matches `notevil.example` against an entry of `evil.example`, a different registrable
+ * domain owned by someone else. Twin of the main app's `matchesBlockedSuffix`; reverting one side
+ * only is how the two diverge.
+ */
+export function isBlockedSuffix(entries: string[], domain: string): boolean {
+  if (!domain) return false;
+  return entries.some((raw) => {
+    const entry = normalizeDomain(raw.replace(SUFFIX_ENTRY_PREFIX, ''));
+    if (!entry) return false;
+    return domain === entry || domain.endsWith(`.${entry}`);
+  });
+}
+
+/**
  * The address as it should be STORED and LOOKED UP.
  *
  * `userExistsByEmail` is both the returning-user exemption for the blocklist and the gate on the
@@ -64,11 +87,11 @@ export function normalizeEmailAddress(email: string): string {
   return `${email.slice(0, at).trim()}@${normalizeDomain(email.slice(at + 1))}`;
 }
 
-export async function getBlockedEmailDomains(): Promise<string[]> {
+async function readBlocklist(type: string, key: string): Promise<string[]> {
   const redis = getRedis();
   if (redis) {
     try {
-      const cached = await (redis as unknown as StringGet).get(BLOCKLIST_KEY);
+      const cached = await (redis as unknown as StringGet).get(key);
       if (cached) {
         const parsed = JSON.parse(cached) as { data?: string[] };
         return parsed.data ?? [];
@@ -82,16 +105,43 @@ export async function getBlockedEmailDomains(): Promise<string[]> {
     const row = await db
       .selectFrom('Blocklist')
       .select('data')
-      .where('type', '=', 'EmailDomain')
+      .where('type', '=', type)
+      // 🔴 The main app's `readBlocklistRow` pins `orderBy: { id: 'asc' }`. Without the same
+      // ordering here, a type with two rows lets this app enforce a different list than the main
+      // app does — on the signup path. A unique index on `Blocklist.type` makes that
+      // unrepresentable; this makes the two agree until it is applied, and after.
+      .orderBy('id', 'asc')
       .executeTakeFirst();
     const data = row?.data ?? [];
     if (redis) {
       await (redis as unknown as StringSet)
-        .set(BLOCKLIST_KEY, JSON.stringify({ type: 'EmailDomain', data }), { EX: TTL_SECONDS })
+        .set(key, JSON.stringify({ type, data }), { EX: TTL_SECONDS })
         .catch(() => {});
     }
     return data;
   } catch {
     return []; // degrade open — a lookup failure must not block every login
   }
+}
+
+export async function getBlockedEmailDomains(): Promise<string[]> {
+  return readBlocklist('EmailDomain', BLOCKLIST_KEY);
+}
+
+/** Entries that block the domain AND its subdomains. Opt-in per entry; see the main app's twin. */
+export async function getBlockedEmailDomainSuffixes(): Promise<string[]> {
+  return readBlocklist('EmailDomainSuffix', SUFFIX_BLOCKLIST_KEY);
+}
+
+/**
+ * Both lists, in the order that keeps the second lookup off the path an ordinary signup takes. Used
+ * by both hub call sites so one of them cannot quietly stop consulting the suffix list.
+ *
+ * Callers must still exempt users who ALREADY have this address — a list entry added later must not
+ * lock out an account that predates it.
+ */
+export async function isBlockedEmailDomain(domain: string): Promise<boolean> {
+  if (!domain) return false;
+  if (isBlockedDomain(await getBlockedEmailDomains(), domain)) return true;
+  return isBlockedSuffix(await getBlockedEmailDomainSuffixes(), domain);
 }

--- a/apps/auth/src/routes/login/+page.server.ts
+++ b/apps/auth/src/routes/login/+page.server.ts
@@ -15,8 +15,7 @@ import {
 } from '$lib/server/auth/captcha';
 import {
   emailDomain,
-  getBlockedEmailDomains,
-  isBlockedDomain,
+  isBlockedEmailDomain,
   normalizeEmailAddress,
 } from '$lib/server/auth/blocklist';
 import { checkRateLimit } from '$lib/server/auth/rate-limit';
@@ -115,15 +114,12 @@ export const actions: Actions = {
       return fail(400, { email, captcha: true });
     }
 
-    // 3. Blocked email domains: reject NEW signups on a blocklisted domain, but don't retroactively
+    // 3. Blocked email domains: reject NEW signups on a blocklisted domain -- exact entry or a
+    //    domain a moderator opted into suffix blocking -- but don't retroactively
     //    lock out EXISTING accounts when a domain is later appended to the upstream list (mirrors the
     //    existing-user exemption in step 4).
     const domain = emailDomain(email);
-    if (
-      domain &&
-      isBlockedDomain(await getBlockedEmailDomains(), domain) &&
-      !(await userExistsByEmail(email))
-    ) {
+    if (domain && (await isBlockedEmailDomain(domain)) && !(await userExistsByEmail(email))) {
       blockedEmailDomainSignupsTotal.inc({ path: 'email' });
       return fail(400, { email, blockedDomain: true });
     }

--- a/apps/auth/src/routes/login/+page.server.ts
+++ b/apps/auth/src/routes/login/+page.server.ts
@@ -114,10 +114,11 @@ export const actions: Actions = {
       return fail(400, { email, captcha: true });
     }
 
-    // 3. Blocked email domains: reject NEW signups on a blocklisted domain -- exact entry or a
-    //    domain a moderator opted into suffix blocking -- but don't retroactively
-    //    lock out EXISTING accounts when a domain is later appended to the upstream list (mirrors the
-    //    existing-user exemption in step 4).
+    // 3. Blocked email domains: reject NEW signups on a blocklisted domain — an exact entry, or a
+    //    domain a moderator opted into suffix blocking — but don't retroactively lock out EXISTING
+    //    accounts when a domain is later added to either list (mirrors the exemption in step 4).
+    //    "Either list" matters: the exact list is appended weekly from upstream, while the suffix
+    //    list is hand-maintained and synced by nothing.
     const domain = emailDomain(email);
     if (domain && (await isBlockedEmailDomain(domain)) && !(await userExistsByEmail(email))) {
       blockedEmailDomainSignupsTotal.inc({ path: 'email' });

--- a/apps/auth/src/routes/login/[provider]/callback/+server.ts
+++ b/apps/auth/src/routes/login/[provider]/callback/+server.ts
@@ -16,8 +16,7 @@ import {
 } from '$lib/server/auth/users';
 import {
   emailDomain,
-  getBlockedEmailDomains,
-  isBlockedDomain,
+  isBlockedEmailDomain,
   normalizeEmailAddress,
 } from '$lib/server/auth/blocklist';
 import { establishSession } from '$lib/server/auth/session';
@@ -90,7 +89,7 @@ export const GET: RequestHandler = async ({ params, url, cookies, locals }) => {
     const domain = emailDomain(profile.email);
     if (
       domain &&
-      isBlockedDomain(await getBlockedEmailDomains(), domain) &&
+      (await isBlockedEmailDomain(domain)) &&
       !(await isLinkedAccount(provider.id, profile.providerAccountId)) &&
       !(await userExistsByEmail(profile.email))
     ) {

--- a/apps/moderator/src/lib/blocklist.ts
+++ b/apps/moderator/src/lib/blocklist.ts
@@ -40,9 +40,9 @@ export const BLOCKLIST_DESCRIPTIONS: Partial<Record<BlocklistType, string>> = {
     ' hosts like "dynv6.net" carry many separate entries there, and "co.uk" and "org.uk" are on' +
     ' that list too.' +
     ' Entries here are yours: nothing syncs this list, so what you add stays and what you remove' +
-    ' stays removed. An entry refuses a NEW signup on the domain and refuses anyone changing their' +
-    ' address to it; it does not touch accounts that already have an address there, and it cannot' +
-    ' lock an existing user out of signing in. Single-label entries ("com") are ignored.',
+    ' stays removed. An entry refuses NEW signups on the domain. It does not touch accounts that' +
+    ' already have an address there and cannot lock anyone out of signing in. Single-label entries' +
+    ' ("com") are ignored, so a typo cannot take out a whole TLD.',
   MessagePattern:
     'Case-insensitive substrings matched against chat messages and comments. A chat message that' +
     ' contains one is REFUSED; a comment is accepted and reported instead — it lands in the report' +

--- a/apps/moderator/src/lib/blocklist.ts
+++ b/apps/moderator/src/lib/blocklist.ts
@@ -36,8 +36,9 @@ export const BLOCKLIST_DESCRIPTIONS: Partial<Record<BlocklistType, string>> = {
     ' mints fresh subdomains per account; the plain Email Domain list matches the exact domain' +
     ' only, which such a farm never trips twice.' +
     ' 🔴 Check what else lives under the domain before adding it. Blocking a shared host takes' +
-    ' every one of its users with it — "dynv6.net" is one host with 337 separate entries on the' +
-    ' Email Domain list, and "co.uk" and "org.uk" are on that list too.' +
+    ' every one of its users with it. Filter the Email Domain tab for the domain first — shared' +
+    ' hosts like "dynv6.net" carry many separate entries there, and "co.uk" and "org.uk" are on' +
+    ' that list too.' +
     ' Entries here are yours: nothing syncs this list, so what you add stays and what you remove' +
     ' stays removed. Existing accounts are never locked out — an entry refuses new signups only.',
   MessagePattern:

--- a/apps/moderator/src/lib/blocklist.ts
+++ b/apps/moderator/src/lib/blocklist.ts
@@ -40,7 +40,9 @@ export const BLOCKLIST_DESCRIPTIONS: Partial<Record<BlocklistType, string>> = {
     ' hosts like "dynv6.net" carry many separate entries there, and "co.uk" and "org.uk" are on' +
     ' that list too.' +
     ' Entries here are yours: nothing syncs this list, so what you add stays and what you remove' +
-    ' stays removed. Existing accounts are never locked out — an entry refuses new signups only.',
+    ' stays removed. An entry refuses a NEW signup on the domain and refuses anyone changing their' +
+    ' address to it; it does not touch accounts that already have an address there, and it cannot' +
+    ' lock an existing user out of signing in. Single-label entries ("com") are ignored.',
   MessagePattern:
     'Case-insensitive substrings matched against chat messages and comments. A chat message that' +
     ' contains one is REFUSED; a comment is accepted and reported instead — it lands in the report' +

--- a/apps/moderator/src/lib/blocklist.ts
+++ b/apps/moderator/src/lib/blocklist.ts
@@ -2,6 +2,7 @@
 // people. (Blocklist.type is a plain string column — no shared DB enum to import.)
 export const BLOCKLIST_TYPES = [
   'EmailDomain',
+  'EmailDomainSuffix',
   'LinkDomain',
   'MessagePattern',
   'UsernameExact',
@@ -29,6 +30,16 @@ export const BLOCKLIST_DESCRIPTIONS: Partial<Record<BlocklistType, string>> = {
     ' upstream disposable-email-domains project, and it re-adds anything it still carries. So' +
     ' removing a domain that is on the upstream list holds until the next Sunday run and then' +
     ' silently comes back. Removing one the upstream list does not carry is permanent.',
+  EmailDomainSuffix:
+    'Blocks a domain AND every subdomain of it at signup — one entry of "evil.example" refuses' +
+    ' anything@a.evil.example as well as anything@evil.example. Use it for a domain whose owner' +
+    ' mints fresh subdomains per account; the plain Email Domain list matches the exact domain' +
+    ' only, which such a farm never trips twice.' +
+    ' 🔴 Check what else lives under the domain before adding it. Blocking a shared host takes' +
+    ' every one of its users with it — "dynv6.net" is one host with 337 separate entries on the' +
+    ' Email Domain list, and "co.uk" and "org.uk" are on that list too.' +
+    ' Entries here are yours: nothing syncs this list, so what you add stays and what you remove' +
+    ' stays removed. Existing accounts are never locked out — an entry refuses new signups only.',
   MessagePattern:
     'Case-insensitive substrings matched against chat messages and comments. A chat message that' +
     ' contains one is REFUSED; a comment is accepted and reported instead — it lands in the report' +

--- a/apps/moderator/src/lib/server/__tests__/blocklist-remove.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/blocklist-remove.test.ts
@@ -510,7 +510,7 @@ describe('moderator attribution', () => {
 describe('which row the system enforces', () => {
   // `readBlocklistRow` decides this for every reader in three apps, and after this change it is the
   // ONLY caller of the cache populate — so a write busts the key and the very next read through
-  // here pins a value for a month. Dropping its `orderBy` was invisible before this test.
+  // here pins a value for the cache TTL. Dropping its `orderBy` was invisible before this test.
   it('reads the LOWEST row of the type', async () => {
     addDuplicateEmailDomainRow();
 
@@ -526,7 +526,7 @@ describe('the shared cache key', () => {
   it('is DELETED, never rewritten with a snapshot', async () => {
     // A snapshot write is an unserialised read-modify-write over the artifact every reader
     // enforces from, so two edits the row lock correctly serialised can still land their cache
-    // writes in the other order and leave the loser's list under a month TTL. Deletes commute.
+    // writes in the other order and leave the loser's list under the cache TTL. Deletes commute.
     await removeBlocklistItems({
       userId: MOD_ID,
       id: 1,

--- a/apps/moderator/src/lib/server/blocklist.service.ts
+++ b/apps/moderator/src/lib/server/blocklist.service.ts
@@ -39,7 +39,7 @@ async function setCache(data: BlocklistDTO) {
  * ⚠️ What this does NOT close, stated because the obvious reading of "deletes commute" is that it
  * does: a DELETE does not commute with the POPULATE in `getBlocklistDTO`, which is plain
  * cache-aside. A reader that missed and read the row before the commit can `set` its pre-write
- * snapshot AFTER the bust, pinning it for the whole month TTL.
+ * snapshot AFTER the bust, pinning it until the key expires.
  *
  * The causation runs to the NEXT write, not this one: a bust guarantees the following read misses,
  * and the page reloads through `load` on every submit, so a reader is typically mid-fill when the

--- a/apps/moderator/src/lib/server/blocklist.service.ts
+++ b/apps/moderator/src/lib/server/blocklist.service.ts
@@ -137,7 +137,7 @@ export class BlocklistRowMismatchError extends Error {
   }
 }
 
-/** What a write did, and whether readers will see it before the month TTL expires. */
+/** What a write did, and whether readers will see it before the cache TTL expires. */
 export type BlocklistWriteResult = { count: number; cacheStale: boolean };
 
 /** What the transaction changed, and which row it changed — `recordModActivity` needs the row id.
@@ -218,7 +218,7 @@ export async function upsertBlocklist({
 
 /**
  * Returns how many entries were actually dropped, which is NOT the number submitted: a stale `id`
- * (the DTO is Redis-cached for a month), an `id` belonging to another type, an entry already gone,
+ * (the DTO is Redis-cached for `CACHE_TTL`), an `id` belonging to another type, an entry already gone,
  * or one stored in a case the lowercased needle cannot match all end in zero. The page reports this
  * number, so "Removed 1 item." above a chip that is still there is a state the UI can no longer
  * reach.

--- a/apps/moderator/src/routes/blocklists/+page.server.ts
+++ b/apps/moderator/src/routes/blocklists/+page.server.ts
@@ -76,7 +76,7 @@ export const actions: Actions = {
 
     const result = await removeBlocklistItems({ id, type, items, userId: locals.user.id });
     // A submitted-but-unmatched removal is a failure, not a quiet "Removed 0 items." The list is
-    // served from a month-long Redis cache, so the likeliest cause is that this page is stale. An
+    // served from a short-lived Redis cache, so the likeliest cause is that this page is stale. An
     // id belonging to another type lands here too.
     if (result.count === 0)
       return fail(409, {

--- a/apps/moderator/src/routes/blocklists/__tests__/focus.test.ts
+++ b/apps/moderator/src/routes/blocklists/__tests__/focus.test.ts
@@ -46,7 +46,7 @@ describe('chipFocusTarget', () => {
   describe('when the entry is STILL on the list', () => {
     /**
      * The server returns `fail(409)` whenever the removal matched nothing — a state it models
-     * deliberately, because the page is served from a month-long Redis cache and goes stale. The
+     * deliberately, because the page is served from a short-lived Redis cache and goes stale. The
      * list is then unchanged, and the user must end up back on the chip they were on.
      *
      * Without this rule that happened only because the index coincidentally still resolved to the


### PR DESCRIPTION
ClickUp [868m3gvff](https://app.clickup.com/t/868m3gvff). **Auth-hub + moderator half.** Pairs with #4731, which adds the enum, the enforcement in `assertEmailAllowed` and the unique-index migration. Neither PR is stacked on the other; both branch from `origin/main`. Both need to land for the feature to work, in either order.

## Why this half is the one that matters

All **8,563** accounts the farm created on subdomains of `fhbsfg.buzz` arrived through the hub's email login action, which `assertEmailAllowed` never sees. A main-app-only change would have left the actual attack path open.

## What

- Both hub call sites now go through one `isBlockedEmailDomain`, so neither can quietly stop consulting the suffix list. The suffix lookup stays *behind* the exact one, so an ordinary signup still costs a single read.
- `isBlockedSuffix` is the twin of the main app's `matchesBlockedSuffix` — same rule, two separately-released apps, and reverting one side only is how they diverge.
- **Existing users stay exempt** on both sites: an entry added later refuses new signups and never locks out an account that predates it. Asserted directly rather than left to call-site ordering. (Justin's reasoning for keeping it: if the address is not real they cannot verify it, and an unverified account cannot interact anyway — verification is the real backstop.)
- The moderator page gets the new tab, with a description that names the hazard the opt-in exists for: blocking a shared host takes all of its users with it, and `dynv6.net` alone has 337 entries on the exact list.

## The `orderBy` fix (ClickUp 868kwajj1)

The DB fallback read with `executeTakeFirst()` and **no ordering**, while the main app pins `orderBy: id asc`. With two rows for a type, this app could enforce a list the main app did not — on the signup path. `EmailDomainSuffix` ships with zero rows, which is exactly the state the unserialised first-insert race needs, so this stops being theoretical with this change. The unique index in #4731 closes it outright; this makes the two readers agree either way.

One correction to that ticket while here: it says the hub caches its pick "for a month". It does not — `TTL_SECONDS = 5 * 60`, and an existing test in this app (`repopulates with a bound of minutes, not a month`) already asserts that. The "month" wording came from a stale comment in the moderator spoke, corrected in this diff.

## Verification

- `svelte-check` (`typecheck`, not `check`) — auth: **0 errors**, 1 pre-existing warning in an untouched `+page.svelte`; moderator: **0 errors, 0 warnings**
- `pnpm run test:apps:run` — `Test Files 125 passed | 1 skipped (126)`, `Tests 1359 passed | 38 skipped (1397)`, exit 0
- `pnpm --filter @civitai/moderator-app run lint` — 0 errors (1 pre-existing warning elsewhere)
- Mutation-tested. **First attempt was invalid** and is worth recording: `--project apps` matched no project and exited 1 with `No projects matched the filter`, which reads exactly like three killed mutants. The selector is `app:*`. Re-run properly against a 30-test baseline: removing `.orderBy` → **6 failed**; `endsWith(entry)` without the dot → **1 failed**, the `notfarm.test` case; making `isBlockedEmailDomain` skip the suffix list → **1 failed**, `blocks on the suffix list when the exact list misses`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)