### PR TITLE
fix(account): correct the account settings v2 pane on tester feedback

### DIFF
--- a/docs/feature-flag-truthy-migration.md
+++ b/docs/feature-flag-truthy-migration.md
@@ -180,7 +180,7 @@ The type "lies" — it claims every flag is present and boolean, when at runtime
 - The wire payload is still sparse (Phase 2 stays — half the win was the bytes)
 - **The flag-removal safety net still works**: `FeatureFlagKey` is the keyspace, so removing a flag from the registry shrinks the union and produces a type error at every consumer (including destructure sites)
 
-**What we lose:** the type doesn't enforce write safety (`features.X = false` compiles even though wire payload never produces `false`). Acceptable — no consumer writes to the cache except [SettingsCard.tsx:334](../src/components/Account/SettingsCard.tsx#L334), and that one assignment is internal optimistic-cache state, not the wire payload.
+**What we lose:** the type doesn't enforce write safety (`features.X = false` compiles even though wire payload never produces `false`). Acceptable — no consumer writes to the cache except [SettingsCard.tsx:335](../src/components/Account/SettingsCard.tsx#L335), and that one assignment is internal optimistic-cache state, not the wire payload.
 
 ### Phase 4 — Benefits realized
 

--- a/docs/implementation-plan-multi-domain-buzz-restrictions.md
+++ b/docs/implementation-plan-multi-domain-buzz-restrictions.md
@@ -4,6 +4,9 @@
 
 This plan addresses the migration to support multiple sub-domains where each supports one primary Buzz currency (Yellow or Green) while allowing Blue Buzz everywhere. The implementation enforces currency restrictions at both transaction and UI levels.
 
+> **Shipped — with a different hook signature than the blocks below.** `useAvailableBuzz(baseTypes: BuzzSpendType[] = [])` takes an array, not an `includeBlue` boolean, and blue is **not** included by default: `useQueryBuzz()` with no argument totals the domain's own type alone. The Phase 2 code blocks are the original proposal; read `src/components/Buzz/useAvailableBuzz.ts` and `src/components/Buzz/useBuzz.ts` for the shipped shape.
+
+
 ## Current Architecture Analysis
 
 ### Current Buzz Implementation

--- a/src/components/Account/AccountLayout.tsx
+++ b/src/components/Account/AccountLayout.tsx
@@ -14,6 +14,7 @@ import {
   resolveLegacyAnchor,
   searchAccountSections,
 } from '~/components/Account/account-sections';
+import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
 import { useQueryBuzz } from '~/components/Buzz/useBuzz';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
