### PR TITLE
fix(metabase-skill): repair variable + dashcard writes against current API

### DIFF
--- a/.claude/skills/metabase/SKILL.md
+++ b/.claude/skills/metabase/SKILL.md
@@ -55,9 +55,30 @@ node .claude/skills/metabase/metabase.mjs create-question \
 
 **Variable types:** `text`, `number`, `date`, `date/single`, `date/range`, `date/month-year`, `date/quarter-year`, `date/relative`, `date/all-options`
 
-### update-question — Change display type or visualization
+### run-card — Run a SAVED question, with its parameters
+
+`run-query` runs ad-hoc SQL, which does **not** tell you whether a saved card works: a card
+whose parameters are mis-wired stores the right SQL and still returns nothing. Run the card
+itself to check.
 
 ```bash
+node .claude/skills/metabase/metabase.mjs run-card --id 3301 --params '{"from":"2026-09-09","to":"2026-10-01"}'
+node .claude/skills/metabase/metabase.mjs run-card --id 3303          # no parameters
+```
+
+Names in `--params` are `{{variable}}` names; an unknown one is an error rather than a
+silently ignored filter.
+
+### update-question — Change SQL, display, description, or archive it
+
+```bash
+# Replace the SQL (reads the card back and fails if the stored query differs)
+node .claude/skills/metabase/metabase.mjs update-question --id 123 --query "SELECT 1"   --variables '{"from":{"id":"f","name":"from","display-name":"From","type":"date"}}'
+
+# Description, or retire a superseded card
+node .claude/skills/metabase/metabase.mjs update-question --id 123 --description "..."
+node .claude/skills/metabase/metabase.mjs update-question --id 123 --archived true
+
 # Change to bar chart
 node .claude/skills/metabase/metabase.mjs update-question --id 123 --display bar
 
@@ -267,6 +288,24 @@ By default, `{{variable}}` template tags render as plain text inputs. To make th
 - Each command reads the existing template tag ID and wires it up correctly
 
 **Important:** Each call to `set-dropdown` or `set-date-picker` preserves other existing parameters. You can call them one at a time.
+
+## MBQL 4 vs MBQL 5 — the shape a GET returns is not the shape a PUT accepts
+
+A `GET /card/:id` returns MBQL 5: `dataset_query` has `stages` and `lib/type`, the SQL lives
+at `stages[0].native` as a string, and `template-tags` is an **array** of records. A write
+must send the MBQL 4 shape — `{database, type: 'native', native: {query, 'template-tags'}}`
+with tags as an **object keyed by name**. Spreading what a GET returned into a PUT is
+rejected with `MBQL 4 keys like :type, :query, or :native are not allowed in MBQL 5 queries
+with :lib/type`.
+
+The array-vs-object half is the one that bites quietly: looking a tag up by name on the
+array finds nothing, and `set-dropdown` / `set-date-picker` then report
+`Template tag "from" not found ... Available tags: 0, 1` — which reads as a missing variable
+rather than a wrong shape. Every command here normalises both shapes; new ones must too.
+
+Related: `POST /dashboard/:id/cards` no longer exists. Dashcards are written by PUTting the
+whole `dashcards` array back to `/dashboard/:id`, with a negative placeholder `id` on each
+new entry.
 
 ## Tips
 

--- a/.claude/skills/metabase/metabase.mjs
+++ b/.claude/skills/metabase/metabase.mjs
@@ -273,38 +273,32 @@ async function addToDashboard(opts) {
     if (bottom > maxY) maxY = bottom;
   }
 
-  const added = [];
-  for (let i = 0; i < cardIds.length; i++) {
-    const col = i % perRow;
-    const row = Math.floor(i / perRow);
-    const result = await api('POST', `/dashboard/${dashId}/cards`, {
-      cardId: cardIds[i],
-    });
+  // Dashcards are created by PUTting the whole `dashcards` array, not by POSTing to
+  // /dashboard/:id/cards -- that endpoint is gone and 404s. A new card is an entry with a
+  // negative placeholder id; the server assigns the real one.
+  const added = cardIds.map((cardId, i) => ({
+    id: -1 - i,
+    card_id: cardId,
+    row: maxY + Math.floor(i / perRow) * cardHeight,
+    col: (i % perRow) * cardWidth,
+    size_x: cardWidth,
+    size_y: cardHeight,
+    parameter_mappings: [],
+    visualization_settings: {},
+  }));
 
-    // Position the card via PUT
-    const dashcardId = result.id;
-    added.push({
-      id: dashcardId,
-      card_id: cardIds[i],
-      row: maxY + row * cardHeight,
-      col: col * cardWidth,
-      size_x: cardWidth,
-      size_y: cardHeight,
-    });
-  }
+  const saved = await api('PUT', `/dashboard/${dashId}`, {
+    dashcards: [...existingCards, ...added],
+  });
 
-  // Update layout positions in bulk
-  if (added.length > 0) {
-    // Re-fetch the full dashboard to get all dashcard data
-    const fullDash = await api('GET', `/dashboard/${dashId}`);
-    const allCards = fullDash.dashcards.map(dc => {
-      const override = added.find(a => a.id === dc.id);
-      if (override) {
-        return { ...dc, row: override.row, col: override.col, size_x: override.size_x, size_y: override.size_y };
-      }
-      return dc;
-    });
-    await api('PUT', `/dashboard/${dashId}`, { dashcards: allCards });
+  // Read back rather than trust the write: a dashboard that saved no cards renders empty,
+  // which looks the same as a permissions problem.
+  const present = new Set((saved.dashcards || []).map((dc) => dc.card_id));
+  const missing = cardIds.filter((id) => !present.has(id));
+  if (missing.length > 0) {
+    console.error(`Dashboard ${dashId} did not take card(s): ${missing.join(', ')}`);
+    console.error(`  URL: ${METABASE_URL}/dashboard/${dashId}`);
+    process.exit(1);
   }
 
   console.log(`Added ${cardIds.length} card(s) to dashboard ${dashId}`);
@@ -410,16 +404,100 @@ async function listDatabases() {
   }
 }
 
-async function updateQuestion(opts) {
-  const { id, display, visualization } = opts;
+async function runCard(opts) {
+  const { id, params } = opts;
   const cardId = parseInt(id, 10);
   if (!cardId) {
-    console.error('Usage: update-question --id <id> [--display <type>] [--visualization \'{"key":"value"}\']');
+    console.error('Usage: run-card --id <id> [--params \'{"from":"2026-09-09","to":"2026-09-10"}\']');
+    process.exit(1);
+  }
+
+  const card = await api('GET', `/card/${cardId}`);
+  // MBQL 4 stores template-tags as an object keyed by name; MBQL 5 (what a GET returns
+  // today) stores the same records as an array. Normalise to the keyed form.
+  const rawTags =
+    card.dataset_query?.native?.['template-tags'] ??
+    card.dataset_query?.stages?.[0]?.['template-tags'] ??
+    {};
+  const tags = Array.isArray(rawTags)
+    ? Object.fromEntries(rawTags.map((t) => [t.name, t]))
+    : rawTags;
+
+  let values = {};
+  if (params) {
+    try {
+      values = JSON.parse(params);
+    } catch (e) {
+      console.error('Error: --params must be valid JSON');
+      process.exit(1);
+    }
+  }
+
+  const parameters = Object.entries(values).map(([name, value]) => {
+    const tag = tags[name];
+    if (!tag) {
+      console.error(`Error: question ${cardId} has no {{${name}}} variable`);
+      process.exit(1);
+    }
+    return {
+      id: tag.id,
+      type: tag.type === 'date' ? 'date/single' : `category`,
+      value,
+      target: ['variable', ['template-tag', name]],
+    };
+  });
+
+  const result = await api('POST', `/card/${cardId}/query`, { parameters });
+  if (result.status && result.status !== 'completed') {
+    console.error(`Query ${result.status}: ${result.error || 'unknown error'}`);
+    process.exit(1);
+  }
+  const cols = result.data.cols.map((c) => c.display_name || c.name);
+  console.log(`Columns: ${cols.join(', ')}`);
+  console.log('─'.repeat(60));
+  for (const row of result.data.rows) {
+    console.log(JSON.stringify(Object.fromEntries(cols.map((c, i) => [c, row[i]])), null, 2));
+  }
+  console.log(`\n${result.data.rows.length} row(s)`);
+}
+
+async function updateQuestion(opts) {
+  const { id, display, visualization, query, description, archived, variables } = opts;
+  const cardId = parseInt(id, 10);
+  if (!cardId) {
+    console.error('Usage: update-question --id <id> [--display <type>] [--visualization \'{"key":"value"}\'] [--query "SQL"] [--variables \'{...}\'] [--description "..."] [--archived true|false]');
     process.exit(1);
   }
 
   const body = {};
   if (display) body.display = display;
+  if (description !== undefined) body.description = description;
+  if (archived !== undefined) body.archived = archived === 'true' || archived === true;
+  if (query) {
+    // A card's dataset_query must be sent whole, so start from the stored one and
+    // swap the SQL. Template tags are rebuilt because a changed query may add or
+    // drop {{variables}}, and Metabase drops a parameter whose tag disappears.
+    const existing = await api('GET', `/card/${cardId}`);
+    // A GET returns MBQL 5 (`lib/type` + `stages`), but PUT rejects a body that mixes
+    // that with `type`/`native` — so rebuild the MBQL 4 shape create-question sends
+    // rather than spreading what came back. Read the old tags from either shape.
+    const oldNative =
+      existing.dataset_query?.native ?? existing.dataset_query?.stages?.[0] ?? {};
+    let templateTags = oldNative['template-tags'] || oldNative.template_tags || {};
+    if (variables) {
+      try {
+        templateTags = JSON.parse(variables);
+      } catch (e) {
+        console.error('Error: --variables must be valid JSON');
+        process.exit(1);
+      }
+    }
+    body.dataset_query = {
+      database: existing.database_id ?? existing.dataset_query?.database,
+      type: 'native',
+      native: { query, 'template-tags': templateTags },
+    };
+  }
   if (visualization) {
     try {
       body.visualization_settings = JSON.parse(visualization);
@@ -432,6 +510,16 @@ async function updateQuestion(opts) {
   const card = await api('PUT', `/card/${cardId}`, body);
   console.log(`Question ${cardId} updated`);
   console.log(`  Display: ${card.display}`);
+  if (query) {
+    const stored =
+      card.dataset_query?.native?.query ?? card.dataset_query?.stages?.[0]?.native;
+    if (stored !== query) {
+      console.error('Error: the stored query does not match what was sent');
+      process.exit(1);
+    }
+    console.log('  Verified: the stored query matches what was sent');
+  }
+  if (body.archived !== undefined) console.log(`  Archived: ${card.archived}`);
   console.log(`  URL: ${METABASE_URL}/question/${cardId}`);
 }
 
@@ -500,7 +588,13 @@ async function setDropdown(opts) {
 
   // Find the template tag to get its ID
   const nativeQuery = card.dataset_query?.native || card.dataset_query?.stages?.[0];
-  const tags = nativeQuery?.['template-tags'] || {};
+  const rawTags = nativeQuery?.['template-tags'] || {};
+  // MBQL 5 returns template-tags as an array of records, MBQL 4 as an object keyed by
+  // name. Looking up by name on the array finds nothing and lists the indices as the
+  // available tags, which reads as "that variable is missing" rather than "wrong shape".
+  const tags = Array.isArray(rawTags)
+    ? Object.fromEntries(rawTags.map((t) => [t.name, t]))
+    : rawTags;
   const tag = tags[variable];
   if (!tag) {
     console.error(`Error: Template tag "${variable}" not found in question ${cardId}`);
@@ -548,7 +642,13 @@ async function setDatePicker(opts) {
   const existingParams = card.parameters || [];
 
   const nativeQuery = card.dataset_query?.native || card.dataset_query?.stages?.[0];
-  const tags = nativeQuery?.['template-tags'] || {};
+  const rawTags = nativeQuery?.['template-tags'] || {};
+  // MBQL 5 returns template-tags as an array of records, MBQL 4 as an object keyed by
+  // name. Looking up by name on the array finds nothing and lists the indices as the
+  // available tags, which reads as "that variable is missing" rather than "wrong shape".
+  const tags = Array.isArray(rawTags)
+    ? Object.fromEntries(rawTags.map((t) => [t.name, t]))
+    : rawTags;
   const tag = tags[variable];
   if (!tag) {
     console.error(`Error: Template tag "${variable}" not found in question ${cardId}`);
@@ -646,6 +746,7 @@ const commands = {
   'run-query': runQuery,
   'create-question': createQuestion,
   'update-question': updateQuestion,
+  'run-card': runCard,
   'create-dashboard': createDashboard,
   'add-to-dashboard': addToDashboard,
   'add-dashboard-filter': addDashboardFilter,


### PR DESCRIPTION
Justin's commit `fd66bb11f1`, written 2026-09-09, was sitting unpushed on the shared primary checkout's local `main`. It was parked on a safety branch while cutting `moderator-v0.0.57` and is landed here as a PR rather than pushed directly. Cherry-picked onto fresh `origin/main`, authorship preserved.

Two files, both under `.claude/skills/metabase/`. No app code.

## What it repairs

- **`set-dropdown` / `set-date-picker` could not find any variable.** A GET now returns MBQL 5, where `template-tags` is an array rather than an object keyed by name, so the lookup missed. Both call sites normalise either shape.
- **`add-to-dashboard` 404d.** `POST /dashboard/:id/cards` is gone; it now PUTs the whole `dashcards` array and reads the dashboard back, so a dashboard that saved no cards fails loudly instead of rendering empty.
- Adds `update-question --query/--variables/--description/--archived` (previously no way to change a saved card's SQL at all) and `run-card`, which runs a saved card with its parameters. `run-query` only runs ad-hoc SQL, so it cannot show whether a card's parameter wiring works.

## Verification

Exercised against a throwaway card (3334) and throwaway dashboard (793) on the **Sample Database**, both since archived and confirmed archived by reading them back. Each repaired path was run on the pre-fix script first, so the fix is measured against a reproduced failure rather than only a passing new path.

| Path | Pre-fix script | This branch |
|---|---|---|
| `set-dropdown` | exit 1, `Available tags: 0` | exit 0, dropdown set |
| `set-date-picker` | exit 1, `Available tags: 0, 1` | exit 0, picker set |
| `add-to-dashboard` | exit 1, `API Error 404 POST /dashboard/793/cards: API endpoint does not exist.` | exit 0, card added; dashboard read back shows the dashcard persisted |
| `update-question` | command absent | exit 0, SQL + variables replaced, card read back matches |
| `run-card` | command absent | exit 0, returned `{"n": 7, "d": "2026-09-10"}` |

`Available tags: 0` and `Available tags: 0, 1` are array indices being printed where names belong — the exact symptom the commit describes, and the reason it reads as a missing variable rather than a wrong shape. The fixed script prints `Available tags: n` for a genuinely absent tag, which is how a real absence should look.

Footgun noticed while exercising this, NOT fixed here and worth one line so the next person does not lose the same round: `run-card` takes `--params`, and calling it `--parameters` was **accepted silently** rather than rejected. The run then failed with a server-side 400 `missing required parameters` and `parameterized: false`, which reads as a broken card rather than a mistyped flag.

No test suite covers this skill; nothing under `src/` changed, so no typecheck/lint/unit run is implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ksjgy6AdwyKLtbZnemZ3kv
