### PR TITLE
fix(ping): validate the page-view beacon body with a zod schema

### DIFF
--- a/src/pages/api/internal/ping.ts
+++ b/src/pages/api/internal/ping.ts
@@ -1,5 +1,6 @@
 import { isDev } from '~/env/other';
 import { Tracker } from '~/server/clickhouse/client';
+import { pageViewBeaconSchema } from '~/server/schema/track.schema';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { getMatchingPathname } from '~/shared/constants/pathname.constants';
 
@@ -30,13 +31,23 @@ export default PublicEndpoint(
     // correct — but a malformed/empty body throws SyntaxError. Invalid input →
     // 400 (was an unguarded raw 500). NOTE: only the parse is guarded; a genuine
     // failure in the tracker.pageView path below still surfaces normally.
-    let body: { ads?: boolean; duration: number; path: string; windowWidth?: number; windowHeight?: number };
+    let parsed: unknown;
     try {
-      body = JSON.parse(req.body);
+      parsed = JSON.parse(req.body);
     } catch {
       return res.status(400).send('invalid request');
     }
-    const { ads, duration, path, windowWidth, windowHeight } = body;
+
+    // The parse above yields `any`, and this handler used to TYPE-assert its
+    // shape and pass the fields straight through — so nothing was checked at
+    // runtime and three things went wrong silently. See pageViewBeaconSchema for
+    // the full account; in short it COERCES-AND-DEFAULTS every optional field
+    // (so a body that already wrote a row still writes one) and REQUIRES only
+    // `path`, which has no meaningful default and throws downstream when absent
+    // or non-string — the same unguarded-raw-500 class as the two guards above.
+    const result = pageViewBeaconSchema.safeParse(parsed);
+    if (!result.success) return res.status(400).send('invalid request');
+    const { ads, duration, path, windowWidth, windowHeight } = result.data;
     const country = (req.headers['cf-ipcountry'] as string) ?? 'undefined';
 
     const match = getMatchingPathname(path);
@@ -48,13 +59,14 @@ export default PublicEndpoint(
       path,
       host,
       country,
-      ads: ads ?? false,
+      // The schema guarantees `ads` is a real boolean and the three numeric
+      // fields are finite numbers, so the old `?? false` / `?? 0` fallbacks are
+      // gone. The downstream per-column clamp still runs on the numeric three —
+      // it enforces the column WIDTH, which the schema deliberately does not.
+      ads,
       duration: Math.floor(duration),
-      // pageView requires number; a malformed body (the case we now tolerate) may
-      // omit these — 0 is a safe fallback (the client always sends them, so the
-      // legit path is unchanged).
-      windowWidth: windowWidth ?? 0,
-      windowHeight: windowHeight ?? 0,
+      windowWidth,
+      windowHeight,
     });
 
     return res.status(200).end();

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -36,6 +36,72 @@ export const VIEW_ENTITY_TYPES = [
   'Model3D',
 ] as const;
 
