### PR TITLE
fix(app-blocks): derive the revocation marker TTL from the max token lifetime

### DIFF
--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -585,14 +585,13 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
       signAppId: block.appId,
       signAppBlockId: block.id,
       // Synthetic, revocable PAGE instance id — same shape as the prod page mint.
-      // NOTE (revocation-wiring caveat): dev page tokens share the
-      // `page_<appBlockId>` instanceId shape with PRODUCTION page mints. The
-      // revocation WRITE path (block-revocation.service.ts revokeInstance /
-      // clearInstance) is currently UNWIRED (no callers). If it is ever wired,
-      // dev instance ids on THIS path must be namespaced distinctly (e.g.
-      // `devpage_`) and/or the revocation marker TTL must cover the 4h dev token
-      // lifetime — otherwise a dev revocation (or a 4h marker) would bleed into
-      // production page tokens for the SAME app (collision on `page_<appBlockId>`).
+      // That shared shape means one revocation would reach BOTH, so a caller
+      // that revokes by page instance id must namespace dev ids first (e.g.
+      // `devpage_`). No such caller exists: both wired call sites in
+      // block-registry.service revoke `blockUserSubscription.blockInstanceId`,
+      // which `newBlockInstanceId` mints as `bki_<ulid>`. The marker's TTL is
+      // not what gates this — it decides how long a revocation lasts, never
+      // which id it is written under.
       blockInstanceId: `${PAGE_INSTANCE_PREFIX}${block.id}`,
       // DEV budget default = the APPROVED manifest's declared per-gen budget so
       // an app whose `page.buzzBudgetPerGen` exceeds the flat 50 default is

--- a/src/server/services/__tests__/block-registry.service.test.ts
+++ b/src/server/services/__tests__/block-registry.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { REDIS_KEYS } from '~/server/redis/client';
 const mockDbRead = dbMock.dbRead;
 const mockDbWrite = dbMock.dbWrite;
 const mockRedis = redisMock.redis;
@@ -202,6 +203,67 @@ describe('BlockRegistry.installOnModel preserves settings on omit (audit M2)', (
       data: { settings?: unknown };
     };
     expect(args.data).toHaveProperty('settings', { foo: 'bar' });
+  });
+});
+
+/**
+ * Re-installing over a `toggleEnabled(false)` row revives that row's existing
+ * blockInstanceId, so the marker written on disable would otherwise keep 403ing
+ * an install the DB reports as enabled — for the marker's whole TTL, which now
+ * covers the longest token lifetime rather than 15 minutes.
+ */
+describe('BlockRegistry.installOnModel clears a revocation marker on the revived row', () => {
+  const REVOKED_PREFIX = `${REDIS_KEYS.BLOCKS.REVOKED_INSTANCE}:`;
+  const revokedKeysDeleted = () =>
+    mockRedis.del.mock.calls
+      .flatMap((c) => (Array.isArray(c[0]) ? c[0] : [c[0]]))
+      .map(String)
+      .filter((k) => k.startsWith(REVOKED_PREFIX));
+
+  beforeEach(() => {
+    mockDbWrite.appBlock.findUnique.mockResolvedValue({
+      status: 'approved',
+      blockId: 'g',
+      manifest: {},
+      approvedScopes: [],
+    });
+    mockDbWrite.blockUserSubscription.findMany.mockReset();
+    mockDbWrite.blockUserSubscription.findMany.mockResolvedValue([]);
+    mockDbWrite.blockUserSubscription.findFirst.mockReset();
+    mockDbWrite.blockUserSubscription.create.mockReset();
+    mockDbWrite.blockUserSubscription.update.mockReset();
+    mockDbWrite.blockUserSubscription.update.mockResolvedValue({});
+    mockDbWrite.blockUserSubscription.create.mockResolvedValue({});
+    mockRedis.del.mockClear();
+  });
+
+  it('clears the marker for the id the row already carried', async () => {
+    mockDbWrite.blockUserSubscription.findFirst.mockResolvedValue({
+      id: 'bus_existing',
+      blockInstanceId: 'bki_revived',
+    });
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.installOnModel({
+      modelId: 1,
+      appBlockId: 'ab_test',
+      slotId: 'model.sidebar_top',
+      installedByUserId: 42,
+    });
+    expect(revokedKeysDeleted()).toEqual([`${REVOKED_PREFIX}bki_revived`]);
+  });
+
+  it('clears no marker for a first install — that id has no history to clear', async () => {
+    // Negative control: without it, a blanket unconditional clear would pass
+    // the case above while telling us nothing about which id it targeted.
+    mockDbWrite.blockUserSubscription.findFirst.mockResolvedValue(null);
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.installOnModel({
+      modelId: 1,
+      appBlockId: 'ab_test',
+      slotId: 'model.sidebar_top',
+      installedByUserId: 42,
+    });
+    expect(revokedKeysDeleted()).toEqual([]);
   });
 });
 