@@ -166,7 +167,8 @@ function AccountNav({ activeId }: { activeId: string }) {
 
 function MobileIndex() {
   const currentUser = useCurrentUser();
-  const { data: buzz } = useQueryBuzz();
+  const availableBuzzTypes = useAvailableBuzz(['blue']);
+  const { data: buzz } = useQueryBuzz(availableBuzzTypes);
   const [query, setQuery] = useState('');
   const matches = useMemo(() => searchAccountSections(query), [query]);
 

--- a/src/components/Account/AccountOverview.tsx
+++ b/src/components/Account/AccountOverview.tsx
@@ -1,6 +1,5 @@
-import { Alert, Button, Card, Text } from '@mantine/core';
+import { Button, Card, Text } from '@mantine/core';
 import {
-  IconAlertTriangle,
   IconArrowUpRight,
   IconBell,
   IconCreditCard,
@@ -15,6 +14,7 @@ import {
 import React from 'react';
 
 import { accountSections, getAccountSectionHref } from '~/components/Account/account-sections';
+import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
 import { useQueryBuzz } from '~/components/Buzz/useBuzz';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
@@ -77,7 +77,8 @@ const quickLinks: { id: string; icon: React.ReactNode }[] = [
 export function AccountOverview() {
   const currentUser = useCurrentUser();
   const features = useFeatureFlags();
-  const { data: buzz } = useQueryBuzz();
+  const availableBuzzTypes = useAvailableBuzz(['blue']);
+  const { data: buzz } = useQueryBuzz(availableBuzzTypes);
   const { data: strikeSummary } = trpc.strike.getMyStrikeSummary.useQuery(undefined, {
     enabled: !!currentUser && !!features.strikes,
   });
@@ -91,6 +92,8 @@ export function AccountOverview() {
   if (!currentUser) return null;
 
   const emailVerified = !!currentUser.emailVerified;
+  // This endpoint returns every OWNED cosmetic, and `Username` takes the first of each type.
+  const equippedCosmetics = profile?.cosmetics?.filter((cosmetic) => !!cosmetic.equippedAt);
   const standing = accountStandingFromPoints(strikeSummary?.totalActivePoints ?? 0);
   const StandingIcon = standing.good ? IconShieldCheck : IconShieldExclamation;
   const tierBadge = subscription ? getPlanDetails(subscription.product, features).image : undefined;
@@ -98,14 +101,6 @@ export function AccountOverview() {
 
   return (
     <>
-      {!emailVerified && (
-        <Alert color="yellow" icon={<IconAlertTriangle size={18} />} title="Verify your email">
-          <Text size="sm">
-            Until you do, you can&apos;t publish models, withdraw Buzz, or recover the account.
-          </Text>
-        </Alert>
-      )}
-
       <Card withBorder padding="lg">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
           <div className="flex min-w-0 flex-1 items-center gap-4">
@@ -113,14 +108,15 @@ export function AccountOverview() {
             <div className="flex min-w-0 flex-col gap-1">
               <Username
                 username={currentUser.username}
-                cosmetics={profile?.cosmetics}
+                cosmetics={equippedCosmetics}
                 size="xl"
                 badgeSize={26}
               />
-              <Text size="sm" c="dimmed">
-                {currentUser.email}
-                {currentUser.createdAt && ` · Member since ${formatDate(currentUser.createdAt)}`}
-              </Text>
+              {currentUser.createdAt && (
+                <Text size="sm" c="dimmed">
+                  {`Member since ${formatDate(currentUser.createdAt)}`}
+                </Text>
+              )}
             </div>
           </div>
           <Button

--- a/src/components/Account/AccountOverview.tsx
+++ b/src/components/Account/AccountOverview.tsx
@@ -14,15 +14,13 @@ import {
 import React from 'react';
 
 import { accountSections, getAccountSectionHref } from '~/components/Account/account-sections';
-import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
-import { useQueryBuzz } from '~/components/Buzz/useBuzz';
-import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { NextLink } from '~/components/NextLink/NextLink';
 import { openUserProfileEditModal } from '~/components/Dialog/triggers/user-profile-edit';
 import { useActiveSubscription } from '~/components/Stripe/memberships.util';
 import { getPlanDetails } from '~/components/Subscriptions/getPlanDetails';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
+import { UserBuzz } from '~/components/User/UserBuzz';
 import { Username } from '~/components/User/Username';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -38,7 +36,7 @@ function StatTile({
 }: {
   label: string;
   href: string;
-  icon: React.ReactNode;
+  icon?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
@@ -77,8 +75,6 @@ const quickLinks: { id: string; icon: React.ReactNode }[] = [
 export function AccountOverview() {
   const currentUser = useCurrentUser();
   const features = useFeatureFlags();
-  const availableBuzzTypes = useAvailableBuzz(['blue']);
-  const { data: buzz } = useQueryBuzz(availableBuzzTypes);
   const { data: strikeSummary } = trpc.strike.getMyStrikeSummary.useQuery(undefined, {
     enabled: !!currentUser && !!features.strikes,
   });
@@ -97,7 +93,6 @@ export function AccountOverview() {
   const standing = accountStandingFromPoints(strikeSummary?.totalActivePoints ?? 0);
   const StandingIcon = standing.good ? IconShieldCheck : IconShieldExclamation;
   const tierBadge = subscription ? getPlanDetails(subscription.product, features).image : undefined;
-  const funded = (buzz?.accounts ?? []).filter((account) => account.balance > 0);
 
   return (
     <>
@@ -147,28 +142,16 @@ export function AccountOverview() {
           </Text>
         </StatTile>
 
-        <StatTile
-          label="Buzz balance"
-          href="/user/buzz-dashboard"
-          icon={<CurrencyIcon currency="BUZZ" size={16} />}
-        >
-          <div className="flex min-w-0 flex-col">
-            <Text size="lg" fw={700}>
-              {(buzz?.total ?? 0).toLocaleString()}
-            </Text>
-            {funded.length > 1 && (
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-                {funded.map((account) => (
-                  <div key={account.type} className="flex items-center gap-0.5">
-                    <CurrencyIcon currency="BUZZ" type={account.type} size={11} />
-                    <Text size="xs" c="dimmed">
-                      {account.balance.toLocaleString()}
-                    </Text>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
+        <StatTile label="Buzz balance" href="/user/buzz-dashboard">
+          {/* `UserBuzz` hardcodes `lh={0}` on the balance span and spreads props onto its outer
+              wrapper, so a plain `lh` prop cannot reach it. */}
+          <UserBuzz
+            iconSize={18}
+            textSize="lg"
+            withAbbreviation={false}
+            withTooltip
+            className="[&_span]:!leading-[var(--mantine-line-height-lg)]"
+          />
         </StatTile>
 
         <StatTile

--- a/src/components/Account/AdContent.tsx
+++ b/src/components/Account/AdContent.tsx
@@ -1,22 +1,15 @@
 import { Switch } from '@mantine/core';
 import React from 'react';
 import { useBrowsingSettings } from '~/providers/BrowserSettingsProvider';
-import { useMutateUserSettings } from '~/components/UserSettings/hooks';
 import { SettingRow, SettingsSection } from '~/components/Account/SettingsLayout';
 
 export function AdContent({ flat }: { flat?: boolean } = {}) {
   const allowAds = useBrowsingSettings((x) => x.allowAds);
   const setState = useBrowsingSettings((x) => x.setState);
 
-  const updateUserSettingsMutation = useMutateUserSettings({
-    onError(error) {
-      setState((state) => ({ allowAds: !state.allowAds }));
-    },
-  });
-
+  // BrowserSettingsProvider persists the store on a debounce; a mutation here would double-write.
   const handleToggleAds: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     setState({ allowAds: e.target.checked });
-    // updateUserSettingsMutation.mutate({ allowAds: e.target.checked });
   };
 
   if (flat)
@@ -29,7 +22,6 @@ export function AdContent({ flat }: { flat?: boolean } = {}) {
             <Switch
               checked={allowAds}
               onChange={handleToggleAds}
-              disabled={updateUserSettingsMutation.isPending}
             />
           }
         />
@@ -50,7 +42,6 @@ export function AdContent({ flat }: { flat?: boolean } = {}) {
           label="Allow on-site ads"
           checked={allowAds}
           onChange={handleToggleAds}
-          disabled={updateUserSettingsMutation.isPending}
         />
       </div>
     </div>

--- a/src/components/Account/ContentPane.tsx
+++ b/src/components/Account/ContentPane.tsx
@@ -21,15 +21,14 @@ export function ContentPane() {
 
   return (
     <SettingsStack>
-      {features.canViewNsfw && (
-        <SettingsNote icon={<IconEye size={18} />}>
-          The eye button in the header overrides this for one session. These are the defaults it
-          returns to.
-        </SettingsNote>
-      )}
+      {currentUser?.isMember && <AdContent flat />}
 
       {features.canViewNsfw && (
         <SettingsSection title="Mature content">
+          <SettingsNote icon={<IconEye size={18} />}>
+            The eye button in the header overrides this for one session. These are the defaults it
+            returns to.
+          </SettingsNote>
           <MatureContentSettings flat />
         </SettingsSection>
       )}
@@ -45,8 +44,6 @@ export function ContentPane() {
 
       <HiddenTagsSection flat />
       <HiddenUsersSection flat />
-
-      {currentUser?.isMember && <AdContent flat />}
     </SettingsStack>
   );
 }

--- a/src/components/Account/CreatorControlsCard.tsx
+++ b/src/components/Account/CreatorControlsCard.tsx
@@ -24,9 +24,9 @@ import { useSyncAccount } from '~/hooks/useSyncAccount';
  * user holds a valid Creator Program membership (enforced read-side); non/lapsed
  * members see an upsell and disabled toggles.
  *
- * Renting out space on your own images — stickers, and remix galleries — sits
- * above that gate and is NOT a membership benefit. The alert says "below this
- * point" for that reason; it is a boundary in the card, not a description of it.
+ * Renting out space on your own images — stickers and remix galleries — is NOT a
+ * membership benefit. In the legacy card that boundary is positional: the alert says
+ * "below this point", so nothing ungated may be moved beneath it.
  */
 export function CreatorControlsCard({
   flat,
@@ -42,8 +42,7 @@ export function CreatorControlsCard({
   const { mutate: mutateSetting, isPending: isLoadingSetting } = useMutateUserSettings();
 
   if (!user) return null;
-  // Renting out your own images is not a Creator Program benefit, so the two
-  // halves are gated apart. With neither, the card would be a bare heading.
+  // With neither half, the card would be a bare heading.
   if (!flags.creatorControls && !flags.stickerPlacement && !flags.remixGallery)
     return <>{stickerFooter}</>;
 
@@ -114,8 +113,6 @@ export function CreatorControlsCard({
   if (flat)
     return (
       <div id="creator-controls" className="flex flex-col gap-8">
-        <PlacementSpaceSection flat footer={stickerFooter} />
-        <RemixGallerySettings flat />
         {flags.creatorControls && (
           <SettingsSection
             title={
@@ -150,6 +147,8 @@ export function CreatorControlsCard({
             ))}
           </SettingsSection>
         )}
+        <PlacementSpaceSection flat footer={stickerFooter} />
+        <RemixGallerySettings flat />
       </div>
     );
 

--- a/src/components/Account/MatureContentSettings.tsx
+++ b/src/components/Account/MatureContentSettings.tsx
@@ -20,6 +20,12 @@ export function MatureContentSettings({ flat }: { flat?: boolean } = {}) {
           description="Confirms you are over 18."
           control={<Switch checked={showNsfw} onChange={toggleShowNsfw} />}
         />
+        <SettingRow
+          label="Blur mature content"
+          control={
+            <Switch checked={showNsfw && blurNsfw} onChange={toggleBlurNsfw} disabled={!showNsfw} />
+          }
+        />
         {showNsfw && (
           <SettingRow
             block
@@ -29,12 +35,6 @@ export function MatureContentSettings({ flat }: { flat?: boolean } = {}) {
             <BrowsingLevelsStacked />
           </SettingRow>
         )}
-        <SettingRow
-          label="Blur mature content"
-          control={
-            <Switch checked={showNsfw && blurNsfw} onChange={toggleBlurNsfw} disabled={!showNsfw} />
-          }
-        />
       </>
     );
 

--- a/src/components/Account/PreferencesPane.tsx
+++ b/src/components/Account/PreferencesPane.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {
   AssistantPersonalitySelect,
+  assistantToggleableFeatures,
   AutoplayGifsToggle,
   EarlyAdopterToggle,
   HideBlueBuzzToggle,
@@ -70,19 +71,29 @@ export function PreferencesPane() {
         )}
       </SettingsSection>
 
+      {assistantToggleableFeatures.length > 0 && (
+        <SettingsSection title="CivBot Assistant">
+          {assistantToggleableFeatures.map((feature) => (
+            <SettingRow block key={feature.key}>
+              <ToggleableFeatures data={[feature]} />
+            </SettingRow>
+          ))}
+          {flags.assistant && (
+            <SettingRow
+              label="Personality"
+              description="Available to subscribers."
+              control={<AssistantPersonalitySelect />}
+            />
+          )}
+        </SettingsSection>
+      )}
+
       <SettingsSection title="Features">
         {otherToggleableFeatures.map((feature) => (
           <SettingRow block key={feature.key}>
             <ToggleableFeatures data={[feature]} />
           </SettingRow>
         ))}
-        {flags.assistant && (
-          <SettingRow
-            label="Assistant personality"
-            description="Available to subscribers."
-            control={<AssistantPersonalitySelect />}
-          />
-        )}
         {flags.buzz && (
           <SettingRow block>
             <HideBlueBuzzToggle />

--- a/src/components/Account/ProfileCard.tsx
+++ b/src/components/Account/ProfileCard.tsx
@@ -33,8 +33,8 @@ import { showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 import { openUserProfileEditModal } from '~/components/Dialog/triggers/user-profile-edit';
 import { SettingsSection } from '~/components/Account/SettingsLayout';
-import { maskEmail } from '~/components/Account/mask-email';
 import { showErrorNotification } from '~/utils/notifications';
+import { maskEmail } from '~/utils/string-helpers';
 
 const schema = z.object({
   id: z.number(),

--- a/src/components/Account/ProfileCard.tsx
+++ b/src/components/Account/ProfileCard.tsx
@@ -1,4 +1,5 @@
 import {
+  ActionIcon,
   Alert,
   Button,
   Card,
@@ -10,9 +11,18 @@ import {
   TextInput,
   Popover,
   Modal,
+  Tooltip,
 } from '@mantine/core';
-import { IconPencilMinus, IconInfoSquareRounded, IconMail } from '@tabler/icons-react';
+import {
+  IconPencilMinus,
+  IconInfoSquareRounded,
+  IconMail,
+  IconMailCheck,
+  IconEye,
+  IconEyeOff,
+} from '@tabler/icons-react';
 import { useDisclosure } from '@mantine/hooks';
+import React from 'react';
 import * as z from 'zod';
 
 import { useSession } from '~/providers/SessionProvider';
@@ -23,6 +33,8 @@ import { showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 import { openUserProfileEditModal } from '~/components/Dialog/triggers/user-profile-edit';
 import { SettingsSection } from '~/components/Account/SettingsLayout';
+import { maskEmail } from '~/components/Account/mask-email';
+import { showErrorNotification } from '~/utils/notifications';
 
 const schema = z.object({
   id: z.number(),
@@ -38,6 +50,17 @@ export function ProfileCard({ flat }: { flat?: boolean } = {}) {
   const session = useCurrentUser();
   const { data } = useSession();
   const [emailModalOpened, { open: openEmailModal, close: closeEmailModal }] = useDisclosure();
+  const [emailRevealed, setEmailRevealed] = React.useState(false);
+  const [verificationSent, setVerificationSent] = React.useState(false);
+
+  const resendEmailVerification = trpc.user.resendEmailVerification.useMutation({
+    onSuccess: () => setVerificationSent(true),
+    onError: (error) =>
+      showErrorNotification({
+        title: 'Could not send the verification email',
+        error: new Error(error.message),
+      }),
+  });
 
   const currentUser = data?.user;
 
@@ -121,7 +144,31 @@ export function ProfileCard({ flat }: { flat?: boolean } = {}) {
               <InputText name="username" label="Username" required />
             </div>
             <div className="flex-1">
-              <TextInput label="Account email" value={currentUser?.email ?? ''} disabled readOnly />
+              <TextInput
+                label="Account email"
+                value={
+                  currentUser?.email
+                    ? emailRevealed
+                      ? currentUser.email
+                      : maskEmail(currentUser.email)
+                    : ''
+                }
+                disabled
+                readOnly
+                rightSection={
+                  <Tooltip label={emailRevealed ? 'Hide email' : 'Show email'} withArrow>
+                    <ActionIcon
+                      size="sm"
+                      variant="subtle"
+                      color="gray"
+                      aria-label={emailRevealed ? 'Hide email address' : 'Show email address'}
+                      onClick={() => setEmailRevealed((current) => !current)}
+                    >
+                      {emailRevealed ? <IconEyeOff size={14} /> : <IconEye size={14} />}
+                    </ActionIcon>
+                  </Tooltip>
+                }
+              />
             </div>
           </div>
         ) : (
@@ -145,11 +192,30 @@ export function ProfileCard({ flat }: { flat?: boolean } = {}) {
                   </Button>
                 </Group>
                 <TextInput
-                  value={currentUser?.email ?? ''}
+                  value={
+                    currentUser?.email
+                      ? emailRevealed
+                        ? currentUser.email
+                        : maskEmail(currentUser.email)
+                      : ''
+                  }
                   disabled
                   styles={{
                     root: { flex: 1 },
                   }}
+                  rightSection={
+                    <Tooltip label={emailRevealed ? 'Hide email' : 'Show email'} withArrow>
+                      <ActionIcon
+                        size="sm"
+                        variant="subtle"
+                        color="gray"
+                        aria-label={emailRevealed ? 'Hide email address' : 'Show email address'}
+                        onClick={() => setEmailRevealed((current) => !current)}
+                      >
+                        {emailRevealed ? <IconEyeOff size={14} /> : <IconEye size={14} />}
+                      </ActionIcon>
+                    </Tooltip>
+                  }
                 />
               </Stack>
             </Grid.Col>
@@ -167,6 +233,23 @@ export function ProfileCard({ flat }: { flat?: boolean } = {}) {
         )}
         {flat && (
           <Group justify="flex-end" gap="sm">
+            {/* `emailVerified`, deliberately NOT `requiresEmailVerification`: the accounts that
+                cannot verify any other way are the unstamped ones the gate — and so the banner
+                that carries the only other resend button — excludes. Offering the action makes no
+                claim about what the account is allowed to do, so the two predicates differ here on
+                purpose. */}
+            {!currentUser?.emailVerified && (
+              <Button
+                variant="default"
+                size="compact-sm"
+                leftSection={<IconMailCheck size={14} />}
+                onClick={() => resendEmailVerification.mutate()}
+                loading={resendEmailVerification.isPending}
+                disabled={verificationSent}
+              >
+                {verificationSent ? 'Verification sent' : 'Verify email'}
+              </Button>
+            )}
             <Button
               variant="default"
               size="compact-sm"
@@ -193,7 +276,6 @@ export function ProfileCard({ flat }: { flat?: boolean } = {}) {
     <Card withBorder={!flat} p={flat ? 0 : undefined} bg={flat ? 'transparent' : undefined}>
       {flat ? <SettingsSection title="Account info">{formBody}</SettingsSection> : formBody}
 
-      {/* Email Change Modal */}
       <Modal
         opened={emailModalOpened}
         onClose={closeEmailModal}

--- a/src/components/Account/SettingsCard.tsx
+++ b/src/components/Account/SettingsCard.tsx
@@ -32,15 +32,14 @@ export const assistantToggleableFeatures = toggleableFeatures.filter(
   (feature) => feature.key === 'assistant'
 );
 
-/**
- * Which pane section a toggleable flag belongs to. Anything not named here lands in Features, so a
- * flag added to `featureFlags` shows up somewhere rather than silently disappearing from the pane.
- */
 const mediaFeatureKeys: string[] = ['largerGenerationImages', 'nativeVideoControls'];
 export const mediaToggleableFeatures = toggleableFeatures.filter((feature) =>
   mediaFeatureKeys.includes(feature.key)
 );
-export const otherToggleableFeatures = toggleableFeatures.filter(
+
+// Denylist, not an allowlist: a flag added to `featureFlags` and routed to no section still shows
+// up in Features rather than silently vanishing from the pane.
+export const otherToggleableFeatures = normalizedToggleableFeatures.filter(
   (feature) => !mediaFeatureKeys.includes(feature.key)
 );
 

--- a/src/components/Account/mask-email.ts
+++ b/src/components/Account/mask-email.ts
@@ -1,0 +1,9 @@
+/**
+ * A fixed run of dots, not one per character: the address length is itself a hint when the account
+ * page is on a stream or a shared screen.
+ */
+export function maskEmail(email: string) {
+  const at = email.lastIndexOf('@');
+  if (at <= 0) return '•••••';
+  return `${email.slice(0, 1)}•••••${email.slice(at)}`;
+}

--- a/src/components/Account/mask-email.ts
+++ b/src/components/Account/mask-email.ts
@@ -1,9 +1,0 @@
-/**
- * A fixed run of dots, not one per character: the address length is itself a hint when the account
- * page is on a stream or a shared screen.
- */
-export function maskEmail(email: string) {
-  const at = email.lastIndexOf('@');
-  if (at <= 0) return '•••••';
-  return `${email.slice(0, 1)}•••••${email.slice(at)}`;
-}

--- a/src/components/Buzz/useAvailableBuzz.ts
+++ b/src/components/Buzz/useAvailableBuzz.ts
@@ -6,7 +6,8 @@ import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
  * Hook that returns available buzz types based on current domain feature flags.
  * Mirrors the backend getAllowedAccountTypes logic for frontend consistency.
  *
- * @param baseTypes - Base array of account types to include (defaults to ['blue'])
+ * @param baseTypes - Extra spend types to keep alongside the domain's own. Defaults to `[]`, so
+ *   a caller that wants Blue Buzz in the total must pass `['blue']` — `useQueryBuzz()` does not.
  * @returns Array of BuzzSpendType that are allowed on the current domain
  */
 export function useAvailableBuzz(baseTypes: BuzzSpendType[] = []): BuzzSpendType[] {

--- a/src/pages/verify-email.tsx
+++ b/src/pages/verify-email.tsx
@@ -15,6 +15,7 @@ import type { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { Meta } from '~/components/Meta/Meta';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { trpc } from '~/utils/trpc';
 
 type VerifyEmailPageProps = {
@@ -27,6 +28,8 @@ export default function VerifyEmailPage({ token }: VerifyEmailPageProps) {
   const [message, setMessage] = useState('');
   const [newEmail, setNewEmail] = useState('');
   const [currentEmail, setCurrentEmail] = useState('');
+  const [isEmailChange, setIsEmailChange] = useState(false);
+  const currentUser = useCurrentUser();
 
   const { data: tokenData, error: tokenError } = trpc.user.validateEmailToken.useQuery(
     { token: token || '' },
@@ -34,9 +37,12 @@ export default function VerifyEmailPage({ token }: VerifyEmailPageProps) {
   );
 
   const verifyEmailMutation = trpc.user.verifyEmailChange.useMutation({
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       setStatus('success');
       setMessage(data.message);
+      // `refreshSession` emits a session:refresh signal, but that only reaches a tab holding a
+      // live connection and this page is public — so pull the session rather than rely on it.
+      await currentUser?.refresh();
     },
     onError: (error) => {
       setStatus('error');
@@ -44,7 +50,6 @@ export default function VerifyEmailPage({ token }: VerifyEmailPageProps) {
     },
   });
 
-  // Update status based on token validation
   useEffect(() => {
     if (!token) {
       setStatus('error');
@@ -56,6 +61,7 @@ export default function VerifyEmailPage({ token }: VerifyEmailPageProps) {
       setStatus('pending');
       setNewEmail(tokenData.newEmail);
       setCurrentEmail(tokenData.currentEmail);
+      setIsEmailChange(tokenData.isEmailChange);
     }
   }, [token, tokenData, tokenError]);
 
@@ -66,7 +72,8 @@ export default function VerifyEmailPage({ token }: VerifyEmailPageProps) {
     }
   };
 
-  const handleReturnToAccount = () => {
+  const handleReturnToAccount = async () => {
+    await currentUser?.refresh();
     router.push('/user/account');
   };
 
@@ -84,34 +91,43 @@ export default function VerifyEmailPage({ token }: VerifyEmailPageProps) {
               {status === 'pending' && (
                 <>
                   <Text ta="center" size="lg" fw={500}>
-                    Confirm Email Change
+                    {isEmailChange ? 'Confirm Email Change' : 'Confirm Your Email Address'}
                   </Text>
                   <Text ta="center" c="dimmed">
-                    You&rsquo;re about to change your email address:
+                    {isEmailChange
+                      ? 'You\u2019re about to change your email address:'
+                      : 'Confirm this is your email address:'}
                   </Text>
-                  {currentEmail && newEmail && (
-                    <Stack gap="xs" align="center">
-                      <Group gap="xs" align="center">
-                        <Text size="md" fw={500}>
-                          From:
-                        </Text>
-                        <Text size="md" c="red" fw={600}>
-                          {currentEmail}
-                        </Text>
-                      </Group>
-                      <Text size="xl" c="dimmed">
-                        ↓
-                      </Text>
-                      <Group gap="xs" align="center">
-                        <Text size="md" fw={500}>
-                          To:
-                        </Text>
-                        <Text size="md" c="green" fw={600}>
+                  {isEmailChange
+                    ? currentEmail &&
+                      newEmail && (
+                        <Stack gap="xs" align="center">
+                          <Group gap="xs" align="center">
+                            <Text size="md" fw={500}>
+                              From:
+                            </Text>
+                            <Text size="md" c="red" fw={600}>
+                              {currentEmail}
+                            </Text>
+                          </Group>
+                          <Text size="xl" c="dimmed">
+                            ↓
+                          </Text>
+                          <Group gap="xs" align="center">
+                            <Text size="md" fw={500}>
+                              To:
+                            </Text>
+                            <Text size="md" c="green" fw={600}>
+                              {newEmail}
+                            </Text>
+                          </Group>
+                        </Stack>
+                      )
+                    : newEmail && (
+                        <Text size="md" fw={600}>
                           {newEmail}
                         </Text>
-                      </Group>
-                    </Stack>
-                  )}
+                      )}
                   <Text ta="center" c="dimmed" size="sm">
                     Please confirm this action. You will not need to sign in again.
                   </Text>
@@ -120,7 +136,7 @@ export default function VerifyEmailPage({ token }: VerifyEmailPageProps) {
                       Cancel
                     </Button>
                     <Button onClick={handleConfirmChange} disabled={!newEmail}>
-                      Yes, Change Email
+                      {isEmailChange ? 'Yes, Change Email' : 'Verify Email'}
                     </Button>
                   </Group>
                 </>
@@ -138,7 +154,11 @@ export default function VerifyEmailPage({ token }: VerifyEmailPageProps) {
               {status === 'success' && (
                 <>
                   <IconCheck size={48} color="green" />
-                  <Alert color="green" title="Success!" w="100%">
+                  <Alert
+                    color="green"
+                    title={isEmailChange ? 'Email updated!' : 'Email verified!'}
+                    w="100%"
+                  >
                     {message}
                   </Alert>
                   <Button onClick={handleReturnToAccount} fullWidth>

--- a/src/server/email/templates/emailVerification.email.ts
+++ b/src/server/email/templates/emailVerification.email.ts
@@ -5,15 +5,18 @@ type EmailVerificationData = {
   to: string;
   username: string;
   verificationUrl: string;
+  isEmailChange: boolean;
 };
 
 export const emailVerificationEmail = createEmail({
-  header: ({ to }: EmailVerificationData) => ({
-    subject: 'Verify your new email address - Civitai',
+  header: ({ to, isEmailChange }: EmailVerificationData) => ({
+    subject: isEmailChange
+      ? 'Verify your new email address - Civitai'
+      : 'Verify your email address - Civitai',
     to,
   }),
 
-  html({ username, verificationUrl }: EmailVerificationData) {
+  html({ username, verificationUrl, isEmailChange }: EmailVerificationData) {
     const brandColor = '#346df1';
 
     const color = {
@@ -33,7 +36,12 @@ export const emailVerificationEmail = createEmail({
         <tr><td>
           <table width="100%" border="0" cellspacing="20" cellpadding="0" style="background: ${color.mainBackground}; border-radius: 10px;">
             <tr>
-              <td align="center" style="padding: 20px 0px; font-size: 24px; font-family: Helvetica, Arial, sans-serif; color: ${color.text};">
+              <td align="center" style="padding: 10px 0px;">
+                <img src="${`${getBaseUrl()}/images/logo_light_mode.png`}" alt="Civitai" width="142" style="display: block; border: 0;" />
+              </td>
+            </tr>
+            <tr>
+              <td align="center" style="padding: 10px 0px 20px 0px; font-size: 24px; font-family: Helvetica, Arial, sans-serif; color: ${color.text};">
                 <strong>Email Address Verification</strong>
               </td>
             </tr>
@@ -44,7 +52,11 @@ export const emailVerificationEmail = createEmail({
             </tr>
             <tr>
               <td style="padding: 0px 20px; font-size: 16px; line-height: 22px; font-family: Helvetica, Arial, sans-serif; color: ${color.text};">
-                You requested to change your email address on Civitai. Please click the button below to verify your new email address:
+                ${
+                  isEmailChange
+                    ? 'You requested to change your email address on Civitai. Please click the button below to verify your new email address:'
+                    : 'Please click the button below to verify your email address on Civitai:'
+                }
               </td>
             </tr>
             <tr>
@@ -73,7 +85,7 @@ export const emailVerificationEmail = createEmail({
             </tr>
             <tr>
               <td style="padding: 20px 20px 10px 20px; font-size: 14px; line-height: 20px; font-family: Helvetica, Arial, sans-serif; color: ${color.muted};">
-                This verification link will expire in 15 minutes. If you didn't request this change, please ignore this email.
+                This verification link will expire in 15 minutes. If you didn't request this, please ignore this email.
               </td>
             </tr>
           </table>
@@ -89,14 +101,18 @@ export const emailVerificationEmail = createEmail({
     `;
   },
 
-  text({ username, verificationUrl }: EmailVerificationData) {
+  text({ username, verificationUrl, isEmailChange }: EmailVerificationData) {
     return `Hi ${username},
 
-You requested to change your email address on Civitai. Please visit the following link to verify your new email address:
+${
+  isEmailChange
+    ? 'You requested to change your email address on Civitai. Please visit the following link to verify your new email address:'
+    : 'Please visit the following link to verify your email address on Civitai:'
+}
 
 ${verificationUrl}
 
-This verification link will expire in 15 minutes. If you didn't request this change, please ignore this email.
+This verification link will expire in 15 minutes. If you didn't request this, please ignore this email.
 
 ---
 Civitai Team
@@ -107,5 +123,6 @@ Civitai Team
     to: 'test@example.com',
     username: 'TestUser',
     verificationUrl: `${getBaseUrl()}/verify-email?token=test-token`,
+    isEmailChange: false,
   }),
 });

--- a/src/server/email/templates/index.ts
+++ b/src/server/email/templates/index.ts
@@ -12,4 +12,5 @@ export { merchClaimInviteEmail } from './merchClaimInvite.email';
 export { merchBuzzCreditedEmail } from './merchBuzzCredited.email';
 export { membershipGiftReceivedEmail } from './membershipGiftReceived.email';
 export { membershipGiftSentEmail } from './membershipGiftSent.email';
+export { emailVerificationEmail } from './emailVerification.email';
 export type { Email } from './base.email';

--- a/src/server/services/email-verification.service.ts
+++ b/src/server/services/email-verification.service.ts
@@ -52,13 +52,17 @@ export async function validateEmailChangeToken(token: string) {
     throw throwNotFoundError('User not found');
   }
 
+  // Verify-only flows — resend and onboarding — mint a token for the address the row already has,
+  // so equal addresses mean "prove it", not "change to it".
   return {
     ...verificationData,
     currentEmail: user.email,
+    isEmailChange: user.email !== verificationData.newEmail,
   } as {
     userId: number;
     newEmail: string;
     currentEmail: string;
+    isEmailChange: boolean;
     createdAt: string;
   };
 }
@@ -113,17 +117,13 @@ export async function requestEmailChange(userId: number, newEmail: string) {
   const token = await generateEmailVerificationToken(userId, newEmail);
 
   // Send verification email
-  await sendVerificationEmail(newEmail, user.username || 'User', token);
+  await sendVerificationEmail(newEmail, user.username || 'User', token, true);
 
-  // Refresh the cached session shape. 🔴 This does NOT log the user out or force a re-authentication
-  // — `refreshSession` marks the user's tokens `refresh` and busts the shaped session-user entry;
-  // only `invalidateSession` marks them `invalid`. (The comment here used to claim re-authentication,
-  // which would make the `.catch` below read as downgrading a security control. There is no such
-  // control on this path, and nothing on the user row has changed yet at this point.)
-  //
-  // Best-effort: the verification email has already been SENT and the token issued, so a failed
-  // cache bust must not 500 this call — the user would see "failed", re-request, and receive a
-  // second email for work that already succeeded. Logged rather than swallowed.
+  // Best-effort refresh of the cached session shape. 🔴 `refreshSession` marks the user's tokens
+  // `refresh` and busts the shaped session-user entry; only `invalidateSession` marks them
+  // `invalid`, so this is not a logout. The verification email has already been SENT and the token
+  // issued, so a failed cache bust must not 500 this call — the user would see "failed",
+  // re-request, and receive a second email for work that already succeeded.
   await refreshSession(userId, { caller: 'email-verification' }).catch(handleLogError);
 
   return { success: true, message: 'Verification email sent' };
@@ -141,10 +141,11 @@ export async function requestEmailChange(userId: number, newEmail: string) {
 export async function issueEmailVerification(
   userId: number,
   email: string,
-  username: string | null
+  username: string | null,
+  isEmailChange = false
 ) {
   const token = await generateEmailVerificationToken(userId, email);
-  await sendVerificationEmail(email, username || 'User', token);
+  await sendVerificationEmail(email, username || 'User', token, isEmailChange);
 
   return { success: true, message: 'Verification email sent' };
 }
@@ -172,6 +173,11 @@ export async function sendEmailVerification(userId: number) {
 export async function confirmEmailChange(token: string) {
   const { userId, newEmail } = await verifyEmailChangeToken(token);
 
+  // Primary, not the replica: an onboarding token is minted immediately after the address is
+  // written, and a lagging replica would report that as a change.
+  const existing = await dbWrite.user.findUnique({ where: { id: userId }, select: { email: true } });
+  const isEmailChange = existing?.email !== newEmail;
+
   // Clicking the token link sent to newEmail proves inbox ownership, so mark the email verified — not just
   // set it. emailVerified (not email) is what gates the last-login-method delete guard and hub magic-link
   // login, so leaving it null traps users who can't otherwise self-serve a verified email (ClickUp 868k9gug8).
@@ -182,23 +188,35 @@ export async function confirmEmailChange(token: string) {
 
   userUpdateCounter?.inc({ location: 'email-verification.service:confirmEmailChange' });
 
-  // Refresh the cached session shape so the new email is served rather than the old one. As above,
-  // this is a REFRESH, not a logout — see the note in `requestEmailChange`.
+  // Refresh the cached session shape: emailVerified always changes here, the address only on a
+  // change token. As above, a REFRESH, not a logout — see the note in `requestEmailChange`.
   // 🔴 Best-effort is load-bearing here: the email column is already written AND the one-time token
   // has been consumed, so a throw would report a permanent failure for a change that succeeded and
   // that the user can no longer retry (the link is spent). Staleness is bounded by the session
   // entry's own TTL; a misreported, unretryable write is not.
   await refreshSession(userId, { caller: 'email-verification' }).catch(handleLogError);
 
-  return { success: true, message: 'Email address updated successfully' };
+  return {
+    success: true,
+    isEmailChange,
+    message: isEmailChange
+      ? 'Email address updated successfully'
+      : 'Email address verified successfully',
+  };
 }
 
-async function sendVerificationEmail(email: string, username: string, token: string) {
+async function sendVerificationEmail(
+  email: string,
+  username: string,
+  token: string,
+  isEmailChange: boolean
+) {
   const verificationUrl = `${env.NEXTAUTH_URL}/verify-email?token=${token}`;
 
   await emailVerificationEmail.send({
     to: email,
     username,
     verificationUrl,
+    isEmailChange,
   });
 }

--- a/src/utils/__tests__/mask-string.test.ts
+++ b/src/utils/__tests__/mask-string.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { maskEmail, maskString } from '~/utils/string-helpers';
+
+describe('maskString', () => {
+  it('keeps the requested ends and hides the middle', () => {
+    expect(maskString('abcdefghij', { start: 2, end: 3 })).toBe('ab•••••hij');
+  });
+
+  it('keeps only the front when no end is asked for', () => {
+    expect(maskString('abcdefghij', { start: 2 })).toBe('ab•••••');
+  });
+
+  it('hides everything when neither end is kept', () => {
+    expect(maskString('abcdefghij')).toBe('•••••');
+  });
+
+  /**
+   * The reason the run is fixed rather than one character per hidden character. A per-character
+   * mask passes every other assertion here while still telling a reader how long the secret is.
+   */
+  it('emits the same mask whatever the input length', () => {
+    const short = maskString('aa@b.co', { start: 1, end: 5 });
+    const long = maskString('aaaaaaaaaaaaaaaaaaaaaaaaa@b.co', { start: 1, end: 5 });
+
+    expect(short).toBe(long);
+    expect(long).not.toContain('aa');
+  });
+
+  it('returns the mask alone rather than the input when the kept ends cover it', () => {
+    expect(maskString('abc', { start: 2, end: 2 })).toBe('•••••');
+    expect(maskString('abc', { start: 3 })).toBe('•••••');
+  });
+
+  it('treats negative bounds as zero rather than slicing from the far end', () => {
+    expect(maskString('abcdefghij', { start: -4, end: -4 })).toBe('•••••');
+  });
+
+  it('accepts a custom mask', () => {
+    expect(maskString('abcdefghij', { start: 1, end: 1, mask: '***' })).toBe('a***j');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(maskString('')).toBe('');
+  });
+});
+
+describe('maskEmail', () => {
+  it('keeps the first character and the whole domain', () => {
+    expect(maskEmail('someone@example.com')).toBe('s•••••@example.com');
+  });
+
+  it('does not leak the length of the local part', () => {
+    expect(maskEmail('ab@example.com')).toBe(maskEmail('aaaaaaaaaaaaaaaaaaaa@example.com'));
+  });
+
+  /**
+   * Keeping the first character AND the domain of `a@example.com` would show the whole address
+   * behind decoy dots. Masking outright is the honest result.
+   */
+  it('masks everything when the local part is too short to hide any of it', () => {
+    expect(maskEmail('a@example.com')).toBe('•••••');
+  });
+
+  it('splits on the LAST @, so a local part containing one still masks', () => {
+    expect(maskEmail('we"ir"d@e@example.com')).toBe('w•••••@example.com');
+  });
+
+  it('hides the whole value when there is no domain to keep', () => {
+    expect(maskEmail('not-an-email')).toBe('•••••');
+  });
+
+  it('hides the whole value when the address starts with @', () => {
+    expect(maskEmail('@example.com')).toBe('•••••');
+  });
+});

--- a/src/utils/string-helpers.ts
+++ b/src/utils/string-helpers.ts
@@ -165,6 +165,41 @@ export function filenamize(value: string, length = 20) {
   return camelCase(truncate(value, { length, separator: '_', omission: '' }));
 }
 
+/**
+ * Replace the middle of a string with a FIXED run of characters — never one per hidden character,
+ * which leaks the original's length to anyone reading a shared screen or a stream.
+ *
+ * Keeps `start` characters from the front and `end` from the back. When the kept ends already
+ * cover the whole string there is nothing left to hide, so it returns the mask alone rather than
+ * handing back the input untouched.
+ */
+export function maskString(
+  value: string,
+  { start = 0, end = 0, mask = '•••••' }: { start?: number; end?: number; mask?: string } = {}
+) {
+  if (!value) return '';
+
+  const head = Math.max(0, start);
+  const tail = Math.max(0, end);
+  if (head + tail >= value.length) return mask;
+
+  return `${value.slice(0, head)}${mask}${tail > 0 ? value.slice(value.length - tail) : ''}`;
+}
+
+/**
+ * Hides the local part but keeps the domain, so the account stays recognisable to its owner.
+ *
+ * A local part short enough that keeping its first character would reveal the whole address falls
+ * back to masking everything: showing `a•••••@example.com` conceals nothing while looking as if it
+ * does, which is worse than an obviously-hidden value.
+ */
+export function maskEmail(email: string) {
+  const at = email.lastIndexOf('@');
+  if (at <= 0) return maskString(email);
+
+  return maskString(email, { start: 1, end: email.length - at });
+}
+
 export function replaceInsensitive(value: string, search: string, replace: string) {
   const escaped = search.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
   return value.replace(new RegExp(escaped, 'gi'), replace);


### PR DESCRIPTION
Fixes everything testers raised on the account settings v2 redesign in the Discord thread, plus two follow-ups from review.

Base is `main`, behind `account-settings-v2` (still `enabled: false`), so nothing here is live until that flag ramps.

## Bugs

**Overview showed the wrong badge and nameplate.** `userProfile.get` uses `userWithProfileSelect`, which — unlike `userWithCosmeticsSelect` — has no `equippedAt` filter and returns every *owned* cosmetic. `Username` takes the first of each type, so the pane rendered an arbitrary one. Every other consumer of that endpoint (`ProfileSidebar`, `CosmeticPreview`, `UserProfileEditModal`) already filters; Overview didn't.

**The Buzz total excluded blue.** `useQueryBuzz()` with no argument resolves to the domain's own account type alone, so blue was missing from the *number*, not just the breakdown. Overview and the mobile index were the only two no-arg call sites in the repo. Note the fix is `useQueryBuzz(useAvailableBuzz(['blue']))`, not `useQueryBuzz(['blue'])` — inside the hook, `buzzTypes ?? defaultTypes` takes the raw array when you pass one, so the shorter form would have shown blue *only*.

**The CivBot toggle was separated from its personality select** by the Chats toggle, because the feature list renders in flag declaration order (`air` → `assistant` → `chat`). They now share a section.

**The "Verify your email" alert was false, twice over.** It claimed an unverified account can't publish models, withdraw Buzz, or recover the account. Publishing is gated; Buzz withdrawal is `protectedProcedure` with no email check, and there is no account-recovery feature at all. It also keyed off `emailVerified` rather than `requiresEmailVerification`, so it showed to accounts gated on nothing — 7.1M accounts have `emailVerified IS NULL` and the column was only ever populated by magic-link and some verified OAuth.

Removed rather than reworded: once the predicate is right, its audience is exactly the one `VerifyEmailBanner` already serves, on the same page, higher up, with a working Resend button.

## Feedback

- **Email is masked** behind a reveal toggle on Profile & Account, and no longer appears in the Overview card at all. The Email stat tile still reports Verified/Unverified — status, not address.
- **A "Verify email" button** on Profile & Account, wired to the existing `resendEmailVerification` procedure. This was previously reachable only from `VerifyEmailBanner`, which unstamped accounts never see — so an OAuth user with an unverified address had no way to trigger one. That's the report that started this.
- **Content & Browsing** leads with Ads (it sat below two unbounded hidden-entity lists), the eye-button note moved inside the Mature content section, and "Blur mature content" now sits directly under "Show mature content".
- **The Creator pane** leads with Metric visibility instead of burying it under the sticker and remix sections.

## Deliberate call worth a reviewer's eye

The new Verify button gates on `!emailVerified`, **not** `requiresEmailVerification` — the predicate this same PR removes from the Overview alert. That looks inconsistent and is on purpose: the accounts that need a resend most are precisely the unstamped ones the gate (and therefore the banner) excludes. Offering an action makes no claim about what the account may do, which is what made the alert wrong. The button is neutral-styled rather than warning-coloured for the same reason, and there's a comment at the call site so it doesn't get "fixed".

## Incidental

- `useAvailableBuzz`'s JSDoc claimed `baseTypes` defaults to `['blue']`; it defaults to `[]`. That wrong doc is the easiest way to write the bug above. Corrected, along with two docs a review found pointing at a hook shape that never shipped.
- Dropped a commented-out mutation in `AdContent` and the `disabled` props that depended on it — `BrowserSettingsProvider` persists the store on a debounce, so the toggle worked; the leftovers just read as broken.

## Verification

Typecheck clean. `SettingsCard.earlyAdopter.browser.test.tsx` (the only existing suite that loads a touched module) 6/6.

Driven end to end in the local app against three accounts picked so each fix was actually exercised, rather than just rendered:

| Fix | Evidence |
|---|---|
| Badge | Account with 79 owned badges, 1 equipped. Rendered **Champion Badge** (equipped), not **Server On Fire** (first in row order) |
| Buzz | Same account: total **550** = **423 + 127**, two types. Pre-fix: 423, no breakdown |
| CivBot | Section contains toggle → Personality, adjacent; Chats now in Features |
| Alert | Account with `emailVerified IS NULL`: no alert, and no global banner either — that account genuinely isn't gated |
| Mask | Masked → reveal → hide round trip, aria-label flips |
| Ads | Sections: Ads → Mature content → Topics → Hidden tags → Hidden users, on a member account |
| Metrics | Metric visibility → Stickers → Remix galleries |
| Verify button | Renders for the unverified account. **Not clicked** — it sends real mail to a real address |

`comment-review` and `docs-drift-review` both run; findings applied except the one argued against above.

## Not in this PR

Two things surfaced while investigating that want their own decision:

- **~7.1M accounts have `emailVerified IS NULL` mostly as a stamping gap, not an identity gap.** Of users who withdrew cash in the last 12 months, 77 of 196 are unverified — and 75 of those 77 authenticate via OAuth (68 Google). Backfilling `emailVerified` from providers that assert it would fix the banner's audience properly and is a prerequisite for gating anything on email.
- **`buzzWithdrawalRequest` is dead** — last row Feb 2025, live payouts go through `creatorProgram.withdrawCash` — but the router is still registered with UI wired to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NoyDuuoL1BM1KvSShYBWT