+/**
+ * Accepts a real number OR a numeric string, and falls back to 0 for everything
+ * else (a boolean, an object, `null`, a non-numeric string, or an absent key).
+ *
+ * Why a fallback rather than a rejection: these fields feed analytics columns
+ * whose row must still be written. Rejecting an unparseable dimension would turn
+ * a slightly-wrong row into NO row, which silently reduces the very volume this
+ * schema exists to protect.
+ *
+ * Why not `z.coerce.number()`: it runs `Number()` over ANY input, so `true`
+ * becomes 1 and `null`/`''` become 0 while reporting success — the same
+ * silent-wrong-value class as the banned `z.coerce.boolean()` (see
+ * src/server/services/__tests__/no-coerce-boolean-in-api.test.ts). The union
+ * below only ever coerces something that was genuinely a number or a string,
+ * and `Number.isFinite` rejects the NaN/Infinity results.
+ */
+const numberOrNumericString = z
+  .union([z.number(), z.string()])
+  .transform((value) => (typeof value === 'number' ? value : Number(value)))
+  .refine((value) => Number.isFinite(value))
+  .catch(0);
+
+/**
+ * Body schema for the POST /api/internal/ping page-view beacon (client:
+ * src/components/TrackView/TrackPageView.tsx).
+ *
+ * The handler used to TYPE-assert `JSON.parse`'s `any` and pass the fields
+ * straight through, so nothing was checked at runtime. Three consequences, all
+ * of which this schema closes:
+ *
+ *  1. `ads` reached a BOOLEAN analytics column with whatever the caller sent.
+ *     A string/number/object there is rejected by the analytics client, which
+ *     drops the row without the app ever seeing an error — the beacon response
+ *     is fire-and-forget, so an invalid `ads` destroyed the page view silently.
+ *  2. A missing or non-string `path` threw inside `getMatchingPathname` (its
+ *     first operation is `url.replace(...)`), escaping as a raw 500 on a public
+ *     endpoint. Same class as the two throws this route already hardened into
+ *     400s. `path` is the one field that is genuinely REQUIRED, so it is the one
+ *     field that rejects.
+ *  3. A numeric STRING dimension (`windowWidth: '1920'`) became 0, because the
+ *     downstream column clamp opens with `Number.isFinite(value)` and that is
+ *     `false` for a string — no coercion, no error, just a wrong value.
+ *
+ * COERCE-AND-DEFAULT, DO NOT REJECT. A body that omits `duration` or the window
+ * dimensions already wrote a row before this schema existed — an absent
+ * dimension hit a `?? 0`, and an absent `duration` reached the insert as NaN and
+ * was mapped to 0 by the column clamp — so turning either into a 400 would
+ * quietly cut page-view volume. Only `path` — which cannot be defaulted to
+ * anything meaningful, and which throws downstream when absent — is required.
+ *
+ * A non-boolean `ads` becomes `false` rather than a 400, matching the spirit of
+ * the previous `ads ?? false` and keeping the row.
+ *
+ * The object is non-strict, so unknown keys are stripped rather than forwarded
+ * into the analytics insert.
+ */
+export const pageViewBeaconSchema = z.object({
+  ads: z.boolean().catch(false),
+  duration: numberOrNumericString,
+  path: z.string(),
+  windowWidth: numberOrNumericString,
+  windowHeight: numberOrNumericString,
+});
+
+export type PageViewBeaconSchema = z.infer<typeof pageViewBeaconSchema>;
+
 export const addViewSchema = z.object({
   type: z.enum(VIEW_TYPES),
   entityType: z.enum(VIEW_ENTITY_TYPES),

--- a/src/tests/api/internal/ping.test.ts
+++ b/src/tests/api/internal/ping.test.ts
@@ -46,8 +46,17 @@ vi.mock('~/server/clickhouse/client', () => ({
 // getMatchingPathname maps the request path to a page id; a match dispatches the
 // insert, no-match short-circuits to 200. Return the path itself as the id so a
 // known path matches and an unknown one (returning undefined) does not.
+//
+// The leading `.replace` mirrors the real implementation's FIRST operation
+// (`url.replace(/^\//, '')`), which is what makes a missing or non-string `path`
+// throw a TypeError in production. Keeping it here is what lets the body-schema
+// tests below prove that case is a 400 and not an escaping raw 500 — a mock that
+// silently tolerated a non-string would have made those tests vacuous.
 vi.mock('~/shared/constants/pathname.constants', () => ({
-  getMatchingPathname: (path: string) => (path === '/models/1' ? '/models/[id]' : undefined),
+  getMatchingPathname: (path: string) => {
+    path.replace(/^\//, '');
+    return path === '/models/1' ? '/models/[id]' : undefined;
+  },
 }));
 
 function makeRes() {
@@ -93,14 +102,24 @@ describe('POST /api/internal/ping', () => {
 
   it('dispatches Tracker.pageView on a well-formed same-origin request (200)', async () => {
     const handler = (await import('~/pages/api/internal/ping')).default;
-    const req = makeReq({ host: 'civitai.com', referer: 'https://civitai.com/models/1', body: validBody });
+    const req = makeReq({
+      host: 'civitai.com',
+      referer: 'https://civitai.com/models/1',
+      body: validBody,
+    });
     const res = makeRes();
 
     await handler(req as any, res);
 
     expect(mockPageView).toHaveBeenCalledTimes(1);
     expect(mockPageView).toHaveBeenCalledWith(
-      expect.objectContaining({ pageId: '/models/[id]', path: '/models/1', host: 'civitai.com', ads: true, duration: 5000 })
+      expect.objectContaining({
+        pageId: '/models/[id]',
+        path: '/models/1',
+        host: 'civitai.com',
+        ads: true,
+        duration: 5000,
+      })
     );
     expect(res.status).toHaveBeenCalledWith(200);
   });
@@ -122,7 +141,11 @@ describe('POST /api/internal/ping', () => {
   it('returns 400 (not 500) on a malformed body, no insert', async () => {
     const handler = (await import('~/pages/api/internal/ping')).default;
     // Passes the referer/host guard, then JSON.parse('{not json') throws.
-    const req = makeReq({ host: 'civitai.com', referer: 'https://civitai.com/models/1', body: '{not json' });
+    const req = makeReq({
+      host: 'civitai.com',
+      referer: 'https://civitai.com/models/1',
+      body: '{not json',
+    });
     const res = makeRes();
 
     await handler(req as any, res);
@@ -146,7 +169,11 @@ describe('POST /api/internal/ping', () => {
 
   it('rejects a cross-origin request (host mismatch) with 400 and no insert', async () => {
     const handler = (await import('~/pages/api/internal/ping')).default;
-    const req = makeReq({ host: 'civitai.com', referer: 'https://evil.example/models/1', body: validBody });
+    const req = makeReq({
+      host: 'civitai.com',
+      referer: 'https://evil.example/models/1',
+      body: validBody,
+    });
     const res = makeRes();
 
     await handler(req as any, res);
@@ -172,7 +199,11 @@ describe('POST /api/internal/ping', () => {
     // in the insert path must still surface (reject), not become a 400.
     mockPageView.mockRejectedValueOnce(new Error('clickhouse down'));
     const handler = (await import('~/pages/api/internal/ping')).default;
-    const req = makeReq({ host: 'civitai.com', referer: 'https://civitai.com/models/1', body: validBody });
+    const req = makeReq({
+      host: 'civitai.com',
+      referer: 'https://civitai.com/models/1',
+      body: validBody,
+    });
     const res = makeRes();
 
     await expect(handler(req as any, res)).rejects.toThrow('clickhouse down');
@@ -182,12 +213,264 @@ describe('POST /api/internal/ping', () => {
   it('short-circuits to 200 in dev without inserting', async () => {
     devStore.isDev = true;
     const handler = (await import('~/pages/api/internal/ping')).default;
-    const req = makeReq({ host: 'civitai.com', referer: 'https://civitai.com/models/1', body: validBody });
+    const req = makeReq({
+      host: 'civitai.com',
+      referer: 'https://civitai.com/models/1',
+      body: validBody,
+    });
     const res = makeRes();
 
     await handler(req as any, res);
 
     expect(mockPageView).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+
+/**
+ * Body-shape validation (pageViewBeaconSchema).
+ *
+ * Before the schema the handler TYPE-asserted `JSON.parse`'s `any` and forwarded
+ * the fields verbatim, which produced three silent defects:
+ *
+ *  1. `ads` reached a BOOLEAN analytics column carrying whatever the caller sent.
+ *     The analytics client rejects a non-boolean there and drops the row without
+ *     the app seeing an error (the beacon is fire-and-forget), so a bad `ads`
+ *     destroyed the page view invisibly.
+ *  2. A missing or non-string `path` threw inside `getMatchingPathname` and
+ *     escaped as a raw 500 on a public endpoint.
+ *  3. A numeric STRING dimension became 0, because the downstream column clamp
+ *     opens with `Number.isFinite(value)` and that is `false` for a string.
+ *
+ * The schema COERCES-AND-DEFAULTS rather than rejecting, because a body omitting
+ * `duration`/the window dimensions already wrote a row and 400ing it would cut
+ * page-view volume. `path` is the sole required field.
+ */
+describe('POST /api/internal/ping — body shape', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    devStore.isDev = false;
+  });
+
+  async function post(body: unknown) {
+    const handler = (await import('~/pages/api/internal/ping')).default;
+    const req = makeReq({
+      host: 'civitai.com',
+      referer: 'https://civitai.com/models/1',
+      body: JSON.stringify(body),
+    });
+    const res = makeRes();
+    await handler(req as any, res);
+    return res;
+  }
+
+  /** The single payload the tracker was handed, or undefined if it was never called. */
+  function payload() {
+    return mockPageView.mock.calls[0]?.[0];
+  }
+
+  describe('ads must reach the boolean column as a real boolean', () => {
+    // Defect 1. The tell is the TYPE, not just the value — asserting `false`
+    // alone would pass for the string 'false', which is exactly what kills the row.
+    // `null` is an INVARIANT guard, not a regression test — the previous
+    // `ads ?? false` already handled it. The other four were the live defect.
+    it.each([
+      ['a string', 'true'],
+      ['a number', 1],
+      ['an object', {}],
+      ['an array', []],
+      ['null (invariant guard — already handled by the previous `?? false`)', null],
+    ])('coerces %s to boolean false and still writes the row', async (_label, ads) => {
+      const res = await post({
+        ads,
+        duration: 5000,
+        path: '/models/1',
+        windowWidth: 1920,
+        windowHeight: 1080,
+      });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockPageView).toHaveBeenCalledTimes(1);
+      expect(typeof payload().ads).toBe('boolean');
+      expect(payload().ads).toBe(false);
+    });
+
+    it('defaults an absent ads to boolean false', async () => {
+      // The real client sends `ads: undefined` and removeEmpty strips it, so
+      // this is the COMMON production shape, not an edge case. INVARIANT guard:
+      // the previous `ads ?? false` already produced `false` here.
+      const res = await post({
+        duration: 5000,
+        path: '/models/1',
+        windowWidth: 1920,
+        windowHeight: 1080,
+      });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(typeof payload().ads).toBe('boolean');
+      expect(payload().ads).toBe(false);
+    });
+
+    it('passes a genuine ads:true through unchanged', async () => {
+      // Invariant guard, not a regression test: this passed before the schema too.
+      const res = await post({
+        ads: true,
+        duration: 5000,
+        path: '/models/1',
+        windowWidth: 1920,
+        windowHeight: 1080,
+      });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(payload().ads).toBe(true);
+    });
+  });
+
+  describe('path is required and must be a string', () => {
+    // Defect 2. Each of these previously reached `getMatchingPathname`, whose
+    // first operation is `url.replace(...)` — a TypeError escaping as a raw 500.
+    it.each([
+      ['a number', 123],
+      ['null', null],
+      ['an object', {}],
+      ['an array', []],
+      ['a boolean', true],
+    ])('rejects %s path with 400 and no insert', async (_label, path) => {
+      const res = await post({
+        ads: true,
+        duration: 5000,
+        path,
+        windowWidth: 1920,
+        windowHeight: 1080,
+      });
+
+      expect(mockPageView).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.send).toHaveBeenCalledWith('invalid request');
+    });
+
+    it('rejects an absent path with 400 and no insert', async () => {
+      const res = await post({ ads: true, duration: 5000, windowWidth: 1920, windowHeight: 1080 });
+
+      expect(mockPageView).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.send).toHaveBeenCalledWith('invalid request');
+    });
+
+    it.each([
+      ['a JSON null body', null],
+      ['a JSON string body', 'hello'],
+      ['a JSON number body', 7],
+    ])('rejects %s with 400 and no insert', async (_label, body) => {
+      // These parse fine as JSON but are not objects. `null` in particular threw
+      // on destructuring — another raw 500 on the same path.
+      const res = await post(body);
+
+      expect(mockPageView).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('numeric fields accept a numeric string without losing the value', () => {
+    // Defect 3. `Number.isFinite('1920')` is false — no coercion — so the
+    // downstream clamp wrote 0 for a dimension the client did send.
+    it('preserves numeric-string window dimensions', async () => {
+      const res = await post({
+        ads: true,
+        duration: 5000,
+        path: '/models/1',
+        windowWidth: '1920',
+        windowHeight: '1080',
+      });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(payload().windowWidth).toBe(1920);
+      expect(payload().windowHeight).toBe(1080);
+      expect(typeof payload().windowWidth).toBe('number');
+      expect(typeof payload().windowHeight).toBe('number');
+    });
+
+    it('preserves a numeric-string duration', async () => {
+      // INVARIANT guard, and the asymmetry is the point: `duration` went through
+      // `Math.floor`, which DOES coerce a numeric string, so this one field was
+      // already correct. The window dimensions went through `?? 0` and then a
+      // `Number.isFinite` clamp, which does NOT coerce — hence defect 3 hitting
+      // only them. The schema now makes all three behave the same way.
+      const res = await post({ ads: true, duration: '5000', path: '/models/1' });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(payload().duration).toBe(5000);
+    });
+
+    // `null` is an INVARIANT guard (`null ?? 0` and `Math.floor(null)` were both
+    // already 0); the other four were previously forwarded verbatim or as NaN.
+    it.each([
+      ['a non-numeric string', 'abc'],
+      ['a boolean', true],
+      ['an object', {}],
+      ['null (invariant guard — already 0)', null],
+      ['an empty string', ''],
+    ])('falls back to 0 for %s rather than rejecting the row', async (_label, value) => {
+      const res = await post({
+        ads: true,
+        duration: value,
+        path: '/models/1',
+        windowWidth: value,
+        windowHeight: value,
+      });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockPageView).toHaveBeenCalledTimes(1);
+      expect(payload().duration).toBe(0);
+      expect(payload().windowWidth).toBe(0);
+      expect(payload().windowHeight).toBe(0);
+    });
+  });
+
+  describe('coerce-and-default preserves the rows that already wrote', () => {
+    // No-regression guard for the design decision. A `.strict()` schema that
+    // 400d on a missing field would silently reduce page-view volume, which is
+    // the opposite of the point.
+    it('still writes a row for a body carrying only path', async () => {
+      // INVARIANT guard for the design decision — a body this sparse DID write a
+      // row before the schema, and this test pins that it still does. It is the
+      // guard that would go red if anyone later tightened the schema into a
+      // `.strict()` reject-everything parse, which would silently cut volume.
+      const res = await post({ path: '/models/1' });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockPageView).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalledWith(400);
+    });
+
+    it('sends finite numbers, not NaN, for a body carrying only path', async () => {
+      // Regression half of the test above: previously `Math.floor(undefined)`
+      // handed the insert a NaN duration. The row survived only because the
+      // downstream clamp mapped NaN to 0 — this pins the value at the boundary
+      // the handler owns, so the fix does not depend on that clamp.
+      await post({ path: '/models/1' });
+
+      expect(payload()).toEqual(
+        expect.objectContaining({
+          pageId: '/models/[id]',
+          path: '/models/1',
+          ads: false,
+          duration: 0,
+          windowWidth: 0,
+          windowHeight: 0,
+        })
+      );
+      expect(Number.isNaN(payload().duration)).toBe(false);
+    });
+
+    it('strips an unknown key rather than forwarding it into the insert', async () => {
+      // INVARIANT guard: the previous code destructured named fields explicitly,
+      // so an unknown key never reached the insert either. Pinned because the
+      // schema is now the thing responsible for it.
+      const res = await post({ path: '/models/1', duration: 5000, injected: 'nope' });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(payload()).not.toHaveProperty('injected');
+    });
   });
 });


### PR DESCRIPTION
## What

`POST /api/internal/ping` — the page-view beacon — type-asserted `JSON.parse`'s `any` and forwarded the fields straight to the analytics insert:

```ts
let body: { ads?: boolean; duration: number; path: string; windowWidth?: number; windowHeight?: number };
try { body = JSON.parse(req.body); } catch { return res.status(400).send('invalid request'); }
const { ads, duration, path, windowWidth, windowHeight } = body;
```

That annotation is a compile-time assertion. Nothing was checked at runtime. This PR replaces it with a `zod` schema (`pageViewBeaconSchema`, added next to the sibling beacon's `addViewSchema` in `src/server/schema/track.schema.ts`) parsed via `safeParse`, matching how `/api/internal/pulse` already validates its body.

## The three defects

**1. `ads` could destroy the row, silently.** `ads ?? false` guards only `null`/`undefined`, so `ads: "true"`, `ads: 1` or `ads: {}` passed through to a **boolean** analytics column. The analytics client rejects a non-boolean there and drops the row client-side — and because the beacon is fire-and-forget, the app logs nothing and returns success. The page view was destroyed invisibly. This was the last unguarded typed field on this path; `duration` / `windowWidth` / `windowHeight` were already width-clamped downstream.

**2. A non-string `path` was an unguarded 500.** `getMatchingPathname(path)` opens with `url.replace(/^\//, '')`, which throws a `TypeError` when `path` is absent or not a string — escaping as a raw 500 on a **public** endpoint. This is the same class as the two throws this route had already hardened into 400s (the file's own comments say "was an unguarded raw 500" twice); this one was missed. A JSON body of `null` reached the same outcome one line earlier, via destructuring.

**3. A numeric-string dimension silently became 0.** The per-column clamp opens with `if (!Number.isFinite(value)) return 0;`, and `Number.isFinite("1920")` is `false` — no coercion. So `windowWidth: "1920"` wrote **0**, not 1920. Not a rejection; a silent fidelity loss.

## The design decision: coerce and default, do not reject

A naive `.strict()` schema that 400s on anything unexpected would be a **regression**. Today a body missing `duration` still writes a row (it reaches the insert as `NaN` and the clamp maps it to 0), and a body missing the window dimensions still writes a row (`?? 0`). Turning those into 400s would quietly reduce page-view volume — the exact failure this arc exists to stop.

So:

| field | behaviour | rationale |
|---|---|---|
| `ads` | `z.boolean().catch(false)` | anything non-boolean becomes `false` and **keeps the row**, matching the spirit of the previous `ads ?? false`. Documented in the schema. |
| `duration` | number or numeric string, else `0` | preserves today's row-writing behaviour while guaranteeing the type |
| `windowWidth` / `windowHeight` | number or numeric string, else `0` | same — and this is what fixes defect 3 |
| `path` | **required `z.string()`** → `400 'invalid request'` | the sole field with no meaningful default, and the one that throws downstream. The 400 matches the two existing guards in this file verbatim. |

`z.coerce.number()` is deliberately **not** used: it runs `Number()` over any input, so `true` becomes `1` and `null` / `''` become `0` while reporting success — the same silent-wrong-value class as the repo's already-banned `z.coerce.boolean()` (`src/server/services/__tests__/no-coerce-boolean-in-api.test.ts`). The union only ever coerces a value that was genuinely a number or a string, and `Number.isFinite` rejects the `NaN`/`Infinity` results.

The object is non-strict, so unknown keys are stripped rather than forwarded into the insert. The downstream per-column clamp is untouched and not duplicated — it enforces column **width**, which the schema deliberately does not.

### Client compatibility

`TrackPageView.tsx` sends `removeEmpty({ duration, ads: ads ? true : undefined, path, windowWidth, windowHeight })`. `removeEmpty` uses lodash `isNil`, so it strips **only `null`/`undefined` — not `0`**. That means:

- `ads` is legitimately **absent** on most requests (the common production shape) → schema defaults it to `false`, unchanged behaviour.
- A `0` window dimension is **not** stripped, so the dimensions are always present from the real client; the schema tolerates their absence anyway.
- `duration` is always a number ≥ 1000 from the real client.

The legitimate client path is unchanged in every case.

## Test matrix — red at `origin/main`, green at `HEAD`

26 tests added to the existing route suite (`src/tests/api/internal/ping.test.ts`), run with the **same test file** against the base handler and the new one.

**19 red at `origin/main` → green at `HEAD`:**

| test | red at base because |
|---|---|
| `ads: 'true'` → boolean `false` | forwarded the string `'true'` |
| `ads: 1` → boolean `false` | forwarded `1` |
| `ads: {}` → boolean `false` | forwarded `{}` |
| `ads: []` → boolean `false` | forwarded `[]` |
| `path: 123` → 400, no insert | `TypeError` escaped as a 500 |
| `path: null` → 400, no insert | `TypeError` escaped as a 500 |
| `path: {}` → 400, no insert | `TypeError` escaped as a 500 |
| `path: []` → 400, no insert | `TypeError` escaped as a 500 |
| `path: true` → 400, no insert | `TypeError` escaped as a 500 |
| absent `path` → 400, no insert | `TypeError` escaped as a 500 |
| JSON body `null` → 400 | threw on destructuring |
| JSON body `"hello"` → 400 | `TypeError` escaped as a 500 |
| JSON body `7` → 400 | `TypeError` escaped as a 500 |
| `windowWidth: '1920'` → `1920` | **defect 3** — became 0 |
| `duration`/dims `'abc'` → 0 | forwarded the string verbatim |
| `duration`/dims `true` → 0 | forwarded `true` verbatim |
| `duration`/dims `{}` → 0 | forwarded `{}` verbatim |
| `duration`/dims `''` → 0 | forwarded `''` verbatim |
| body with only `path` sends finite numbers, not `NaN` | `Math.floor(undefined)` → `NaN` |

**7 green on both — labelled in-file as invariant guards, not regression coverage:**

`ads: null` → `false` and absent `ads` → `false` (the previous `?? false` already handled both) · `ads: true` unchanged · numeric-string `duration` (`Math.floor` *does* coerce a string — the asymmetry with the window dimensions is exactly why defect 3 hit only them) · `null` dimensions → 0 · a body with only `path` still **writes a row** (the no-regression pin for the coerce-don't-reject decision — this is the guard that goes red if anyone later tightens the schema into a reject-everything parse) · unknown keys stripped.

The `getMatchingPathname` mock was updated to mirror the real function's leading `url.replace(...)`. Without that, a mocked function tolerating a non-string would have made all six `path` tests pass vacuously at base.

## Verification

| check | result |
|---|---|
| new/updated route suite at `HEAD` | **34 passed / 34** (8 pre-existing + 26 new) |
| same file against base handler | **19 failed / 15 passed / 34** |
| touched-surface sweep (16 files: track schema, tracker `pageView` + clamp, both beacons, `TrackView` buffers, track router/services, the `no-coerce-boolean` convention guard) | **244 passed / 244** |
| `pnpm typecheck` | **0 type errors** (72s, heap cap 8192 MB) |
| `eslint` on the three changed files | **0 errors** (13 pre-existing `any` warnings, matching the file's existing style) |
| `prettier --check` on the three changed files | clean (the test file already failed at base; reformatted) |

Counts are reported rather than pass/fail because a suite that fails to import reports "no tests" and reads as green.

## Not done

`Math.floor(duration)` in the handler is left as-is. It is now redundant with the clamp's `Math.trunc`, but removing it is a separate change.