--- a/src/server/services/__tests__/block-revocation-ttl.test.ts
+++ b/src/server/services/__tests__/block-revocation-ttl.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { BlockRevocation } from '../block-revocation.service';
+import { BLOCK_TOKEN_LIFETIMES_SECONDS } from '../block-token-lifetimes';
+import { BlockTokenService } from '../block-token.service';
+
+/**
+ * A revocation marker that expires before the token it revokes stops the gate
+ * refusing, and stops it SILENTLY — `isRevoked` reads an absent key as "not
+ * revoked", so nothing errors and nothing is logged. That is what happened when
+ * dev:live tokens went to 4h and this TTL stayed at 15min.
+ *
+ * The assertions below therefore compare the marker's TTL against lifetimes
+ * OBSERVED from real signed tokens, never against a copied number: a literal
+ * expectation drifts with whichever of the two constants is edited next, which
+ * is the defect itself rather than a guard against it.
+ */
+
+type Kind = keyof typeof BLOCK_TOKEN_LIFETIMES_SECONDS;
+
+const baseInput = {
+  userId: 7,
+  blockId: 'blk_ttl',
+  appId: 'app_ttl',
+  appBlockId: 'apb_ttl',
+  blockInstanceId: 'bki_ttl',
+  ctx: {},
+};
+
+const MINT_PER_KIND: Record<Kind, Parameters<typeof BlockTokenService.sign>[0]> = {
+  default: { ...baseInput, scopes: ['models:read:self'] },
+  settings: { ...baseInput, scopes: ['block:settings:read'] },
+  dev: { ...baseInput, scopes: ['models:read:self'], dev: true },
+};
+
+/** `exp - iat` off the real signed JWT — what the token is actually worth. */
+async function signedLifetimeSeconds(kind: Kind): Promise<number> {
+  const input = MINT_PER_KIND[kind];
+  expect(
+    input,
+    `no mint recipe for the "${kind}" lifetime — add one, or this kind is measured by nothing`
+  ).toBeTruthy();
+  const { token } = await BlockTokenService.sign(input);
+  const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf8'));
+  expect(typeof payload.exp, `${kind} token carries no exp`).toBe('number');
+  expect(typeof payload.iat, `${kind} token carries no iat`).toBe('number');
+  return payload.exp - payload.iat;
+}
+
+/** The EX the service actually hands Redis, not the constant behind it. */
+async function markerTtlSeconds(): Promise<number> {
+  redisMock.redis.set.mockClear();
+  await BlockRevocation.revokeInstance('bki_ttl_probe');
+  const call = redisMock.redis.set.mock.calls.at(-1);
+  expect(call, 'revokeInstance wrote no Redis key — this probe is measuring nothing').toBeTruthy();
+  const ex = (call![2] as { EX?: number } | undefined)?.EX;
+  expect(typeof ex, 'revokeInstance set a key with no EX — the marker never expires').toBe(
+    'number'
+  );
+  return ex as number;
+}
+
+describe('a revocation marker outlives every token it can revoke', () => {
+  it('distinguishes the token kinds it is about to compare against', async () => {
+    // Positive control. If the probe returned one constant regardless of input,
+    // every assertion below would pass while measuring nothing.
+    const [dev, def, settings] = await Promise.all([
+      signedLifetimeSeconds('dev'),
+      signedLifetimeSeconds('default'),
+      signedLifetimeSeconds('settings'),
+    ]);
+    expect(dev).toBeGreaterThan(def);
+    expect(def).toBeGreaterThan(settings);
+  });
+
+  it.each(Object.keys(BLOCK_TOKEN_LIFETIMES_SECONDS) as Kind[])(
+    'covers a %s token for its whole life',
+    async (kind) => {
+      const lifetime = await signedLifetimeSeconds(kind);
+      const ttl = await markerTtlSeconds();
+      expect(
+        ttl,
+        `a ${kind} token is valid for ${lifetime}s but the revocation marker expires after ${ttl}s, ` +
+          `leaving ${lifetime - ttl}s in which a revoked token is still accepted`
+      ).toBeGreaterThanOrEqual(lifetime);
+    }
+  );
+});
+
+describe('the signer mints no lifetime the marker TTL is unaware of', () => {
+  // The suite above can only compare against kinds it enumerates, so a new one
+  // minted from a constant of its own would be covered by nothing. This reads
+  // the signer's own selection instead: the ledger has to match in BOTH
+  // directions, or `MAX_BLOCK_TOKEN_LIFETIME_SECONDS` is not the max.
+  const source = readFileSync(path.join(__dirname, '../block-token.service.ts'), 'utf8');
+  const expression = source.match(/const lifetime =([\s\S]*?);/)?.[1];
+
+  it('selects its lifetime somewhere this test can read', () => {
+    expect(
+      expression,
+      'no `const lifetime = …` in block-token.service.ts — if the selection moved, point this guard at it'
+    ).toBeTruthy();
+  });
+
+  it('takes every branch from the shared lifetime record', () => {
+    const residue = expression!.replace(/BLOCK_TOKEN_LIFETIMES_SECONDS\.\w+/g, '');
+    expect(
+      residue,
+      'the lifetime selection has a hard-coded duration; move it into BLOCK_TOKEN_LIFETIMES_SECONDS ' +
+        'so the revocation TTL rises with it'
+    ).not.toMatch(/\d/);
+    expect(
+      residue,
+      'the lifetime selection reads a duration constant outside BLOCK_TOKEN_LIFETIMES_SECONDS'
+    ).not.toMatch(/[A-Z][A-Z0-9_]*_SECONDS/);
+  });
+
+  it('mints every kind the record declares, and no other', () => {
+    const referenced = new Set(
+      [...expression!.matchAll(/BLOCK_TOKEN_LIFETIMES_SECONDS\.(\w+)/g)].map((m) => m[1])
+    );
+    expect(
+      [...referenced].sort(),
+      'BLOCK_TOKEN_LIFETIMES_SECONDS and the signer disagree — an entry nothing mints still inflates ' +
+        'the max, and a kind minted from elsewhere is not counted by it'
+    ).toEqual(Object.keys(BLOCK_TOKEN_LIFETIMES_SECONDS).sort());
+  });
+});

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -2248,6 +2248,10 @@ export class BlockRegistry {
         where: { id: existing.id },
         data: { ...updateData, blockInstanceId: instanceId },
       });
