### PR TITLE
test(app-blocks): freeze the clock in the app-spend-cap suite

### DIFF
--- a/src/server/services/blocks/__tests__/app-spend-cap.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-spend-cap.service.test.ts
@@ -25,9 +25,35 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  * sysRedis is a stateful in-memory fake so the atomic INCRBY accumulation (the
  * whole point of the TOCTOU-safe design) is exercised for real. The limit
  * resolver is mocked so each case can pin the ceilings it is testing.
+ *
+ * 🔴 THE WHOLE FILE RUNS ON A FROZEN CLOCK, and that is load-bearing, not
+ * tidiness. Both key shapes under test are derived from the WALL CLOCK — the
+ * velocity key is `floor(Date.now()/1000/60)`, a FIXED 60s window (the service's
+ * own `spendCapVelocityKey`), and the daily key is a UTC-day string. Meanwhile
+ * most velocity cases loop to a ceiling (up to 3,000 iterations for `platform`)
+ * and then assert an EXACT denial count. Those assertions are only sound while
+ * the bucket is constant for the whole case: if a boundary falls inside the
+ * loop the counter restarts mid-run, the expected denials never happen, and the
+ * case fails for a reason that has nothing to do with the code. That is a
+ * genuine intermittent — it reddened `Unit tests (1)` on civitai#4668 and then
+ * passed on a re-run of the identical commit.
+ *
+ * MEASURED, not assumed: with the clock advanced 100ms per read starting 30s
+ * into a bucket (a slow CI run, made deterministic), FIVE cases in this file go
+ * red — the two velocity ceilings, the 0-cost burst, the `trusted`/`platform`
+ * tier ceilings and the 120-throttle regression case. Freezing the clock takes
+ * that to zero. `frozen clock` below is the guard that keeps it frozen.
  */
 
 const SPEND_CAP_PREFIX = 'system:blocks:app-spend-cap';
