### PR TITLE
chore(flipt): remove the eval-context source gate, keep what it was about

### DIFF
--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -1,275 +1,53 @@
-import { readdirSync, readFileSync, statSync } from 'fs';
-import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { OnboardingSteps } from '~/server/common/enums';
 import { buildFliptContext } from '~/server/services/feature-flags.service';
 import type { SessionUser } from '~/types/session';
 
 /**
- * 🔴 SOURCE GATE + BEHAVIOURAL PAIR — an entity-scoped Flipt evaluation must
- * carry an evaluation CONTEXT.
- *
- * THE DEFECT CLASS. A Flipt segment constraint reads one of two inputs, and
- * which one is decided by the constraint's TYPE, not by the flag:
+ * A Flipt segment constraint reads one of two inputs, and which one is decided by the constraint's
+ * TYPE, not by the flag:
  *
  * - `ENTITY_ID_COMPARISON_TYPE` matches the `entityId` ARGUMENT.
  * - `STRING_COMPARISON_TYPE` matches a named property of the CONTEXT argument.
  *
- * Measured against flipt-state's `civitai-app/default/features.yaml`: of the 15
- * segments defined there, 12 are built from `STRING_COMPARISON_TYPE` constraints
- * — every identity, tier and cohort segment we have (`moderators`, `testers`,
- * `early-adopters`, `members`, `app-dev-testers`, `license-fee-tester`,
- * `CreatorProgram`, …). Only three (`is-zach`, `is-koen`, `is-debuggador`) read
- * the entityId. 65 of the 125 flags carry at least one segment rollout.
+ * Measured against flipt-state's `civitai-app/default/features.yaml`: of the 15 segments defined
+ * there, 12 are built from `STRING_COMPARISON_TYPE` constraints — every identity, tier and cohort
+ * segment we have (`moderators`, `testers`, `early-adopters`, `members`, `app-dev-testers`,
+ * `license-fee-tester`, `CreatorProgram`, …). Only three (`is-zach`, `is-koen`, `is-debuggador`) read
+ * the entityId.
  *
- * So an evaluation that names a subject in `entityId` and passes NO context can
- * match `all-users` and the three entityId segments, and nothing else. For every
- * other segment it returns the flag's base `enabled` value — which is
- * indistinguishable from an honest "this subject is not in the segment". There
- * is no error, no log line, and no way to tell the two apart from the outside.
+ * So an evaluation that names a subject in `entityId` and passes NO context can match `all-users`
+ * and those three, and nothing else. For every other segment it returns the flag's base `enabled`
+ * value — indistinguishable from an honest "this subject is not in the segment". No error, no log
+ * line, no way to tell the two apart from the outside. It has cost this repo twice: the feedback
+ * gate (#4042) and `resolveTestingAccess`, whose `testers` rollout was structurally unreachable for
+ * every non-moderator.
  *
- * That is the failure this repo has already paid for twice: once in the feedback
- * gate (fixed in #4042 by threading `buildFliptContext`) and once in
- * `resolveTestingAccess`, whose `testers` rollout was structurally unreachable
- * for every non-moderator (fixed in the commit that adds this file).
+ * The tests below pin that mechanism against the live segment shapes, so the claim stays true as
+ * `buildFliptContext` changes.
  *
- * WHY THE RULE IS "entityId ⇒ context" AND NOT "user-keyed ⇒ context". A scan
- * cannot reliably tell a user-derived entityId from any other: one of the sites
- * below passes a bare local called `entityId` that happens to hold a user id.
- * Keying the rule on the presence of the entityId argument needs no such guess —
- * and it is the honest rule anyway, since an entityId is a claim that the
- * evaluation is scoped to a subject, and a scoped evaluation with no context can
- * only see a quarter of the segment vocabulary. A genuinely global evaluation
- * passes one argument and is not covered here.
+ * 🔴 WHAT USED TO BE HERE, AND WHY IT IS NOT — read this before adding it back.
  *
- * WHAT THIS IS NOT. It is structural. It cannot tell a CORRECT context from a
- * wrong one — `isFlipt(flag, id, {})` satisfies it. The behavioural claim lives
- * in the second half of this file (the segment predicates below) and, for the
- * one call site fixed alongside this gate, in
- * `generation.service.testing-access-flag-context.test.ts`. This gate exists so
- * that the population those tests speak for cannot silently grow a member.
+ * The first half of this file was a SOURCE GATE: it walked `src/`, found every Flipt evaluation,
+ * and failed if one passed an `entityId` with no context unless the site was listed in a hand-typed
+ * ledger. **Justin removed it deliberately on 2026-09-09** (ClickUp 868kwa4w4), on this evidence:
+ *
+ * - In the three weeks it existed, it caught NOTHING. `git log -S"ENTITY_WITHOUT_CONTEXT_LEDGER"`
+ *   over its own file returns zero commits, so no one ever had to ledger a new violation.
+ * - It cost ~20 renumberings of its own rows, at least two PRs going CONFLICTING (and a conflicted
+ *   PR gets no CI in this repo, so they were unverifiable rather than merely unmergeable), and one
+ *   full unit suite going red in a file the diff never touched. The ledger was keyed on `file:line`,
+ *   so any two PRs touching `image.service.ts` collided in it for no informational reason.
+ *
+ * A PR to make the gate cheap (#4726, keyed on file+flag with the sites named) was closed unmerged
+ * in favour of this. The trade accepted: the defect class above is now caught by review and by the
+ * behavioural tests below, not by a scan — so a NEW context-less evaluation ships silently.
+ *
+ * If you are about to re-add a source gate here, that is a reversal of a decision made with numbers,
+ * not an oversight being corrected. Bring numbers.
  */
 
