### PR TITLE
Shadow the image feed against the PostgreSQL feed service, behind a Flipt flag

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2056,6 +2056,9 @@ export const REDIS_SYS_KEYS = {
     PENDING_IMAGE_RESTORES: 'system:pending-image-restores',
     // Hash { sampleRate: '0'..'1', until?: ISO-8601 | epoch ms }; missing or 0 = off.
     FEED_REQUEST_CAPTURE: 'system:feed-request-capture',
+    // Hash { sampleRate, until?, timeoutMs?, maxInflight? }: mirror a share of image-feed
+    // searches to the candidate feed service and record the comparison. Off when missing.
+    FEED_SHADOW: 'system:feed-shadow',
   },
   INDEX_UPDATES: {
     IMAGE_METRIC: 'index-updates:image-metric',

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -461,6 +461,8 @@ export const serverSchema = z
     SEARCH_API_KEY: z.string().optional(),
     METRICS_SEARCH_HOST: z.url().optional(),
     METRICS_SEARCH_API_KEY: z.string().optional(),
+    // Candidate image-feed service for shadow comparisons; unset = shadow mode inert.
+    FEED_SHADOW_URL: z.url().optional(),
     // Debounce window (ms) for flushing model-metric-affected ids into the
     // model search-index update queue. The model metric processor runs every
     // minute and accumulates every model whose ModelVersionMetric.updatedAt

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -462,7 +462,7 @@ export const serverSchema = z
     METRICS_SEARCH_HOST: z.url().optional(),
     METRICS_SEARCH_API_KEY: z.string().optional(),
     // Candidate image-feed service for shadow comparisons; unset = shadow mode inert.
-    FEED_SHADOW_URL: z.url().optional(),
+    FEED_SERVICE_URL: z.url().optional(),
     // Debounce window (ms) for flushing model-metric-affected ids into the
     // model search-index update queue. The model metric processor runs every
     // minute and accumulates every model whose ModelVersionMetric.updatedAt

--- a/src/server/clickhouse/migrations/2026-09-09-feed-shadow.sql
+++ b/src/server/clickhouse/migrations/2026-09-09-feed-shadow.sql
@@ -8,7 +8,7 @@
 --   HSET system:feed-shadow sampleRate 0.01 timeoutMs 2500 maxInflight 32   -- 1% trickle
 --   HSET system:feed-shadow sampleRate 0                                     -- off
 --
--- FEED_SHADOW_URL (env) is the candidate's base URL; unset leaves shadow mode inert.
+-- FEED_SERVICE_URL (env) is the feed service base URL; unset leaves shadow mode inert.
 
 CREATE TABLE IF NOT EXISTS default.feedShadow
 (

--- a/src/server/clickhouse/migrations/2026-09-09-feed-shadow.sql
+++ b/src/server/clickhouse/migrations/2026-09-09-feed-shadow.sql
@@ -1,0 +1,57 @@
+-- Feed shadow comparison — ClickHouse DDL. Apply MANUALLY (we do not auto-run DDL).
+--
+-- One row per image-feed search mirrored to the candidate feed service (civitai-feed):
+-- the mapped query, both answers, both latencies, and how much they agree. Rows whose
+-- search shape the mapper cannot express carry a skipReason instead of an answer, so the
+-- table also measures request coverage. The viewer's response is never affected.
+--
+--   HSET system:feed-shadow sampleRate 0.01 timeoutMs 2500 maxInflight 32   -- 1% trickle
+--   HSET system:feed-shadow sampleRate 0                                     -- off
+--
+-- FEED_SHADOW_URL (env) is the candidate's base URL; unset leaves shadow mode inert.
+
+CREATE TABLE IF NOT EXISTS default.feedShadow
+(
+  time DateTime64(3),
+  traceId String,
+  userId UInt32,
+  sort LowCardinality(String),
+  period LowCardinality(String),
+  browsingLevel UInt16,
+  useCombinedNsfwLevel UInt8,
+  cursor String,
+  -- allowlisted query-shape keys of the search input as JSON (same allowlist as feedRequests)
+  input String,
+  -- query string sent to the candidate; empty when skipped
+  feedQuery String,
+  -- why the search could not be mirrored (input:<key>, flag:<name>, offset>N, ...); empty when it was
+  skipReason LowCardinality(String),
+  feedStatus UInt16,
+  feedMs UInt32,
+  feedRoute LowCardinality(String),
+  feedEstimate UInt32,
+  feedCandidates UInt32,
+  feedCount UInt16,
+  feedIds Array(UInt32),
+  meiliMs UInt32,
+  meiliCount UInt16,
+  meiliIds Array(UInt32),
+  -- |meili ∩ feed| / |meili|, and the same over the first 10
+  overlap Float32,
+  overlapTop10 Float32,
+  -- first position where the two orders differ; -1 when the shorter list is a prefix of the other
+  firstMismatch Int32,
+  error UInt8
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(time)
+ORDER BY time
+TTL toDateTime(time) + INTERVAL 30 DAY
+SETTINGS ttl_only_drop_parts = 1;
+
+-- Coverage and agreement over the last hour:
+--
+--   SELECT skipReason, count() FROM feedShadow WHERE time > now() - INTERVAL 1 HOUR GROUP BY 1 ORDER BY 2 DESC;
+--   SELECT sort, period, count(), avg(overlap), quantile(0.5)(feedMs), quantile(0.99)(feedMs),
+--          quantile(0.5)(meiliMs), quantile(0.99)(meiliMs)
+--   FROM feedShadow WHERE time > now() - INTERVAL 1 HOUR AND skipReason = '' GROUP BY 1, 2 ORDER BY 3 DESC;

--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -35,6 +35,7 @@ import type {
 import { createLogger } from '~/utils/logging';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import type { ChatAuditRow } from '~/server/common/chat-audit.constants';
+import { FEED_SHADOW_TABLE, type FeedShadowRow } from '~/server/common/feed-shadow.constants';
 import { CHAT_AUDIT_FLAG } from '~/server/common/chat-audit.constants';
 import type { EntityChangeRow } from '~/server/common/entity-change.constants';
 import { ENTITY_CHANGE_TRACKING_FLAG } from '~/server/common/entity-change.constants';
@@ -947,6 +948,16 @@ export class Tracker {
     // separately. Same choice `entityChanges` makes, so DDL is the only
     // dependency.
     return this.trackMany('chatAuditEvents', [row], { skipActorMeta: true });
+  }
+
+  // One row per sampled image-feed search compared against the feed service.
+  // trackMany, like entityChanges and chatAudit: a direct insert needs only the
+  // table, where track would need a tracker-service route registered too. The row
+  // carries its own userId, so actor meta would only add ip/userAgent the table
+  // has no column for.
+  public async feedShadow(rows: FeedShadowRow[]) {
+    if (!rows.length) return;
+    return this.trackMany(FEED_SHADOW_TABLE, rows, { skipActorMeta: true });
   }
 
   // One row per sticker PLACEMENT, matching the consumption rule — a comment

--- a/src/server/common/feed-shadow.constants.ts
+++ b/src/server/common/feed-shadow.constants.ts
@@ -1,0 +1,30 @@
+export const FEED_SHADOW_TABLE = 'feedShadow';
+
+/** One sampled image-feed search, as answered by Meilisearch and by the feed service. */
+export type FeedShadowRow = {
+  time: string;
+  traceId: string;
+  userId: number;
+  sort: string;
+  period: string;
+  browsingLevel: number;
+  useCombinedNsfwLevel: number;
+  cursor: string;
+  input: string;
+  feedQuery: string;
+  skipReason: string;
+  feedStatus: number;
+  feedMs: number;
+  feedRoute: string;
+  feedEstimate: number;
+  feedCandidates: number;
+  feedCount: number;
+  feedIds: number[];
+  meiliMs: number;
+  meiliCount: number;
+  meiliIds: number[];
+  overlap: number;
+  overlapTop10: number;
+  firstMismatch: number;
+  error: number;
+};

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:3279':
+  'server/services/image.service.ts:3291':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:3323':
+  'server/services/image.service.ts:3363':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4092':
+  'server/services/image.service.ts:4134':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4902':
+  'server/services/image.service.ts:4946':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -219,7 +219,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:3323')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:3363')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -9,6 +9,9 @@ export enum FLIPT_FEATURE_FLAGS {
   ARTICLE_RATING_DISPUTE = 'article-rating-dispute',
   FEED_IMAGE_EXISTENCE = 'feed-image-existence',
   FEED_POST_FILTER = 'feed-fetch-filter-in-post',
+  // Answers getImagesFromSearch from the PostgreSQL feed service instead of Meilisearch
+  // for matching users; everyone else keeps Meilisearch with the feed service in shadow.
+  FEED_SERVICE_PRIMARY = 'feed-service-primary',
   REDIS_CLUSTER_ENHANCED_FAILOVER = 'redis-cluster-enhanced-failover',
 
   GIFT_CARD_VENDOR_WAIFU_WAY = 'gift-card-vendor-waifu-way',

--- a/src/server/services/__tests__/feed-primary.service.test.ts
+++ b/src/server/services/__tests__/feed-primary.service.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { feedFliptContext, serveFromFeed } from '../feed-primary.service';
+import type { FeedAnswer } from '../feed-shadow.service';
+
+const base = { sort: 'Most Reactions', period: 'Week', browsingLevel: 31, limit: 100 };
+const answer = (ids: number[], extra: Partial<FeedAnswer> = {}): FeedAnswer => ({
+  status: 200,
+  ms: 7,
+  ids,
+  ...extra,
+});
+const rows = (ids: number[]) => ids.map((id) => ({ id, url: `u${id}` }));
+
+describe('serveFromFeed', () => {
+  it('keeps the feed order, drops what hydration filtered out and hands back a feed cursor', async () => {
+    const hydrate = vi.fn(async (ids: number[]) => rows(ids.filter((id) => id !== 5).reverse()));
+    const fetchFeed = vi.fn(async () =>
+      answer([9, 5, 2], { nextCursor: '17808|2', route: 'tag-walk' })
+    );
+    const r = await serveFromFeed(base, { fetchFeed, hydrate });
+    expect(r.ok && r.page.data.map((d) => d.id)).toEqual([9, 2]);
+    expect(r.ok && r.page.nextCursor).toBe('feed:17808:2');
+    expect(r.ok && r.page.route).toBe('tag-walk');
+    expect(hydrate).toHaveBeenCalledWith([9, 5, 2]);
+    expect(new URLSearchParams(fetchFeed.mock.calls[0]?.[0] as string).get('sort')).toBe(
+      'reactions'
+    );
+  });
+
+  it('serves an empty page as end of feed without hydrating', async () => {
+    const hydrate = vi.fn(async () => []);
+    const r = await serveFromFeed(base, { fetchFeed: async () => answer([]), hydrate });
+    expect(r).toEqual({
+      ok: true,
+      page: { data: [], nextCursor: undefined, feedMs: 7, route: undefined },
+    });
+    expect(hydrate).not.toHaveBeenCalled();
+  });
+
+  it('falls back with a reason when the shape, the call or the status is not servable', async () => {
+    const hydrate = async () => [];
+    expect(
+      await serveFromFeed(
+        { ...base, followed: true },
+        { fetchFeed: async () => answer([1]), hydrate }
+      )
+    ).toEqual({
+      ok: false,
+      reason: 'flag:followed',
+    });
+    const timeout = Object.assign(new Error('t'), { name: 'TimeoutError' });
+    expect(
+      await serveFromFeed(base, { fetchFeed: async () => Promise.reject(timeout), hydrate })
+    ).toEqual({
+      ok: false,
+      reason: 'timeout',
+    });
+    expect(
+      await serveFromFeed(base, { fetchFeed: async () => answer([], { status: 503 }), hydrate })
+    ).toEqual({
+      ok: false,
+      reason: 'status:503',
+    });
+  });
+});
+
+describe('feedFliptContext', () => {
+  it('matches the shape of the request-path context for the fields the search input carries', () => {
+    expect(feedFliptContext({})).toEqual({ isLoggedIn: 'false' });
+    expect(feedFliptContext({ currentUserId: 6, isModerator: true })).toEqual({
+      userId: '6',
+      isModerator: 'true',
+      isLoggedIn: 'true',
+    });
+  });
+});

--- a/src/server/services/__tests__/feed-shadow.service.test.ts
+++ b/src/server/services/__tests__/feed-shadow.service.test.ts
@@ -76,6 +76,8 @@ describe('mapSearchInputToFeedQuery', () => {
     expect(reason({ sort: 'Random' })).toBe('sort:Random');
     expect(reason({ notPublished: true })).toBe('flag:unpublished:no-user');
     expect(reason({ notPublished: true, userId: 3 })).toBe('ok');
+    expect(reason({ tags: [0] })).toBe('tags:none');
+    expect(reason({ tags: [0, 5] })).toBe('ok');
   });
 
   it('continues a feed-served page only when the feed is primary', () => {

--- a/src/server/services/__tests__/feed-shadow.service.test.ts
+++ b/src/server/services/__tests__/feed-shadow.service.test.ts
@@ -1,0 +1,167 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  buildFeedShadowRow,
+  compareIds,
+  createFeedShadow,
+  mapSearchInputToFeedQuery,
+  parseShadowConfig,
+  type FeedShadowConfig,
+  type FeedShadowRow,
+} from '../feed-shadow.service';
+
+const T0 = Date.UTC(2026, 8, 9, 12, 0, 0);
+const ALWAYS: FeedShadowConfig = { sampleRate: 1, until: Number.POSITIVE_INFINITY, timeoutMs: 1000, maxInflight: 2 };
+const outcome = { source: 'getImagesFromSearch' as const, elapsedMs: 12, resultIds: [3, 1, 2] };
+const base = { sort: 'Most Reactions', period: 'Week', browsingLevel: 31, limit: 100 };
+
+describe('parseShadowConfig', () => {
+  it('is off when missing and clamps the knobs', () => {
+    expect(parseShadowConfig(null).sampleRate).toBe(0);
+    expect(parseShadowConfig({ sampleRate: '0.05', timeoutMs: '99999', maxInflight: '0' })).toEqual({
+      sampleRate: 0.05,
+      until: Number.POSITIVE_INFINITY,
+      timeoutMs: 10_000,
+      maxInflight: 32,
+    });
+  });
+});
+
+describe('mapSearchInputToFeedQuery', () => {
+  it('maps the search shape onto the feed query', () => {
+    const m = mapSearchInputToFeedQuery({
+      ...base,
+      tags: [5],
+      excludedTagIds: [7, 8],
+      excludedUserIds: [9],
+      modelVersionId: 290640,
+      types: ['image'],
+      baseModels: ['Pony'],
+      useCombinedNsfwLevel: true,
+      cursor: '400|1788000012345',
+    });
+    expect(m.ok).toBe(true);
+    const q = m.ok ? new URLSearchParams(m.query) : new URLSearchParams();
+    expect(q.get('levels')).toBe('1,2,4,8,16');
+    expect(q.get('combinedLevels')).toBe('1');
+    expect(q.get('tags')).toBe('5');
+    expect(q.get('excludedTags')).toBe('7,8');
+    expect(q.get('excludedUserIds')).toBe('9');
+    expect(q.get('versionIds')).toBe('290640');
+    expect(q.get('sort')).toBe('reactions');
+    expect(q.get('periodDays')).toBe('7');
+    expect(q.get('offset')).toBe('400');
+    expect(q.get('before')).toBe('1788000000000');
+  });
+
+  it('names the first thing it cannot express', () => {
+    const reason = (i: Record<string, unknown>) => {
+      const m = mapSearchInputToFeedQuery({ ...base, ...i });
+      return m.ok ? 'ok' : m.reason;
+    };
+    expect(reason({ followed: true })).toBe('flag:followed');
+    expect(reason({ postId: 4 })).toBe('input:postId');
+    expect(reason({ modelId: 4 })).toBe('modelId');
+    expect(reason({ cursor: '30000|1788000000000' })).toBe('offset>20000');
+    expect(reason({ sort: 'Random' })).toBe('sort:Random');
+    expect(reason({ notPublished: true })).toBe('flag:unpublished:no-user');
+    expect(reason({ notPublished: true, userId: 3 })).toBe('ok');
+  });
+});
+
+describe('compareIds', () => {
+  it('measures overlap, top-10 overlap and the first order break', () => {
+    expect(compareIds([1, 2, 3, 4], [1, 2, 4, 9])).toEqual({ overlap: 0.75, overlapTop10: 0.75, firstMismatch: 2 });
+    expect(compareIds([1, 2], [1, 2, 3])).toEqual({ overlap: 1, overlapTop10: 1, firstMismatch: -1 });
+    expect(compareIds([], [])).toEqual({ overlap: 1, overlapTop10: 1, firstMismatch: -1 });
+    expect(compareIds([], [5]).overlap).toBe(0);
+  });
+});
+
+describe('feedShadow row ↔ DDL parity', () => {
+  it('writes exactly the columns the table declares', () => {
+    const sql = readFileSync(path.resolve(__dirname, '../../clickhouse/migrations/2026-09-09-feed-shadow.sql'), 'utf8');
+    const body = sql.slice(sql.indexOf('feedShadow\n(') + 'feedShadow\n('.length, sql.indexOf('\n)\nENGINE'));
+    const columns = body
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('--'))
+      .map((l) => l.split(/\s+/)[0]);
+    const row = buildFeedShadowRow({}, outcome, T0, '', { ok: false, reason: 'x' });
+    expect(new Set(Object.keys(row))).toEqual(new Set(columns));
+  });
+});
+
+describe('createFeedShadow', () => {
+  function harness(config: FeedShadowConfig, fetchFeed = async () => ({ status: 200, ms: 5, ids: [3, 1, 9], route: 'r', estimate: 1, candidates: 2 })) {
+    const batches: FeedShadowRow[][] = [];
+    const shadow = createFeedShadow({
+      getConfig: async () => config,
+      fetchFeed,
+      insert: async (rows) => {
+        batches.push(rows);
+      },
+      now: () => T0,
+      random: () => 0.5,
+      flushIntervalMs: 60_000,
+      onError: () => undefined,
+    });
+    return { shadow, batches };
+  }
+
+  it('records the comparison and never throws', async () => {
+    const { shadow, batches } = harness(ALWAYS);
+    await shadow.compare(base, outcome);
+    await shadow.flush();
+    expect(batches).toHaveLength(1);
+    const row = batches[0][0];
+    expect(row.skipReason).toBe('');
+    expect(row.feedIds).toEqual([3, 1, 9]);
+    expect(row.overlap).toBeCloseTo(2 / 3);
+    expect(row.firstMismatch).toBe(2);
+    expect(row.error).toBe(0);
+  });
+
+  it('records skipped shapes without calling the feed', async () => {
+    let calls = 0;
+    const { shadow, batches } = harness(ALWAYS, async () => {
+      calls++;
+      return { status: 200, ms: 1, ids: [] };
+    });
+    await shadow.compare({ ...base, followed: true }, outcome);
+    await shadow.flush();
+    expect(calls).toBe(0);
+    expect(batches[0][0].skipReason).toBe('flag:followed');
+  });
+
+  it('drops when the inflight cap is reached and counts a timeout as an error row', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const { shadow, batches } = harness(ALWAYS, async () => {
+      await gate;
+      const err = new Error('t');
+      err.name = 'TimeoutError';
+      throw err;
+    });
+    const a = shadow.compare(base, outcome);
+    const b = shadow.compare(base, outcome);
+    const c = shadow.compare(base, outcome);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(shadow.inflight).toBe(2);
+    release();
+    await Promise.all([a, b, c]);
+    await shadow.flush();
+    expect(shadow.dropped).toBe(1);
+    expect(batches[0]).toHaveLength(2);
+    expect(batches[0][0].feedStatus).toBe(504);
+    expect(batches[0][0].error).toBe(1);
+  });
+
+  it('does nothing when off', async () => {
+    const { shadow, batches } = harness({ ...ALWAYS, sampleRate: 0 });
+    await shadow.compare(base, outcome);
+    await shadow.flush();
+    expect(batches).toHaveLength(0);
+  });
+});

--- a/src/server/services/__tests__/feed-shadow.service.test.ts
+++ b/src/server/services/__tests__/feed-shadow.service.test.ts
@@ -10,8 +10,8 @@ import {
   parseFeedCursor,
   parseShadowConfig,
   type FeedShadowConfig,
-  type FeedShadowRow,
 } from '../feed-shadow.service';
+import type { FeedShadowRow } from '~/server/common/feed-shadow.constants';
 
 const T0 = Date.UTC(2026, 8, 9, 12, 0, 0);
 const ALWAYS: FeedShadowConfig = {
@@ -141,27 +141,25 @@ describe('createFeedShadow', () => {
       candidates: 2,
     })
   ) {
-    const batches: FeedShadowRow[][] = [];
+    const rows: FeedShadowRow[] = [];
     const shadow = createFeedShadow({
       getConfig: async () => config,
       fetchFeed,
-      insert: async (rows) => {
-        batches.push(rows);
+      record: async (row) => {
+        rows.push(row);
       },
       now: () => T0,
       random: () => 0.5,
-      flushIntervalMs: 60_000,
       onError: () => undefined,
     });
-    return { shadow, batches };
+    return { shadow, rows };
   }
 
   it('records the comparison and never throws', async () => {
-    const { shadow, batches } = harness(ALWAYS);
+    const { shadow, rows } = harness(ALWAYS);
     await shadow.compare(base, outcome);
-    await shadow.flush();
-    expect(batches).toHaveLength(1);
-    const row = batches[0][0];
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
     expect(row.skipReason).toBe('');
     expect(row.feedIds).toEqual([3, 1, 9]);
     expect(row.overlap).toBeCloseTo(2 / 3);
@@ -171,20 +169,19 @@ describe('createFeedShadow', () => {
 
   it('records skipped shapes without calling the feed', async () => {
     let calls = 0;
-    const { shadow, batches } = harness(ALWAYS, async () => {
+    const { shadow, rows } = harness(ALWAYS, async () => {
       calls++;
       return { status: 200, ms: 1, ids: [] };
     });
     await shadow.compare({ ...base, followed: true }, outcome);
-    await shadow.flush();
     expect(calls).toBe(0);
-    expect(batches[0][0].skipReason).toBe('flag:followed');
+    expect(rows[0].skipReason).toBe('flag:followed');
   });
 
   it('drops when the inflight cap is reached and counts a timeout as an error row', async () => {
     let release!: () => void;
     const gate = new Promise<void>((r) => (release = r));
-    const { shadow, batches } = harness(ALWAYS, async () => {
+    const { shadow, rows } = harness(ALWAYS, async () => {
       await gate;
       const err = new Error('t');
       err.name = 'TimeoutError';
@@ -197,17 +194,15 @@ describe('createFeedShadow', () => {
     expect(shadow.inflight).toBe(2);
     release();
     await Promise.all([a, b, c]);
-    await shadow.flush();
     expect(shadow.dropped).toBe(1);
-    expect(batches[0]).toHaveLength(2);
-    expect(batches[0][0].feedStatus).toBe(504);
-    expect(batches[0][0].error).toBe(1);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].feedStatus).toBe(504);
+    expect(rows[0].error).toBe(1);
   });
 
   it('does nothing when off', async () => {
-    const { shadow, batches } = harness({ ...ALWAYS, sampleRate: 0 });
+    const { shadow, rows } = harness({ ...ALWAYS, sampleRate: 0 });
     await shadow.compare(base, outcome);
-    await shadow.flush();
-    expect(batches).toHaveLength(0);
+    expect(rows).toHaveLength(0);
   });
 });

--- a/src/server/services/__tests__/feed-shadow.service.test.ts
+++ b/src/server/services/__tests__/feed-shadow.service.test.ts
@@ -5,26 +5,35 @@ import {
   buildFeedShadowRow,
   compareIds,
   createFeedShadow,
+  encodeFeedCursor,
   mapSearchInputToFeedQuery,
+  parseFeedCursor,
   parseShadowConfig,
   type FeedShadowConfig,
   type FeedShadowRow,
 } from '../feed-shadow.service';
 
 const T0 = Date.UTC(2026, 8, 9, 12, 0, 0);
-const ALWAYS: FeedShadowConfig = { sampleRate: 1, until: Number.POSITIVE_INFINITY, timeoutMs: 1000, maxInflight: 2 };
+const ALWAYS: FeedShadowConfig = {
+  sampleRate: 1,
+  until: Number.POSITIVE_INFINITY,
+  timeoutMs: 1000,
+  maxInflight: 2,
+};
 const outcome = { source: 'getImagesFromSearch' as const, elapsedMs: 12, resultIds: [3, 1, 2] };
 const base = { sort: 'Most Reactions', period: 'Week', browsingLevel: 31, limit: 100 };
 
 describe('parseShadowConfig', () => {
   it('is off when missing and clamps the knobs', () => {
     expect(parseShadowConfig(null).sampleRate).toBe(0);
-    expect(parseShadowConfig({ sampleRate: '0.05', timeoutMs: '99999', maxInflight: '0' })).toEqual({
-      sampleRate: 0.05,
-      until: Number.POSITIVE_INFINITY,
-      timeoutMs: 10_000,
-      maxInflight: 32,
-    });
+    expect(parseShadowConfig({ sampleRate: '0.05', timeoutMs: '99999', maxInflight: '0' })).toEqual(
+      {
+        sampleRate: 0.05,
+        until: Number.POSITIVE_INFINITY,
+        timeoutMs: 10_000,
+        maxInflight: 32,
+      }
+    );
   });
 });
 
@@ -68,12 +77,31 @@ describe('mapSearchInputToFeedQuery', () => {
     expect(reason({ notPublished: true })).toBe('flag:unpublished:no-user');
     expect(reason({ notPublished: true, userId: 3 })).toBe('ok');
   });
+
+  it('continues a feed-served page only when the feed is primary', () => {
+    const input = { ...base, cursor: 'feed:17808:68701222', offset: 300 };
+    expect(mapSearchInputToFeedQuery(input)).toEqual({ ok: false, reason: 'cursor:feed' });
+    const m = mapSearchInputToFeedQuery(input, 'primary');
+    const q = m.ok ? new URLSearchParams(m.query) : new URLSearchParams();
+    expect(q.get('cursor')).toBe('17808|68701222');
+    expect(q.has('offset')).toBe(false);
+    expect(encodeFeedCursor('1788000012345|42')).toBe('feed:1788000012345:42');
+    expect(parseFeedCursor('400|1788000012345')).toBeUndefined();
+  });
 });
 
 describe('compareIds', () => {
   it('measures overlap, top-10 overlap and the first order break', () => {
-    expect(compareIds([1, 2, 3, 4], [1, 2, 4, 9])).toEqual({ overlap: 0.75, overlapTop10: 0.75, firstMismatch: 2 });
-    expect(compareIds([1, 2], [1, 2, 3])).toEqual({ overlap: 1, overlapTop10: 1, firstMismatch: -1 });
+    expect(compareIds([1, 2, 3, 4], [1, 2, 4, 9])).toEqual({
+      overlap: 0.75,
+      overlapTop10: 0.75,
+      firstMismatch: 2,
+    });
+    expect(compareIds([1, 2], [1, 2, 3])).toEqual({
+      overlap: 1,
+      overlapTop10: 1,
+      firstMismatch: -1,
+    });
     expect(compareIds([], [])).toEqual({ overlap: 1, overlapTop10: 1, firstMismatch: -1 });
     expect(compareIds([], [5]).overlap).toBe(0);
   });
@@ -81,8 +109,14 @@ describe('compareIds', () => {
 
 describe('feedShadow row ↔ DDL parity', () => {
   it('writes exactly the columns the table declares', () => {
-    const sql = readFileSync(path.resolve(__dirname, '../../clickhouse/migrations/2026-09-09-feed-shadow.sql'), 'utf8');
-    const body = sql.slice(sql.indexOf('feedShadow\n(') + 'feedShadow\n('.length, sql.indexOf('\n)\nENGINE'));
+    const sql = readFileSync(
+      path.resolve(__dirname, '../../clickhouse/migrations/2026-09-09-feed-shadow.sql'),
+      'utf8'
+    );
+    const body = sql.slice(
+      sql.indexOf('feedShadow\n(') + 'feedShadow\n('.length,
+      sql.indexOf('\n)\nENGINE')
+    );
     const columns = body
       .split('\n')
       .map((l) => l.trim())
@@ -94,7 +128,17 @@ describe('feedShadow row ↔ DDL parity', () => {
 });
 
 describe('createFeedShadow', () => {
-  function harness(config: FeedShadowConfig, fetchFeed = async () => ({ status: 200, ms: 5, ids: [3, 1, 9], route: 'r', estimate: 1, candidates: 2 })) {
+  function harness(
+    config: FeedShadowConfig,
+    fetchFeed = async () => ({
+      status: 200,
+      ms: 5,
+      ids: [3, 1, 9],
+      route: 'r',
+      estimate: 1,
+      candidates: 2,
+    })
+  ) {
     const batches: FeedShadowRow[][] = [];
     const shadow = createFeedShadow({
       getConfig: async () => config,

--- a/src/server/services/feed-primary.service.ts
+++ b/src/server/services/feed-primary.service.ts
@@ -1,0 +1,93 @@
+import { env } from '~/env/server';
+import { registerCounterWithLabels } from '~/server/prom/client';
+import type { CapturableSearchInput } from '~/server/services/feed-request-capture.service';
+import {
+  encodeFeedCursor,
+  fetchFeedAnswer,
+  mapSearchInputToFeedQuery,
+  type FeedAnswer,
+} from '~/server/services/feed-shadow.service';
+
+export const FEED_PRIMARY_TIMEOUT_MS = 5_000;
+
+const requestCounter = registerCounterWithLabels({
+  name: 'feed_primary_requests_total',
+  help: 'Image-feed searches answered by the feed service instead of Meilisearch, by outcome',
+  labelNames: ['outcome'] as const,
+});
+
+export type FeedPrimaryPage<T> = {
+  data: T[];
+  nextCursor: string | undefined;
+  feedMs: number;
+  route?: string;
+};
+export type FeedPrimaryResult<T> =
+  | { ok: true; page: FeedPrimaryPage<T> }
+  | { ok: false; reason: string };
+
+export type FeedPrimaryDeps<T extends { id: number }> = {
+  fetchFeed: (query: string, timeoutMs: number) => Promise<FeedAnswer>;
+  /** Loads the page's records in any order; the feed's order is restored here. */
+  hydrate: (ids: number[]) => Promise<T[]>;
+  timeoutMs?: number;
+};
+
+/** Truthful subset of the request-path Flipt context (feature-flags.service.ts) built
+ *  from what the search input carries, so segments on userId/isModerator can match. */
+export function feedFliptContext(input: {
+  currentUserId?: number;
+  isModerator?: boolean;
+}): Record<string, string> {
+  if (!input.currentUserId) return { isLoggedIn: 'false' };
+  return {
+    userId: String(input.currentUserId),
+    isModerator: String(!!input.isModerator),
+    isLoggedIn: 'true',
+  };
+}
+
+export async function serveFromFeed<T extends { id: number }>(
+  input: CapturableSearchInput,
+  deps: FeedPrimaryDeps<T>
+): Promise<FeedPrimaryResult<T>> {
+  const mapping = mapSearchInputToFeedQuery(input, 'primary');
+  if (!mapping.ok) {
+    requestCounter.inc({ outcome: 'unmapped' });
+    return { ok: false, reason: mapping.reason };
+  }
+  let answer: FeedAnswer;
+  try {
+    answer = await deps.fetchFeed(mapping.query, deps.timeoutMs ?? FEED_PRIMARY_TIMEOUT_MS);
+  } catch (e) {
+    const name = (e as Error)?.name;
+    const reason = name === 'TimeoutError' || name === 'AbortError' ? 'timeout' : 'error';
+    requestCounter.inc({ outcome: reason });
+    return { ok: false, reason };
+  }
+  if (answer.status !== 200) {
+    requestCounter.inc({ outcome: 'error' });
+    return { ok: false, reason: `status:${answer.status}` };
+  }
+  const nextCursor = answer.nextCursor ? encodeFeedCursor(answer.nextCursor) : undefined;
+  if (!answer.ids.length) {
+    requestCounter.inc({ outcome: 'served' });
+    return { ok: true, page: { data: [], nextCursor, feedMs: answer.ms, route: answer.route } };
+  }
+  const rows = await deps.hydrate(answer.ids);
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  const data = answer.ids.flatMap((id) => {
+    const row = byId.get(id);
+    return row ? [row] : [];
+  });
+  requestCounter.inc({ outcome: 'served' });
+  return { ok: true, page: { data, nextCursor, feedMs: answer.ms, route: answer.route } };
+}
+
+export function feedPrimaryAvailable() {
+  return !!env.FEED_SERVICE_URL;
+}
+
+export function fetchFeedPrimary(query: string, timeoutMs: number) {
+  return fetchFeedAnswer(env.FEED_SERVICE_URL as string, query, timeoutMs, 'primary');
+}

--- a/src/server/services/feed-primary.service.ts
+++ b/src/server/services/feed-primary.service.ts
@@ -74,7 +74,13 @@ export async function serveFromFeed<T extends { id: number }>(
     requestCounter.inc({ outcome: 'served' });
     return { ok: true, page: { data: [], nextCursor, feedMs: answer.ms, route: answer.route } };
   }
-  const rows = await deps.hydrate(answer.ids);
+  let rows: T[];
+  try {
+    rows = await deps.hydrate(answer.ids);
+  } catch {
+    requestCounter.inc({ outcome: 'error' });
+    return { ok: false, reason: 'hydrate:error' };
+  }
   const byId = new Map(rows.map((r) => [r.id, r]));
   const data = answer.ids.flatMap((id) => {
     const row = byId.get(id);

--- a/src/server/services/feed-request-capture.service.ts
+++ b/src/server/services/feed-request-capture.service.ts
@@ -137,7 +137,7 @@ export type FeedRequestSource = 'getImagesFromSearch' | 'getAllImages';
 export type FeedRequestOutcome = {
   source: FeedRequestSource;
   /** Meili path only: which feed-fetch-filter variant answered ('none' = no search client). */
-  filterMode?: 'pre' | 'post' | 'none';
+  filterMode?: 'pre' | 'post' | 'none' | 'feed';
   error?: boolean;
   elapsedMs: number;
   resultIds: number[];

--- a/src/server/services/feed-shadow.service.ts
+++ b/src/server/services/feed-shadow.service.ts
@@ -117,6 +117,10 @@ const present = (v: unknown) =>
   );
 const ints = (v: unknown): number[] =>
   Array.isArray(v) ? v.filter((n): n is number => Number.isInteger(n) && n > 0) : [];
+// An inclusion list whose ids are all impossible (prod sends `tags: [0]`) matches
+// nothing in Meili. Dropping them silently would widen the query to the whole feed,
+// so the request is left to Meili instead.
+const emptied = (v: unknown) => Array.isArray(v) && v.length > 0 && ints(v).length === 0;
 
 export type FeedQueryMapping = { ok: true; query: string } | { ok: false; reason: string };
 export type FeedQueryMode = 'shadow' | 'primary';
@@ -163,6 +167,7 @@ export function mapSearchInputToFeedQuery(
   const levels = LEVELS.filter((l) => (mask & l) !== 0);
   if (!levels.length) return skip('browsingLevel:0');
 
+  for (const key of ['tags', 'ids'] as const) if (emptied(input[key])) return skip(`${key}:none`);
   const tags = ints(input.tags);
   const excludedTags = ints(input.excludedTagIds);
   if (tags.length > 100) return skip('tags>100');

--- a/src/server/services/feed-shadow.service.ts
+++ b/src/server/services/feed-shadow.service.ts
@@ -39,7 +39,9 @@ export type FeedShadowConfig = {
 
 const SHADOW_OFF: FeedShadowConfig = { sampleRate: 0, until: 0, timeoutMs: 2500, maxInflight: 32 };
 
-export function parseShadowConfig(raw: Record<string, string> | null | undefined): FeedShadowConfig {
+export function parseShadowConfig(
+  raw: Record<string, string> | null | undefined
+): FeedShadowConfig {
   const rate = Number(raw?.sampleRate ?? 0);
   const untilRaw = raw?.until?.trim();
   let until = Number.POSITIVE_INFINITY;
@@ -49,8 +51,14 @@ export function parseShadowConfig(raw: Record<string, string> | null | undefined
   return {
     sampleRate: Number.isFinite(rate) ? Math.min(Math.max(rate, 0), 1) : 0,
     until: Number.isNaN(until) ? 0 : until,
-    timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? Math.min(timeoutMs, 10_000) : SHADOW_OFF.timeoutMs,
-    maxInflight: Number.isInteger(maxInflight) && maxInflight > 0 ? Math.min(maxInflight, 256) : SHADOW_OFF.maxInflight,
+    timeoutMs:
+      Number.isFinite(timeoutMs) && timeoutMs > 0
+        ? Math.min(timeoutMs, 10_000)
+        : SHADOW_OFF.timeoutMs,
+    maxInflight:
+      Number.isInteger(maxInflight) && maxInflight > 0
+        ? Math.min(maxInflight, 256)
+        : SHADOW_OFF.maxInflight,
   };
 }
 
@@ -61,7 +69,13 @@ const SORTS: Record<string, string> = {
   Newest: 'newest',
   Oldest: 'oldest',
 };
-const PERIOD_DAYS: Record<string, number | undefined> = { Day: 1, Week: 7, Month: 30, Year: 365, AllTime: undefined };
+const PERIOD_DAYS: Record<string, number | undefined> = {
+  Day: 1,
+  Week: 7,
+  Month: 30,
+  Year: 365,
+  AllTime: undefined,
+};
 const LEVELS = [1, 2, 4, 8, 16, 32];
 // Filters the candidate has no dimension for; the app resolves the server-side lists
 // (followed, hidden, newCreators) inside the search functions, out of this hook's reach.
@@ -93,14 +107,35 @@ const UNSUPPORTED_FLAGS = [
 ] as const;
 
 const present = (v: unknown) =>
-  !(v === undefined || v === null || v === false || v === 0 || v === '' || (Array.isArray(v) && v.length === 0));
+  !(
+    v === undefined ||
+    v === null ||
+    v === false ||
+    v === 0 ||
+    v === '' ||
+    (Array.isArray(v) && v.length === 0)
+  );
 const ints = (v: unknown): number[] =>
   Array.isArray(v) ? v.filter((n): n is number => Number.isInteger(n) && n > 0) : [];
 
 export type FeedQueryMapping = { ok: true; query: string } | { ok: false; reason: string };
+export type FeedQueryMode = 'shadow' | 'primary';
+
+// A feed-served page continues with the feed's own keyset cursor. It carries no `|` on
+// purpose: getAllImagesIndex splits the client cursor on `|` and reads numbers, so a
+// feed cursor handed to the Meilisearch path parses as offset 0, a clean restart.
+const FEED_CURSOR_RE = /^feed:(\d{1,16}):(\d{1,12})$/;
+export const encodeFeedCursor = (next: string) => `feed:${next.replace('|', ':')}`;
+export function parseFeedCursor(cursor: unknown): string | undefined {
+  const m = typeof cursor === 'string' ? FEED_CURSOR_RE.exec(cursor) : null;
+  return m ? `${m[1]}|${m[2]}` : undefined;
+}
 
 /** The candidate's query for a search input, or the first reason it cannot be expressed. */
-export function mapSearchInputToFeedQuery(input: CapturableSearchInput): FeedQueryMapping {
+export function mapSearchInputToFeedQuery(
+  input: CapturableSearchInput,
+  mode: FeedQueryMode = 'shadow'
+): FeedQueryMapping {
   const skip = (reason: string): FeedQueryMapping => ({ ok: false, reason });
   for (const key of UNSUPPORTED_KEYS) if (present(input[key])) return skip(`input:${key}`);
   for (const flag of UNSUPPORTED_FLAGS) if (input[flag] === true) return skip(`flag:${flag}`);
@@ -108,7 +143,10 @@ export function mapSearchInputToFeedQuery(input: CapturableSearchInput): FeedQue
   let offset = 0;
   let before: number | undefined;
   const cursor = input.cursor;
-  if (typeof cursor === 'string' && cursor) {
+  const feedCursor = parseFeedCursor(cursor);
+  if (feedCursor) {
+    if (mode !== 'primary') return skip('cursor:feed');
+  } else if (typeof cursor === 'string' && cursor) {
     const m = /^(\d{1,12})\|(\d{1,15})$/.exec(cursor);
     if (!m) return skip('cursor:unparsed');
     offset = Number(m[1]);
@@ -130,13 +168,19 @@ export function mapSearchInputToFeedQuery(input: CapturableSearchInput): FeedQue
   if (tags.length > 100) return skip('tags>100');
   if (excludedTags.length > 100) return skip('excludedTags>100');
   const types = Array.isArray(input.types) ? input.types.map(String) : [];
-  if (types.some((t) => !['image', 'video', 'audio'].includes(t))) return skip(`types:${types.join(',')}`);
+  if (types.some((t) => !['image', 'video', 'audio'].includes(t)))
+    return skip(`types:${types.join(',')}`);
 
   let versionIds: number[] | undefined;
   if (present(input.modelVersionId)) versionIds = [Number(input.modelVersionId)];
   else if (present(input.modelId)) return skip('modelId');
   const userId = present(input.userId) ? Number(input.userId) : undefined;
-  const visibility = input.notPublished === true ? 'unpublished' : input.scheduled === true ? 'scheduled' : undefined;
+  const visibility =
+    input.notPublished === true
+      ? 'unpublished'
+      : input.scheduled === true
+      ? 'scheduled'
+      : undefined;
   if (visibility && !userId) return skip(`flag:${visibility}:no-user`);
 
   const params = new URLSearchParams();
@@ -149,7 +193,9 @@ export function mapSearchInputToFeedQuery(input: CapturableSearchInput): FeedQue
   if (versionIds) params.set('versionIds', versionIds.join(','));
   if (userId) params.set('userIds', String(userId));
   if (types.length) params.set('types', types.join(','));
-  const baseModels = Array.isArray(input.baseModels) ? input.baseModels.map(String).filter(Boolean) : [];
+  const baseModels = Array.isArray(input.baseModels)
+    ? input.baseModels.map(String).filter(Boolean)
+    : [];
   if (baseModels.length) params.set('baseModels', baseModels.join(','));
   const tools = ints(input.tools);
   if (tools.length) params.set('tools', tools.join(','));
@@ -162,14 +208,17 @@ export function mapSearchInputToFeedQuery(input: CapturableSearchInput): FeedQue
   params.set('sort', sort);
   const days = PERIOD_DAYS[period];
   if (days) params.set('periodDays', String(days));
-  const limit = typeof input.limit === 'number' && input.limit > 0 ? Math.min(input.limit, 200) : 100;
+  const limit =
+    typeof input.limit === 'number' && input.limit > 0 ? Math.min(input.limit, 200) : 100;
   params.set('limit', String(limit));
-  if (offset) params.set('offset', String(offset));
+  if (feedCursor) params.set('cursor', feedCursor);
+  else if (offset) params.set('offset', String(offset));
   if (before) params.set('before', String(before));
   return { ok: true, query: params.toString() };
 }
 
 export type FeedAnswer = {
+  nextCursor?: string;
   status: number;
   ms: number;
   ids: number[];
@@ -237,7 +286,9 @@ export function buildFeedShadowRow(
   answer?: FeedAnswer
 ): FeedShadowRow {
   const base = buildFeedRequestRow(input, outcome, at, traceId);
-  const cmp = answer ? compareIds(base.resultIds, answer.ids) : { overlap: 0, overlapTop10: 0, firstMismatch: -1 };
+  const cmp = answer
+    ? compareIds(base.resultIds, answer.ids)
+    : { overlap: 0, overlapTop10: 0, firstMismatch: -1 };
   return {
     time: base.time,
     traceId,
@@ -372,7 +423,8 @@ export function createFeedShadow(deps: ShadowDeps): FeedShadow {
       try {
         answer = await deps.fetchFeed(mapping.query, config.timeoutMs);
       } catch (e) {
-        const timedOut = (e as Error)?.name === 'TimeoutError' || (e as Error)?.name === 'AbortError';
+        const timedOut =
+          (e as Error)?.name === 'TimeoutError' || (e as Error)?.name === 'AbortError';
         requestCounter.inc({ outcome: timedOut ? 'timeout' : 'error' });
         answer = { status: timedOut ? 504 : 0, ms: now() - at, ids: [] };
       } finally {
@@ -408,21 +460,35 @@ const disabledShadow: FeedShadow = {
   dropped: 0,
 };
 
-export async function fetchFeedAnswer(baseUrl: string, query: string, timeoutMs: number): Promise<FeedAnswer> {
+export async function fetchFeedAnswer(
+  baseUrl: string,
+  query: string,
+  timeoutMs: number,
+  source: FeedQueryMode = 'shadow'
+): Promise<FeedAnswer> {
   const started = Date.now();
   const res = await fetch(`${baseUrl.replace(/\/$/, '')}/v1/feed?${query}`, {
     signal: AbortSignal.timeout(timeoutMs),
-    headers: { 'x-request-source': 'shadow' },
+    headers: { 'x-request-source': source },
   });
   const ms = Date.now() - started;
   if (!res.ok) return { status: res.status, ms, ids: [] };
   const body = (await res.json()) as {
     items?: number[];
+    nextCursor?: string;
     route?: string;
     estimate?: number;
     candidates?: number;
   };
-  return { status: res.status, ms, ids: ints(body.items), route: body.route, estimate: body.estimate, candidates: body.candidates };
+  return {
+    status: res.status,
+    ms,
+    ids: ints(body.items),
+    nextCursor: typeof body.nextCursor === 'string' ? body.nextCursor : undefined,
+    route: body.route,
+    estimate: body.estimate,
+    candidates: body.candidates,
+  };
 }
 
 let instance: FeedShadow | undefined;
@@ -430,7 +496,7 @@ let instance: FeedShadow | undefined;
 export function feedShadow(): FeedShadow {
   if (instance) return instance;
   const client = clickhouse;
-  const baseUrl = env.FEED_SHADOW_URL;
+  const baseUrl = env.FEED_SERVICE_URL;
   if (!client || !baseUrl) return (instance = disabledShadow);
   return (instance = createFeedShadow({
     getConfig: createTtlMemo(async () => {

--- a/src/server/services/feed-shadow.service.ts
+++ b/src/server/services/feed-shadow.service.ts
@@ -1,8 +1,9 @@
 import { trace } from '@opentelemetry/api';
 import { env } from '~/env/server';
-import { clickhouse } from '~/server/clickhouse/client';
+import { Tracker } from '~/server/clickhouse/tracker';
 import { logToAxiom } from '~/server/logging/client';
 import { registerCounterWithLabels } from '~/server/prom/client';
+import type { FeedShadowRow } from '~/server/common/feed-shadow.constants';
 import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { createTtlMemo } from '~/server/utils/ttl-memoize';
 import {
@@ -11,22 +12,13 @@ import {
   type FeedRequestOutcome,
 } from '~/server/services/feed-request-capture.service';
 
-export const FEED_SHADOW_TABLE = 'feedShadow';
 export const MAX_OFFSET = 20_000;
 const CONFIG_TTL_MS = 15_000;
-const FLUSH_INTERVAL_MS = 2_000;
-const FLUSH_AT_ROWS = 200;
-export const MAX_BUFFERED_ROWS = 2_000;
 const ERROR_LOG_INTERVAL_MS = 60_000;
 
 const requestCounter = registerCounterWithLabels({
   name: 'feed_shadow_requests_total',
   help: 'Image-feed searches mirrored to the candidate feed, by outcome',
-  labelNames: ['outcome'] as const,
-});
-const batchCounter = registerCounterWithLabels({
-  name: 'feed_shadow_batches_total',
-  help: 'Feed shadow ClickHouse inserts by outcome',
   labelNames: ['outcome'] as const,
 });
 
@@ -252,34 +244,6 @@ export function compareIds(meili: number[], feed: number[]) {
   };
 }
 
-export type FeedShadowRow = {
-  time: string;
-  traceId: string;
-  userId: number;
-  sort: string;
-  period: string;
-  browsingLevel: number;
-  useCombinedNsfwLevel: number;
-  cursor: string;
-  input: string;
-  feedQuery: string;
-  skipReason: string;
-  feedStatus: number;
-  feedMs: number;
-  feedRoute: string;
-  feedEstimate: number;
-  feedCandidates: number;
-  feedCount: number;
-  feedIds: number[];
-  meiliMs: number;
-  meiliCount: number;
-  meiliIds: number[];
-  overlap: number;
-  overlapTop10: number;
-  firstMismatch: number;
-  error: number;
-};
-
 const u32 = (n: number | undefined) => Math.min(Math.max(Math.round(n ?? 0), 0), 4_294_967_295);
 
 export function buildFeedShadowRow(
@@ -326,8 +290,6 @@ export function buildFeedShadowRow(
 export type FeedShadow = {
   /** Fire-and-forget at the call site; returns the settled promise for tests. */
   compare: (input: CapturableSearchInput, outcome: FeedRequestOutcome) => Promise<void>;
-  flush: () => Promise<void>;
-  readonly pending: number;
   readonly inflight: number;
   readonly dropped: number;
 };
@@ -335,74 +297,33 @@ export type FeedShadow = {
 type ShadowDeps = {
   getConfig: () => Promise<FeedShadowConfig>;
   fetchFeed: (query: string, timeoutMs: number) => Promise<FeedAnswer>;
-  insert: (rows: FeedShadowRow[]) => Promise<void>;
+  record: (row: FeedShadowRow) => Promise<void>;
   now?: () => number;
   random?: () => number;
-  flushIntervalMs?: number;
-  onError?: (error: Error, rows: number) => void;
+  onError?: (error: Error) => void;
 };
 
 export function createFeedShadow(deps: ShadowDeps): FeedShadow {
   const now = deps.now ?? Date.now;
   const random = deps.random ?? Math.random;
-  const flushIntervalMs = deps.flushIntervalMs ?? FLUSH_INTERVAL_MS;
-  let buffer: FeedShadowRow[] = [];
-  let inflightInsert: Promise<void> | null = null;
   let inflight = 0;
-  let timer: ReturnType<typeof setTimeout> | null = null;
   let dropped = 0;
   let lastErrorAt = 0;
 
-  function reportFailure(e: Error, rows: number) {
-    batchCounter.inc({ outcome: 'failed' });
-    if (deps.onError) return deps.onError(e, rows);
+  function reportFailure(e: Error) {
+    if (deps.onError) return deps.onError(e);
     if (now() - lastErrorAt <= ERROR_LOG_INTERVAL_MS) return;
     lastErrorAt = now();
     logToAxiom(
-      { type: 'error', name: 'feedShadow flush failed', details: { rows }, message: e.message },
+      { type: 'error', name: 'feedShadow insert failed', message: e.message },
       'clickhouse'
     ).catch(() => undefined);
   }
 
-  async function flush() {
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
-    }
-    if (inflightInsert || buffer.length === 0) return;
-    const rows = buffer;
-    buffer = [];
-    inflightInsert = deps
-      .insert(rows)
-      .then(
-        () => batchCounter.inc({ outcome: 'ok' }),
-        (e) => reportFailure(e as Error, rows.length)
-      )
-      .finally(() => {
-        inflightInsert = null;
-        if (buffer.length) scheduleFlush();
-      });
-    await inflightInsert;
-  }
-
-  function scheduleFlush() {
-    if (timer) return;
-    timer = setTimeout(() => {
-      timer = null;
-      void flush();
-    }, flushIntervalMs);
-    timer.unref?.();
-  }
-
-  function push(row: FeedShadowRow) {
-    if (buffer.length >= MAX_BUFFERED_ROWS) {
-      dropped++;
-      requestCounter.inc({ outcome: 'dropped' });
-      return;
-    }
-    buffer.push(row);
-    if (buffer.length >= FLUSH_AT_ROWS) void flush();
-    else scheduleFlush();
+  // One row per comparison, straight to ClickHouse: `async_insert` on the shared
+  // client batches server-side, so an in-process buffer would only duplicate it.
+  function record(row: FeedShadowRow) {
+    deps.record(row).catch((e) => reportFailure(e as Error));
   }
 
   async function compare(input: CapturableSearchInput, outcome: FeedRequestOutcome) {
@@ -415,7 +336,7 @@ export function createFeedShadow(deps: ShadowDeps): FeedShadow {
       const mapping = mapSearchInputToFeedQuery(input);
       if (!mapping.ok) {
         requestCounter.inc({ outcome: 'skipped' });
-        push(buildFeedShadowRow(input, outcome, at, traceId, mapping));
+        record(buildFeedShadowRow(input, outcome, at, traceId, mapping));
         return;
       }
       if (inflight >= config.maxInflight) {
@@ -436,7 +357,7 @@ export function createFeedShadow(deps: ShadowDeps): FeedShadow {
         inflight--;
       }
       requestCounter.inc({ outcome: answer.status === 200 ? 'compared' : 'error' });
-      push(buildFeedShadowRow(input, outcome, at, traceId, mapping, answer));
+      record(buildFeedShadowRow(input, outcome, at, traceId, mapping, answer));
     } catch {
       // Shadow mode must never surface on the feed path.
     }
@@ -444,10 +365,6 @@ export function createFeedShadow(deps: ShadowDeps): FeedShadow {
 
   return {
     compare,
-    flush,
-    get pending() {
-      return buffer.length;
-    },
     get inflight() {
       return inflight;
     },
@@ -459,8 +376,6 @@ export function createFeedShadow(deps: ShadowDeps): FeedShadow {
 
 const disabledShadow: FeedShadow = {
   compare: async () => undefined,
-  flush: async () => undefined,
-  pending: 0,
   inflight: 0,
   dropped: 0,
 };
@@ -500,9 +415,9 @@ let instance: FeedShadow | undefined;
 
 export function feedShadow(): FeedShadow {
   if (instance) return instance;
-  const client = clickhouse;
   const baseUrl = env.FEED_SERVICE_URL;
-  if (!client || !baseUrl) return (instance = disabledShadow);
+  if (!baseUrl) return (instance = disabledShadow);
+  const tracker = new Tracker();
   return (instance = createFeedShadow({
     getConfig: createTtlMemo(async () => {
       try {
@@ -514,8 +429,6 @@ export function feedShadow(): FeedShadow {
       }
     }, CONFIG_TTL_MS),
     fetchFeed: (query, timeoutMs) => fetchFeedAnswer(baseUrl, query, timeoutMs),
-    insert: async (rows) => {
-      await client.insert({ table: FEED_SHADOW_TABLE, values: rows, format: 'JSONEachRow' });
-    },
+    record: (row) => tracker.feedShadow([row]),
   }));
 }

--- a/src/server/services/feed-shadow.service.ts
+++ b/src/server/services/feed-shadow.service.ts
@@ -1,0 +1,450 @@
+import { trace } from '@opentelemetry/api';
+import { env } from '~/env/server';
+import { clickhouse } from '~/server/clickhouse/client';
+import { logToAxiom } from '~/server/logging/client';
+import { registerCounterWithLabels } from '~/server/prom/client';
+import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
+import { createTtlMemo } from '~/server/utils/ttl-memoize';
+import {
+  buildFeedRequestRow,
+  type CapturableSearchInput,
+  type FeedRequestOutcome,
+} from '~/server/services/feed-request-capture.service';
+
+export const FEED_SHADOW_TABLE = 'feedShadow';
+export const MAX_OFFSET = 20_000;
+const CONFIG_TTL_MS = 15_000;
+const FLUSH_INTERVAL_MS = 2_000;
+const FLUSH_AT_ROWS = 200;
+export const MAX_BUFFERED_ROWS = 2_000;
+const ERROR_LOG_INTERVAL_MS = 60_000;
+
+const requestCounter = registerCounterWithLabels({
+  name: 'feed_shadow_requests_total',
+  help: 'Image-feed searches mirrored to the candidate feed, by outcome',
+  labelNames: ['outcome'] as const,
+});
+const batchCounter = registerCounterWithLabels({
+  name: 'feed_shadow_batches_total',
+  help: 'Feed shadow ClickHouse inserts by outcome',
+  labelNames: ['outcome'] as const,
+});
+
+export type FeedShadowConfig = {
+  sampleRate: number;
+  until: number;
+  timeoutMs: number;
+  maxInflight: number;
+};
+
+const SHADOW_OFF: FeedShadowConfig = { sampleRate: 0, until: 0, timeoutMs: 2500, maxInflight: 32 };
+
+export function parseShadowConfig(raw: Record<string, string> | null | undefined): FeedShadowConfig {
+  const rate = Number(raw?.sampleRate ?? 0);
+  const untilRaw = raw?.until?.trim();
+  let until = Number.POSITIVE_INFINITY;
+  if (untilRaw) until = /^\d+$/.test(untilRaw) ? Number(untilRaw) : Date.parse(untilRaw);
+  const timeoutMs = Number(raw?.timeoutMs ?? SHADOW_OFF.timeoutMs);
+  const maxInflight = Number(raw?.maxInflight ?? SHADOW_OFF.maxInflight);
+  return {
+    sampleRate: Number.isFinite(rate) ? Math.min(Math.max(rate, 0), 1) : 0,
+    until: Number.isNaN(until) ? 0 : until,
+    timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? Math.min(timeoutMs, 10_000) : SHADOW_OFF.timeoutMs,
+    maxInflight: Number.isInteger(maxInflight) && maxInflight > 0 ? Math.min(maxInflight, 256) : SHADOW_OFF.maxInflight,
+  };
+}
+
+const SORTS: Record<string, string> = {
+  'Most Reactions': 'reactions',
+  'Most Collected': 'collected',
+  'Most Comments': 'comments',
+  Newest: 'newest',
+  Oldest: 'oldest',
+};
+const PERIOD_DAYS: Record<string, number | undefined> = { Day: 1, Week: 7, Month: 30, Year: 365, AllTime: undefined };
+const LEVELS = [1, 2, 4, 8, 16, 32];
+// Filters the candidate has no dimension for; the app resolves the server-side lists
+// (followed, hidden, newCreators) inside the search functions, out of this hook's reach.
+const UNSUPPORTED_KEYS = [
+  'postId',
+  'postIds',
+  'collectionId',
+  'collectionTagId',
+  'hubId',
+  'reviewId',
+  'prioritizedUserIds',
+  'imageId',
+  'generation',
+  'reactions',
+  'blockedFor',
+] as const;
+const UNSUPPORTED_FLAGS = [
+  'followed',
+  'newCreators',
+  'hidden',
+  'withMeta',
+  'requiringMeta',
+  'fromPlatform',
+  'hideAutoResources',
+  'hideManualResources',
+  'hideChallenges',
+  'pending',
+  'publishedOnly',
+] as const;
+
+const present = (v: unknown) =>
+  !(v === undefined || v === null || v === false || v === 0 || v === '' || (Array.isArray(v) && v.length === 0));
+const ints = (v: unknown): number[] =>
+  Array.isArray(v) ? v.filter((n): n is number => Number.isInteger(n) && n > 0) : [];
+
+export type FeedQueryMapping = { ok: true; query: string } | { ok: false; reason: string };
+
+/** The candidate's query for a search input, or the first reason it cannot be expressed. */
+export function mapSearchInputToFeedQuery(input: CapturableSearchInput): FeedQueryMapping {
+  const skip = (reason: string): FeedQueryMapping => ({ ok: false, reason });
+  for (const key of UNSUPPORTED_KEYS) if (present(input[key])) return skip(`input:${key}`);
+  for (const flag of UNSUPPORTED_FLAGS) if (input[flag] === true) return skip(`flag:${flag}`);
+
+  let offset = 0;
+  let before: number | undefined;
+  const cursor = input.cursor;
+  if (typeof cursor === 'string' && cursor) {
+    const m = /^(\d{1,12})\|(\d{1,15})$/.exec(cursor);
+    if (!m) return skip('cursor:unparsed');
+    offset = Number(m[1]);
+    before = Math.floor(Number(m[2]) / 60_000) * 60_000;
+  } else if (cursor) return skip('cursor:unparsed');
+  if (typeof input.offset === 'number' && input.offset > 0) offset = Math.max(offset, input.offset);
+  if (offset > MAX_OFFSET) return skip(`offset>${MAX_OFFSET}`);
+
+  const sort = SORTS[String(input.sort)];
+  if (!sort) return skip(`sort:${String(input.sort || 'none')}`);
+  const period = String(input.period ?? 'AllTime');
+  if (!(period in PERIOD_DAYS)) return skip(`period:${period}`);
+  const mask = typeof input.browsingLevel === 'number' ? input.browsingLevel : 1;
+  const levels = LEVELS.filter((l) => (mask & l) !== 0);
+  if (!levels.length) return skip('browsingLevel:0');
+
+  const tags = ints(input.tags);
+  const excludedTags = ints(input.excludedTagIds);
+  if (tags.length > 100) return skip('tags>100');
+  if (excludedTags.length > 100) return skip('excludedTags>100');
+  const types = Array.isArray(input.types) ? input.types.map(String) : [];
+  if (types.some((t) => !['image', 'video', 'audio'].includes(t))) return skip(`types:${types.join(',')}`);
+
+  let versionIds: number[] | undefined;
+  if (present(input.modelVersionId)) versionIds = [Number(input.modelVersionId)];
+  else if (present(input.modelId)) return skip('modelId');
+  const userId = present(input.userId) ? Number(input.userId) : undefined;
+  const visibility = input.notPublished === true ? 'unpublished' : input.scheduled === true ? 'scheduled' : undefined;
+  if (visibility && !userId) return skip(`flag:${visibility}:no-user`);
+
+  const params = new URLSearchParams();
+  params.set('levels', levels.join(','));
+  if (input.useCombinedNsfwLevel) params.set('combinedLevels', '1');
+  if (tags.length) params.set('tags', tags.join(','));
+  if (excludedTags.length) params.set('excludedTags', excludedTags.join(','));
+  const excludedUsers = ints(input.excludedUserIds);
+  if (excludedUsers.length) params.set('excludedUserIds', excludedUsers.slice(0, 1000).join(','));
+  if (versionIds) params.set('versionIds', versionIds.join(','));
+  if (userId) params.set('userIds', String(userId));
+  if (types.length) params.set('types', types.join(','));
+  const baseModels = Array.isArray(input.baseModels) ? input.baseModels.map(String).filter(Boolean) : [];
+  if (baseModels.length) params.set('baseModels', baseModels.join(','));
+  const tools = ints(input.tools);
+  if (tools.length) params.set('tools', tools.join(','));
+  const techniques = ints(input.techniques);
+  if (techniques.length) params.set('techniques', techniques.join(','));
+  const ids = ints(input.ids);
+  if (ids.length) params.set('ids', ids.slice(0, 200).join(','));
+  if (present(input.model3dId)) params.set('model3dIds', String(input.model3dId));
+  if (visibility) params.set('visibility', visibility);
+  params.set('sort', sort);
+  const days = PERIOD_DAYS[period];
+  if (days) params.set('periodDays', String(days));
+  const limit = typeof input.limit === 'number' && input.limit > 0 ? Math.min(input.limit, 200) : 100;
+  params.set('limit', String(limit));
+  if (offset) params.set('offset', String(offset));
+  if (before) params.set('before', String(before));
+  return { ok: true, query: params.toString() };
+}
+
+export type FeedAnswer = {
+  status: number;
+  ms: number;
+  ids: number[];
+  route?: string;
+  estimate?: number;
+  candidates?: number;
+};
+
+export function compareIds(meili: number[], feed: number[]) {
+  const feedSet = new Set(feed);
+  const hits = meili.filter((id) => feedSet.has(id)).length;
+  const top = meili.slice(0, 10);
+  const topHits = top.filter((id) => feedSet.has(id)).length;
+  let firstMismatch = -1;
+  const n = Math.min(meili.length, feed.length);
+  for (let i = 0; i < n; i++) {
+    if (meili[i] !== feed[i]) {
+      firstMismatch = i;
+      break;
+    }
+  }
+  return {
+    overlap: meili.length ? hits / meili.length : feed.length ? 0 : 1,
+    overlapTop10: top.length ? topHits / top.length : feed.length ? 0 : 1,
+    firstMismatch,
+  };
+}
+
+export type FeedShadowRow = {
+  time: string;
+  traceId: string;
+  userId: number;
+  sort: string;
+  period: string;
+  browsingLevel: number;
+  useCombinedNsfwLevel: number;
+  cursor: string;
+  input: string;
+  feedQuery: string;
+  skipReason: string;
+  feedStatus: number;
+  feedMs: number;
+  feedRoute: string;
+  feedEstimate: number;
+  feedCandidates: number;
+  feedCount: number;
+  feedIds: number[];
+  meiliMs: number;
+  meiliCount: number;
+  meiliIds: number[];
+  overlap: number;
+  overlapTop10: number;
+  firstMismatch: number;
+  error: number;
+};
+
+const u32 = (n: number | undefined) => Math.min(Math.max(Math.round(n ?? 0), 0), 4_294_967_295);
+
+export function buildFeedShadowRow(
+  input: CapturableSearchInput,
+  outcome: FeedRequestOutcome,
+  at: number,
+  traceId: string,
+  mapping: FeedQueryMapping,
+  answer?: FeedAnswer
+): FeedShadowRow {
+  const base = buildFeedRequestRow(input, outcome, at, traceId);
+  const cmp = answer ? compareIds(base.resultIds, answer.ids) : { overlap: 0, overlapTop10: 0, firstMismatch: -1 };
+  return {
+    time: base.time,
+    traceId,
+    userId: base.userId,
+    sort: base.sort,
+    period: base.period,
+    browsingLevel: base.browsingLevel,
+    useCombinedNsfwLevel: base.useCombinedNsfwLevel,
+    cursor: base.cursor,
+    input: base.input,
+    feedQuery: mapping.ok ? mapping.query : '',
+    skipReason: mapping.ok ? '' : mapping.reason,
+    feedStatus: answer?.status ?? 0,
+    feedMs: u32(answer?.ms),
+    feedRoute: answer?.route ?? '',
+    feedEstimate: u32(answer?.estimate),
+    feedCandidates: u32(answer?.candidates),
+    feedCount: Math.min(answer?.ids.length ?? 0, 65_535),
+    feedIds: answer?.ids ?? [],
+    meiliMs: base.elapsedMs,
+    meiliCount: base.resultCount,
+    meiliIds: base.resultIds,
+    overlap: cmp.overlap,
+    overlapTop10: cmp.overlapTop10,
+    firstMismatch: cmp.firstMismatch,
+    error: outcome.error || (answer !== undefined && answer.status !== 200) ? 1 : 0,
+  };
+}
+
+export type FeedShadow = {
+  /** Fire-and-forget at the call site; returns the settled promise for tests. */
+  compare: (input: CapturableSearchInput, outcome: FeedRequestOutcome) => Promise<void>;
+  flush: () => Promise<void>;
+  readonly pending: number;
+  readonly inflight: number;
+  readonly dropped: number;
+};
+
+type ShadowDeps = {
+  getConfig: () => Promise<FeedShadowConfig>;
+  fetchFeed: (query: string, timeoutMs: number) => Promise<FeedAnswer>;
+  insert: (rows: FeedShadowRow[]) => Promise<void>;
+  now?: () => number;
+  random?: () => number;
+  flushIntervalMs?: number;
+  onError?: (error: Error, rows: number) => void;
+};
+
+export function createFeedShadow(deps: ShadowDeps): FeedShadow {
+  const now = deps.now ?? Date.now;
+  const random = deps.random ?? Math.random;
+  const flushIntervalMs = deps.flushIntervalMs ?? FLUSH_INTERVAL_MS;
+  let buffer: FeedShadowRow[] = [];
+  let inflightInsert: Promise<void> | null = null;
+  let inflight = 0;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let dropped = 0;
+  let lastErrorAt = 0;
+
+  function reportFailure(e: Error, rows: number) {
+    batchCounter.inc({ outcome: 'failed' });
+    if (deps.onError) return deps.onError(e, rows);
+    if (now() - lastErrorAt <= ERROR_LOG_INTERVAL_MS) return;
+    lastErrorAt = now();
+    logToAxiom(
+      { type: 'error', name: 'feedShadow flush failed', details: { rows }, message: e.message },
+      'clickhouse'
+    ).catch(() => undefined);
+  }
+
+  async function flush() {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (inflightInsert || buffer.length === 0) return;
+    const rows = buffer;
+    buffer = [];
+    inflightInsert = deps
+      .insert(rows)
+      .then(
+        () => batchCounter.inc({ outcome: 'ok' }),
+        (e) => reportFailure(e as Error, rows.length)
+      )
+      .finally(() => {
+        inflightInsert = null;
+        if (buffer.length) scheduleFlush();
+      });
+    await inflightInsert;
+  }
+
+  function scheduleFlush() {
+    if (timer) return;
+    timer = setTimeout(() => {
+      timer = null;
+      void flush();
+    }, flushIntervalMs);
+    timer.unref?.();
+  }
+
+  function push(row: FeedShadowRow) {
+    if (buffer.length >= MAX_BUFFERED_ROWS) {
+      dropped++;
+      requestCounter.inc({ outcome: 'dropped' });
+      return;
+    }
+    buffer.push(row);
+    if (buffer.length >= FLUSH_AT_ROWS) void flush();
+    else scheduleFlush();
+  }
+
+  async function compare(input: CapturableSearchInput, outcome: FeedRequestOutcome) {
+    const traceId = trace.getActiveSpan()?.spanContext().traceId ?? '';
+    const at = now();
+    try {
+      const config = await deps.getConfig();
+      if (config.sampleRate <= 0 || at > config.until) return;
+      if (random() >= config.sampleRate) return;
+      const mapping = mapSearchInputToFeedQuery(input);
+      if (!mapping.ok) {
+        requestCounter.inc({ outcome: 'skipped' });
+        push(buildFeedShadowRow(input, outcome, at, traceId, mapping));
+        return;
+      }
+      if (inflight >= config.maxInflight) {
+        dropped++;
+        requestCounter.inc({ outcome: 'dropped' });
+        return;
+      }
+      inflight++;
+      let answer: FeedAnswer;
+      try {
+        answer = await deps.fetchFeed(mapping.query, config.timeoutMs);
+      } catch (e) {
+        const timedOut = (e as Error)?.name === 'TimeoutError' || (e as Error)?.name === 'AbortError';
+        requestCounter.inc({ outcome: timedOut ? 'timeout' : 'error' });
+        answer = { status: timedOut ? 504 : 0, ms: now() - at, ids: [] };
+      } finally {
+        inflight--;
+      }
+      requestCounter.inc({ outcome: answer.status === 200 ? 'compared' : 'error' });
+      push(buildFeedShadowRow(input, outcome, at, traceId, mapping, answer));
+    } catch {
+      // Shadow mode must never surface on the feed path.
+    }
+  }
+
+  return {
+    compare,
+    flush,
+    get pending() {
+      return buffer.length;
+    },
+    get inflight() {
+      return inflight;
+    },
+    get dropped() {
+      return dropped;
+    },
+  };
+}
+
+const disabledShadow: FeedShadow = {
+  compare: async () => undefined,
+  flush: async () => undefined,
+  pending: 0,
+  inflight: 0,
+  dropped: 0,
+};
+
+export async function fetchFeedAnswer(baseUrl: string, query: string, timeoutMs: number): Promise<FeedAnswer> {
+  const started = Date.now();
+  const res = await fetch(`${baseUrl.replace(/\/$/, '')}/v1/feed?${query}`, {
+    signal: AbortSignal.timeout(timeoutMs),
+    headers: { 'x-request-source': 'shadow' },
+  });
+  const ms = Date.now() - started;
+  if (!res.ok) return { status: res.status, ms, ids: [] };
+  const body = (await res.json()) as {
+    items?: number[];
+    route?: string;
+    estimate?: number;
+    candidates?: number;
+  };
+  return { status: res.status, ms, ids: ints(body.items), route: body.route, estimate: body.estimate, candidates: body.candidates };
+}
+
+let instance: FeedShadow | undefined;
+
+export function feedShadow(): FeedShadow {
+  if (instance) return instance;
+  const client = clickhouse;
+  const baseUrl = env.FEED_SHADOW_URL;
+  if (!client || !baseUrl) return (instance = disabledShadow);
+  return (instance = createFeedShadow({
+    getConfig: createTtlMemo(async () => {
+      try {
+        return parseShadowConfig(
+          await withSysReadDeadline(sysRedis.hGetAll<string>(REDIS_SYS_KEYS.SYSTEM.FEED_SHADOW))
+        );
+      } catch {
+        return SHADOW_OFF;
+      }
+    }, CONFIG_TTL_MS),
+    fetchFeed: (query, timeoutMs) => fetchFeedAnswer(baseUrl, query, timeoutMs),
+    insert: async (rows) => {
+      await client.insert({ table: FEED_SHADOW_TABLE, values: rows, format: 'JSONEachRow' });
+    },
+  }));
+}

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -20,6 +20,12 @@ import { clickhouse } from '~/server/clickhouse/client';
 import { toClickhouseInt64 } from '~/server/clickhouse/int64';
 import { feedRequestCapture } from '~/server/services/feed-request-capture.service';
 import { feedShadow } from '~/server/services/feed-shadow.service';
+import {
+  feedFliptContext,
+  feedPrimaryAvailable,
+  fetchFeedPrimary,
+  serveFromFeed,
+} from '~/server/services/feed-primary.service';
 import { purgeCache } from '~/server/cloudflare/client';
 import {
   CacheTTL,
@@ -3120,9 +3126,8 @@ export const getAllImagesIndex = async (
   }
 
   let nextCursor: string | undefined;
-  if (searchNextCursor) {
-    nextCursor = `${offset + input.limit}|${searchNextCursor}`;
-  }
+  if (typeof searchNextCursor === 'string') nextCursor = searchNextCursor;
+  else if (searchNextCursor) nextCursor = `${offset + input.limit}|${searchNextCursor}`;
 
   return {
     nextCursor,
@@ -3189,6 +3194,8 @@ type ImageSearchInput = GetInfiniteImagesOutput & {
   blockedFor?: string[];
   signal?: AbortSignal;
   actor?: string;
+  /** Hydrate exactly these ids: a page the feed service already selected and ordered. */
+  feedIds?: number[];
   // Unhandled
   //prioritizedUserIds?: number[];
   //userIds?: number | number[];
@@ -3241,13 +3248,13 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
     const result = await searchImages(input);
     const outcome = {
       source: 'getImagesFromSearch' as const,
-      filterMode: result.filterMode,
+      filterMode: result.source === 'feed' ? ('feed' as const) : result.filterMode,
       elapsedMs: Date.now() - started,
       resultIds: result.data.map((i: { id: number }) => i.id),
       nextCursor: result.nextCursor,
     };
     void feedRequestCapture().record(input, outcome);
-    void feedShadow().compare(input, outcome);
+    if (result.source !== 'feed') void feedShadow().compare(input, outcome);
     return result;
   } catch (err) {
     void feedRequestCapture().record(input, {
@@ -3270,6 +3277,7 @@ async function searchImages(input: ImageSearchInput) {
     };
   let searchFn = getImagesFromSearchPreFilter;
   let filterMode: 'pre' | 'post' = 'pre';
+  let feedFirst = false;
   // Wrap Flipt feature-flag evaluation so the trace shows whether per-request
   // flag fetch is contributing to the parent span's latency. Routes through
   // getFliptBoolean instead of direct per-request wasm evaluateBoolean calls on
@@ -3279,13 +3287,46 @@ async function searchImages(input: ImageSearchInput) {
   // fallthrough (flags default off → pre-filter).
   input = await withSpan('image:flipt:eval', async () => {
     const entityId = input.currentUserId?.toString() || 'anonymous';
-    const postFilter = await getFliptBoolean(FLIPT_FEATURE_FLAGS.FEED_POST_FILTER, entityId);
+    const [postFilter, feedPrimary] = await Promise.all([
+      getFliptBoolean(FLIPT_FEATURE_FLAGS.FEED_POST_FILTER, entityId),
+      feedPrimaryAvailable()
+        ? getFliptBoolean(
+            FLIPT_FEATURE_FLAGS.FEED_SERVICE_PRIMARY,
+            entityId,
+            feedFliptContext(input)
+          )
+        : false,
+    ]);
     if (postFilter) {
       searchFn = getImagesFromSearchPostFilter;
       filterMode = 'post';
     }
+    feedFirst = feedPrimary;
     return input;
   });
+
+  // The feed service selects and orders the page; Meilisearch only hydrates those ids
+  // through the same search function, so every post-filter still applies. Anything the
+  // feed cannot answer (unmapped shape, timeout, error) falls through to Meilisearch.
+  if (feedFirst) {
+    const served = await withSpan('image:feedPrimary', () =>
+      serveFromFeed(input, {
+        fetchFeed: fetchFeedPrimary,
+        hydrate: async (ids) =>
+          (
+            await searchFn({
+              ...input,
+              feedIds: ids,
+              limit: ids.length,
+              offset: 0,
+              entry: undefined,
+              cursor: undefined,
+            })
+          ).data,
+      })
+    );
+    if (served.ok) return { ...served.page, source: 'feed' as const, filterMode };
+  }
 
   const result = await searchFn(input);
 
@@ -3949,6 +3990,8 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     filters.push(makeMeiliImageSearchFilter('techniqueIds', `IN [${techniques.join(',')}]`));
   if (postIds?.length)
     filters.push(makeMeiliImageSearchFilter('postId', `IN [${postIds.join(',')}]`));
+  if (input.feedIds?.length)
+    filters.push(makeMeiliImageSearchFilter('id', `IN [${input.feedIds.join(',')}]`));
   if (baseModels?.length)
     filters.push(makeMeiliImageSearchFilter('baseModel', `IN [${strArray(baseModels)}]`));
 
@@ -4588,6 +4631,8 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
     filters.push(makeMeiliImageSearchFilter('techniqueIds', `IN [${techniques.join(',')}]`));
   if (postIds?.length)
     filters.push(makeMeiliImageSearchFilter('postId', `IN [${postIds.join(',')}]`));
+  if (input.feedIds?.length)
+    filters.push(makeMeiliImageSearchFilter('id', `IN [${input.feedIds.join(',')}]`));
   if (baseModels?.length)
     filters.push(makeMeiliImageSearchFilter('baseModel', `IN [${strArray(baseModels)}]`));
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -19,6 +19,7 @@ import type { VotableTagModel } from '~/libs/tags';
 import { clickhouse } from '~/server/clickhouse/client';
 import { toClickhouseInt64 } from '~/server/clickhouse/int64';
 import { feedRequestCapture } from '~/server/services/feed-request-capture.service';
+import { feedShadow } from '~/server/services/feed-shadow.service';
 import { purgeCache } from '~/server/cloudflare/client';
 import {
   CacheTTL,
@@ -3238,13 +3239,15 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
   const started = Date.now();
   try {
     const result = await searchImages(input);
-    void feedRequestCapture().record(input, {
-      source: 'getImagesFromSearch',
+    const outcome = {
+      source: 'getImagesFromSearch' as const,
       filterMode: result.filterMode,
       elapsedMs: Date.now() - started,
       resultIds: result.data.map((i: { id: number }) => i.id),
       nextCursor: result.nextCursor,
-    });
+    };
+    void feedRequestCapture().record(input, outcome);
+    void feedShadow().compare(input, outcome);
     return result;
   } catch (err) {
     void feedRequestCapture().record(input, {


### PR DESCRIPTION
Two ways to exercise the PostgreSQL feed service (`civitai/civitai-feed`) against real traffic, both inert until `FEED_SERVICE_URL` is set.

**Shadow (default).** `getImagesFromSearch` keeps answering from Meilisearch. A sampled copy of each request goes to the feed service, and the two answers are compared (id overlap, top-10 overlap, first order mismatch) into ClickHouse `feedShadow`. Sampling, timeout and concurrency come from the sysRedis hash `system:feed-shadow`, so it can be turned up or off without a deploy, and it is capped: bounded in-flight, bounded buffer, every failure swallowed. Nothing about the served response changes.

**Primary (opt-in).** With the Flipt flag `feed-service-primary` matching (civitai/flipt-state#86 rolls it out to `testers`), the feed service selects and orders the page and Meilisearch hydrates exactly those ids through the same search function, so every post-filter still applies and the response shape is identical. Pages continue with a `feed:<key>:<id>` cursor that the Meilisearch path reads as a restart, so flipping the flag mid-scroll is safe. Anything the feed cannot answer — unsupported filter, timeout, error — falls back to Meilisearch for that request.

Also: prod sends `tags: [0]`. The mapper dropped the id and emitted no tag filter, turning a query Meilisearch answers with an empty page into a request for the whole feed; those requests now stay on Meilisearch.

**Before this does anything**
- Apply `src/server/clickhouse/migrations/2026-09-09-feed-shadow.sql`.
- Set `FEED_SERVICE_URL` on the deployment.
- Set `system:feed-shadow` in sysRedis (`sampleRate`, `until`, `timeoutMs`, `maxInflight`).

Rows go to ClickHouse through `Tracker.trackMany`, one per comparison — the same direct-insert path `entityChanges` and `chatAudit` use, so the table DDL is the only dependency. No in-process buffering: the shared client sets `async_insert`, so batching happens server-side.

Metrics: `feed_shadow_requests_total{outcome}`, `feed_primary_requests_total{outcome}`.

Tests: 14 unit tests over the mapper, the comparison, the buffer and the primary path. Typecheck is at its pre-existing error count with none in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