+
+/**
+ * Mid-bucket AND mid-day on purpose: 30s into a 60s velocity window and 12
+ * hours from either UTC midnight, so neither boundary is anywhere near, and a
+ * case that sets its own time (the rollover and midnight-straddle cases below)
+ * is moving away from a known-quiet position rather than off an edge.
+ */
+const FROZEN_CLOCK = new Date('2026-07-31T12:00:30Z');
 
 const { store, ttls, mockSysRedis, mockResolveAppCapLimits } = vi.hoisted(() => {
   const store = new Map<string, number>();
@@ -102,6 +128,12 @@ function velocityKey(app = APP_BLOCK_ID): string {
 }
 
 beforeEach(() => {
+  // 🔴 FIRST, before anything derives a key: freeze the clock so every case is
+  // judged against ONE velocity bucket and ONE UTC day. See the file header.
+  // Cases that need time to move (the window rollover, the midnight straddle)
+  // call `vi.setSystemTime` themselves and step off this position deliberately.
+  vi.useFakeTimers();
+  vi.setSystemTime(FROZEN_CLOCK);
   store.clear();
   ttls.clear();
   mockSysRedis.incrBy.mockClear();
@@ -118,7 +150,9 @@ beforeEach(() => {
     store.set(key, next);
     return next;
   });
-  mockSysRedis.ttl.mockImplementation(async (key: string) => (ttls.has(key) ? ttls.get(key)! : 1000));
+  mockSysRedis.ttl.mockImplementation(async (key: string) =>
+    ttls.has(key) ? ttls.get(key)! : 1000
+  );
   // 🔴 `expire` needs its implementation RE-ESTABLISHED, not just `mockClear()`ed:
   // mockClear wipes call history but leaves any `mockRejectedValue` in place, so a
   // fault-injection case would leak its failure into every later test in the file.
@@ -134,6 +168,40 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+});
+
+describe('the harness itself', () => {
+  /**
+   * 🔴 This pins the PRECONDITION every velocity case below relies on, because
+   * a case cannot assert it about itself: they loop to a ceiling and then
+   * assert an exact denial count, which is only sound while `floor(now/60s)`
+   * holds still for the whole loop.
+   *
+   * It asserts the two things that can independently break that, and nothing
+   * else: (1) the clock is frozen at all, and (2) it is frozen somewhere with
+   * room on both sides — a freeze parked 200ms before a bucket rollover is
+   * still a freeze, and would still be sound here, but it is one careless
+   * `setSystemTime` edit away from not being, and the margin is free.
+   *
+   * ⚠️ It CANNOT be written the obvious way — as a busy-wait proving real time
+   * moved while `Date.now()` did not. Measured in this repo (vitest 4.1.11):
+   * under `vi.useFakeTimers()` **`performance.now()` and `process.hrtime()` are
+   * frozen too**, not just `Date`. A spin keyed on either never terminates (one
+   * ran 32s to its iteration cap), so there is no real-time source in scope to
+   * compare against. Do not "improve" this into a timing test.
+   */
+  it('runs on a FROZEN clock, parked clear of both the bucket and UTC-day edges', () => {
+    expect(vi.isFakeTimers()).toBe(true);
+
+    const now = Date.now();
+    const secondsIntoBucket = (now / 1000) % BLOCK_APP_SPEND_VELOCITY_WINDOW_SECONDS;
+    expect(secondsIntoBucket).toBeGreaterThan(5);
+    expect(secondsIntoBucket).toBeLessThan(BLOCK_APP_SPEND_VELOCITY_WINDOW_SECONDS - 5);
+
+    const msIntoUtcDay = now % 86_400_000;
+    expect(msIntoUtcDay).toBeGreaterThan(60_000);
+    expect(msIntoUtcDay).toBeLessThan(86_400_000 - 60_000);
+  });
 });
 
 describe('cap constants (the GLOBAL CEILINGS that clamp every tier)', () => {
@@ -376,7 +444,9 @@ describe('THE REGRESSION THIS PR FIXES — a legitimately busy app is no longer 
     for (let i = 0; i < BUSY_APP_GENS_PER_WINDOW; i++) {
       if (!(await reserveAppSpend(APP_BLOCK_ID, 100)).allowed) denied++;
     }
-    expect(denied).toBe(BUSY_APP_GENS_PER_WINDOW - APP_SPEND_TIER_CAP_LIMITS.standard.velocityMaxGens);
+    expect(denied).toBe(
+      BUSY_APP_GENS_PER_WINDOW - APP_SPEND_TIER_CAP_LIMITS.standard.velocityMaxGens
+    );
     expect(denied).toBe(180);
   });
 
@@ -492,9 +562,9 @@ describe('refundAppSpend', () => {
     // including keys written by an earlier deploy. Per-app limits must not have
     // moved the key shape.
     const res = await reserveAppSpend(APP_BLOCK_ID, 42);
-    expect(res.dailyKey).toBe(`${SPEND_CAP_PREFIX}:${APP_BLOCK_ID}:${new Date()
-      .toISOString()
-      .slice(0, 10)}`);
+    expect(res.dailyKey).toBe(
+      `${SPEND_CAP_PREFIX}:${APP_BLOCK_ID}:${new Date().toISOString().slice(0, 10)}`
+    );
   });
 
   it('refunds the PINNED key even when the request straddles midnight UTC', async () => {

--- a/src/server/services/blocks/__tests__/app-spend-cap.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-spend-cap.service.test.ts
@@ -34,15 +34,36 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  * and then assert an EXACT denial count. Those assertions are only sound while
  * the bucket is constant for the whole case: if a boundary falls inside the
  * loop the counter restarts mid-run, the expected denials never happen, and the
- * case fails for a reason that has nothing to do with the code. That is a
- * genuine intermittent — it reddened `Unit tests (1)` on civitai#4668 and then
- * passed on a re-run of the identical commit.
+ * case fails for a reason that has nothing to do with the code.
  *
- * MEASURED, not assumed: with the clock advanced 100ms per read starting 30s
- * into a bucket (a slow CI run, made deterministic), FIVE cases in this file go
- * red — the two velocity ceilings, the 0-cost burst, the `trusted`/`platform`
- * tier ceilings and the 120-throttle regression case. Freezing the clock takes
- * that to zero. `frozen clock` below is the guard that keeps it frozen.
+ * ⚠️ The originating report — `Unit tests (1)` red on civitai#4668, then green
+ * on a re-run of the identical commit — is REPEATED FROM THE RECORD, not
+ * measured here: that PR's rollup now shows only its latest run, so the red is
+ * no longer readable. What IS measured is everything below.
+ *
+ * MEASURED, not assumed. 🔴 NAME THE PROBE OR THE NUMBER IS NOT RE-DERIVABLE:
+ * with **`Date.now()` alone** advanced 100ms per CALL, starting 30s into a
+ * bucket (a slow CI run, made deterministic), these cases go red at
+ * `origin/main` — count them, do not trust a total:
+ *   - `DENIES + REFUNDS the daily reserve when the short-window gen ceiling is exceeded`
+ *   - `enforces velocity even for 0-cost gens (a burst of cache-hits is bounded)`
+ *   - `enforces the \`trusted\` tier ceilings, not a global constant`
+ *   - `enforces the \`platform\` tier ceilings, not a global constant`
+ *   - `…and would have been throttled at the 120 ceiling (still the \`standard\` tier)`
+ * Freezing the clock takes that to zero. A probe that ALSO ticks `new Date()`
+ * reddens one more (`standard`), so the set is a property of the probe as well
+ * as of the file — which is why the probe is specified rather than described.
+ * `runs on a FROZEN clock` below is the guard that keeps it frozen.
+ *
+ * ⚠️ WHAT THE FREEZE DOES NOT BUY, disclosed because the position below reads
+ * like an unqualified virtue: parking mid-UTC-day means this file CANNOT catch
+ * a daily key that derives a LOCAL date instead of a UTC one. Measured —
+ * mutating `spendCapWindowKey` to `toLocaleDateString('en-CA')` survives the
+ * whole file under a UTC-negative TZ (America/Chicago) and kills 11 cases under
+ * `TZ=Pacific/Auckland`. That is PRE-EXISTING (the base file survives it too)
+ * and no TZ is pinned in `vitest.config.mts`, so it is a gap this change
+ * neither creates nor closes. Closing it would mean running the midnight
+ * straddle at BOTH `23:30Z` and `00:30Z`, which is TZ-independent.
  */
 
 const SPEND_CAP_PREFIX = 'system:blocks:app-spend-cap';
@@ -183,12 +204,20 @@ describe('the harness itself', () => {
    * still a freeze, and would still be sound here, but it is one careless
    * `setSystemTime` edit away from not being, and the margin is free.
    *
-   * ⚠️ It CANNOT be written the obvious way — as a busy-wait proving real time
+   * ⚠️ Do NOT rewrite it as the obvious busy-wait — a spin proving real time
    * moved while `Date.now()` did not. Measured in this repo (vitest 4.1.11):
-   * under `vi.useFakeTimers()` **`performance.now()` and `process.hrtime()` are
-   * frozen too**, not just `Date`. A spin keyed on either never terminates (one
-   * ran 32s to its iteration cap), so there is no real-time source in scope to
-   * compare against. Do not "improve" this into a timing test.
+   * under `vi.useFakeTimers()` **`performance.now()`, `process.hrtime()` and
+   * `process.hrtime.bigint()` are frozen too**, not just `Date`, so a spin keyed
+   * on any of those never terminates — one ran 32s to its iteration cap.
+   *
+   * 🔴 An earlier version of this comment concluded from that "there is no
+   * real-time source in scope to compare against". **That was FALSE and is
+   * retracted**: `process.uptime()` is NOT faked (measured — it advanced 29.1ms
+   * across a spin in which `Date.now()` and `performance.now()` both moved 0),
+   * so such a test IS writable. The reason not to write it is different and
+   * narrower: it would pin a deterministic precondition with a real-time race,
+   * in the one file whose entire purpose is removing a real-time race. Keep the
+   * assertion on STATE, not on elapsed time.
    */
   it('runs on a FROZEN clock, parked clear of both the bucket and UTC-day edges', () => {
     expect(vi.isFakeTimers()).toBe(true);

--- a/src/server/services/blocks/__tests__/app-spend-cap.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-spend-cap.service.test.ts
@@ -212,12 +212,17 @@ describe('the harness itself', () => {
    *
    * 🔴 An earlier version of this comment concluded from that "there is no
    * real-time source in scope to compare against". **That was FALSE and is
-   * retracted**: `process.uptime()` is NOT faked (measured — it advanced 29.1ms
-   * across a spin in which `Date.now()` and `performance.now()` both moved 0),
-   * so such a test IS writable. The reason not to write it is different and
-   * narrower: it would pin a deterministic precondition with a real-time race,
-   * in the one file whose entire purpose is removing a real-time race. Keep the
-   * assertion on STATE, not on elapsed time.
+   * retracted**: `process.uptime()` is NOT faked, so such a test IS writable.
+   * Measured — across one busy spin it advances by tens of milliseconds while
+   * `Date.now()` and `performance.now()` both move exactly **0**. (Per this
+   * file's own rule above, the magnitude is not quoted as a bare figure: it is
+   * a property of the spin's LENGTH, which nothing here pins. The ZERO is the
+   * re-derivable part, and it is the part that matters.)
+   *
+   * The reason not to write it is narrower than the retracted one: it would pin
+   * a deterministic precondition on a spin whose TERMINATION TIME depends on
+   * the wall clock, in the one file whose purpose is removing wall-clock
+   * dependence. Keep the assertion on STATE, not on elapsed time.
    */
   it('runs on a FROZEN clock, parked clear of both the bucket and UTC-day edges', () => {
     expect(vi.isFakeTimers()).toBe(true);


### PR DESCRIPTION
## What

Freezes the clock for `src/server/services/blocks/__tests__/app-spend-cap.service.test.ts`, and adds one guard that keeps it frozen.

## Why — the suite's outcome depends on when it runs

Both key shapes under test come from the wall clock:

- velocity key — `floor(Date.now()/1000/60)`, a **fixed** 60s window (`app-cap-limits.constants.ts` calls it "the standard fixed-window limiter")
- daily key — a UTC-day string

Most velocity cases loop to a ceiling — up to **3,000** iterations for the `platform` tier — and then assert an **exact** denial count. Those assertions are only sound while the bucket holds still for the whole loop. If a boundary lands inside the loop the counter restarts mid-run, the expected denials never happen, and the case fails for a reason unrelated to the code.

That matches the intermittent recorded against #4668 — `Unit tests (1)` red, then green on a re-run of the identical commit. ⚠️ That origin report is **repeated from the record, not measured here**: #4668's rollup now shows only its latest run, so the red is no longer readable. Everything below *is* measured.

## Evidence — measured, not argued

I made the condition deterministic instead of waiting for it: a throwaway probe advances the clock 100ms per `Date.now()` read starting 30s into a bucket, so a 600-iteration loop straddles exactly one boundary. That is the slow-CI case, compressed.

| tree | probe | result |
|---|---|---|
| `origin/main` | applied | **5 failed / 27 passed (32)** |
| this branch | applied | 0 failed / **33 passed (33)** |
| this branch | none | 0 failed / **33 passed (33)** |

Same probe, same tree, only the freeze differs. The cases that go red at base are these — count them, do not trust a total:

1. `DENIES + REFUNDS the daily reserve when the short-window gen ceiling is exceeded`
2. `enforces velocity even for 0-cost gens (a burst of cache-hits is bounded)`
3. `enforces the `trusted` tier ceilings, not a global constant`
4. `enforces the `platform` tier ceilings, not a global constant`
5. `…and would have been throttled at the 120 ceiling (still the `standard` tier)`

The set is a property of the probe as well as of the file: the probe above ticks **`Date.now()` alone**, and one that also ticks `new Date()` reddens a sixth (`standard`) — measured, 6 failed / 26 passed. Their failure signatures are exactly the flake's shape — `expected true to be false`, `expected +0 to be 5`, `expected 60 to be 180`.

## The guard, and its mutation matrix

A case cannot assert this precondition about itself, so `the harness itself > runs on a FROZEN clock, parked clear of both the bucket and UTC-day edges` pins it. It checks the two things that can independently break it: that the clock is frozen at all, and that it is frozen with margin on both sides.

Three **isolated** mutants, each killing it on its own assertion:

| mutant | failure |
|---|---|
| remove the freeze from `beforeEach` | `expected false to be true` |
| freeze at `12:00:59Z` (1s before a bucket rollover) | `expected 59 to be less than 55` |
| freeze at `23:59:30Z` (mid-bucket, 30s before UTC midnight) | `expected 86370000 to be less than 86340000` |

Mutants 2 and 3 **clear the earlier legs first**, so each leg is proven reachable rather than dying to the assertion above it. All three compiled and failed in ~5ms with the other 32 cases still passing — so none is a mount-crash or a timeout ceiling.

## One thing that does not work, recorded so nobody retries it

🔴 **This section originally claimed the busy-wait guard was *not implementable*, and that there was *no real-time source in scope*. That conclusion was FALSE and is retracted** (audit round 1). It is corrected here rather than deleted, because a reviewer may already have read the wrong version.

What is true, and measured on vitest 4.1.11 in this repo: `vi.useFakeTimers()` freezes `performance.now()`, `process.hrtime()` and `process.hrtime.bigint()` as well as `Date`, so a spin keyed on any of those never terminates — one ran 32s to its iteration cap.

What is false: concluding from that there is no real-time source at all. **`process.uptime()` is not faked** — across one busy spin it advances by tens of milliseconds while `Date.now()` and `performance.now()` both move exactly **0**. (The magnitude is a property of the spin's length; the zero is the point.) So the busy-wait test *is* writable.

The reason not to write it is narrower: it would pin a deterministic precondition on a spin whose termination time depends on the wall clock, in the one file whose purpose is removing wall-clock dependence. The guard asserts **state**, not elapsed time.

## Scope

Test-only. No production file is touched, and no assertion's *meaning* changed — the same ceilings are enforced against the same keys, just at a pinned instant. The frozen instant is deliberately mid-bucket **and** mid-day so the two cases that move time themselves (the window rollover, the midnight straddle) step off a known-quiet position rather than off an edge.

Also rewraps three pre-existing over-width statements the formatter flags now that the file is in the changed set — whitespace only. (`origin/main`'s copy of this file does not satisfy `prettier --check`; that is pre-existing, verified against the base blob.)