-const SRC = path.resolve(__dirname, '../../..');
-
-/** The four evaluation entry points `~/server/flipt/client` exports. */
-const EVAL_FNS = ['isFlipt', 'isFliptSync', 'getFliptBoolean', 'getFliptVariant'] as const;
-
-const SKIP_DIRS = new Set(['node_modules', '__tests__', '__screenshots__']);
-const isTestFile = (name: string) => /\.(test|spec)\.[cm]?[jt]sx?$/.test(name);
-
-function walk(dir: string, out: string[] = []): string[] {
-  for (const entry of readdirSync(dir)) {
-    if (SKIP_DIRS.has(entry)) continue;
-    const full = path.join(dir, entry);
-    if (statSync(full).isDirectory()) walk(full, out);
-    else if (/\.tsx?$/.test(entry) && !isTestFile(entry)) out.push(full);
-  }
-  return out;
-}
-
-/**
- * Blank comments out rather than deleting them, so a reported line number still
- * matches the file on disk. (This file, and `client.ts`, both write example
- * calls in prose; an unstripped scan would count them as call sites.)
- */
-const stripComments = (s: string) =>
-  s
-    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
-    .replace(/^[ \t]*\/\/.*$/gm, (m) => ' '.repeat(m.length));
-
-/**
- * Split the argument list starting at `open` (the index of `(`). Depth-counting
- * rather than a regex, because two of the real call sites pass a nested call and
- * one passes an object literal containing a comma.
- */
-function splitArgs(src: string, open: number): string[] | null {
-  let depth = 0;
-  const parts: string[] = [];
-  let cur = '';
-  for (let i = open; i < src.length; i++) {
-    const c = src[i];
-    if (c === '(' || c === '[' || c === '{') depth++;
-    else if (c === ')' || c === ']' || c === '}') {
-      depth--;
-      if (depth === 0) {
-        parts.push(cur);
-        return parts.map((p) => p.trim()).filter((p, idx) => !(idx === 0 && p === ''));
-      }
-    }
-    if (depth === 1 && c === ',') {
-      parts.push(cur);
-      cur = '';
-      continue;
-    }
-    if (depth >= 1) cur += c;
-  }
-  return null;
-}
-
-type EvalCall = { site: string; fn: string; argc: number };
-
-function scanEvalCalls(): { calls: EvalCall[]; scanned: number } {
-  const calls: EvalCall[] = [];
-  let scanned = 0;
-  for (const file of walk(SRC)) {
-    scanned++;
-    const rel = path.relative(SRC, file).split(path.sep).join('/');
-    const src = stripComments(readFileSync(file, 'utf8'));
-    // `[\w$]+\.` so the module-object form (`_fliptModule.isFliptSync(...)`) in
-    // feature-flags.service is seen; the leading `[^\w.$]` keeps a longer
-    // identifier ending in one of these names out.
-    const re = new RegExp(`(?:^|[^\\w.$])(?:[\\w$]+\\.)?(${EVAL_FNS.join('|')})\\s*\\(`, 'g');
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(src))) {
-      const open = src.indexOf('(', m.index + m[0].length - 1);
-      const args = splitArgs(src, open);
-      if (!args) continue;
-      const line = src.slice(0, m.index).split('\n').length;
-      calls.push({ site: `${rel}:${line}`, fn: m[1], argc: args.length });
-    }
-  }
-  return { calls, scanned };
-}
-
-/**
- * 🔴 HAND-TYPED. Sites that pass an `entityId` and no context, accepted for the
- * stated reason. Every reason was checked against the flag's definition in
- * flipt-state, not assumed.
- *
- * "No segments today" is a statement about the flag as it stands, NOT a licence:
- * add one segment rollout to any of these flags and the site below goes silently
- * wrong. The reason each is here rather than fixed is that the fix is not free —
- * the four feed sites are on hot list paths where `buildFliptContext` was
- * deliberately hoisted out of per-flag work, and the dispute helper has a bare
- * `userId` and no `SessionUser` to build a truthful context from.
- */
-const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
-  // flag `article-rating-dispute`: enabled=true, 0 rules, 0 rollouts → answers
-  // true for every entity regardless of context. A background auto-resolve path
-  // with only `pending.userId` in hand; building a real context would cost a
-  // user fetch. Revisit the moment this flag gains a rollout.
-  'server/services/article-rating-review.helpers.ts:482':
-    'article-rating-dispute has no segment rollouts; background path with no SessionUser',
-  // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:3279':
-    'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
-  // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:3323':
-    'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4092':
-    'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4902':
-    'feed-image-existence has no segment rollouts; hot feed path',
-  // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
-  // 0 rollouts (checked against flipt-state and against the evaluation API on
-  // 2026-08-20, which returned DEFAULT_EVALUATION_REASON for both).
-  //
-  // These two are entity-keyed ON PURPOSE, and a context could not help them. The
-  // entityId is a MODEL id, not a user id — every STRING_COMPARISON segment we have
-  // describes a person (moderators, testers, members, tiers, cohorts), and none of
-  // them can say anything about a model. The intended rollout here is a `threshold`
-  // rollout, which buckets on the entityId itself, so the entityId is the whole
-  // point rather than a missing context. The adapter also runs from a webhook with
-  // no session at all, so there is no SessionUser to build a truthful context from.
-  //
-  // The caveat above still applies with force: if either flag ever gains a SEGMENT
-  // rollout it will silently match nothing here. A percentage rollout is fine.
-  'server/services/model-moderation.adapter.ts:123':
-    'model-text-moderation-xguard has no segment rollouts; entityId is a MODEL id (no user segment can describe it) and the rollout is threshold-keyed; webhook path with no SessionUser',
-  'server/services/model-moderation.adapter.ts:228':
-    'model-text-moderation-xguard-apply has no segment rollouts; entityId is a MODEL id (no user segment can describe it) and the rollout is threshold-keyed; webhook path with no SessionUser',
-  // flag `text-blurbs`: default-off, no rules and no rollouts.
-  //
-  // Entity-keyed on purpose. The entityId is the CONTENT OWNER's user id, not the actor's, so a
-  // threshold rollout buckets a sticky subset of creators and a moderator editing someone else's
-  // page resolves the same blurbs the owner would. Supplying a context would mean assembling a
-  // SessionUser for the OWNER — whose session neither a moderator's request nor the fan-out job
-  // carries — so it costs a user fetch on a path that runs on every content write.
-  //
-  // 🔴 So this flag can only be ramped by PERCENTAGE or BOOLEAN. A SEGMENT rollout silently
-  // matches nothing here and looks exactly like "blurbs are off". The full warning is on
-  // FLIPT_FEATURE_FLAGS.TEXT_BLURBS, which is where someone running the ramp will look.
-  'server/services/blurb-materialize.service.ts:66':
-    'text-blurbs has no segment rollouts; entityId is the CONTENT OWNER (not the actor) so the intended threshold rollout is sticky per creator; no SessionUser for the owner exists on either the moderator-edit path or the fan-out job',
-};
-
-describe('flipt evaluation context — source gate', () => {
-  const { calls, scanned } = scanEvalCalls();
-
-  // POSITIVE CONTROLS. Every assertion below compares against this scan, and a
-  // scan wired to nothing returns an empty list — which would make "no new
-  // context-less evaluation" vacuously true. Floors are well under the real
-  // numbers (≈3,800 files, ≈69 calls) so ordinary growth never trips them.
-  it('actually walked the server tree', () => {
-    expect(scanned).toBeGreaterThan(2500);
-  });
-
-  it('actually found Flipt evaluations, of all three argument shapes', () => {
-    expect(calls.length).toBeGreaterThan(40);
-    // Named shapes, not just a total: a scanner that collapsed every call to one
-    // arity would still clear a total-count floor.
-    expect(calls.some((c) => c.argc === 1)).toBe(true);
-    expect(calls.some((c) => c.argc === 2)).toBe(true);
-    expect(calls.some((c) => c.argc >= 3)).toBe(true);
-  });
-
-  it('sees a known contexted site as contexted, and a known bare site as bare', () => {
-    // The pair matters. A detector hardwired to "3 args" would pass the first of
-    // these and fail the second, and vice versa.
-    const bySite = new Map(calls.map((c) => [c.site, c]));
-    expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:3323')?.argc).toBe(2);
-  });
-
-  it('adds no Flipt evaluation that names an entity but passes no context', () => {
-    const unledgered = calls
-      .filter((c) => c.argc === 2)
-      .map((c) => c.site)
-      .filter((site) => !(site in ENTITY_WITHOUT_CONTEXT_LEDGER))
-      .sort();
-    expect(
-      unledgered,
-      'A Flipt evaluation passes an entityId with no evaluation context. Every identity, ' +
-        'tier and cohort segment in flipt-state is a STRING_COMPARISON_TYPE constraint, ' +
-        'which reads the CONTEXT and never the entityId — so this evaluation cannot match ' +
-        'any of them, and returns the flag default instead. That is indistinguishable from ' +
-        '"the subject is not in the segment". Pass `buildFliptContext(user)`, or the ' +
-        'properties you actually know; if the flag genuinely has no segment rollout, add ' +
-        'the site to ENTITY_WITHOUT_CONTEXT_LEDGER with the reason you checked.'
-    ).toEqual([]);
-  });
-
-  it('keeps the ledger honest — a fixed or moved site must be removed from it', () => {
-    // The direction that gets left out. Without it the ledger silently becomes a
-    // list of line numbers that stopped meaning anything, and the next reviewer
-    // reads five accepted exceptions that are no longer there.
-    const bare = new Set(calls.filter((c) => c.argc === 2).map((c) => c.site));
-    const stale = Object.keys(ENTITY_WITHOUT_CONTEXT_LEDGER)
-      .filter((site) => !bare.has(site))
-      .sort();
-    expect(
-      stale,
-      'A ledgered site no longer passes an entityId without a context — it was fixed, ' +
-        'deleted, or the line moved. Drop or update its row.'
-    ).toEqual([]);
-  });
-});
-
-/**
- * THE BEHAVIOURAL HALF.
- *
- * The gate above is a claim about argument counts. On its own it would be
- * satisfied by `isFlipt(flag, id, {})`, and it asserts nothing at all about WHY
- * a context is required. These cases drive the real `buildFliptContext` against
- * hand-typed transcriptions of the live segments and show the mechanism: the
- * same subject matches with a context and does not match without one.
- *
- * The predicates are transcribed from flipt-state's `features.yaml`, so they can
- * disagree with the code. Deriving them from `buildFliptContext`'s output would
- * make them agree with anything.
- */
-describe('flipt evaluation context — the mechanism the gate exists for', () => {
+describe('flipt evaluation context — what a missing context costs', () => {
   const EARLY_ADOPTER_ID = 8123;
   const PLAIN_ID = 4471;
 

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -61,7 +61,7 @@ describe('flipt evaluation context — what a missing context costs', () => {
   // The one property this app adds on top of the shared `@civitai/flipt/context` builder, and the
   // only one no package test can cover.
   //
-  // 🔴 THREE ARMS, AND THE FIRST ONE IS WHY. A real member's `onboarding` carries the completion
+  // 🔴 FOUR ARMS, AND THE FIRST ONE IS WHY. A real member's `onboarding` carries the completion
   // bits too (`OnboardingComplete` is 15, so a member reads 31) — so an arm that sets the
   // CreatorProgram bit ALONE cannot tell `hasFlag` from `===`, and `===` returns false for every
   // real member. That is the segment going dark for 100% of the people it targets, with no error
@@ -76,8 +76,8 @@ describe('flipt evaluation context — what a missing context costs', () => {
       buildFliptContext(sessionUser({ onboarding: OnboardingComplete })).isInCreatorProgram
     ).toBe('false');
     expect(buildFliptContext(sessionUser()).isInCreatorProgram).toBe('false');
-    // A HIGHER bit set without this one — someone banned from the program. Kills a `>=` mutant,
-    // which the three arms above cannot see, and which would read every banned user as a member.
+    // A HIGHER bit set without this one. Kills a `>=` mutant, which the three arms above cannot
+    // see.
     expect(
       buildFliptContext(
         sessionUser({ onboarding: OnboardingComplete | OnboardingSteps.BannedCreatorProgram })

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -23,28 +23,15 @@ import type { SessionUser } from '~/types/session';
  * gate (#4042) and `resolveTestingAccess`, whose `testers` rollout was structurally unreachable for
  * every non-moderator.
  *
- * The tests below pin that mechanism against the live segment shapes, so the claim stays true as
- * `buildFliptContext` changes.
+ * The tests below pin what `buildFliptContext` emits, against a model of those segments
+ * HAND-COPIED from flipt-state on 2026-08-20 (`buildFliptContext` at
+ * `~/server/services/feature-flags.service`). Nothing here reads flipt-state, so a segment that
+ * changes shape upstream drifts from this file silently.
  *
- * 🔴 WHAT USED TO BE HERE, AND WHY IT IS NOT — read this before adding it back.
- *
- * The first half of this file was a SOURCE GATE: it walked `src/`, found every Flipt evaluation,
- * and failed if one passed an `entityId` with no context unless the site was listed in a hand-typed
- * ledger. **Justin removed it deliberately on 2026-09-09** (ClickUp 868kwa4w4), on this evidence:
- *
- * - In the three weeks it existed, it caught NOTHING. `git log -S"ENTITY_WITHOUT_CONTEXT_LEDGER"`
- *   over its own file returns zero commits, so no one ever had to ledger a new violation.
- * - It cost ~20 renumberings of its own rows, at least two PRs going CONFLICTING (and a conflicted
- *   PR gets no CI in this repo, so they were unverifiable rather than merely unmergeable), and one
- *   full unit suite going red in a file the diff never touched. The ledger was keyed on `file:line`,
- *   so any two PRs touching `image.service.ts` collided in it for no informational reason.
- *
- * A PR to make the gate cheap (#4726, keyed on file+flag with the sites named) was closed unmerged
- * in favour of this. The trade accepted: the defect class above is now caught by review and by the
- * behavioural tests below, not by a scan — so a NEW context-less evaluation ships silently.
- *
- * If you are about to re-add a source gate here, that is a reversal of a decision made with numbers,
- * not an oversight being corrected. Bring numbers.
+ * 🔴 A source gate that scanned every call site for this used to live here. It was removed
+ * deliberately on 2026-09-09 (PR #4735) after catching nothing in three weeks, at a cost in merge
+ * conflicts. Re-adding one is a reversal of a decision made with numbers, not an oversight being
+ * corrected. Bring numbers.
  */
 
 describe('flipt evaluation context — what a missing context costs', () => {
@@ -71,14 +58,15 @@ describe('flipt evaluation context — what a missing context costs', () => {
   const members = (ctx: Record<string, string>) =>
     ctx.isMember === 'true' || ctx.isModerator === 'true';
 
-  it('an EMPTY context matches none of the live property segments', () => {
-    // This is the whole defect in one line: the entityId is not on offer to any
-    // of these, so a context-less evaluation is a uniform miss.
-    const empty: Record<string, string> = {};
-    expect(earlyAdopters(empty)).toBe(false);
-    expect(moderators(empty)).toBe(false);
-    expect(members(empty)).toBe(false);
-    expect(idListed([String(EARLY_ADOPTER_ID), String(PLAIN_ID)])(empty)).toBe(false);
+  // The one property this app adds on top of the shared `@civitai/flipt/context` builder, and the
+  // only one no package test can cover. Asserted BOTH ways: the false arm alone stays green when the
+  // bit test is replaced by the literal 'false', which is a live CreatorProgram segment going dark.
+  it('reads isInCreatorProgram off the onboarding bit, not a constant', () => {
+    expect(
+      buildFliptContext(sessionUser({ onboarding: OnboardingSteps.CreatorProgram }))
+        .isInCreatorProgram
+    ).toBe('true');
+    expect(buildFliptContext(sessionUser()).isInCreatorProgram).toBe('false');
   });
 
   it('buildFliptContext emits the properties those segments read', () => {
@@ -109,7 +97,7 @@ describe('flipt evaluation context — what a missing context costs', () => {
     expect(members(buildFliptContext(sessionUser({ tier: 'free' })))).toBe(false);
   });
 
-  it('a userId-list segment reads the CONTEXT property, so the entityId cannot serve it', () => {
+  it('a userId-list segment reads context.userId, so an empty context misses it', () => {
     const user = sessionUser({ id: PLAIN_ID });
     const segment = idListed([String(PLAIN_ID)]);
     expect(segment(buildFliptContext(user))).toBe(true);

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { OnboardingSteps } from '~/server/common/enums';
+import { OnboardingComplete, OnboardingSteps } from '~/server/common/enums';
 import { buildFliptContext } from '~/server/services/feature-flags.service';
 import type { SessionUser } from '~/types/session';
 
@@ -23,15 +23,15 @@ import type { SessionUser } from '~/types/session';
  * gate (#4042) and `resolveTestingAccess`, whose `testers` rollout was structurally unreachable for
  * every non-moderator.
  *
- * The tests below pin what `buildFliptContext` emits, against a model of those segments
- * HAND-COPIED from flipt-state on 2026-08-20 (`buildFliptContext` at
- * `~/server/services/feature-flags.service`). Nothing here reads flipt-state, so a segment that
- * changes shape upstream drifts from this file silently.
+ * The tests below pin what `buildFliptContext` (`~/server/services/feature-flags.service`) emits,
+ * against a model of those segments HAND-COPIED from flipt-state on 2026-08-20. Nothing here
+ * reads flipt-state, so a segment that changes shape upstream drifts from this file silently.
  *
  * 🔴 A source gate that scanned every call site for this used to live here. It was removed
  * deliberately on 2026-09-09 (PR #4735) after catching nothing in three weeks, at a cost in merge
  * conflicts. Re-adding one is a reversal of a decision made with numbers, not an oversight being
- * corrected. Bring numbers.
+ * corrected — and a cheaper file+flag-keyed version was already built and closed unmerged
+ * (#4726), so proposing that is not new either. Bring numbers.
  */
 
 describe('flipt evaluation context — what a missing context costs', () => {
@@ -59,14 +59,30 @@ describe('flipt evaluation context — what a missing context costs', () => {
     ctx.isMember === 'true' || ctx.isModerator === 'true';
 
   // The one property this app adds on top of the shared `@civitai/flipt/context` builder, and the
-  // only one no package test can cover. Asserted BOTH ways: the false arm alone stays green when the
-  // bit test is replaced by the literal 'false', which is a live CreatorProgram segment going dark.
-  it('reads isInCreatorProgram off the onboarding bit, not a constant', () => {
+  // only one no package test can cover.
+  //
+  // 🔴 THREE ARMS, AND THE FIRST ONE IS WHY. A real member's `onboarding` carries the completion
+  // bits too (`OnboardingComplete` is 15, so a member reads 31) — so an arm that sets the
+  // CreatorProgram bit ALONE cannot tell `hasFlag` from `===`, and `===` returns false for every
+  // real member. That is the segment going dark for 100% of the people it targets, with no error
+  // and no log line.
+  it('reads isInCreatorProgram off the onboarding BIT, not the whole value', () => {
+    const withProgram = OnboardingComplete | OnboardingSteps.CreatorProgram;
+    expect(buildFliptContext(sessionUser({ onboarding: withProgram })).isInCreatorProgram).toBe(
+      'true'
+    );
+    // Other bits set, this one not: kills a mutant that reads any onboarding progress as membership.
     expect(
-      buildFliptContext(sessionUser({ onboarding: OnboardingSteps.CreatorProgram }))
-        .isInCreatorProgram
-    ).toBe('true');
+      buildFliptContext(sessionUser({ onboarding: OnboardingComplete })).isInCreatorProgram
+    ).toBe('false');
     expect(buildFliptContext(sessionUser()).isInCreatorProgram).toBe('false');
+    // A HIGHER bit set without this one — someone banned from the program. Kills a `>=` mutant,
+    // which the three arms above cannot see, and which would read every banned user as a member.
+    expect(
+      buildFliptContext(
+        sessionUser({ onboarding: OnboardingComplete | OnboardingSteps.BannedCreatorProgram })
+      ).isInCreatorProgram
+    ).toBe('false');
   });
 
   it('buildFliptContext emits the properties those segments read', () => {
@@ -97,7 +113,7 @@ describe('flipt evaluation context — what a missing context costs', () => {
     expect(members(buildFliptContext(sessionUser({ tier: 'free' })))).toBe(false);
   });
 
-  it('a userId-list segment reads context.userId, so an empty context misses it', () => {
+  it('a userId-list segment reads context.userId, so a context without it misses', () => {
     const user = sessionUser({ id: PLAIN_ID });
     const segment = idListed([String(PLAIN_ID)]);
     expect(segment(buildFliptContext(user))).toBe(true);

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -233,9 +233,9 @@ const flipt = (globalThis.__civitaiFliptClient ??= createFliptClient({
 // `buildFliptContext(user)`, or at minimum the properties you actually know.
 // `buildFliptContext`’s output is pinned by `flipt-eval-context.test.ts`, against a HAND-COPIED
 // model of the segment constraints — nothing reads flipt-state, so a segment changing shape
-// upstream is caught by review only. No call site is scanned; the one exception is
-// `resolveTestingAccess`, whose evaluation arguments are asserted by name in
-// `generation.service.testing-access-flag-context.test.ts`.
+// upstream is caught by review only. No call site is SCANNED — though a few high-cost sites
+// have their own seam tests asserting the evaluation arguments by name: `resolveTestingAccess`,
+// the feedback gate, and the app-blocks store pair.
 export const isFlipt = flipt.isEnabled;
 export const getFliptVariant = flipt.getVariant;
 export const getFliptBoolean = flipt.getBoolean;

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -115,7 +115,7 @@ export enum FLIPT_FEATURE_FLAGS {
   // the entity is the content OWNER and no SessionUser for the owner is on hand there. Every
   // identity/tier/cohort segment in flipt-state is a STRING_COMPARISON constraint that reads the
   // context, so a segment rule here returns the flag default and looks exactly like "blurbs are
-  // off". The site is recorded in ENTITY_WITHOUT_CONTEXT_LEDGER (flipt-eval-context.test.ts).
+  // off". Nothing checks that automatically — the source gate that did was removed 2026-09-09.
   TEXT_BLURBS = 'text-blurbs',
 
   // 🔴 BOOLEAN ONLY — neither a segment NOR a percentage rollout works on this one.
@@ -231,7 +231,8 @@ const flipt = (globalThis.__civitaiFliptClient ??= createFliptClient({
 // It returns the flag's base `enabled` value instead, which is indistinguishable
 // from an honest "this user is not in the segment" — no error, no log line. Pass
 // `buildFliptContext(user)`, or at minimum the properties you actually know.
-// Enforced by `src/server/flipt/__tests__/flipt-eval-context.test.ts`.
+// The mechanism is pinned by `src/server/flipt/__tests__/flipt-eval-context.test.ts`; call sites
+// are not scanned for it any more (source gate removed 2026-09-09).
 export const isFlipt = flipt.isEnabled;
 export const getFliptVariant = flipt.getVariant;
 export const getFliptBoolean = flipt.getBoolean;

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -115,7 +115,7 @@ export enum FLIPT_FEATURE_FLAGS {
   // the entity is the content OWNER and no SessionUser for the owner is on hand there. Every
   // identity/tier/cohort segment in flipt-state is a STRING_COMPARISON constraint that reads the
   // context, so a segment rule here returns the flag default and looks exactly like "blurbs are
-  // off". Nothing checks that automatically — the source gate that did was removed 2026-09-09.
+  // off". Nothing checks that automatically.
   TEXT_BLURBS = 'text-blurbs',
 
   // 🔴 BOOLEAN ONLY — neither a segment NOR a percentage rollout works on this one.
@@ -231,8 +231,11 @@ const flipt = (globalThis.__civitaiFliptClient ??= createFliptClient({
 // It returns the flag's base `enabled` value instead, which is indistinguishable
 // from an honest "this user is not in the segment" — no error, no log line. Pass
 // `buildFliptContext(user)`, or at minimum the properties you actually know.
-// The mechanism is pinned by `src/server/flipt/__tests__/flipt-eval-context.test.ts`; call sites
-// are not scanned for it any more (source gate removed 2026-09-09).
+// `buildFliptContext`’s output is pinned by `flipt-eval-context.test.ts`, against a HAND-COPIED
+// model of the segment constraints — nothing reads flipt-state, so a segment changing shape
+// upstream is caught by review only. No call site is scanned; the one exception is
+// `resolveTestingAccess`, whose evaluation arguments are asserted by name in
+// `generation.service.testing-access-flag-context.test.ts`.
 export const isFlipt = flipt.isEnabled;
 export const getFliptVariant = flipt.getVariant;
 export const getFliptBoolean = flipt.getBoolean;

--- a/src/server/services/model-moderation.adapter.ts
+++ b/src/server/services/model-moderation.adapter.ts
@@ -121,7 +121,8 @@ export function isModelTextNsfw({
 /** Is model text moderation submitting at all for this model? */
 async function submitEnabled(entityId: number) {
   // No context on purpose: the entityId is a MODEL id, and every segment we have describes a
-  // person, so none could match it. Ramp this by threshold or percentage, never a segment.
+  // person, so none could match it. Ramp by threshold or percentage, never a segment. There is
+  // also no SessionUser here to build one from — this runs from a webhook.
   return isFlipt(FLIPT_FEATURE_FLAGS.MODEL_TEXT_MODERATION_XGUARD, String(entityId));
 }
 
@@ -227,6 +228,8 @@ export const modelModerationAdapter: ModerationAdapter = {
     const triggeredLabels = [...triggered];
     if (!triggeredLabels.some((label) => LEVEL_LABEL_SET.has(label))) return;
 
+    // Same as the submit gate above: a MODEL id with no context, deliberately. Threshold or
+    // percentage only, and no SessionUser exists on this webhook path.
     if (!(await isFlipt(FLIPT_FEATURE_FLAGS.MODEL_TEXT_MODERATION_XGUARD_APPLY, String(entityId))))
       return;
 

--- a/src/server/services/model-moderation.adapter.ts
+++ b/src/server/services/model-moderation.adapter.ts
@@ -120,9 +120,6 @@ export function isModelTextNsfw({
 
 /** Is model text moderation submitting at all for this model? */
 async function submitEnabled(entityId: number) {
-  // No context on purpose: the entityId is a MODEL id, and every segment we have describes a
-  // person, so none could match it. Ramp by threshold or percentage, never a segment. There is
-  // also no SessionUser here to build one from — this runs from a webhook.
   return isFlipt(FLIPT_FEATURE_FLAGS.MODEL_TEXT_MODERATION_XGUARD, String(entityId));
 }
 
@@ -228,8 +225,6 @@ export const modelModerationAdapter: ModerationAdapter = {
     const triggeredLabels = [...triggered];
     if (!triggeredLabels.some((label) => LEVEL_LABEL_SET.has(label))) return;
 
-    // Same as the submit gate above: a MODEL id with no context, deliberately. Threshold or
-    // percentage only, and no SessionUser exists on this webhook path.
     if (!(await isFlipt(FLIPT_FEATURE_FLAGS.MODEL_TEXT_MODERATION_XGUARD_APPLY, String(entityId))))
       return;
 

--- a/src/server/services/model-moderation.adapter.ts
+++ b/src/server/services/model-moderation.adapter.ts
@@ -120,6 +120,8 @@ export function isModelTextNsfw({
 
 /** Is model text moderation submitting at all for this model? */
 async function submitEnabled(entityId: number) {
+  // No context on purpose: the entityId is a MODEL id, and every segment we have describes a
+  // person, so none could match it. Ramp this by threshold or percentage, never a segment.
   return isFlipt(FLIPT_FEATURE_FLAGS.MODEL_TEXT_MODERATION_XGUARD, String(entityId));
 }
 


### PR DESCRIPTION
Closes ClickUp 868kwa4w4 as **guard removed, class accepted** — not as fixed. Those are different closes.

## The decision

Justin, 2026-09-09, after asking the right question: *"Do we actually even need the test?"*

I went and measured it rather than defending it:

- **It has caught nothing.** `git log -S"ENTITY_WITHOUT_CONTEXT_LEDGER" --since=2026-08-20` over the test file returns **zero commits**. In the three weeks the gate existed, nobody ever had to add a ledger row — so it never once flagged a new violation.
- **Its cost over the same window:** ~20 renumberings of its own rows, at least two PRs going CONFLICTING (a conflicted PR gets no CI in this repo, so those were *unverifiable* rather than merely unmergeable), and one full unit suite going red in a file the diff never touched. The ledger was keyed on `file:line`, so any two PRs touching `image.service.ts` collided in it for no informational reason.

**The counter-argument, recorded because it is real:** the gate covered a *silent* failure. A Flipt segment rollout that matches nobody is indistinguishable from "the flag is off" — no error, no log line. It has cost this repo twice: the feedback gate (#4042), and `resolveTestingAccess`, whose `testers` rollout was structurally unreachable for every non-moderator.

PR #4726 would have kept the gate and removed the cost. It is **closed unmerged** in favour of this. The trade being accepted: a new context-less evaluation now ships silently, and the class is caught by review rather than by a scan.

## Only the gate goes

That file had two halves and only the first was the guard.

**Removed** — the tree walk, `stripComments`, `splitArgs`, `scanEvalCalls`, `ENTITY_WITHOUT_CONTEXT_LEDGER` and its assertions.

**Kept** — the 7 tests of `buildFliptContext` against the live segment predicates. They share none of the scan machinery (checked, not assumed: no `scanEvalCalls`, `SRC`, `walk`, `stripComments`, `splitArgs`, `readFileSync` or ledger reference below the split), and they are not what was being deleted. The `describe` is renamed to *"what a missing context costs"*, since the gate it used to exist beside is gone.

**They earn their place, and here are the controls rather than the claim.** Re-measured on the head
of this branch, since the fix rounds changed both the tests and their composition:

| mutant | result |
|---|---|
| `buildFliptContext` returns `{}` for any user | **5 failed / 2 passed** |
| `Flags.hasFlag(onboarding, CreatorProgram)` → `onboarding === CreatorProgram` | **1 failed** — the form that ships broken for every real member |
| same → `onboarding >= CreatorProgram` | **1 failed** |
| same → `!!onboarding` | **2 failed** |
| restored | **7 passed (7)**, exit 0 |

The other three test pure predicate shapes and correctly do not depend on it. Restored afterwards; `git diff --stat` on `feature-flags.service.ts` empty.

## The decision is pinned in the file

The surviving docblock carries a short 🔴 note: that a source gate used to live here, that it was
removed deliberately on 2026-09-09 after catching nothing in three weeks, that a cheaper file+flag
keyed version was already built and closed unmerged (#4726), and:

> If you are about to re-add a source gate here, that is a reversal of a decision made with numbers,
> not an oversight being corrected. Bring numbers.

**It does NOT carry the evidence itself** — the zero-catches figure, the renumbering count, the
trade. An earlier revision of this branch did, and a review lane correctly called it out: 19 lines of
decision narration duplicating this PR body, which is the shape `CLAUDE.md`'s comment section
forbids and which rots. The evidence lives here; the file keeps only the sentence that changes a
future editor's behaviour.

Two comments in `client.ts` are corrected for the same reason — `:118` pointed at the ledger by
name, `:234` claimed enforcement that no longer exists. A comment describing a guard that is gone is
worse than no comment.

## Verification

- `pnpm run typecheck` — `OK — 0 type errors in 380s`, exit 0
- `pnpm exec eslint` on both changed files — clean, exit 0
- `pnpm exec prettier --write` on both
- the surviving tests: `Test Files 1 passed (1)`, `Tests 7 passed (7)`, exit 0
- **full unit suite**: `Test Files  1 failed | 1735 passed | 3 skipped (1739)` / `Tests  1 failed | 39588 passed | 35 skipped (39624)`, exit 1. Both lines account for every file and every test.

The one failure is `src/server/integrations/__tests__/moderation-cache-probe.test.ts`, a `vi.waitFor` under full-suite contention. It has failed the same way all evening on two other branches by other seats, it passes in isolation, and nothing in this diff is reachable from it. Named rather than buried.

**One trap worth recording**, because it nearly cost an hour: the first typecheck run reported **9 errors**, all `Cannot find module '@civitai/orchestration-client'` in orchestrator files this diff never touches. That was not the diff — the worktree's `node_modules` predated a base switch, and `package.json` declares `@civitai/orchestration-client@0.2.0-beta.103` while `node_modules/@civitai/orchestration-client` did not exist. `pnpm install` + `db:generate` cleared all nine. A check red in a place your diff never went near is a dependency problem.

And the background-task notification for that run reported **exit code 0** while the command itself printed `TYPECHECK_EXIT=2` and `9 type error(s)`. Judge by what the command printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaEeWAaE22DMKtQRhhASVH

---

## Where the card's "-470" went

The decision card quoted **-470 lines**. The shipped diff is **40 insertions / 268 deletions** against `main`, net **-228**. Reconciling it, because anyone checking the merge against the decision will land on that gap:

- The file was **353 lines**, not 470. I wrote the -470 on the card from a stale count and did not check it.
- **119 lines survive** — the 7 behavioural tests, their fixtures and predicates, and a short docblock. Those were never part of the guard and produce none of the cost the decision was buying out: no `file:line`, no source reads, nothing that can renumber.

So the delta is smaller than the card said, and the difference is a number I got wrong rather than scope I quietly kept. The guard itself is entirely gone.

## Review round

Five lanes read `35df9a9498`. Fixes are in `2d9b4696ee`.

**Two findings would have shipped:**

🔴 **An internal ClickUp ticket id was committed to this public repository** in the surviving docblock. `CLAUDE.md`'s security section lists internal ticket ids under "do not commit these". Removed from the source; the date and PR number carry the same pointer. It remains in the earlier commit message and in this body's history, which are permanent — treated as disclosed, per the repo's own rule that removal is not remediation.

🔴 **`isInCreatorProgram` was asserted only in the false direction.** It is the one property this app adds on top of the shared `@civitai/flipt/context` builder, and the only one no package test covers. Replacing the bit test with the literal `'false'` left all 7 tests green — a live CreatorProgram segment going dark for everyone in it, with no error and no log line, which is precisely the failure this file describes. Now asserted both ways; the mutant fails by name (`expected 'false' to be 'true'`, `Tests 1 failed | 6 passed (7)`).

**Also taken:**
- The docblock was 19 lines of decision narration already present in this body. `CLAUDE.md`: explain decisions in your response, not in the file; dated measurements rot. Cut to what a future editor needs.
- It claimed the tests pin the mechanism "against the live segment shapes". They pin a **hand-copied** model of them; nothing in this repo reads flipt-state. Now says so, with the date it was copied.
- `client.ts` — my replacement fixed an understatement and introduced an overstatement. "The mechanism is pinned by" became "`buildFliptContext`’s output is pinned … against a hand-copied model". A later round corrected a second error in the same comment: it had called `resolveTestingAccess` "the one exception" with a per-call-site guard, when three suites do that — `resolveTestingAccess`, the feedback gate, and the app-blocks store pair. It now names all three and claims no exhaustiveness.
- **Deleted a vacuous test.** `an EMPTY context matches none of the live property segments` applied locally-defined lambdas to `{}` — `undefined === 'true'` is a property of the operator, and no mutation of any source file could redden it. That is why it survived the original mutant.
- **~~Restored the one fact the ledger held~~ — REVERTED, see below.** I added a note at the adapter call sites recording that the entityId is a model id. Two rounds later it was reverted: `model-moderation.adapter.ts` is now byte-identical to `main`.

**Clean:** reuse (nothing orphaned, no import breakage) and perf (no production subject; the deleted scan measured 1,337 ms over 4,260 files, the file now runs 7 tests in 5 ms).

⚠️ **One finding that outlives this PR.** The removed gate's `file:line` ledger key was effectively **unique**. Of ~12 tree-walking guards under `src/server/services/__tests__/`, the rest key by path+count, path+reason, an in-source marker, or an external JSON allowlist; the only other `file:line` entry is a single non-stale one in `no-untruthy-query-gate`. **So the cost argument that justified this removal does not generalise** — this merge is not precedent for deleting the other guards.

**Verification on `2d9b4696ee`:** typecheck `OK — 0 type errors in 401s` exit 0; eslint clean on all three files exit 0; the file `7 passed (7)` exit 0; full suite `Test Files  1 failed | 1735 passed | 3 skipped (1739)` / `Tests  1 failed | 39588 passed | 35 skipped (39624)`. Same single red as before — `moderation-cache-probe` under contention, which has failed identically on three other branches tonight.

---

## Final state, and why the adapter comments are gone

Head is `c64de1a452`. `git diff --stat origin/main...HEAD` — **2 files, 55 insertions / 269 deletions.**

`src/server/services/model-moderation.adapter.ts` is **byte-identical to `main`**: `git diff origin/main -- src/server/services/model-moderation.adapter.ts` returns nothing.

I had added a note at both of its Flipt call sites recording that the entityId is a **model** id, so the rollout must be threshold-keyed — the one fact the deleted ledger held that nothing else records. A review lane then found the clause I attached to it was **false on one of the two rows**: I wrote that there is no SessionUser because the path is a webhook, but `submitEnabled` is reached from `upsertModel` (which passes `isModerator` off the session user in the same call) and from the retry cron. Only `applyResult` is webhook-driven.

**It is reverted rather than corrected, on purpose.** "Delete the guard entirely" did not commission comments on a moderation adapter. The information is real and worth recording — but it is a separate concern with a separate owner, and it deserves its own small PR reviewed on its own merits instead of riding a deletion.

### Why that is the shape of this round

Four fix rounds on this branch each introduced a defect, and **every one was in prose I added — never in the deletion**, which no lane has questioned since the first commit. A ticket id, an overstatement, a false exclusivity claim, and a false claim about a call path. Each felt like an improvement in precision while being written.

So this round was constrained to contain **no new sentences**. Every line it adds:

```
+  // 🔴 FOUR ARMS, AND THE FIRST ONE IS WHY. A real member's `onboarding` carries the completion
+    // A HIGHER bit set without this one. Kills a `>=` mutant, which the three arms above cannot
+    // see.
```

One number (the round that added a fourth arm had shipped a header saying THREE), and one sentence shortened by deleting an overclaim — it had called that arm "someone banned from the program" when the fixture has `Banned` set and `CreatorProgram` clear, i.e. a user who was never a member.

### Mutants against the four-arm test, measured

| mutant | result |
|---|---|
| `hasFlag` → `===` | 1 failed — the form that reads `'false'` for every real member |
| `hasFlag` → `>=` | 1 failed — survived the first three arms; the fourth kills it |
| `hasFlag` → `!!onboarding` | 2 failed |
| `buildFliptContext` → `{}` | 5 failed |
| restored | 7 passed (7), exit 0 |

A review lane independently confirmed the four arms also kill `>`, negation, `&`→`|`, every single-bit flag substitution, and the swapped-argument form — that last one would have survived the original single-bit arm.

**One surviving mutant, named and not fixed:** widening the flag to `hasFlag(onboarding, OnboardingComplete | CreatorProgram)`. The lane rated it low priority and would not hold the merge for it; closing it means adding surface in the exact place that has failed repeatedly.

### Verification on `c64de1a452`

- `pnpm run typecheck` — `OK — 0 type errors in 69s`, exit 0
- `pnpm exec eslint` on both changed files — clean, exit 0
- the changed test file — `Tests 7 passed (7)`, exit 0
- full unit suite — `Test Files  1 failed | 1735 passed | 3 skipped (1739)` / `Tests  1 failed | 39588 passed | 35 skipped (39624)`

The single red is `moderation-cache-probe` under contention, which has now failed identically six times tonight across four branches and passes in isolation. Nothing in a two-file Flipt diff is reachable from it.