+      // Re-installing over a disabled row revives the SAME blockInstanceId, so
+      // a marker left by toggleEnabled(false) would 403 the revived install
+      // until it expires. Same clear toggleEnabled(true) does.
+      await BlockRevocation.clearInstance(instanceId);
       resultInstanceId = instanceId;
     } else {
       const instanceId = newBlockInstanceId();

--- a/src/server/services/block-revocation.service.ts
+++ b/src/server/services/block-revocation.service.ts
@@ -1,15 +1,11 @@
 import { redis, REDIS_KEYS } from '~/server/redis/client';
+import { MAX_BLOCK_TOKEN_LIFETIME_SECONDS } from '~/server/services/block-token-lifetimes';
 
-// 15 minutes. NOTE: this NO LONGER covers the worst-case token lifetime — App
-// Blocks dev:live tokens now live up to DEV_TOKEN_LIFETIME_SECONDS (4h, see
-// block-token.service.ts). This TTL is intentionally left at 15min because the
-// revocation WRITE path (revokeInstance/clearInstance) is currently UNWIRED
-// (zero callers). BEFORE wiring a revocation write path, you MUST: (1) raise
-// this TTL to cover the max token lifetime, AND (2) namespace dev instance ids
-// distinctly (dev page tokens share the `page_<appBlockId>` shape with prod page
-// mints — see the note in api/v1/blocks/dev-token.ts), or a dev revocation will
-// bleed into production page tokens for the same app.
-const REVOCATION_TTL_SECONDS = 900;
+// A marker shorter than the token it revokes lapses while that token is still
+// accepted, and the gate reads a missing key as "not revoked" — the control
+// stops refusing without failing. Same relationship key-rotation overlap states
+// in block-token.service.ts; deriving it is what stops the two drifting again.
+const REVOCATION_TTL_SECONDS = MAX_BLOCK_TOKEN_LIFETIME_SECONDS;
 
 function revokedKey(blockInstanceId: string) {
   return `${REDIS_KEYS.BLOCKS.REVOKED_INSTANCE}:${blockInstanceId}` as const;
@@ -32,9 +28,8 @@ export class BlockRevocation {
     } catch {
       // Fail open: an uninstall/toggle/ban write path must not block on a
       // Redis incident. If the marker isn't written, tokens for this
-      // instance remain valid until natural exp (15 min for most scopes,
-      // 5 min for settings). Exposure is bounded by the token lifetime
-      // rather than by Redis-recovery time. Accepted tradeoff.
+      // instance remain valid until natural exp — exposure is bounded by the
+      // token lifetime rather than by Redis-recovery time. Accepted tradeoff.
     }
   }
 
@@ -49,10 +44,11 @@ export class BlockRevocation {
   }
 
   /**
-   * Clears a revocation marker. Called by `toggleEnabled(true)` so re-enabling
-   * an install doesn't leave a stale marker that 403s every token for the
-   * next 15 minutes (audit B1). blockInstanceId is preserved across toggle,
-   * so the marker written on disable would otherwise survive re-enable.
+   * Clears a revocation marker. Every path that brings an install back — both
+   * `toggleEnabled(true)` and `installOnModel` on an existing row — must call
+   * it: blockInstanceId is preserved across disable, so the marker written
+   * then otherwise survives, and 403s the revived install's tokens for the
+   * rest of REVOCATION_TTL_SECONDS (audit B1).
    */
   static async clearInstance(blockInstanceId: string): Promise<void> {
     try {

--- a/src/server/services/block-token-lifetimes.ts
+++ b/src/server/services/block-token-lifetimes.ts
@@ -1,0 +1,22 @@
+/**
+ * Every lifetime `BlockTokenService.sign` can stamp, in one place.
+ *
+ * Controls that have to OUTLAST a token — the revocation marker's TTL,
+ * key-rotation overlap, the verifier's per-type max-age cap — need the worst
+ * case, and restating it as a number is what let the revocation TTL sit at
+ * 15min for the whole time dev:live tokens lived 4h. Derive from
+ * `MAX_BLOCK_TOKEN_LIFETIME_SECONDS` so a new kind added here raises them too.
+ *
+ * A new lifetime therefore belongs in this record, not beside its call site.
+ */
+export const BLOCK_TOKEN_LIFETIMES_SECONDS = {
+  default: 900,
+  /** block:settings:* — tightest replay window (M-4 / audit-9 #3) */
+  settings: 300,
+  /** dev:live pasted tokens — mod-only, self-bound, budget-capped */
+  dev: 4 * 60 * 60,
+} as const;
+
+export const MAX_BLOCK_TOKEN_LIFETIME_SECONDS = Math.max(
+  ...Object.values(BLOCK_TOKEN_LIFETIMES_SECONDS)
+);

--- a/src/server/services/block-token.service.ts
+++ b/src/server/services/block-token.service.ts
@@ -2,18 +2,17 @@ import { createHash, createPrivateKey, createPublicKey, KeyObject, randomBytes }
 import { SignJWT } from 'jose';
 import { env } from '~/env/server';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
+import { BLOCK_TOKEN_LIFETIMES_SECONDS } from '~/server/services/block-token-lifetimes';
 
 // L7 (audit-10): shared issuer/audience constants exported for the
 // middleware so a typo in one place can't desynchronize sign-vs-verify.
 export const BLOCK_TOKEN_ISSUER = 'civitai';
 export const BLOCK_TOKEN_AUDIENCE = 'civitai-app-block';
 
-const TOKEN_LIFETIME_SECONDS = 900; // 15 minutes — default
-const SETTINGS_TOKEN_LIFETIME_SECONDS = 300; // 5 minutes for block:settings:*
-// Exported so the verifier (block-scope.middleware.ts) caps the dev max-age off
-// the SAME constant the signer uses — if these desynced, dev tokens between the
-// two values would silently 401 (fail-closed but confusing).
-export const DEV_TOKEN_LIFETIME_SECONDS = 4 * 60 * 60; // 4h — dev:live pasted tokens (self-bound, budget-capped, mod-only)
+// Re-exported so the verifier (block-scope.middleware.ts) caps the dev max-age
+// off the SAME constant the signer uses — if these desynced, dev tokens between
+// the two values would silently 401 (fail-closed but confusing).
+export const DEV_TOKEN_LIFETIME_SECONDS = BLOCK_TOKEN_LIFETIMES_SECONDS.dev;
 const RATE_LIMIT_WINDOW_SECONDS = 60;
 const RATE_LIMIT_MAX = 60;
 
@@ -244,10 +243,10 @@ export class BlockTokenService {
     // the precedence unambiguous.
     const lifetime =
       input.dev === true
-        ? DEV_TOKEN_LIFETIME_SECONDS
+        ? BLOCK_TOKEN_LIFETIMES_SECONDS.dev
         : input.scopes.some(isSettingsScope)
-        ? SETTINGS_TOKEN_LIFETIME_SECONDS
-        : TOKEN_LIFETIME_SECONDS;
+        ? BLOCK_TOKEN_LIFETIMES_SECONDS.settings
+        : BLOCK_TOKEN_LIFETIMES_SECONDS.default;
     const exp = iat + lifetime;
     const sub = input.userId == null ? 'anon' : `user:${input.userId}`;
 


### PR DESCRIPTION
## What

`REVOCATION_TTL_SECONDS` (900s) was shorter than the longest lifetime
`BlockTokenService.sign` can stamp (`dev:live`, 4h). A revocation marker could
therefore expire while a token it revoked was still inside its validity window,
and `BlockRevocation.isRevoked` treats an absent key as "not revoked" — so the
control stops refusing without erroring, logging, or otherwise announcing it.

Both values now derive from one record:

```ts
// src/server/services/block-token-lifetimes.ts
export const BLOCK_TOKEN_LIFETIMES_SECONDS = { default: 900, settings: 300, dev: 4 * 60 * 60 };
export const MAX_BLOCK_TOKEN_LIFETIME_SECONDS = Math.max(...Object.values(...));
```

`block-token.service.ts` selects from it, `block-revocation.service.ts` takes
its TTL from the max. This is the same relationship the repo already states for
key rotation a few lines above `getBlockTokenVerificationKeysByKid`:

> KEY-ROTATION OVERLAP must be >= the MAX token lifetime (now 4h for dev:live
> tokens — `DEV_TOKEN_LIFETIME_SECONDS` — not 15min).

Revocation is the sibling control and never got that reasoning.

## Was namespacing the dev instance ids required first?

The note on the dev page mint said raising the TTL was blocked on dev page
tokens sharing the `page_<appBlockId>` instance-id shape with production page
mints. **Measured, it is not** — the two are independent:

- The only writers of revocation markers are `uninstallFromModel` and
  `toggleEnabled` in `block-registry.service.ts`. Both pass
  `blockUserSubscription.blockInstanceId`.
- The only writer of that column is `installOnModel`, via `newBlockInstanceId()`
  → `bki_<ulid>` (`src/server/utils/app-block-ids.ts`). No other create/update
  path sets it, in Prisma or raw SQL.
- So nothing hands a `page_` id to `revokeInstance`. The TTL governs how long a
  marker lives; it cannot change which id a marker is written under.

A caller that revokes *by page instance id* would still need the namespacing
first — that remains true, and the comment now says so without tying it to the
TTL. It also claimed the write path had no callers, which stopped being true
when uninstall/toggle were wired.

Separately, the `DEV_TOKEN_SCOPE_ALLOWLIST` note in `block-token.service.ts`
is about a different collision — `dev: true` vs a `block:settings:*` scope in
the *lifetime selection* — so the two comments were never in conflict.

## The one thing that did have to change with it

`installOnModel` on an existing row sets `enabled: true` and revives that row's
existing `blockInstanceId`, but did not clear the marker `toggleEnabled(false)`
wrote. Disable → re-install therefore left a live marker against an install the
database reports as enabled. At 900s that self-healed in minutes; at the new TTL
it would have persisted for hours. `installOnModel` now clears it, exactly as
`toggleEnabled(true)` does.

## Guards

`src/server/services/__tests__/block-revocation-ttl.test.ts` asserts the
relationship, never a number — a literal expectation would drift with whichever
constant is edited next, which is the defect rather than a guard against it:

- signs a **real token per kind**, reads `exp - iat` off the JWT, and compares it
  to the **`EX` `revokeInstance` actually hands Redis**;
- a positive control that the probe distinguishes the kinds (`dev > default >
  settings`), so a probe wired to a constant cannot pass silently;
- a ledger over the signer's own `const lifetime = …` selection, failing if it
  reads a hard-coded duration or a constant outside the record, and if the set of
  kinds it mints differs from the record's in **either** direction.

Together those mean a new, longer-lived token kind cannot be introduced without
the TTL following it.

`block-registry.service.test.ts` gains the `installOnModel` clear, with a
negative control that a *first* install clears nothing — without it a blanket
unconditional clear would pass.

### Red/green

| | `origin/main` (`6172ad991d`) | this branch |
|---|---|---|
| `covers a dev token for its whole life` | **fail** — 900s marker vs 14400s token | pass |
| `covers a default / settings token …` | pass (those are 900s / 300s) | pass |
| ledger over the signer's selection | **fail** | pass |

Mutations, each killed by its own assertion: TTL back to 900; TTL at
`MAX − 1`; a hard-coded duration in the signer; a registry entry nothing mints;
a named lifetime constant outside the record (which reaches the second ledger
assertion rather than being shadowed by the first). On the registry side:
removing the clear, and moving it to the create branch.

## Checks

`pnpm typecheck` 0 errors · `test:lint-rules` 36 files / 501 tests · covering
suites 52 files / 1361 tests · full unit suite green. `prettier:check` still
flags `block-token.service.ts`; it was already unformatted on `main` and the
unrelated hunk was deliberately left alone.

## Cost

Markers persist 16× longer. Each is one tiny key written on an uninstall or a
disable, so the resident set is bounded by that event rate rather than by
traffic; `clearInstance` still removes one the moment the install comes back,
and that path is now complete.

## Scope of the claim

The "nothing writes a `page_` id" finding is an enumeration of the write paths
in source — every `revokeInstance` caller, and every writer of
`blockUserSubscription.blockInstanceId` in Prisma and raw SQL. It is not a scan
of existing rows; a legacy row predating those paths is outside what this diff
can establish.

## Note

Touches `block-revocation.service.ts`, which #4723 also edits (comments only).
Whichever lands second needs a trivial rebase.
