### PR TITLE
feat(app-blocks): enforce scope grants + a per-app consent budget on the runtime

### DIFF
--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -58,7 +58,7 @@ check at request time (`enforceContextBinding`).
 | -------------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `models:read:self`               | `query.id == ctx.modelId`                         |                                                                                                                                                                         |
 | `media:read:owned`               | non-anon `sub`                                    |                                                                                                                                                                         |
-| `buzz:read:self`                 | non-anon `sub`                                    |                                                                                                                                                                         |
+| `buzz:read:self`                 | non-anon `sub`                                    | **required for EVERY host-mediated buzz read**, `blocks.getMyBuzzBalance` included — it is no longer scope-free. A token without it gets `block lacks buzz:read:self scope` (FORBIDDEN) |
 | `social:tip:self`                | non-anon `sub`                                    |                                                                                                                                                                         |
 | `user:read:self`                 | non-anon `sub`                                    | viewer identity — read via the `useViewer()` hook (`GET_VIEWER` bridge → `blocks.getMyViewer`). Also gates the **deprecated** `/api/v1/blocks/me` REST route (retiring) |
 | `ai:write:budgeted`              | positive `buzzBudget`                             |                                                                                                                                                                         |
@@ -310,6 +310,11 @@ Civitai Buzz is split into spendable pools — **blue** (purchased), **green**
   `blocks.getMyBuzzBalance` mutation, which returns `{ blue, green, yellow }` for
   the token's subject (other account types — red / cash / creator-program — are
   omitted). This backs the SDK `useBuzzBalance()` hook + the account picker.
+  **Declare `buzz:read:self`** — this read requires it, like every other
+  host-mediated buzz read. It used to be scope-free (gated on an authoring
+  capability instead); that capability gate was removed from the runtime, and the
+  user's own scope grant is the authority now. A token without the scope gets
+  `block lacks buzz:read:self scope`.
 - **Choose the funding pool**: a workflow submit body may carry `accountType`
   (`blue | green | yellow`). It is honored **preferred-first** while the maturity
   policy clamp still applies (a SFW-domain block can't widen to a mature currency);
@@ -318,6 +323,39 @@ Civitai Buzz is split into spendable pools — **blue** (purchased), **green**
 - **Which pool actually paid**: the workflow status snapshot carries
   `spentAccountType` — the `accountType` of the largest _realized_ debit — so a
   block can attribute spend after the fact (internal-only accounts are omitted).
+
+### The user's per-app spend limit (consent budget)
+
+A viewer who grants `ai:write:budgeted` may also set a **daily Buzz limit for that
+one app**, stored on their grant row (`app_user_scope_grants.buzz_budget_per_day`).
+It is the only one of the three spend ceilings the user chooses:
+
+| Ceiling | Scope of the key | Who set it |
+| --- | --- | --- |
+| Platform per-user daily cap | one user, ALL their apps | the platform |
+| Per-app aggregate cap | one app, ALL its users | the platform |
+| **Consent budget** | one (user, app) pair, per UTC day | **the user** |
+
+- **Both apply; the tighter one binds.** The consent budget is bounded above by the
+  platform per-user daily cap, so it can only ever narrow. `null` (the default, and
+  the state of every grant made before the field existed) means "no limit of my own"
+  and behaves exactly as it did before.
+- **Set at consent time** in the permission modal (shown only when the scope being
+  granted is `ai:write:budgeted` — a limit next to "read your username" bounds
+  nothing), and **changed, cleared or simply read afterwards** on
+  **Apps → Permissions** (`/apps/activity`). Both write through
+  `blocks.grantScopes`, whose `buzzBudgetPerDay` input has three distinct states: a
+  number sets/replaces, `null` clears, and an **omitted** key leaves the stored value
+  alone (so re-consenting to an unrelated scope can never wipe a limit).
+- **What an app sees when it binds.** The submit is refused before any spend with a
+  `failed` snapshot whose error names the user's own number — e.g. `app Buzz limit
+  reached: 400 already spent today by this app on your behalf, this generation may
+  cost up to 150, your limit for this app is 500`. Unlike the platform per-app cap
+  (a platform secret), this ceiling is the user's own setting, so telling the app is
+  what makes the rejection actionable: surface it and let the user raise the limit.
+- **Post-paid jobs reserve the CEILING and settle to actual**, on this counter exactly
+  as on the platform one — so a job that reserves 5,000 and bills 200 gives back 4,800
+  when it reaches a terminal state.
 
 ## Publish / review / deploy lifecycle (no trust on push)
 

--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -41,7 +41,9 @@ install. Each app is served from its own platform-owned subdomain
 ## Tokens
 
 - RS256, signed by `BLOCK_TOKEN_PRIVATE_KEY`, verified via JWKS.
-- 15-minute lifetime by default; 5-minute lifetime for `block:settings:*` scopes.
+- 15-minute lifetime by default; 5-minute lifetime for `block:settings:*` scopes
+  — a RETIRED scope family (see the Scopes table), so a manifest can no longer
+  declare it and that shorter lifetime is unreachable today.
 - Claims: `iss`, `aud`, `sub` (`user:<id>` or `anon`), `iat`, `nbf`, `exp`,
   `jti`, `blockId`, `appId`, `blockInstanceId`, `ctx`, `scopes`,
   `buzzBudget?`.
@@ -57,12 +59,12 @@ check at request time (`enforceContextBinding`).
 | Scope                            | Bind                                              | Notes                                                                                                                                                                   |
 | -------------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `models:read:self`               | `query.id == ctx.modelId`                         |                                                                                                                                                                         |
-| `media:read:owned`               | non-anon `sub`                                    |                                                                                                                                                                         |
+| ~~`media:read:owned`~~           | —                                                 | **REMOVED** from the scope registry (purely decorative — no endpoint ever checked it). A manifest declaring it is REJECTED. The OAuth `MediaRead` bit is unaffected |
 | `buzz:read:self`                 | non-anon `sub`                                    | **required for EVERY host-mediated buzz read**, `blocks.getMyBuzzBalance` included — it is no longer scope-free. A token without it gets `block lacks buzz:read:self scope` (FORBIDDEN) |
 | `social:tip:self`                | non-anon `sub`                                    |                                                                                                                                                                         |
 | `user:read:self`                 | non-anon `sub`                                    | viewer identity — read via the `useViewer()` hook (`GET_VIEWER` bridge → `blocks.getMyViewer`). Also gates the **deprecated** `/api/v1/blocks/me` REST route (retiring) |
 | `ai:write:budgeted`              | positive `buzzBudget`                             |                                                                                                                                                                         |
-| `block:settings:read` / `:write` | `query.blockInstanceId == claims.blockInstanceId` | + caller-is-installer at issuance; `SKIP_OAUTH_CHECK`                                                                                                                   |
+| ~~`block:settings:read` / `:write`~~ | —                                             | **REMOVED** from the scope registry (no runtime capability ever verified them; the settings paths authorize on valid-token + app-developer + installer-resolution). A manifest declaring either is REJECTED |
 | `apps:storage:read` / `:write`   | scope present on `claims.scopes` per op           | per-app KV store (App Storage); no OAuth bit (`SKIP_OAUTH_CHECK`) — gated by the approved-scope snapshot + `resolveStorageContext`                                      |
 
 Unknown scopes are rejected at runtime (deny-by-default in middleware).
@@ -111,7 +113,9 @@ fine-grained tool for ops.
 - **Ownership escalation**: `block:settings:*` tokens require caller
   is the install's `installedByUserId` at issuance. The check is
   authoritative at issue time; deleted-publisher installs (FK SET NULL)
-  fail closed.
+  fail closed. ⚠️ The scope family is RETIRED (see the Scopes table), so this
+  check still exists in `block-tokens/index.ts` but nothing can reach it —
+  the scope cannot be declared, approved or minted.
 
 ## BLOCK_INIT contract
 

--- a/packages/civitai-db-schema/prisma/migrations/20260910120000_app_user_scope_grant_buzz_budget/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260910120000_app_user_scope_grant_buzz_budget/migration.sql
@@ -51,7 +51,7 @@ ALTER TABLE "app_user_scope_grants"
 -- DELIBERATELY A PLAIN `ADD CONSTRAINT`, NOT `NOT VALID` + `VALIDATE CONSTRAINT`.
 -- A plain ADD scans the whole table under ACCESS EXCLUSIVE to prove the existing rows
 -- satisfy it. That is the right trade HERE and only because of what this table is: the
--- column was created NULL two statements earlier in this same migration, so EVERY row
+-- column is created NULL by the statement immediately above, so EVERY row
 -- trivially satisfies the check (`IS NULL`), and the scan is over a consent ledger with
 -- one row per (user, approved app) on a pre-GA, moderator-gated feature — small, and
 -- nothing in the transaction can grow it. The two-step form buys a shorter lock at the

--- a/packages/civitai-db-schema/prisma/migrations/20260910120000_app_user_scope_grant_buzz_budget/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260910120000_app_user_scope_grant_buzz_budget/migration.sql
@@ -1,0 +1,40 @@
+-- App Blocks consent budget — the per-UTC-day Buzz ceiling a VIEWER sets for ONE app
+-- when they consent to `ai:write:budgeted`.
+--
+-- 🔴 APPLY THIS BEFORE THE IMAGE THAT READS IT ROLLS. Migrations in this project are
+-- applied BY HAND, per environment; nothing in CI or the deploy runs them. The column is
+-- additive and NULLable, so applying it EARLY is a no-op for the running code — but a
+-- deploy that lands first makes every Prisma read of `AppUserScopeGrant` fail with a
+-- missing-column error, which is a 500 on the consent + permissions surfaces.
+--
+-- WHY NULLABLE WITH NO BACKFILL. NULL means "the user set no budget", which is exactly
+-- the state of every grant written before this column existed, and the spend path treats
+-- it as "the platform's own 50,000/day per-user ceiling is the only one that applies".
+-- Backfilling a number would silently TIGHTEN every existing consent to something the
+-- user never agreed to. So: no backfill, no default.
+--
+-- `ADD COLUMN ... NULL` with no default is metadata-only in Postgres 11+ (no table
+-- rewrite, no full-table lock beyond the brief ACCESS EXCLUSIVE for the catalog update),
+-- so this is safe to apply while the site is up.
+ALTER TABLE "app_user_scope_grants"
+  ADD COLUMN IF NOT EXISTS "buzz_budget_per_day" INTEGER NULL;
+
+-- Positive-if-present. The upper bound mirrors BLOCK_BUZZ_CAP_PER_DAY (50,000), the
+-- platform per-user daily ceiling: a consent budget ABOVE it could never bind (the
+-- platform cap would always be the tighter of the two), so accepting one would store a
+-- number that means nothing. The same bound is enforced by the zod input on
+-- `blocks.grantScopes`; this is the belt behind it, for any writer that is not that
+-- procedure.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'app_user_scope_grants_buzz_budget_bounds'
+  ) THEN
+    ALTER TABLE "app_user_scope_grants"
+      ADD CONSTRAINT "app_user_scope_grants_buzz_budget_bounds"
+      CHECK (
+        "buzz_budget_per_day" IS NULL
+        OR ("buzz_budget_per_day" >= 1 AND "buzz_budget_per_day" <= 50000)
+      );
+  END IF;
+END $$;

--- a/packages/civitai-db-schema/prisma/migrations/20260910120000_app_user_scope_grant_buzz_budget/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260910120000_app_user_scope_grant_buzz_budget/migration.sql
@@ -1,11 +1,33 @@
 -- App Blocks consent budget — the per-UTC-day Buzz ceiling a VIEWER sets for ONE app
 -- when they consent to `ai:write:budgeted`.
 --
--- 🔴 APPLY THIS BEFORE THE IMAGE THAT READS IT ROLLS. Migrations in this project are
--- applied BY HAND, per environment; nothing in CI or the deploy runs them. The column is
--- additive and NULLable, so applying it EARLY is a no-op for the running code — but a
--- deploy that lands first makes every Prisma read of `AppUserScopeGrant` fail with a
--- missing-column error, which is a 500 on the consent + permissions surfaces.
+-- APPLY ORDER: either order is safe. Migrations in this project are applied BY HAND,
+-- per environment; nothing in CI or the deploy runs them, so the image and the schema
+-- are never deployed atomically and BOTH orders happen in practice.
+--   * Migration first  → a no-op for the running code (the column is additive and
+--                        NULLable; nothing reads it until the new image lands).
+--   * Deploy first     → the app runs CORRECTLY without the column, and reports
+--                        "no consent budget set" for every user, which is the TRUE
+--                        state of a database that cannot store one. The platform's own
+--                        per-user daily Buzz ceiling (BLOCK_BUZZ_CAP_PER_DAY = 50,000)
+--                        keeps enforcing throughout. Every read of this column is
+--                        wrapped: `getConsentBuzzBudget` and `listMyScopeGrants` catch
+--                        Prisma P2022 SPECIFICALLY (never a bare catch — any other DB
+--                        error still throws) and log it once, loudly, at error level;
+--                        every WRITE of the grant row passes an explicit `select` so it
+--                        never reads the column back.
+--
+-- ⚠️ THIS HEADER PREVIOUSLY WARNED THAT A DEPLOY-FIRST ORDER MAKES "every Prisma read
+-- of AppUserScopeGrant fail … a 500 on the consent + permissions surfaces". That was
+-- accurate when written and was MEASURED on this PR's preview environment
+-- (`P2022 … app_user_scope_grants.buzz_budget_per_day does not exist` on
+-- blocks.upsertSubscription → recordInstallConsent → appUserScopeGrant.update, surfacing
+-- as INTERNAL_SERVER_ERROR). The blast radius was actually WIDER than that sentence
+-- said — it 500'd every grant WRITE (install / subscribe / re-consent) as well as the
+-- reads, because Prisma's default selection returns every scalar and so a `create` /
+-- `update` with no `select` emits `RETURNING … buzz_budget_per_day` too. Both halves are
+-- fixed in the code that ships WITH this migration; the warning is kept here as the
+-- record of why the guards exist, not as a live hazard.
 --
 -- WHY NULLABLE WITH NO BACKFILL. NULL means "the user set no budget", which is exactly
 -- the state of every grant written before this column existed, and the spend path treats
@@ -25,6 +47,18 @@ ALTER TABLE "app_user_scope_grants"
 -- number that means nothing. The same bound is enforced by the zod input on
 -- `blocks.grantScopes`; this is the belt behind it, for any writer that is not that
 -- procedure.
+--
+-- DELIBERATELY A PLAIN `ADD CONSTRAINT`, NOT `NOT VALID` + `VALIDATE CONSTRAINT`.
+-- A plain ADD scans the whole table under ACCESS EXCLUSIVE to prove the existing rows
+-- satisfy it. That is the right trade HERE and only because of what this table is: the
+-- column was created NULL two statements earlier in this same migration, so EVERY row
+-- trivially satisfies the check (`IS NULL`), and the scan is over a consent ledger with
+-- one row per (user, approved app) on a pre-GA, moderator-gated feature — small, and
+-- nothing in the transaction can grow it. The two-step form buys a shorter lock at the
+-- cost of a constraint that is briefly unenforced against concurrent writers and a
+-- second statement an operator applying this by hand can forget. If this table is ever
+-- large when a future bounds change lands, use the two-step form then — the reason to
+-- prefer the simple one is the emptiness of the predicate, not a rule about CHECKs.
 DO $$
 BEGIN
   IF NOT EXISTS (

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -3720,6 +3720,15 @@ model AppUserScopeGrant {
   grantedScopes  String[]  @default([]) @map("granted_scopes")
   grantedAt      DateTime  @default(now()) @map("granted_at") @db.Timestamptz(6)
   revokedAt      DateTime? @map("revoked_at") @db.Timestamptz(6)
+  /// The per-UTC-day Buzz ceiling the VIEWER set for THIS app at consent time.
+  /// NULL = the user set no budget, and the app spends under the platform's own
+  /// per-user daily ceiling (`BLOCK_BUZZ_CAP_PER_DAY`, 50,000) alone — which is
+  /// exactly the behaviour of every grant written before this column existed, so
+  /// no backfill is needed and nobody is silently tightened. Non-NULL adds a
+  /// SECOND reservation at spend time keyed on (user, app, UTC-day); both caps
+  /// apply and the tighter one binds. Meaningful only alongside the
+  /// `ai:write:budgeted` scope (nothing else in a grant can spend).
+  buzzBudgetPerDay Int?    @map("buzz_budget_per_day")
 
   @@unique([userId, appBlockId], map: "app_user_scope_grants_user_app_uniq")
   @@map("app_user_scope_grants")

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -577,6 +577,17 @@ export type AppUserScopeGrant = {
   granted_scopes: Generated<string[]>;
   granted_at: Generated<Timestamp>;
   revoked_at: Timestamp | null;
+  /**
+   * The per-UTC-day Buzz ceiling the VIEWER set for THIS app at consent time.
+   * NULL = the user set no budget, and the app spends under the platform's own
+   * per-user daily ceiling (`BLOCK_BUZZ_CAP_PER_DAY`, 50,000) alone — which is
+   * exactly the behaviour of every grant written before this column existed, so
+   * no backfill is needed and nobody is silently tightened. Non-NULL adds a
+   * SECOND reservation at spend time keyed on (user, app, UTC-day); both caps
+   * apply and the tighter one binds. Meaningful only alongside the
+   * `ai:write:budgeted` scope (nothing else in a grant can spend).
+   */
+  buzz_budget_per_day: number | null;
 };
 export type Article = {
   id: Generated<number>;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -2355,6 +2355,7 @@ export interface AppUserScopeGrant {
   grantedScopes: string[];
   grantedAt: Date;
   revokedAt: Date | null;
+  buzzBudgetPerDay: number | null;
 }
 
 export interface AppDevForgejoIdentity {

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1965,6 +1965,27 @@ export const REDIS_SYS_KEYS = {
      * `sysRedis`.
      */
     REVIEW_RUN_FOR_REAL_BUZZ_CAP: 'system:blocks:review-run-for-real-buzz-cap',
+    /**
+     * CONSENT BUDGET — the per-(USER, APP BLOCK, UTC-day) Buzz ceiling the VIEWER
+     * themselves set at consent time (`app_user_scope_grants.buzz_budget_per_day`).
+     * Keyed `${CONSENT_BUDGET}:<userId>:<appBlockId>:<UTC-day>`.
+     *
+     * DISTINCT FROM EVERY SIBLING CAP, and the distinction is the whole point:
+     *   - BUZZ_CAP is PER-USER across ALL apps (a platform abuse ceiling the user
+     *     never chose, 50k/day). It deliberately OMITS appBlockId so N installed
+     *     apps share one ceiling.
+     *   - APP_SPEND_CAP is PER-APP across ALL users (anti-Sybil).
+     *   - This one is PER-(user, app): "I consent to THIS app spending at most N of
+     *     my Buzz per day". It is the user's OWN grant, not a platform ceiling.
+     * Both this and BUZZ_CAP apply to every non-dev, non-run-for-real submit; the
+     * TIGHTER one binds. A NULL `buzz_budget_per_day` means no consent budget was
+     * set and this key is never written — behaviour identical to before the column
+     * existed.
+     *
+     * Same atomic INCRBY reserve-and-refund + first-write-EX (~25h, with a ttl<0
+     * re-arm) shape as BUZZ_CAP, on `sysRedis`, fail-CLOSED on a redis error.
+     */
+    CONSENT_BUDGET: 'system:blocks:consent-budget',
   },
   DOWNLOAD: {
     LIMITS: 'download:limits',

--- a/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
@@ -17,17 +17,25 @@ vi.mock('~/components/Dialog/DialogProvider', () => ({
   useDialogContext: () => ({ opened: true, onClose: vi.fn(), zIndex: 200 }),
 }));
 
+// Hoisted so the tests can read the exact payload the Allow button submits — the budget
+// half of this component is entirely about WHAT IS SENT, and a render-only assertion
+// cannot see the difference between "omit the key" and "send null", which is the one
+// distinction the server acts on.
+const { mutate } = vi.hoisted(() => ({ mutate: vi.fn() }));
+
 vi.mock('~/utils/trpc', () => ({
   trpc: {
     blocks: {
       grantScopes: {
-        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+        useMutation: () => ({ mutate, isPending: false }),
       },
     },
   },
 }));
 
 const { default: BlockConsentModal } = await import('./BlockConsentModal');
+
+const SPEND = 'ai:write:budgeted';
 
 describe('BlockConsentModal — sensitive scope emphasis for the end user', () => {
   test('a sensitive requested scope shows the "Sensitive" indicator; a normal one does not', async () => {
@@ -64,5 +72,116 @@ describe('BlockConsentModal — sensitive scope emphasis for the end user', () =
       .element(page.getByText('Read the model on the page where the block is mounted'))
       .toBeInTheDocument();
     expect(page.getByTestId('sensitive-scope-badge').elements()).toHaveLength(0);
+  });
+});
+
+/**
+ * The per-app SPEND LIMIT the viewer sets at consent time.
+ *
+ * The control is shown ONLY when `ai:write:budgeted` is among the scopes being
+ * consented to — it is the only scope that can spend anything, so a limit beside "read
+ * your username" would be noise.
+ *
+ * 🔴 THE PAYLOAD ASSERTIONS ARE THE POINT, NOT THE RENDER. `recordScopeGrant`
+ * distinguishes three states: a number (set), an explicit `null` (clear), and an OMITTED
+ * key (leave alone). Only the last keeps a re-consent for an unrelated scope from wiping
+ * a limit the user set earlier — so "the toggle is off" must send NO key, not `null`.
+ */
+describe('BlockConsentModal — per-app spend limit', () => {
+  // INVARIANT GUARD — green at origin/main AND at HEAD, and VACUOUSLY at base: there is
+  // no limit control there for it to fail to find. It carries information only at HEAD,
+  // where the control exists and its absence here is a real branch. Not regression
+  // coverage.
+  test('the limit control is absent when no spend scope is being consented to', async () => {
+    renderWithProviders(
+      <BlockConsentModal
+        appBlockId="app-3"
+        blockName="Model Viewer"
+        missingScopes={['models:read:self', 'user:read:self']}
+        onGranted={vi.fn()}
+      />
+    );
+    await expect.element(page.getByRole('button', { name: 'Allow' })).toBeInTheDocument();
+    expect(page.getByTestId('block-consent-budget').elements()).toHaveLength(0);
+  });
+
+  test('the limit control appears when the spend scope is being consented to', async () => {
+    renderWithProviders(
+      <BlockConsentModal
+        appBlockId="app-4"
+        blockName="Generator"
+        missingScopes={[SPEND]}
+        onGranted={vi.fn()}
+      />
+    );
+    await expect
+      .element(page.getByTestId('block-consent-budget-toggle'))
+      .toBeInTheDocument();
+    // OFF by default, so the input is not yet shown.
+    expect(page.getByTestId('block-consent-budget-input').elements()).toHaveLength(0);
+  });
+
+  // INVARIANT GUARD — green at both, and vacuously at base for the same reason: the base
+  // component has no budget to send either way. What it pins at HEAD is the distinction
+  // the SERVER acts on — omitted (leave a stored budget alone) vs explicit null (clear
+  // it) — so an off toggle must send NO key.
+  test('with the limit OFF, Allow OMITS buzzBudgetPerDay entirely (it does not send null)', async () => {
+    mutate.mockClear();
+    renderWithProviders(
+      <BlockConsentModal
+        appBlockId="app-5"
+        blockName="Generator"
+        missingScopes={[SPEND]}
+        onGranted={vi.fn()}
+      />
+    );
+    await page.getByRole('button', { name: 'Allow' }).click();
+    expect(mutate).toHaveBeenCalledTimes(1);
+    const payload = mutate.mock.calls[0][0];
+    expect(payload).toEqual({ appBlockId: 'app-5', scopes: [SPEND] });
+    // Explicitly: the KEY is absent. `toEqual` above would also pass for an explicit
+    // `undefined`, and the server tests the key's presence.
+    expect(Object.hasOwn(payload, 'buzzBudgetPerDay')).toBe(false);
+  });
+
+  test('with the limit ON, Allow sends the entered budget', async () => {
+    mutate.mockClear();
+    renderWithProviders(
+      <BlockConsentModal
+        appBlockId="app-6"
+        blockName="Generator"
+        missingScopes={[SPEND]}
+        onGranted={vi.fn()}
+      />
+    );
+    await page.getByTestId('block-consent-budget-toggle').click();
+    await expect.element(page.getByTestId('block-consent-budget-input')).toBeInTheDocument();
+    await page.getByRole('button', { name: 'Allow' }).click();
+    expect(mutate).toHaveBeenCalledTimes(1);
+    // The pre-filled suggestion is deliberately far below the platform ceiling: the
+    // default should be a limit, not a formality.
+    expect(mutate.mock.calls[0][0]).toEqual({
+      appBlockId: 'app-6',
+      scopes: [SPEND],
+      buzzBudgetPerDay: 1000,
+    });
+  });
+
+  test('an out-of-range budget blocks Allow rather than sending a value the server will refuse', async () => {
+    mutate.mockClear();
+    renderWithProviders(
+      <BlockConsentModal
+        appBlockId="app-7"
+        blockName="Generator"
+        missingScopes={[SPEND]}
+        onGranted={vi.fn()}
+      />
+    );
+    await page.getByTestId('block-consent-budget-toggle').click();
+    const input = page.getByTestId('block-consent-budget-input');
+    await input.clear();
+    await input.fill('999999');
+    await expect.element(page.getByRole('button', { name: 'Allow' })).toBeDisabled();
+    expect(mutate).not.toHaveBeenCalled();
   });
 });

--- a/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
@@ -165,6 +165,61 @@ describe('BlockConsentModal — per-app spend limit', () => {
     });
   });
 
+  // ── OFF-STATE COPY. 🔴 PINNED AS A WHOLE NORMALISED STRING, not by keyword, because
+  // the defect this replaces was a keyword-passing sentence: "No limit set — this app
+  // spends under your account's overall daily cap." That was FALSE whenever a limit was
+  // already stored (this modal never reads the stored value; an off toggle OMITS the
+  // field, meaning "leave it alone", not "there is none"), so it told a user with a live
+  // limit that nothing bounded the app. A word-level guard would walk straight past a
+  // reworded relapse; the whole string will not.
+  test('the OFF-state copy does not claim there is no limit', async () => {
+    renderWithProviders(
+      <BlockConsentModal
+        appBlockId="app-8"
+        blockName="Generator"
+        missingScopes={[SPEND]}
+        onGranted={vi.fn()}
+      />
+    );
+    const el = page.getByTestId('block-consent-budget-off');
+    await expect.element(el).toBeInTheDocument();
+    const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
+    expect(text).toBe(
+      'Any limit you have already set for this app stays as it is. Manage it under ' +
+        'Apps \u2192 Permissions. This app always spends under your account\u2019s overall ' +
+        'daily cap.'
+    );
+  });
+
+  // A very low limit is storable (the floor is 1) and enforced exactly as given, so the
+  // dialog has to say what it does at the moment it is chosen — otherwise the app just
+  // looks broken afterwards, with no explanation and (before the editor existed) no way
+  // back. 90 is the lowest per-engine post-paid ceiling any registered recipe declares.
+  test('warns when the entered limit is too low to fund a generation', async () => {
+    renderWithProviders(
+      <BlockConsentModal
+        appBlockId="app-9"
+        blockName="Generator"
+        missingScopes={[SPEND]}
+        onGranted={vi.fn()}
+      />
+    );
+    await page.getByTestId('block-consent-budget-toggle').click();
+    const input = page.getByTestId('block-consent-budget-input');
+    // 1000 (the default) is comfortably fundable → no warning.
+    expect(page.getByTestId('block-consent-budget-low-warning').elements()).toHaveLength(0);
+    await input.clear();
+    await input.fill('5');
+    await expect.element(page.getByTestId('block-consent-budget-low-warning')).toBeInTheDocument();
+    // …and it goes away again above the threshold, so the warning tracks the VALUE and
+    // is not just "shown once the field was touched".
+    await input.clear();
+    await input.fill('500');
+    await expect
+      .element(page.getByTestId('block-consent-budget-low-warning'))
+      .not.toBeInTheDocument();
+  });
+
   test('an out-of-range budget blocks Allow rather than sending a value the server will refuse', async () => {
     mutate.mockClear();
     renderWithProviders(

--- a/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
@@ -114,9 +114,7 @@ describe('BlockConsentModal — per-app spend limit', () => {
         onGranted={vi.fn()}
       />
     );
-    await expect
-      .element(page.getByTestId('block-consent-budget-toggle'))
-      .toBeInTheDocument();
+    await expect.element(page.getByTestId('block-consent-budget-toggle')).toBeInTheDocument();
     // OFF by default, so the input is not yet shown.
     expect(page.getByTestId('block-consent-budget-input').elements()).toHaveLength(0);
   });

--- a/src/components/AppBlocks/BlockConsentModal.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.tsx
@@ -14,6 +14,8 @@ import { useState } from 'react';
 import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import {
+  BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY,
+  BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
   BLOCK_CONSENT_BUDGET_MAX_PER_DAY,
   BLOCK_CONSENT_BUDGET_MIN_PER_DAY,
   isSensitiveBlockScope,
@@ -32,10 +34,6 @@ interface BlockConsentModalProps {
 
 /** The ONE scope in the vocabulary that can spend the viewer's Buzz. */
 const SPEND_SCOPE = 'ai:write:budgeted';
-
-/** Pre-filled suggestion when the user turns a limit on. Deliberately far below the
- *  platform ceiling: the default should be a limit, not a formality. */
-const DEFAULT_BUDGET_SUGGESTION = 1000;
 
 /**
  * Lazy-consent surface (A6 / design-gaps C2). Opened on demand when a block
@@ -58,10 +56,20 @@ const DEFAULT_BUDGET_SUGGESTION = 1000;
  * ONLY for that scope, because it is the only one that can spend anything — a
  * limit next to "read your username" would be noise.
  *
- * OFF BY DEFAULT, and that is the honest default rather than a lazy one: leaving
- * it off stores NULL, which is exactly what every already-consented user has, so
- * nobody is silently tightened and nobody is silently loosened. The platform's own
- * per-user daily ceiling applies either way; a limit set here only ever narrows.
+ * OFF BY DEFAULT, and that is the honest default rather than a lazy one: with the
+ * switch off the field is OMITTED from the mutation, so a first-time grant stores
+ * NULL — exactly what every already-consented user has — and an app that already has
+ * a limit KEEPS it. Nobody is silently tightened and nobody is silently loosened. The
+ * platform's own per-user daily ceiling applies either way; a limit set here only ever
+ * narrows.
+ *
+ * ⚠️ THIS MODAL IS A WRITE-ONLY SURFACE, BY DESIGN. It is opened on `missingScopes`,
+ * which is empty for every scope the user has already granted — so it can be shown at
+ * most once per app for the spend scope, and it never reads the stored budget.
+ * Raising, lowering, clearing and even SEEING a limit live on /apps/activity
+ * (`AppBudgetControl`), which does read it. Do not add "your current limit is …" copy
+ * here without giving the modal that read; the off-state copy below is worded to be
+ * true WITHOUT it.
  */
 export default function BlockConsentModal({
   appBlockId,
@@ -73,7 +81,7 @@ export default function BlockConsentModal({
   const [error, setError] = useState<string | null>(null);
   const grantsSpend = missingScopes.includes(SPEND_SCOPE);
   const [limitEnabled, setLimitEnabled] = useState(false);
-  const [budget, setBudget] = useState<number | string>(DEFAULT_BUDGET_SUGGESTION);
+  const [budget, setBudget] = useState<number | string>(BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY);
   const grant = trpc.blocks.grantScopes.useMutation({
     onSuccess: () => {
       setError(null);
@@ -150,10 +158,27 @@ export default function BlockConsentModal({
                 data-testid="block-consent-budget-input"
               />
             ) : (
-              <Text size="xs" c="dimmed">
-                No limit set — this app spends under your account&rsquo;s overall daily cap.
+              // 🔴 THIS DOES NOT SAY "no limit set", AND THAT IS THE FIX. This modal
+              // never reads the stored budget — leaving the switch off OMITS the field,
+              // which means "leave whatever is stored alone", not "there is no limit".
+              // A user who set a limit earlier (or who re-consents after a revoke, which
+              // does not clear the stored number) would have been told, falsely, that
+              // nothing bounds this app while their old limit was still being enforced.
+              // Manage the actual value on /apps/activity, which reads it.
+              <Text size="xs" c="dimmed" data-testid="block-consent-budget-off">
+                Any limit you have already set for this app stays as it is. Manage it under Apps →
+                Permissions. This app always spends under your account&rsquo;s overall daily cap.
               </Text>
             )}
+            {/* A very low limit is storable (the floor is 1) and enforced exactly as
+                given, so say what it does at the moment it is chosen. */}
+            {limitEnabled && budgetValid && parsedBudget < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
+              <Text size="xs" c="orange" data-testid="block-consent-budget-low-warning">
+                {parsedBudget.toLocaleString()} Buzz/day is lower than most generations cost — this
+                app will refuse to generate until you raise it. You can change it later under Apps →
+                Permissions.
+              </Text>
+            ) : null}
           </Stack>
         ) : null}
         {error ? (

--- a/src/components/AppBlocks/BlockConsentModal.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.tsx
@@ -1,4 +1,14 @@
-import { Button, Group, List, Modal, NumberInput, Stack, Switch, Text, ThemeIcon } from '@mantine/core';
+import {
+  Button,
+  Group,
+  List,
+  Modal,
+  NumberInput,
+  Stack,
+  Switch,
+  Text,
+  ThemeIcon,
+} from '@mantine/core';
 import { IconShieldLock } from '@tabler/icons-react';
 import { useState } from 'react';
 import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
@@ -86,7 +96,11 @@ export default function BlockConsentModal({
   const budgetBlocksSubmit = grantsSpend && limitEnabled && !budgetValid;
 
   return (
-    <Modal {...dialog} withCloseButton={false} title={`${blockName ?? 'This app'} needs permission`}>
+    <Modal
+      {...dialog}
+      withCloseButton={false}
+      title={`${blockName ?? 'This app'} needs permission`}
+    >
       <Stack gap="md">
         <Group gap="xs" wrap="nowrap" align="flex-start">
           <ThemeIcon color="yellow" variant="light" size="lg">

--- a/src/components/AppBlocks/BlockConsentModal.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.tsx
@@ -1,9 +1,13 @@
-import { Button, Group, List, Modal, Stack, Text, ThemeIcon } from '@mantine/core';
+import { Button, Group, List, Modal, NumberInput, Stack, Switch, Text, ThemeIcon } from '@mantine/core';
 import { IconShieldLock } from '@tabler/icons-react';
 import { useState } from 'react';
 import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
-import { isSensitiveBlockScope } from '~/shared/constants/block-scope.constants';
+import {
+  BLOCK_CONSENT_BUDGET_MAX_PER_DAY,
+  BLOCK_CONSENT_BUDGET_MIN_PER_DAY,
+  isSensitiveBlockScope,
+} from '~/shared/constants/block-scope.constants';
 import { SCOPE_DESCRIPTIONS } from '~/server/services/blocks/scope-descriptions.constants';
 import { trpc } from '~/utils/trpc';
 
@@ -15,6 +19,13 @@ interface BlockConsentModalProps {
   /** Called after the grant lands so the host can re-mint the block token. */
   onGranted: () => void;
 }
+
+/** The ONE scope in the vocabulary that can spend the viewer's Buzz. */
+const SPEND_SCOPE = 'ai:write:budgeted';
+
+/** Pre-filled suggestion when the user turns a limit on. Deliberately far below the
+ *  platform ceiling: the default should be a limit, not a formality. */
+const DEFAULT_BUDGET_SUGGESTION = 1000;
 
 /**
  * Lazy-consent surface (A6 / design-gaps C2). Opened on demand when a block
@@ -28,6 +39,19 @@ interface BlockConsentModalProps {
  * to manifest∩approved) then closes and calls `onGranted`, which re-mints the
  * block token so it carries the newly-granted scopes. The block observes the
  * scope appear on its token (via TOKEN_REFRESH) and retries the action.
+ *
+ * ## The spend limit
+ *
+ * When `ai:write:budgeted` is among the scopes being consented to, the user can
+ * also set a per-day Buzz limit for THIS app, which the server enforces as a
+ * per-(user, app, UTC-day) reservation on every spend path. The control is shown
+ * ONLY for that scope, because it is the only one that can spend anything — a
+ * limit next to "read your username" would be noise.
+ *
+ * OFF BY DEFAULT, and that is the honest default rather than a lazy one: leaving
+ * it off stores NULL, which is exactly what every already-consented user has, so
+ * nobody is silently tightened and nobody is silently loosened. The platform's own
+ * per-user daily ceiling applies either way; a limit set here only ever narrows.
  */
 export default function BlockConsentModal({
   appBlockId,
@@ -37,6 +61,9 @@ export default function BlockConsentModal({
 }: BlockConsentModalProps) {
   const dialog = useDialogContext();
   const [error, setError] = useState<string | null>(null);
+  const grantsSpend = missingScopes.includes(SPEND_SCOPE);
+  const [limitEnabled, setLimitEnabled] = useState(false);
+  const [budget, setBudget] = useState<number | string>(DEFAULT_BUDGET_SUGGESTION);
   const grant = trpc.blocks.grantScopes.useMutation({
     onSuccess: () => {
       setError(null);
@@ -45,6 +72,18 @@ export default function BlockConsentModal({
     },
     onError: (e) => setError(e.message),
   });
+
+  // Clamp defensively rather than trusting the input's own bounds: Mantine's
+  // NumberInput hands back a string while the field is mid-edit (and an empty
+  // string when cleared), so the value reaching the mutation must be narrowed to a
+  // real integer in range or dropped entirely. The server re-validates regardless —
+  // this only keeps the request well-formed.
+  const parsedBudget = typeof budget === 'number' ? budget : Number.parseInt(String(budget), 10);
+  const budgetValid =
+    Number.isInteger(parsedBudget) &&
+    parsedBudget >= BLOCK_CONSENT_BUDGET_MIN_PER_DAY &&
+    parsedBudget <= BLOCK_CONSENT_BUDGET_MAX_PER_DAY;
+  const budgetBlocksSubmit = grantsSpend && limitEnabled && !budgetValid;
 
   return (
     <Modal {...dialog} withCloseButton={false} title={`${blockName ?? 'This app'} needs permission`}>
@@ -72,6 +111,37 @@ export default function BlockConsentModal({
             );
           })}
         </List>
+        {grantsSpend ? (
+          <Stack gap="xs" data-testid="block-consent-budget">
+            <Switch
+              size="sm"
+              checked={limitEnabled}
+              onChange={(event) => setLimitEnabled(event.currentTarget.checked)}
+              label="Set a daily Buzz limit for this app"
+              data-testid="block-consent-budget-toggle"
+            />
+            {limitEnabled ? (
+              <NumberInput
+                size="xs"
+                label="Buzz per day"
+                description={`This app can spend at most this much of your Buzz each day. Max ${BLOCK_CONSENT_BUDGET_MAX_PER_DAY.toLocaleString()}.`}
+                min={BLOCK_CONSENT_BUDGET_MIN_PER_DAY}
+                max={BLOCK_CONSENT_BUDGET_MAX_PER_DAY}
+                step={100}
+                allowDecimal={false}
+                allowNegative={false}
+                value={budget}
+                onChange={setBudget}
+                error={budgetValid ? null : 'Enter a whole number within the allowed range'}
+                data-testid="block-consent-budget-input"
+              />
+            ) : (
+              <Text size="xs" c="dimmed">
+                No limit set — this app spends under your account&rsquo;s overall daily cap.
+              </Text>
+            )}
+          </Stack>
+        ) : null}
         {error ? (
           <Text size="xs" c="red">
             {error}
@@ -85,7 +155,20 @@ export default function BlockConsentModal({
             size="xs"
             color="yellow"
             loading={grant.isPending}
-            onClick={() => grant.mutate({ appBlockId, scopes: missingScopes })}
+            disabled={budgetBlocksSubmit}
+            onClick={() =>
+              grant.mutate({
+                appBlockId,
+                scopes: missingScopes,
+                // OMITTED unless the user actually set a limit. Sending `null` here
+                // would be an explicit CLEAR, which would wipe a budget they set in
+                // an earlier consent — a widening performed by a dialog that never
+                // mentioned the existing limit. See `recordScopeGrant`.
+                ...(grantsSpend && limitEnabled && budgetValid
+                  ? { buzzBudgetPerDay: parsedBudget }
+                  : {}),
+              })
+            }
           >
             Allow
           </Button>

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -56,6 +56,9 @@ import type * as TrpcMod from '~/utils/trpc';
 
 const mocks = vi.hoisted(() => ({
   flags: {} as Record<string, boolean>,
+  /** Shared `mutate` spy for every `useMutation` in the tree — the budget editor is the
+   *  only mutation these tests drive, and they clear it first. */
+  mutate: vi.fn(),
 }));
 
 /**
@@ -127,6 +130,21 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
               slug: 'demo-app',
               scopes: ['read:profile'],
               surfaces: { modelInstallCount: 1, subscriptionScopes: [] },
+              // No spend scope granted → no budget control on this card. Keeping one
+              // such row is what makes the control's presence on the OTHER row a fact
+              // about `spendScopeGranted` rather than about the panel rendering at all.
+              buzzBudgetPerDay: null,
+              spendScopeGranted: false,
+            },
+            {
+              appBlockId: 'apb_spend',
+              blockId: 'spender',
+              name: 'Spender',
+              slug: 'spender',
+              scopes: ['ai:write:budgeted'],
+              surfaces: { modelInstallCount: 0, subscriptionScopes: ['viewer_personal'] },
+              buzzBudgetPerDay: 750,
+              spendScopeGranted: true,
             },
           ]
         : [],
@@ -151,7 +169,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
             // Called at RENDER time, so `mocks.flags` is the arm's own value.
             return () => (read === undefined ? inert : { ...inert, data: read() });
           }
-          if (key === 'useMutation') return () => inert;
+          if (key === 'useMutation') return () => ({ ...inert, mutate: mocks.mutate });
           if (key === 'invalidate' || key === 'fetch') return vi.fn();
           if (key === 'then') return undefined; // never look thenable to await
           return node();
@@ -469,5 +487,116 @@ describe('🔴 the header marketplace CTA is gone; the empty-state anchors remai
       bodyMarketplaceLinks().some((el) => el.textContent?.trim() === 'Browse marketplace'),
       'the removed header CTA is back'
     ).toBe(false);
+  });
+});
+
+/**
+ * The per-app daily Buzz limit on the Permissions panel.
+ *
+ * 🔴 WHY THIS SUITE EXISTS. Before it, `buzzBudgetPerDay` was returned by the API and
+ * read by NO component: the consent modal is the only writer and it only offers the
+ * field while `ai:write:budgeted` is still MISSING, which is true exactly once per app,
+ * forever. A user could therefore set a limit and then had no way to see it, raise it,
+ * lower it or clear it — and the floor is 1, so a too-low value refused every generation
+ * with no path back through the product. `recordScopeGrant`'s documented null-clears
+ * branch had ZERO callers.
+ *
+ * ── RED BEFORE THIS CHANGE ────────────────────────────────────────────────────
+ * Every test below fails against the previous revision of `pages/apps/activity.tsx` for
+ * the reason it names: there is no `app-budget-row`, no `app-budget-edit`, and no
+ * mutation to observe.
+ */
+describe('Apps & permissions — the per-app daily Buzz limit', () => {
+  beforeEach(() => {
+    mocks.mutate.mockClear();
+    // Select the Permissions tab. Mantine keeps every panel MOUNTED but the unselected
+    // ones are not VISIBLE, and a browser-mode `click`/`fill` waits for visibility — so
+    // without this the interaction tests hang to timeout and read as a broken control.
+    router.query = { tab: 'permissions' };
+  });
+
+  test('renders the stored limit for an app the viewer granted the spend scope', async () => {
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByTestId('app-budget-value')).toBeInTheDocument();
+    // The whole line, not a keyword: "750" alone would pass on copy that said the
+    // opposite of what the number means.
+    await expect
+      .element(page.getByTestId('app-budget-value'))
+      .toHaveTextContent('Daily Buzz limit: 750 Buzz/day');
+  });
+
+  // 🔴 THE DISCRIMINATING HALF. The fixture holds TWO apps and only one has the spend
+  // scope GRANTED, so exactly one control may render. Without this, a control rendered
+  // unconditionally would pass the test above.
+  test('renders NO limit control for an app without the granted spend scope', async () => {
+    renderWithProviders(<AppActivityPage />);
+    await expect.element(page.getByTestId('apps-installed-grants-grid')).toBeInTheDocument();
+    // Positive control: BOTH apps really rendered, so "one control" is a fact about the
+    // grant and not about a panel that only drew one card.
+    expect(page.getByTestId('app-budget-value').elements()).toHaveLength(1);
+    const names = Array.from(
+      document.querySelectorAll('[data-testid="apps-installed-grants-grid"] .truncate')
+    ).map((el) => el.textContent?.trim());
+    expect(names).toContain('Demo App');
+    expect(names).toContain('Spender');
+    expect(page.getByTestId('app-budget-row').elements()).toHaveLength(1);
+  });
+
+  test('Save sends the new limit for THAT app, and widens no scope', async () => {
+    renderWithProviders(<AppActivityPage />);
+    await page.getByTestId('app-budget-edit').click();
+    const input = page.getByTestId('app-budget-input');
+    await input.clear();
+    await input.fill('2500');
+    await page.getByTestId('app-budget-save').click();
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    // 🔴 `scopes` IS THE SPEND SCOPE ALONE. `grantScopes` is ADDITIVE, so sending the
+    // app's manifest scopes here would GRANT every scope it declares — a silent widening
+    // performed by a control that says "limit". Re-sending the one scope the user has
+    // already granted unions with itself and cannot change the stored set.
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({
+      appBlockId: 'apb_spend',
+      scopes: ['ai:write:budgeted'],
+      buzzBudgetPerDay: 2500,
+    });
+  });
+
+  test('Remove limit sends an EXPLICIT null (the clear branch), not an omitted key', async () => {
+    renderWithProviders(<AppActivityPage />);
+    await page.getByTestId('app-budget-edit').click();
+    await page.getByTestId('app-budget-clear').click();
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    const payload = mocks.mutate.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).toEqual({
+      appBlockId: 'apb_spend',
+      scopes: ['ai:write:budgeted'],
+      buzzBudgetPerDay: null,
+    });
+    // The SERVER distinguishes an omitted key (leave the stored value alone) from an
+    // explicit null (clear it) via an `in` test, and `toEqual` above would also accept
+    // an absent key. This is the half that pins the clear.
+    expect(Object.hasOwn(payload, 'buzzBudgetPerDay')).toBe(true);
+    expect(payload.buzzBudgetPerDay).toBeNull();
+  });
+
+  test('an out-of-range value disables Save rather than sending one the server refuses', async () => {
+    renderWithProviders(<AppActivityPage />);
+    await page.getByTestId('app-budget-edit').click();
+    const input = page.getByTestId('app-budget-input');
+    await input.clear();
+    await input.fill('999999');
+    await expect.element(page.getByTestId('app-budget-save')).toBeDisabled();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  test('warns when the entered limit is too low to fund a generation', async () => {
+    renderWithProviders(<AppActivityPage />);
+    await page.getByTestId('app-budget-edit').click();
+    // 750 (the stored value the editor opens on) is fundable → no warning.
+    expect(page.getByTestId('app-budget-low-warning').elements()).toHaveLength(0);
+    const input = page.getByTestId('app-budget-input');
+    await input.clear();
+    await input.fill('5');
+    await expect.element(page.getByTestId('app-budget-low-warning')).toBeInTheDocument();
   });
 });

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -198,9 +198,12 @@ type AxiomAPIRequest = NextApiRequest & { log: Logger };
  *
  * ## Gates / hard caps (every one server-side + fail-closed — scope doc §4.1)
  *  - MOD-ONLY (`isAppBlocksEnabled({ user })` + `user.isModerator`) — match the
- *    pre-GA mod posture. The runtime spend procedures already call
- *    `assertViewerIsModerator`, so a non-mod could mint but not spend; we keep
- *    mint mod-gated anyway. RELAX in lockstep with the runtime belt at GA.
+ *    pre-GA mod posture. ⚠️ This bullet used to add "the runtime spend procedures
+ *    already call `assertViewerIsModerator`, so a non-mod could mint but not spend".
+ *    That is FALSE today: the symbol occurs ZERO times in blocks.router / apps.router,
+ *    and the runtime capability gate it described was removed from the money paths by
+ *    the scope-enforcement work. THIS MINT GATE IS NOW THE ONLY CAPABILITY CHECK on
+ *    this path, and it is mint-time only — see the BLAST RADIUS note at the sign step.
  *  - SCOPE CLAMP: granted ⊆ the scope source ⊆ DEV_TOKEN_SCOPE_ALLOWLIST
  *    (EXCLUDES `social:tip:self` + `block:settings:*`) ⊆ [the app's OAuth
  *    ceiling — approved path ONLY] ⊆ requested (if the body narrows), then the
@@ -926,11 +929,22 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   // the 4h max-age cap off it, leaving every PRODUCTION token at 15min).
   //
   // BLAST RADIUS of the 4h lifetime — the token carries NO mod claim, so the
-  // mint-TIME moderator check (step 2) does NOT bound it. What bounds the
-  // money/settings paths is the LIVE per-request moderator re-check
-  // (`assertViewerIsModerator` in apps.router / blocks.router): a demoted/banned
-  // mod's 4h token is rejected there as soon as the demotion lands. The token is
-  // further self-bound, per-call budget capped, and forced-SFW.
+  // mint-TIME moderator check (step 2) does NOT bound it.
+  //
+  // 🔴 NOTHING RE-CHECKS THE MINTER'S CAPABILITY FOR THOSE 4 HOURS, AND THERE IS NO
+  // REPLACEMENT BOUND. This comment used to name a "LIVE per-request moderator
+  // re-check (`assertViewerIsModerator` in apps.router / blocks.router)"; that symbol
+  // occurs ZERO times in either router today (grep it), and the same runtime gate its
+  // successor provided was removed from every money path by the scope-enforcement
+  // work. So a user whose moderator capability is revoked keeps a working, spend-
+  // capable dev token until it expires — up to 4h.
+  //
+  // What DOES bound it is only what the token itself carries: it is SELF-BOUND (the
+  // `sub` is the minter, so any spend is their OWN Buzz), per-call budget capped at
+  // the lower DEV_BUZZ_BUDGET_CAP, subject to the same cumulative per-user daily cap
+  // as everything else, forced-SFW, and revocable through BlockRevocation on its
+  // `blockInstanceId`. That bounds the HARM (self-inflicted, capped) — it does not
+  // bound the LIFETIME, and no comment here should imply otherwise.
   const result = await signDevScopedPageToken({
     userId: user.id,
     signBlockId: resolved.signBlockId,

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -8,6 +8,7 @@ import {
   Divider,
   Group,
   Loader,
+  NumberInput,
   Select,
   Stack,
   Tabs,
@@ -25,7 +26,7 @@ import {
 } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
 import { Meta } from '~/components/Meta/Meta';
@@ -53,6 +54,12 @@ import {
 import type { ActivityTab } from '~/components/Apps/appsActivityTabs';
 import { resolveActivityPageAccess } from '~/components/Apps/resolveActivityPageAccess';
 import { canAccessAppsActivity, hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
+import {
+  BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY,
+  BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
+  BLOCK_CONSENT_BUDGET_MAX_PER_DAY,
+  BLOCK_CONSENT_BUDGET_MIN_PER_DAY,
+} from '~/shared/constants/block-scope.constants';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { formatDate } from '~/utils/date-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
@@ -369,6 +376,152 @@ function buildSurfaceLine(surfaces: {
   return parts.join(' · ');
 }
 
+/** The ONE scope in the vocabulary that can spend the viewer's Buzz. */
+const SPEND_SCOPE = 'ai:write:budgeted';
+
+/**
+ * The per-app daily Buzz limit, rendered and EDITABLE.
+ *
+ * 🔴 WHY THIS EXISTS AT ALL. Before it, the budget was write-once and invisible: the
+ * consent modal is the only writer and it only sends the field while
+ * `ai:write:budgeted` is still MISSING, which is true exactly once per app, forever.
+ * So a user could set a limit and then had no way to raise it, lower it, clear it, or
+ * even SEE it — and a low value (the floor is 1) meant every generation from that app
+ * was refused with no recoverable path through the product. The server raise/clear
+ * path already existed (`blocks.grantScopes`); nothing was wired to it.
+ *
+ * 🔴 THE `scopes` PAYLOAD IS DELIBERATELY `[SPEND_SCOPE]` AND MUST STAY THAT WAY.
+ * `grantScopes` is ADDITIVE over the scope set, so sending the app's manifest scopes
+ * here would GRANT every scope the app declares — a silent widening performed by a
+ * control that says "limit". Re-sending the one scope the user has already granted
+ * (which `spendScopeGranted` is exactly the proof of) unions with itself: the stored
+ * set cannot change. It is also the scope the server requires to be present for a
+ * budget to mean anything, so the write can never be the ignored-budget no-op.
+ *
+ * CLEARING sends an explicit `null`, which is the service's "clear it" state — a
+ * DIFFERENT thing from omitting the key (leave it alone), and the only caller of that
+ * branch.
+ */
+function AppBudgetControl({
+  appBlockId,
+  appName,
+  budget,
+}: {
+  appBlockId: string;
+  appName: string;
+  budget: number | null;
+}) {
+  const utils = trpc.useUtils();
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState<number | string>(
+    budget ?? BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY
+  );
+  const mutation = trpc.blocks.grantScopes.useMutation({
+    onSuccess: async () => {
+      await utils.blocks.listMyScopeGrants.invalidate();
+      setEditing(false);
+    },
+    onError: (e) =>
+      showErrorNotification({ title: 'Could not change the limit', error: new Error(e.message) }),
+  });
+
+  // Mantine's NumberInput hands back a string mid-edit (and '' when cleared), so
+  // narrow to a real integer in range before it can reach the mutation. The server
+  // re-validates the same bounds regardless — this only keeps the request well-formed
+  // and the Save button honest.
+  const parsed = typeof value === 'number' ? value : Number.parseInt(String(value), 10);
+  const valid =
+    Number.isInteger(parsed) &&
+    parsed >= BLOCK_CONSENT_BUDGET_MIN_PER_DAY &&
+    parsed <= BLOCK_CONSENT_BUDGET_MAX_PER_DAY;
+
+  const save = (next: number | null) =>
+    mutation.mutate({ appBlockId, scopes: [SPEND_SCOPE], buzzBudgetPerDay: next });
+
+  if (!editing) {
+    return (
+      <Group justify="space-between" gap="xs" wrap="nowrap" data-testid="app-budget-row">
+        <Text size="xs" c="dimmed" data-testid="app-budget-value">
+          {budget === null
+            ? 'Daily Buzz limit: none — only your account-wide daily cap applies'
+            : `Daily Buzz limit: ${budget.toLocaleString()} Buzz/day`}
+        </Text>
+        <Button
+          size="compact-xs"
+          variant="subtle"
+          data-testid="app-budget-edit"
+          onClick={() => {
+            setValue(budget ?? BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY);
+            setEditing(true);
+          }}
+        >
+          {budget === null ? 'Set limit' : 'Change'}
+        </Button>
+      </Group>
+    );
+  }
+
+  return (
+    <Stack gap={6} data-testid="app-budget-editor">
+      <NumberInput
+        size="xs"
+        label={`Daily Buzz limit for ${appName}`}
+        description={`Most this app can spend of your Buzz per day. Max ${BLOCK_CONSENT_BUDGET_MAX_PER_DAY.toLocaleString()}.`}
+        min={BLOCK_CONSENT_BUDGET_MIN_PER_DAY}
+        max={BLOCK_CONSENT_BUDGET_MAX_PER_DAY}
+        step={100}
+        allowDecimal={false}
+        allowNegative={false}
+        value={value}
+        onChange={setValue}
+        error={valid ? null : 'Enter a whole number within the allowed range'}
+        data-testid="app-budget-input"
+      />
+      {/* A very low limit is a real setting, not a mistake — but it is also the one
+          that makes an app look broken, so say what it does at the point it is set.
+          This is what keeps the floor of 1 tolerable; see BLOCK_CONSENT_BUDGET_MIN_PER_DAY. */}
+      {valid && parsed < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
+        <Text size="xs" c="orange" data-testid="app-budget-low-warning">
+          {parsed.toLocaleString()} Buzz/day is lower than most generations cost — this app will
+          refuse to generate until you raise it. You can change it here at any time.
+        </Text>
+      ) : null}
+      <Group gap="xs" justify="flex-end">
+        <Button
+          size="compact-xs"
+          variant="default"
+          disabled={mutation.isPending}
+          onClick={() => setEditing(false)}
+        >
+          Cancel
+        </Button>
+        {budget !== null ? (
+          <Button
+            size="compact-xs"
+            variant="light"
+            color="gray"
+            loading={mutation.isPending}
+            data-testid="app-budget-clear"
+            onClick={() => save(null)}
+          >
+            Remove limit
+          </Button>
+        ) : null}
+        <Button
+          size="compact-xs"
+          color="yellow"
+          disabled={!valid}
+          loading={mutation.isPending}
+          data-testid="app-budget-save"
+          onClick={() => save(parsed)}
+        >
+          Save
+        </Button>
+      </Group>
+    </Stack>
+  );
+}
+
 function ScopeGrantsPanel() {
   const { data: grants, isLoading } = trpc.blocks.listMyScopeGrants.useQuery();
 
@@ -404,6 +557,20 @@ function ScopeGrantsPanel() {
             </Group>
             <Divider />
             <BlockScopeList scopes={grant.scopes} />
+            {/* Only for an app the viewer has actually GRANTED the spend scope to —
+                `spendScopeGranted` is the grant row, not the manifest. A budget on an
+                app that cannot spend bounds nothing, and the server would ignore the
+                write. */}
+            {grant.spendScopeGranted ? (
+              <>
+                <Divider />
+                <AppBudgetControl
+                  appBlockId={grant.appBlockId}
+                  appName={grant.name}
+                  budget={grant.buzzBudgetPerDay}
+                />
+              </>
+            ) : null}
           </Stack>
         </Card>
       ))}

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -401,6 +401,16 @@ const SPEND_SCOPE = 'ai:write:budgeted';
  * CLEARING sends an explicit `null`, which is the service's "clear it" state — a
  * DIFFERENT thing from omitting the key (leave it alone), and the only caller of that
  * branch.
+ *
+ * ⚠️ KNOWN LIMIT, STATED RATHER THAN PAPERED OVER: `grantScopes` requires the app to be
+ * `approved` AND the sent scope to be inside `manifest ∩ approvedScopes`. If an app is
+ * later un-approved, or a moderator narrows its approved set so it no longer includes
+ * `ai:write:budgeted`, this control surfaces the server's error instead of editing —
+ * the user's stored limit is then not editable here. It is also not ENFORCING anything
+ * in that state (no token can carry the spend scope, so no spend reaches the budget),
+ * so nothing is stuck at a ceiling; the limit is simply frozen until the app is
+ * approved again. Fixing it properly means a budget-only server path that does not go
+ * through the scope ceiling.
  */
 function AppBudgetControl({
   appBlockId,

--- a/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
@@ -81,6 +81,7 @@ vi.mock('~/server/middleware.trpc', async () => {
 });
 
 import { blocksRouter } from '../blocks.router';
+import { BLOCK_BUZZ_CAP_PER_DAY } from '~/shared/constants/block-scope.constants';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
@@ -289,5 +290,129 @@ describe('blocks.getInstallConfig', () => {
     const out = await caller.getInstallConfig({ appBlockId: 'ab_x' });
     expect(out).toEqual({ settings: {}, scopes: [] });
     expect(mockDbReadAppBlockFindUnique).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * `blocks.grantScopes` — the CONSENT BUDGET write half.
+ *
+ * 🔴 THIS IS A SEAM TEST, AND THAT IS WHY IT EXISTS. The enforcement side
+ * (`blocks.router.scopeEnforcement.test.ts`) mocks the grant READ directly, and the
+ * service side (`scope-grant.service.test.ts`) mocks the DB. Both are hermetic and both
+ * pass whether or not the two halves are wired together — nothing in either builds the
+ * combined state. What is asserted here is the RELATIONSHIP: the value `grantScopes`
+ * hands to the write path is the same shape `getConsentBuzzBudget` reads back, so a
+ * budget the user sets can actually reach the spend path.
+ *
+ * The budget is meaningful only alongside `ai:write:budgeted` — nothing else in the
+ * vocabulary can spend — so a budget sent without it is IGNORED rather than rejected.
+ * See the call site for why ignoring beats erroring.
+ */
+describe('blocks.grantScopes — consent budget', () => {
+  /** ctx with the appBlocks feature on (the proc gates on `ctx.features.appBlocks`). */
+  function consentCtx(userId = 42) {
+    const ctx = authedCtx(userId, false) as unknown as { features: Record<string, unknown> };
+    ctx.features = { ...ctx.features, appBlocks: true };
+    return ctx;
+  }
+
+  const grantMock = dbMock.dbWrite.appUserScopeGrant;
+
+  beforeEach(() => {
+    mockDbReadAppBlockFindUnique.mockResolvedValue({
+      status: 'approved',
+      version: '1.2.3',
+      manifest: APPROVED_MANIFEST,
+      approvedScopes: ['ai:write:budgeted', 'models:read:self'],
+    });
+    grantMock.findUnique.mockReset();
+    grantMock.create.mockReset();
+    grantMock.update.mockReset();
+    grantMock.findUnique.mockResolvedValue(null); // no prior grant
+    grantMock.create.mockResolvedValue({});
+    grantMock.update.mockResolvedValue({});
+  });
+
+  it('PERSISTS the budget when ai:write:budgeted is among the granted scopes', async () => {
+    const caller = blocksRouter.createCaller(consentCtx() as never);
+    const out = await caller.grantScopes({
+      appBlockId: 'ab_x',
+      scopes: ['ai:write:budgeted'],
+      buzzBudgetPerDay: 750,
+    });
+    expect(out.granted).toEqual(['ai:write:budgeted']);
+    // The number reached the WRITE, under the column name the read selects.
+    expect(grantMock.create.mock.calls[0][0].data).toMatchObject({ buzzBudgetPerDay: 750 });
+    // ...and the response echoes what was stored, so a client needs no second round-trip.
+    expect(out.buzzBudgetPerDay).toBe(750);
+  });
+
+  it('IGNORES a budget sent without any spend scope (does not error, stores nothing)', async () => {
+    const caller = blocksRouter.createCaller(consentCtx() as never);
+    const out = await caller.grantScopes({
+      appBlockId: 'ab_x',
+      scopes: ['models:read:self'],
+      buzzBudgetPerDay: 750,
+    });
+    expect(out.granted).toEqual(['models:read:self']);
+    // The KEY is absent, not null: an explicit null would CLEAR a stored budget, and
+    // "ignore" must not double as "erase".
+    const data = grantMock.create.mock.calls[0][0].data;
+    expect(Object.hasOwn(data, 'buzzBudgetPerDay')).toBe(false);
+    expect(out.buzzBudgetPerDay).toBeUndefined();
+  });
+
+  it('HONOURS a budget for an app that ALREADY holds the spend scope', async () => {
+    // Raising a limit on an app you consented to earlier: the scope is not in THIS
+    // call's grant, so the meaningfulness test has to consult the stored grant.
+    grantMock.findUnique.mockResolvedValue({
+      id: 'augr_1',
+      grantedScopes: ['ai:write:budgeted'],
+      revokedAt: null,
+    });
+    const caller = blocksRouter.createCaller(consentCtx() as never);
+    const out = await caller.grantScopes({
+      appBlockId: 'ab_x',
+      scopes: ['models:read:self'],
+      buzzBudgetPerDay: 300,
+    });
+    expect(grantMock.update.mock.calls[0][0].data).toMatchObject({ buzzBudgetPerDay: 300 });
+    expect(out.buzzBudgetPerDay).toBe(300);
+  });
+
+  it('OMITTING the budget leaves a stored one untouched', async () => {
+    grantMock.findUnique.mockResolvedValue({
+      id: 'augr_1',
+      grantedScopes: ['ai:write:budgeted'],
+      revokedAt: null,
+    });
+    const caller = blocksRouter.createCaller(consentCtx() as never);
+    await caller.grantScopes({ appBlockId: 'ab_x', scopes: ['models:read:self'] });
+    const data = grantMock.update.mock.calls[0][0].data;
+    expect(Object.hasOwn(data, 'buzzBudgetPerDay')).toBe(false);
+  });
+
+  it('REJECTS a budget above the platform daily cap at the input boundary', async () => {
+    const caller = blocksRouter.createCaller(consentCtx() as never);
+    await expect(
+      caller.grantScopes({
+        appBlockId: 'ab_x',
+        scopes: ['ai:write:budgeted'],
+        buzzBudgetPerDay: BLOCK_BUZZ_CAP_PER_DAY + 1,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(grantMock.create).not.toHaveBeenCalled();
+  });
+
+  it('REJECTS a zero budget (declining the scope is how you express "never")', async () => {
+    const caller = blocksRouter.createCaller(consentCtx() as never);
+    await expect(
+      caller.grantScopes({
+        appBlockId: 'ab_x',
+        scopes: ['ai:write:budgeted'],
+        buzzBudgetPerDay: 0,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(grantMock.create).not.toHaveBeenCalled();
   });
 });

--- a/src/server/routers/__tests__/blocks.router.scopeEnforcement.test.ts
+++ b/src/server/routers/__tests__/blocks.router.scopeEnforcement.test.ts
@@ -1,0 +1,682 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// Type-only namespace import: `typeof import('...')` inline is rejected by
+// @typescript-eslint/consistent-type-imports, so the type is named up here.
+import type * as BlockGenIdempotency from '~/server/utils/block-gen-idempotency';
+
+/**
+ * SCOPE ENFORCEMENT + CONSENT BUDGET on the App Blocks runtime.
+ *
+ * Two changes are under test, and they are two halves of one decision:
+ *
+ *   1. `assertViewerIsAppDeveloper` — an AUTHORING capability — no longer gates the
+ *      RUNTIME procedures. It gated 15 call sites; it now gates exactly one
+ *      (`updateUserSettings`). The consequence is that a viewer who is not an app
+ *      author can finally USE an app. The consequence we must NOT let through is a
+ *      widening on the one runtime proc that had no scope check of its own,
+ *      `getMyBuzzBalance` — so that proc grew a `buzz:read:self` requirement.
+ *
+ *   2. A per-(user, app, UTC-day) CONSENT BUDGET the viewer sets at consent time,
+ *      reserved alongside the platform's per-user daily cap. Both apply; the
+ *      tighter binds. NULL budget ⇒ byte-identical to before.
+ *
+ * 🔴 THE REDIS COUNTERS ARE MODELLED STATEFULLY, NOT STUBBED TO A CONSTANT. The
+ * defect this suite exists to catch is a REFUND that does not happen — a denied
+ * attempt burning the viewer's platform allowance. A stub returning a fixed number
+ * cannot see that: the assertion has to be "the counter came back to where it
+ * started", which needs a counter. `sysRedis.incrBy`/`decrBy` therefore run against
+ * an in-memory map keyed by the REAL key strings the router builds, and the
+ * NULL-budget test doubles as the positive control that the map moves at all.
+ */
+
+const {
+  mockVerifyBlockToken,
+  mockParseSubjectUserId,
+  mockGetOrchestratorToken,
+  mockSubmitWorkflow,
+  mockCreateStepsFromGraph,
+  mockBuildGenerationContext,
+  mockAuditPromptServer,
+  mockGetUserById,
+  mockCheckBlockCatalogRateLimit,
+  mockGetSessionUser,
+  mockIsAppBlocksEnabled,
+  mockIsAppBlocksAuthorEnabled,
+  mockDailyBoostApply,
+  mockDailyBoostGetDetails,
+  mockGetUserBuzzAccounts,
+  mockResolveCanGenerateForVersions,
+  mockGetResourceData,
+  mockGetHighestTierSubscription,
+  mockRecordSpendAttribution,
+} = vi.hoisted(() => ({
+  mockVerifyBlockToken: vi.fn(),
+  mockParseSubjectUserId: vi.fn(),
+  mockGetOrchestratorToken: vi.fn(),
+  mockSubmitWorkflow: vi.fn(),
+  mockCreateStepsFromGraph: vi.fn(),
+  mockBuildGenerationContext: vi.fn(),
+  mockAuditPromptServer: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockCheckBlockCatalogRateLimit: vi.fn(),
+  mockGetSessionUser: vi.fn(),
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockIsAppBlocksAuthorEnabled: vi.fn(),
+  mockDailyBoostApply: vi.fn(),
+  mockDailyBoostGetDetails: vi.fn(),
+  mockGetUserBuzzAccounts: vi.fn(),
+  mockResolveCanGenerateForVersions: vi.fn(),
+  mockGetResourceData: vi.fn(),
+  mockGetHighestTierSubscription: vi.fn(),
+  mockRecordSpendAttribution: vi.fn(),
+}));
+
+const {
+  mockGetActiveDevTunnel,
+  mockReserveDevSessionBuzz,
+  mockRefundDevSessionBuzz,
+  mockChargeDevSessionOverage,
+} = vi.hoisted(() => ({
+  mockGetActiveDevTunnel: vi.fn(async () => null as unknown),
+  mockReserveDevSessionBuzz: vi.fn(async () => ({ allowed: true, total: 0 })),
+  mockRefundDevSessionBuzz: vi.fn(async () => undefined),
+  mockChargeDevSessionOverage: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/blocks/dev-tunnel.service', () => ({
+  getActiveDevTunnel: (...a: unknown[]) => mockGetActiveDevTunnel(...(a as [])),
+  reserveDevSessionBuzz: (...a: unknown[]) => mockReserveDevSessionBuzz(...(a as [])),
+  refundDevSessionBuzz: (...a: unknown[]) => mockRefundDevSessionBuzz(...(a as [])),
+  chargeDevSessionOverage: (...a: unknown[]) => mockChargeDevSessionOverage(...(a as [])),
+}));
+
+const { mockReserveAppSpend, mockRefundAppSpend, mockChargeAppSpendOverage } = vi.hoisted(() => ({
+  mockReserveAppSpend: vi.fn(),
+  mockRefundAppSpend: vi.fn(async () => undefined),
+  mockChargeAppSpendOverage: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/blocks/app-spend-cap.service', () => ({
+  reserveAppSpend: (...a: unknown[]) => mockReserveAppSpend(...(a as [])),
+  refundAppSpend: (...a: unknown[]) => mockRefundAppSpend(...(a as [])),
+  chargeAppSpendOverage: (...a: unknown[]) => mockChargeAppSpendOverage(...(a as [])),
+}));
+
+const { mockUpsertBlockWorkflow, mockListMyBlockWorkflows, mockUpdateBlockWorkflowStatus } =
+  vi.hoisted(() => ({
+    mockUpsertBlockWorkflow: vi.fn(async () => undefined),
+    mockListMyBlockWorkflows: vi.fn(),
+    mockUpdateBlockWorkflowStatus: vi.fn(async () => 1),
+  }));
+vi.mock('~/server/services/blocks/block-workflows.service', () => ({
+  upsertBlockWorkflowOnSubmit: (...a: unknown[]) => mockUpsertBlockWorkflow(...(a as [])),
+  listMyBlockWorkflows: (...a: unknown[]) => mockListMyBlockWorkflows(...(a as [])),
+  updateBlockWorkflowStatus: (...a: unknown[]) => mockUpdateBlockWorkflowStatus(...(a as [])),
+}));
+
+const { mockPersistCustomComfySettle, mockSettleCustomComfySpend } = vi.hoisted(() => ({
+  mockPersistCustomComfySettle: vi.fn(async () => undefined),
+  mockSettleCustomComfySpend: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/blocks/custom-comfy-settle.service', () => ({
+  persistCustomComfySettle: (...a: unknown[]) => mockPersistCustomComfySettle(...(a as [])),
+  settleCustomComfySpend: (...a: unknown[]) => mockSettleCustomComfySpend(...(a as [])),
+}));
+
+const { mockClaimGen, mockFinalizeGen, mockReleaseGen, genIdemStore } = vi.hoisted(() => ({
+  genIdemStore: new Map<string, unknown>(),
+  mockClaimGen: vi.fn(),
+  mockFinalizeGen: vi.fn(),
+  mockReleaseGen: vi.fn(),
+}));
+vi.mock('~/server/utils/block-gen-idempotency', async (importActual) => {
+  const actual = await importActual<typeof BlockGenIdempotency>();
+  return {
+    ...actual,
+    claimGenIdempotency: (...a: unknown[]) => mockClaimGen(...(a as [])),
+    finalizeGenIdempotency: (...a: unknown[]) => mockFinalizeGen(...(a as [])),
+    releaseGenIdempotency: (...a: unknown[]) => mockReleaseGen(...(a as [])),
+  };
+});
+
+vi.mock('~/server/services/blocks/user-app-surface.service', () => ({
+  recordScopeInvocation: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (...args: unknown[]) => mockParseSubjectUserId(...args),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: mockGetOrchestratorToken,
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: mockSubmitWorkflow,
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/orchestration-new.service', () => ({
+  buildGenerationContext: mockBuildGenerationContext,
+  createWorkflowStepsFromGraphInput: mockCreateStepsFromGraph,
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: mockAuditPromptServer,
+}));
+vi.mock('~/server/services/user.service', () => ({ getUserById: mockGetUserById }));
+vi.mock('~/server/auth/session-client', () => ({
+  sessionClient: { getSessionUserById: (...args: unknown[]) => mockGetSessionUser(...args) },
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+}));
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: {
+    apply: (...args: unknown[]) => mockDailyBoostApply(...args),
+    getUserRewardDetails: (...args: unknown[]) => mockDailyBoostGetDetails(...args),
+  },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: (...args: unknown[]) => mockGetUserBuzzAccounts(...args),
+  getUserBuzzTransactions: vi.fn(),
+  getUserBuzzAccount: vi.fn(),
+  getDailyCompensationRewardByUser: vi.fn(),
+}));
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: (...args: unknown[]) => mockCheckBlockCatalogRateLimit(...args),
+}));
+vi.mock('~/server/services/generation/generation.service', () => ({
+  resolveCanGenerateForVersions: (...args: unknown[]) => mockResolveCanGenerateForVersions(...args),
+  getResourceData: (...args: unknown[]) => mockGetResourceData(...args),
+}));
+vi.mock('~/server/services/subscriptions.service', () => ({
+  getHighestTierSubscription: (...args: unknown[]) => mockGetHighestTierSubscription(...args),
+}));
+vi.mock('~/server/services/blocks/buzz-attribution.service', () => ({
+  recordSpendAttribution: (...args: unknown[]) => mockRecordSpendAttribution(...args),
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    upsertUserSettings: vi.fn(async () => ({ ok: true })),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    resolveBlockInstance: vi.fn(async () => ({
+      source: 'install',
+      modelId: 7,
+      slotId: 'model.sidebar_top',
+      enabled: true,
+      settings: {},
+      installedByUserId: 42,
+      appBlock: {
+        id: 'apb_test',
+        blockId: 'gen-from-model',
+        appId: 'app',
+        status: 'approved',
+        manifest: { targets: [{ slotId: 'model.sidebar_top' }] },
+        approvedScopes: ['ai:write:budgeted'],
+        app: { allowedScopes: 33554431 },
+      },
+    })),
+  },
+}));
+// Same import-chain shim the sibling blocks.router suites use: `rateLimit` transitively
+// evaluates a top-level `Prisma.validator(...)`, which cannot run here.
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { REDIS_SYS_KEYS } from '~/server/redis/client';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { BLOCK_BUZZ_CAP_PER_DAY } from '~/shared/constants/block-scope.constants';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+const mockSysRedis = redisMock.sysRedis;
+const mockDbRead = dbMock.dbRead;
+const mockGrantFindUnique = dbMock.dbWrite.appUserScopeGrant.findUnique;
+
+// ── The stateful counter model. See the file header for why this is not a stub.
+const counters = new Map<string, number>();
+/** [key PREFIX, starting value] — lets a test seed "N already spent today" without
+ *  reconstructing the UTC-day suffix the router appends. */
+const seeds: Array<[string, number]> = [];
+function startingValue(key: string): number {
+  const hit = seeds.find(([prefix]) => key.startsWith(prefix));
+  return hit ? hit[1] : 0;
+}
+function currentValue(key: string): number {
+  return counters.has(key) ? (counters.get(key) as number) : startingValue(key);
+}
+/** The one key seen under a prefix. Throws rather than returning undefined: a test that
+ *  asserts on "the daily key" must fail loudly if the router never touched one, instead
+ *  of quietly comparing `undefined` and passing. */
+function keyUnder(prefix: string): string {
+  const found = [...counters.keys()].filter((k) => k.startsWith(prefix));
+  if (found.length !== 1) {
+    throw new Error(`expected exactly 1 redis key under '${prefix}', saw ${found.length}`);
+  }
+  return found[0];
+}
+function anyKeyUnder(prefix: string): boolean {
+  return [...counters.keys()].some((k) => k.startsWith(prefix));
+}
+
+const DAILY_PREFIX = `${REDIS_SYS_KEYS.BLOCKS.BUZZ_CAP}:42:`;
+const CONSENT_PREFIX = `${REDIS_SYS_KEYS.BLOCKS.CONSENT_BUDGET}:42:apb_test:`;
+
+function validClaims(over: Record<string, unknown> = {}) {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'jti_test',
+    blockId: 'blk_test',
+    appId: 'app_test',
+    appBlockId: 'apb_test',
+    blockInstanceId: 'bki_test',
+    ctx: { modelId: 7, slotId: 'model.sidebar_top' },
+    scopes: ['ai:write:budgeted'],
+    buzzBudget: 100,
+    ...over,
+  };
+}
+
+function validBody(over: Record<string, unknown> = {}) {
+  return {
+    kind: 'textToImage' as const,
+    modelId: 7,
+    modelVersionId: 99,
+    params: { prompt: 'a cat', quantity: 1 },
+    ...over,
+  };
+}
+
+function fakeCtx() {
+  return {
+    acceptableOrigin: true,
+    user: undefined,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { canViewNsfw: false, isBlue: false, isGreen: false, isGreenSession: false } as never,
+    track: undefined,
+  };
+}
+
+/** whatIf quote then real submit, both at `cost`. */
+function orchestratorQuoting(cost: number) {
+  mockSubmitWorkflow
+    .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: cost }, steps: [] })
+    .mockResolvedValueOnce({
+      id: 'wf_real',
+      status: 'unassigned',
+      cost: { total: cost },
+      steps: [],
+    });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // 🔴 `clearAllMocks` clears CALLS, not the `mockResolvedValueOnce` QUEUE. A test that
+  // rejects before the real submit leaves its second queued value behind, and the NEXT
+  // test's whatIf then consumes it — so the real submit returns the whatIf's empty id and
+  // the failure reads as "the router did not submit". Reset this one explicitly.
+  mockSubmitWorkflow.mockReset();
+  counters.clear();
+  seeds.length = 0;
+  genIdemStore.clear();
+
+  mockSysRedis.incrBy.mockImplementation(async (key: string, by: number) => {
+    const next = currentValue(key) + by;
+    counters.set(key, next);
+    return next;
+  });
+  mockSysRedis.decrBy.mockImplementation(async (key: string, by: number) => {
+    const next = currentValue(key) - by;
+    counters.set(key, next);
+    return next;
+  });
+  mockSysRedis.get.mockResolvedValue(null);
+  mockSysRedis.expire.mockResolvedValue(true);
+  mockSysRedis.ttl.mockResolvedValue(-1);
+
+  // DEFAULT: no grant row ⇒ no consent budget. This is the pre-change world, and it is
+  // what every test that is not about the budget runs in.
+  mockGrantFindUnique.mockResolvedValue(null);
+
+  mockReserveAppSpend.mockResolvedValue({
+    allowed: true,
+    dailyTotal: 0,
+    velocityCount: 1,
+    dailyKey: 'system:blocks:app-spend-cap:apb_test:day',
+  });
+  mockRefundAppSpend.mockResolvedValue(undefined);
+  mockUpsertBlockWorkflow.mockResolvedValue(undefined);
+  mockListMyBlockWorkflows.mockResolvedValue({ items: [], nextCursor: null });
+  mockPersistCustomComfySettle.mockResolvedValue(undefined);
+  mockSettleCustomComfySpend.mockResolvedValue(undefined);
+
+  mockClaimGen.mockImplementation(async () => ({ state: 'acquired', key: 'k' }));
+  mockFinalizeGen.mockResolvedValue(undefined);
+  mockReleaseGen.mockResolvedValue(undefined);
+
+  mockGetActiveDevTunnel.mockResolvedValue(null);
+  mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 0 });
+  mockRefundDevSessionBuzz.mockResolvedValue(undefined);
+
+  mockRecordSpendAttribution.mockResolvedValue({ written: false, row: null });
+  mockCheckBlockCatalogRateLimit.mockResolvedValue({ allowed: true });
+  mockIsAppBlocksEnabled.mockImplementation(async () => true);
+  // DEFAULT: the subject is NOT an app author. That is the cohort this change exists to
+  // unblock, so it is the default here rather than the exception.
+  mockIsAppBlocksAuthorEnabled.mockImplementation(async () => false);
+  mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: false, tier: 'free' });
+  mockGetUserById.mockResolvedValue({
+    id: 42,
+    isModerator: false,
+    tier: 'free',
+    email: 'u@example.com',
+    username: 'u',
+  });
+  mockParseSubjectUserId.mockImplementation((sub: string) => (sub === 'anon' ? null : 42));
+  mockGetOrchestratorToken.mockResolvedValue('orch_token');
+  mockAuditPromptServer.mockResolvedValue(undefined);
+  mockBuildGenerationContext.mockResolvedValue({ externalCtx: {} });
+  mockCreateStepsFromGraph.mockResolvedValue({
+    steps: [{ $type: 'textToImage', name: 's1', input: {} }],
+    workflowMetadata: undefined,
+  });
+  mockDailyBoostApply.mockResolvedValue(undefined);
+  mockDailyBoostGetDetails.mockResolvedValue({
+    awarded: 0,
+    awardedCount: 0,
+    awardAmount: 25,
+    accountType: 'blue',
+    type: 'dailyBoost',
+    description: 'For claiming daily boost rewards',
+    cap: 25,
+    onDemand: true,
+  });
+  mockGetUserBuzzAccounts.mockResolvedValue({ yellow: 10000, blue: 0, green: 0 });
+  mockResolveCanGenerateForVersions.mockImplementation(
+    async (versions: Array<{ id: number }>) =>
+      new Map(versions.map((v) => [v.id, { canGenerate: true }]))
+  );
+  mockDbRead.modelVersion.findUnique.mockResolvedValue({
+    id: 99,
+    baseModel: 'SDXL 1.0',
+    modelId: 7,
+    status: 'Published',
+    model: { id: 7, type: 'Checkpoint' },
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. The cohort is unblocked, and the widening it could have caused is closed.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('runtime access is governed by SCOPE, not by the authoring capability', () => {
+  // REGRESSION (red at origin/main): the author gate rejected this submit with
+  // FORBIDDEN, which is the whole reason the non-author cohort could not use apps.
+  it('a NON-AUTHOR holding a validly-scoped token can submitWorkflow', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    orchestratorQuoting(25);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+    expect(result.snapshot.workflowId).toBe('wf_real');
+    // The author capability was consulted for nothing on this path — asserting the
+    // OUTCOME alone would still pass if the gate had merely been mocked open, which is
+    // not the claim. The claim is that the runtime no longer asks.
+    expect(mockIsAppBlocksAuthorEnabled).not.toHaveBeenCalled();
+  });
+
+  // REGRESSION (red at origin/main): there was no scope check here at all, so removing
+  // the author gate would have exposed the viewer's balance to ANY valid block token.
+  it('getMyBuzzBalance REJECTS a token lacking buzz:read:self', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: ['ai:write:budgeted'] }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyBuzzBalance({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'block lacks buzz:read:self scope',
+    });
+    // Nothing was read. Without this the test would pass on a FORBIDDEN thrown by any
+    // later gate — including one that had already fetched the balance.
+    expect(mockGetUserBuzzAccounts).not.toHaveBeenCalled();
+  });
+
+  // The positive half of the pair: with the scope, a NON-AUTHOR gets their balance. This
+  // is what proves the FORBIDDEN above is attributable to the scope and not to the
+  // subject being a non-author.
+  it('getMyBuzzBalance SERVES a non-author whose token carries buzz:read:self', async () => {
+    mockVerifyBlockToken.mockResolvedValue(
+      validClaims({ scopes: ['ai:write:budgeted', 'buzz:read:self'] })
+    );
+    mockGetUserBuzzAccounts.mockResolvedValue({ yellow: 7, blue: 3, green: 1 });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyBuzzBalance({ blockToken: 'tok' })).resolves.toEqual({
+      yellow: 7,
+      blue: 3,
+      green: 1,
+    });
+  });
+
+  // INVARIANT GUARD — green at origin/main AND at HEAD. The scope check on these two
+  // procedures already existed; this pins that removing the author gate did not disturb
+  // it. It is NOT regression coverage for this change and must not be counted as such.
+  it('INVARIANT: submitWorkflow rejects a token without ai:write:budgeted', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: ['models:read:self'] }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: 'block lacks ai:write:budgeted scope' });
+  });
+
+  // INVARIANT GUARD — green at origin/main AND at HEAD. Same status as the one above.
+  it('INVARIANT: estimateWorkflow rejects a token without ai:write:budgeted', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: ['models:read:self'] }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.estimateWorkflow({ blockToken: 'tok', body: validBody() })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: 'block lacks ai:write:budgeted scope' });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. The consent budget.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('per-(user, app) consent budget', () => {
+  // 🔴 HOLD THE AUTHOR DIMENSION CONSTANT IN THIS BLOCK. The suite's default subject is a
+  // NON-author, which at `origin/main` is rejected by the author gate before any cap runs
+  // — so every test here would go red at base for a reason that has nothing to do with a
+  // budget, and the red/green matrix would attribute the wrong cause. Granting the author
+  // capability leaves the BUDGET as the only dimension that varies between base and HEAD.
+  beforeEach(() => {
+    mockIsAppBlocksAuthorEnabled.mockImplementation(async () => true);
+    mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: true, tier: 'free' });
+    mockGetUserById.mockResolvedValue({
+      id: 42,
+      isModerator: true,
+      tier: 'free',
+      email: 'u@example.com',
+      username: 'u',
+    });
+  });
+
+  // INVARIANT GUARD — green at origin/main AND at HEAD, and that is the CLAIM: a grant
+  // with no budget must behave byte-identically to the world before the column existed.
+  // It doubles as the POSITIVE CONTROL for the whole counter model: a reassuring "no
+  // consent key was written" is indistinguishable from a harness wired to nothing unless
+  // something in the same test makes a number move, so this asserts BOTH — the platform
+  // counter reached 25, and the consent counter was never touched.
+  it('INVARIANT: NULL budget writes no consent key, and the platform counter still moves', async () => {
+    mockGrantFindUnique.mockResolvedValue({ buzzBudgetPerDay: null, revokedAt: null });
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    orchestratorQuoting(25);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+    expect(result.snapshot.workflowId).toBe('wf_real');
+    expect(counters.get(keyUnder(DAILY_PREFIX))).toBe(25); // the number moved
+    expect(anyKeyUnder(CONSENT_PREFIX)).toBe(false); // and only the one key was used
+  });
+
+  // INVARIANT GUARD — green at both. The platform ceiling is unchanged; this pins that
+  // the second reservation did not accidentally relax it.
+  it('INVARIANT: NULL budget still binds at the 50k platform cap', async () => {
+    mockGrantFindUnique.mockResolvedValue({ buzzBudgetPerDay: null, revokedAt: null });
+    seeds.push([DAILY_PREFIX, BLOCK_BUZZ_CAP_PER_DAY - 10]);
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    orchestratorQuoting(25);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+    expect(result.snapshot.status).toBe('failed');
+    expect(result.snapshot.error).toContain('daily Buzz cap reached');
+    // Only ONE orchestrator call — the whatIf. The real submit never ran.
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  // REGRESSION (red at origin/main — the concept does not exist there).
+  it('a spend over the consented per-app budget is REJECTED', async () => {
+    mockGrantFindUnique.mockResolvedValue({ buzzBudgetPerDay: 100, revokedAt: null });
+    seeds.push([CONSENT_PREFIX, 90]); // 90 already spent by this app today
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    orchestratorQuoting(25); // 90 + 25 = 115 > 100
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+    expect(result.snapshot.status).toBe('failed');
+    expect(result.snapshot.error).toContain('app Buzz limit reached');
+    // The user's own number is in the message — it is their setting, not a platform secret.
+    expect(result.snapshot.error).toContain('your limit for this app is 100');
+    // No real submit. `toHaveBeenCalledTimes(1)` is the whatIf quote only.
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  // 🔴 REGRESSION (red at origin/main), and the correctness requirement this whole
+  // change turns on. A denial that keeps the platform reservation silently burns the
+  // viewer's 50,000/day allowance for a generation that never ran.
+  it('a consent-budget denial REFUNDS the platform daily reservation', async () => {
+    mockGrantFindUnique.mockResolvedValue({ buzzBudgetPerDay: 100, revokedAt: null });
+    seeds.push([CONSENT_PREFIX, 90]);
+    seeds.push([DAILY_PREFIX, 300]); // 300 already spent today across all apps
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    orchestratorQuoting(25);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+    expect(result.snapshot.status).toBe('failed');
+
+    const dailyKey = keyUnder(DAILY_PREFIX);
+    const consentKey = keyUnder(CONSENT_PREFIX);
+    // BACK TO THE PRE-ATTEMPT VALUE — not merely "below the cap".
+    expect(counters.get(dailyKey)).toBe(300);
+    expect(counters.get(consentKey)).toBe(90);
+    // And it genuinely round-tripped rather than never being reserved: both legs were
+    // INCRBY'd and both were DECRBY'd. Without this pair the assertion above would also
+    // pass if the reservation had been skipped entirely.
+    expect(mockSysRedis.incrBy).toHaveBeenCalledWith(dailyKey, 25);
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(dailyKey, 25);
+    expect(mockSysRedis.incrBy).toHaveBeenCalledWith(consentKey, 25);
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(consentKey, 25);
+  });
+
+  // REGRESSION (red at origin/main), and specifically the BOUNDARY case. Without it a
+  // `>` → `>=` mutation of the guard SURVIVES: every other test here sits well clear of
+  // the cap, so only a spend landing EXACTLY on it can tell the two operators apart. The
+  // budget is a ceiling the user consented to, so spending up to it must be allowed.
+  it('a spend landing EXACTLY on the consented budget SUCCEEDS', async () => {
+    mockGrantFindUnique.mockResolvedValue({ buzzBudgetPerDay: 100, revokedAt: null });
+    seeds.push([CONSENT_PREFIX, 75]);
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    orchestratorQuoting(25); // 75 + 25 = 100, exactly the cap
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+    expect(result.snapshot.workflowId).toBe('wf_real');
+    expect(counters.get(keyUnder(CONSENT_PREFIX))).toBe(100);
+  });
+
+  // REGRESSION (red at origin/main). A spend INSIDE the budget goes through and both
+  // counters carry it — the negative image of the two tests above, so "rejected" cannot
+  // be the answer the code gives for everything.
+  it('a spend within the consented budget SUCCEEDS and charges both counters', async () => {
+    mockGrantFindUnique.mockResolvedValue({ buzzBudgetPerDay: 100, revokedAt: null });
+    seeds.push([CONSENT_PREFIX, 50]);
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    orchestratorQuoting(25); // 50 + 25 = 75 <= 100
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+    expect(result.snapshot.workflowId).toBe('wf_real');
+    expect(counters.get(keyUnder(CONSENT_PREFIX))).toBe(75);
+    expect(counters.get(keyUnder(DAILY_PREFIX))).toBe(25);
+  });
+
+  // INVARIANT GUARD — green at origin/main AND at HEAD, and the reason is worth stating
+  // rather than glossing: at base it passes VACUOUSLY, because no consent key exists to
+  // find. It carries information only at HEAD, where the feature is present and the skip
+  // is a real branch. Do NOT count it as regression coverage. A dev/live-harness token is
+  // self-bound and its appBlockId is frequently synthetic, so it takes no consent
+  // reservation — the same exclusion `reserveAppSpend` already takes.
+  it('a dev token takes NO consent reservation even when a budget exists', async () => {
+    mockGrantFindUnique.mockResolvedValue({ buzzBudgetPerDay: 1, revokedAt: null });
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ dev: true }));
+    orchestratorQuoting(25); // would blow a budget of 1 instantly if it applied
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+    expect(result.snapshot.workflowId).toBe('wf_real');
+    expect(anyKeyUnder(CONSENT_PREFIX)).toBe(false);
+    // The grant row was never even read — the skip is upstream of the DB call.
+    expect(mockGrantFindUnique).not.toHaveBeenCalled();
+  });
+
+  // INVARIANT GUARD — green at both, vacuously at base for the same reason as the dev
+  // test above. A revoked grant reports no budget, mirroring getGrantedScopes: a revoked
+  // grant carries no spend scope, so there is nothing for a budget to bound and enforcing
+  // a stale one would be enforcing against nothing.
+  it('a REVOKED grant contributes no consent budget', async () => {
+    mockGrantFindUnique.mockResolvedValue({ buzzBudgetPerDay: 1, revokedAt: new Date() });
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    orchestratorQuoting(25);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+    expect(result.snapshot.workflowId).toBe('wf_real');
+    expect(anyKeyUnder(CONSENT_PREFIX)).toBe(false);
+  });
+
+  // REGRESSION (red at origin/main). Fail CLOSED: a budget that cannot be READ must not
+  // be treated as absent, because absent means "unbounded within the platform cap" — the
+  // one direction a money cap must never drift. And the platform leg must not stay burned.
+  it('a DB error reading the budget fails the submit CLOSED and refunds the platform leg', async () => {
+    mockGrantFindUnique.mockRejectedValue(new Error('replica unavailable'));
+    seeds.push([DAILY_PREFIX, 300]);
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    orchestratorQuoting(25);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
+    ).rejects.toThrow();
+
+    expect(counters.get(keyUnder(DAILY_PREFIX))).toBe(300);
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1); // whatIf only — no real submit
+  });
+});

--- a/src/server/routers/__tests__/blocks.router.scopeEnforcement.test.ts
+++ b/src/server/routers/__tests__/blocks.router.scopeEnforcement.test.ts
@@ -672,9 +672,7 @@ describe('per-(user, app) consent budget', () => {
     orchestratorQuoting(25);
 
     const caller = blocksRouter.createCaller(fakeCtx() as never);
-    await expect(
-      caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
-    ).rejects.toThrow();
+    await expect(caller.submitWorkflow({ blockToken: 'tok', body: validBody() })).rejects.toThrow();
 
     expect(counters.get(keyUnder(DAILY_PREFIX))).toBe(300);
     expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1); // whatIf only — no real submit

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
 // Type-only: names the shape `importOriginal()` returns for the step registry
 // mock below. A `typeof import(...)` annotation there is an eslint error
@@ -568,6 +568,19 @@ redisMock.sysRedis.expire.mockImplementation(async () => true);
 redisMock.sysRedis.ttl.mockImplementation(async () => -1);
 const mockDbRead = dbMock.dbRead;
 const mockDbWriteUserFindUnique = dbMock.dbWrite.user.findUnique;
+/**
+ * The CONSENT-BUDGET read. `getConsentBuzzBudget` goes to the PRIMARY (`dbWrite`) by
+ * design — see its docblock — so this is the handle that decides whether a submit
+ * takes the second reservation at all. Post-`mockReset` the shared db mock answers
+ * `null` for any `findUnique`, i.e. "no grant row" → no consent budget → the pre-PR
+ * behaviour, which is why every other test in this file is unaffected.
+ */
+const mockScopeGrantFindUnique = dbMock.dbWrite.appUserScopeGrant.findUnique;
+const CONSENT_KEY_RE = /^system:blocks:consent-budget:42:apb_test:/;
+/** Declare the viewer's stored per-app daily limit for the app under test. */
+function withConsentBudget(buzzBudgetPerDay: number | null) {
+  mockScopeGrantFindUnique.mockResolvedValue({ buzzBudgetPerDay, revokedAt: null });
+}
 const mockLogToAxiom = loggingMock.logToAxiom;
 
 function validClaims(over: Record<string, unknown> = {}) {
@@ -6528,6 +6541,190 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
     });
   });
 
+  // ── CONSENT BUDGET — the per-(user, app, UTC-day) ceiling the VIEWER set for this
+  // app (`app_user_scope_grants.buzz_budget_per_day`).
+  //
+  // 🔴 THIS SUITE EXISTS BECAUSE THE WHOLE LEG WAS UNGUARDED. Audit round 1 ran a
+  // mutation sweep against the shipped 5,214-test suite: neutralising the customComfy
+  // consent DENY (M3), and blanking `consentBudgetKey` on the settle record (M6), both
+  // SURVIVED — because no test in this file ever drove a submit with a NON-NULL budget,
+  // so the second reservation was never taken and every assertion read `null`.
+  describe("submitWorkflow — CONSENT BUDGET (the viewer's own per-app ceiling)", () => {
+    afterEach(() => {
+      // Per-FILE reset only (see src/__tests__/mocks) — hand the shared handle back to
+      // its "no grant row" default so nothing after this suite inherits a budget.
+      mockScopeGrantFindUnique.mockReset();
+    });
+
+    it('reserves the CEILING on the consent key too and persists that key on the settle record', async () => {
+      withConsentBudget(5000); // comfortably above the 90 ceiling — non-binding
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(result.snapshot.workflowId).toBe('wf_cc_1');
+      // BOTH legs reserved the same per-engine CEILING (zimage default = 90).
+      expect(mockSysRedis.incrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        90
+      );
+      expect(mockSysRedis.incrBy).toHaveBeenCalledWith(expect.stringMatching(CONSENT_KEY_RE), 90);
+      // 🔴 M6: the settle record must carry the consent key, or the post-paid refund
+      // has nothing to unwind and the user's limit stays charged the CEILING all day.
+      expect(mockPersistCustomComfySettle).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflowId: 'wf_cc_1',
+          consentBudgetKey: expect.stringMatching(CONSENT_KEY_RE),
+          ceiling: 90,
+        })
+      );
+    });
+
+    it('🔴 DENIES the submit when the ceiling would exceed the budget — no spend, BOTH legs refunded', async () => {
+      withConsentBudget(100); // 90-Buzz ceiling on top of prior spend → over
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      // Prior spend on the CONSENT key only: the platform 50k cap stays non-binding,
+      // so a denial can only come from the consent leg. (A test that let both bind
+      // could not tell which guard fired.)
+      mockSysRedis.incrBy.mockImplementation(async (key: string) =>
+        CONSENT_KEY_RE.test(key) ? 150 : 90
+      );
+
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(result.snapshot).toMatchObject({ workflowId: 'failed', status: 'failed' });
+      // NUMBER-BEARING copy — the user's own setting, so it is theirs to be told.
+      expect(result.snapshot.error).toBe(
+        'app Buzz limit reached: 60 already spent today by this app on your behalf, ' +
+          'this generation may cost up to 90, your limit for this app is 100'
+      );
+      // NOTHING was spent…
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      // …and BOTH counters were given back — a denial that burned either one would
+      // charge the user for a generation that never ran.
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        90
+      );
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(expect.stringMatching(CONSENT_KEY_RE), 90);
+    });
+
+    it('ALLOWS a submit that lands exactly ON the budget (the boundary is not a breach)', async () => {
+      withConsentBudget(100);
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      // running total === cap → `total > cap` is false → allowed.
+      mockSysRedis.incrBy.mockImplementation(async (key: string) =>
+        CONSENT_KEY_RE.test(key) ? 100 : 90
+      );
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(result.snapshot.workflowId).toBe('wf_cc_1');
+    });
+
+    it('a NULL budget takes NO second reservation and persists a null key (pre-PR behaviour)', async () => {
+      withConsentBudget(null);
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      const consentIncrs = mockSysRedis.incrBy.mock.calls.filter((c) =>
+        String(c[0]).startsWith('system:blocks:consent-budget:')
+      );
+      expect(consentIncrs).toHaveLength(0);
+      expect(mockPersistCustomComfySettle).toHaveBeenCalledWith(
+        expect.objectContaining({ consentBudgetKey: null })
+      );
+    });
+
+    it('a DEV token skips the consent leg entirely (self-bound; synthetic appBlockId joins no grant row)', async () => {
+      withConsentBudget(100);
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ dev: true }));
+      happyCcResources();
+      happySubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      // Not even READ — the skip is before the DB call, so a dev token can never be
+      // denied by someone else's grant row.
+      expect(mockScopeGrantFindUnique).not.toHaveBeenCalled();
+      const consentIncrs = mockSysRedis.incrBy.mock.calls.filter((c) =>
+        String(c[0]).startsWith('system:blocks:consent-budget:')
+      );
+      expect(consentIncrs).toHaveLength(0);
+    });
+
+    // ── The PARTIAL-FAILURE unwind (audit round 1, finding 2). The INCRBY lands, then
+    // the SEPARATE `expire`/`ttl` round-trip throws. The caller refunds the PLATFORM
+    // key and rethrows — it never learns the consent key, because the throw happens
+    // before the reserve returns — so without a self-unwind inside the reserve the
+    // consent counter alone stays charged. Worse on a first write: the call that threw
+    // IS the `expire` that would have armed the TTL, so the leak has no expiry.
+    it('🔴 an expire FAILURE on the consent leg unwinds BOTH counters to their pre-attempt values', async () => {
+      withConsentBudget(5000);
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      // A running tally, so the assertion is about the NET position of each counter
+      // rather than about which calls happened to be made.
+      const net = new Map<string, number>();
+      mockSysRedis.incrBy.mockImplementation(async (key: string, by: number) => {
+        const total = (net.get(key) ?? 0) + by;
+        net.set(key, total);
+        return total;
+      });
+      mockSysRedis.decrBy.mockImplementation(async (key: string, by: number) => {
+        const total = (net.get(key) ?? 0) - by;
+        net.set(key, total);
+        return total;
+      });
+      mockSysRedis.expire.mockImplementation(async (key: string) => {
+        if (CONSENT_KEY_RE.test(key)) throw new Error('redis expire failed');
+        return true;
+      });
+
+      await expect(caller().submitWorkflow({ blockToken: 'tok', body: ccBody() })).rejects.toThrow(
+        /redis expire failed/
+      );
+
+      // Fail CLOSED — nothing was submitted…
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      // …and NEITHER counter is left holding the reservation.
+      const consentKey = [...net.keys()].find((k) => CONSENT_KEY_RE.test(k));
+      expect(consentKey, 'the consent leg must have been reserved at all').toBeDefined();
+      expect(net.get(consentKey as string)).toBe(0);
+      const platformKey = [...net.keys()].find((k) => k.startsWith('system:blocks:buzz-cap:42:'));
+      expect(net.get(platformKey as string)).toBe(0);
+    });
+
+    it('🔴 an expire FAILURE on the PLATFORM leg unwinds it too (same primitive, same guarantee)', async () => {
+      withConsentBudget(null); // consent leg absent — this is purely the platform leg
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      const net = new Map<string, number>();
+      mockSysRedis.incrBy.mockImplementation(async (key: string, by: number) => {
+        const total = (net.get(key) ?? 0) + by;
+        net.set(key, total);
+        return total;
+      });
+      mockSysRedis.decrBy.mockImplementation(async (key: string, by: number) => {
+        const total = (net.get(key) ?? 0) - by;
+        net.set(key, total);
+        return total;
+      });
+      mockSysRedis.expire.mockRejectedValue(new Error('redis expire failed'));
+
+      await expect(caller().submitWorkflow({ blockToken: 'tok', body: ccBody() })).rejects.toThrow(
+        /redis expire failed/
+      );
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      const platformKey = [...net.keys()].find((k) => k.startsWith('system:blocks:buzz-cap:42:'));
+      expect(platformKey, 'the platform leg must have been reserved at all').toBeDefined();
+      expect(net.get(platformKey as string)).toBe(0);
+    });
+  });
+
   describe('submitWorkflow — security seams', () => {
     it('page-only guard: a MODEL token is rejected fail-closed BEFORE any spend', async () => {
       mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 500 })); // model token
@@ -7852,6 +8049,79 @@ describe("step-type registry bridge (kind: 'step')", () => {
         expect.stringMatching(/^system:blocks:buzz-cap:42:/),
         STEP_PRICE
       );
+    });
+
+    // ── CONSENT BUDGET on the registry-step money path. Same requirement as the
+    // per-app cap above and for the same reason: `kind:'step'` must not be a spend
+    // surface a guardrail cannot see.
+    //
+    // 🔴 MUTATION-PROVEN (audit round 1, M4): neutralising the consent deny in the
+    // step branch SURVIVED the shipped suite, because nothing here ever drove a
+    // submit with a NON-NULL budget.
+    describe("consent budget (the viewer's own per-app ceiling)", () => {
+      afterEach(() => {
+        mockScopeGrantFindUnique.mockReset();
+      });
+
+      it('reserves the declared price on the consent key too when the viewer set a budget', async () => {
+        withConsentBudget(5000);
+        mockVerifyBlockToken.mockResolvedValue(stepClaims());
+        happyUser();
+        happyStepSubmit();
+        const result = await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+        expect(result.snapshot.workflowId).toBe('wf_step_1');
+        expect(mockSysRedis.incrBy).toHaveBeenCalledWith(
+          expect.stringMatching(CONSENT_KEY_RE),
+          STEP_PRICE
+        );
+      });
+
+      it('🔴 DENIES the step when it would exceed the budget — no spend, BOTH legs refunded', async () => {
+        withConsentBudget(10);
+        mockVerifyBlockToken.mockResolvedValue(stepClaims());
+        happyUser();
+        happyStepSubmit();
+        // Only the CONSENT key is over; the platform 50k cap stays non-binding, so a
+        // denial can only have come from this guard.
+        mockSysRedis.incrBy.mockImplementation(async (key: string) =>
+          CONSENT_KEY_RE.test(key) ? 12 : STEP_PRICE
+        );
+
+        const result = await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+        expect(result.snapshot).toMatchObject({
+          workflowId: 'failed',
+          status: 'failed',
+          cost: { total: STEP_PRICE },
+        });
+        expect(result.snapshot.error).toBe(
+          'app Buzz limit reached: 11 already spent today by this app on your behalf, ' +
+            'this step costs 1, your limit for this app is 10'
+        );
+        expect(
+          realSubmitCalls(),
+          'the free QUOTE may have run; NOTHING may have been SPENT'
+        ).toHaveLength(0);
+        expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+          expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+          STEP_PRICE
+        );
+        expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+          expect.stringMatching(CONSENT_KEY_RE),
+          STEP_PRICE
+        );
+      });
+
+      it('a NULL budget takes no consent reservation (pre-PR behaviour on this path)', async () => {
+        withConsentBudget(null);
+        mockVerifyBlockToken.mockResolvedValue(stepClaims());
+        happyUser();
+        happyStepSubmit();
+        await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+        const consentIncrs = mockSysRedis.incrBy.mock.calls.filter((c) =>
+          String(c[0]).startsWith('system:blocks:consent-budget:')
+        );
+        expect(consentIncrs).toHaveLength(0);
+      });
     });
 
     it('SKIPS the per-app cap for a DEV token (synthetic non-FK appBlockId), like every other kind', async () => {

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -3477,100 +3477,41 @@ describe('blocks.submitWorkflow — LoRA install precedence', () => {
 });
 
 /**
- * Developer soft-launch (Phase B) — the block-token-authed runtime procedures
- * re-assert the AUTHOR capability against the RESOLVED viewer (from the token
- * subject, NOT ctx.user). A token whose subject resolves to a NON-author
- * (non-mod, not in the `app-blocks-author` cohort) must be rejected with
- * FORBIDDEN even though the token is otherwise valid (valid signature, correct
- * scopes, matching ctx).
+ * The AUTHORING capability NO LONGER GATES THE BLOCK-TOKEN RUNTIME PROCEDURES.
  *
- * This is the defense-in-depth layer beneath the gated token-minting endpoint:
- * even if a token were somehow minted for a non-author, the runtime refuses it.
+ * This block used to assert the opposite, procedure by procedure: a token whose
+ * subject resolved to a non-author was rejected with FORBIDDEN by
+ * `assertViewerIsAppDeveloper`. That was an AUTHORING capability standing in front
+ * of RUNTIME actions, and its effect was that a viewer who was not an app author
+ * could not USE an app at all. The platform now enforces the viewer's own SCOPE
+ * GRANTS on these paths instead; the author gate survives on exactly one
+ * procedure, `updateUserSettings`, which is pinned at the bottom of this block.
  *
- * NB: the AUTHZ gate resolves the subject via sessionClient.getSessionUserById
- * (mockGetSessionUser) and evaluates isAppBlocksAuthorEnabled against it — a
- * non-mod with no cohort grant → the default mock returns false → FORBIDDEN.
+ * 🔴 THE KILL-SWITCH IS NOW THE ONLY IDENTITY-SHAPED BELT ON THESE PROCS, so its
+ * fail-closed behaviour is no longer backed up by a second one. The vanished-viewer
+ * case below is therefore load-bearing in a way it was not before: it used to be
+ * covered incidentally by the author gate, and the flag mock had to be taught the
+ * REAL flag's shape (base-false, segment-gated ⇒ an undefined user resolves false)
+ * for it to mean anything.
  */
-describe('soft-launch — block-token runtime procedures reject non-author viewers', () => {
-  function nonModViewer() {
-    const nonMod = {
+describe('runtime procedures no longer require the AUTHORING capability', () => {
+  function nonAuthorViewer() {
+    const nonAuthor = {
       id: 42,
       isModerator: false,
       tier: 'free',
       email: 'u@example.com',
       username: 'u',
     };
-    // Both runtime gates resolve the subject via getSessionUserById; a non-author
-    // subject (default author mock = mod-floor only) fails assertViewerIsAppDeveloper.
-    mockGetUserById.mockResolvedValue(nonMod);
-    mockGetSessionUser.mockResolvedValue(nonMod);
+    mockGetUserById.mockResolvedValue(nonAuthor);
+    mockGetSessionUser.mockResolvedValue(nonAuthor);
+    // The default author mock is the mod floor, so this subject is NOT an author.
+    mockIsAppBlocksAuthorEnabled.mockImplementation(async () => false);
   }
 
-  it('pollWorkflow → FORBIDDEN for a non-mod resolved viewer', async () => {
+  it('pollWorkflow SERVES a non-author resolved viewer', async () => {
     mockVerifyBlockToken.mockResolvedValue(validClaims());
-    nonModViewer();
-    const caller = blocksRouter.createCaller(fakeCtx() as never);
-    await expect(
-      caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
-    // The orchestrator must never be reached for a non-mod.
-    expect(mockGetWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('cancelWorkflow → FORBIDDEN for a non-mod resolved viewer', async () => {
-    mockVerifyBlockToken.mockResolvedValue(validClaims());
-    nonModViewer();
-    const caller = blocksRouter.createCaller(fakeCtx() as never);
-    await expect(
-      caller.cancelWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
-    expect(mockCancelWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('estimateWorkflow → FORBIDDEN for a non-mod resolved viewer', async () => {
-    mockVerifyBlockToken.mockResolvedValue(validClaims());
-    nonModViewer();
-    const caller = blocksRouter.createCaller(fakeCtx() as never);
-    await expect(
-      caller.estimateWorkflow({ blockToken: 'tok', body: validBody() })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
-    // No orchestrator interaction for a non-mod.
-    expect(mockSubmitWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('submitWorkflow → FORBIDDEN for a non-mod resolved viewer', async () => {
-    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100 }));
-    nonModViewer();
-    const caller = blocksRouter.createCaller(fakeCtx() as never);
-    await expect(
-      caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
-    // The prompt audit + orchestrator must never run for a non-mod.
-    expect(mockAuditPromptServer).not.toHaveBeenCalled();
-    expect(mockSubmitWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('FORBIDDEN when the resolved viewer has vanished (getSessionUserById → null)', async () => {
-    mockVerifyBlockToken.mockResolvedValue(validClaims());
-    // The enabled kill-switch is mocked ON (default), so the FORBIDDEN comes from
-    // the authz gate: a vanished subject → undefined user → no mod floor + the
-    // author mock's `!!undefined?.isModerator` → false → FORBIDDEN.
-    mockGetUserById.mockResolvedValue(null);
-    mockGetSessionUser.mockResolvedValue(null);
-    const caller = blocksRouter.createCaller(fakeCtx() as never);
-    await expect(
-      caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
-  });
-
-  it('author-capable NON-MOD subject passes the authz gate (cohort widening)', async () => {
-    // A curated non-mod author: the enabled kill-switch is ON and the
-    // `appBlocksAuthor` capability resolves true for this subject → the runtime
-    // proc gets PAST the authz gate (reaches the orchestrator read).
-    mockVerifyBlockToken.mockResolvedValue(validClaims());
-    const cohortAuthor = { id: 42, isModerator: false, tier: 'free', username: 'u' };
-    mockGetSessionUser.mockResolvedValue(cohortAuthor);
-    mockIsAppBlocksAuthorEnabled.mockResolvedValue(true);
+    nonAuthorViewer();
     mockGetWorkflow.mockResolvedValue({
       id: 'wf_1',
       status: 'succeeded',
@@ -3578,11 +3519,71 @@ describe('soft-launch — block-token runtime procedures reject non-author viewe
       steps: [],
     });
     const caller = blocksRouter.createCaller(fakeCtx() as never);
-    const ok = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
-    expect(ok.snapshot.workflowId).toBe('wf_1');
-    expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({
-      user: expect.objectContaining({ id: 42, isModerator: false }),
+    const res = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+    expect(res.snapshot.workflowId).toBe('wf_1');
+    // The capability was not even consulted — the claim is that the runtime stopped
+    // asking, not merely that this particular subject was let through.
+    expect(mockIsAppBlocksAuthorEnabled).not.toHaveBeenCalled();
+  });
+
+  it('cancelWorkflow SERVES a non-author resolved viewer', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    nonAuthorViewer();
+    mockCancelWorkflow.mockResolvedValue(undefined);
+    mockGetWorkflow.mockResolvedValue({
+      id: 'wf_1',
+      status: 'canceled',
+      cost: { total: 0 },
+      steps: [],
     });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await caller.cancelWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+    expect(mockCancelWorkflow).toHaveBeenCalled();
+    expect(mockIsAppBlocksAuthorEnabled).not.toHaveBeenCalled();
+  });
+
+  it('submitWorkflow SERVES a non-author resolved viewer', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100 }));
+    nonAuthorViewer();
+    happyVersionLookup();
+    mockSubmitWorkflow
+      .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+      .mockResolvedValueOnce({
+        id: 'wf_real',
+        status: 'unassigned',
+        cost: { total: 25 },
+        steps: [],
+      });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const res = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+    expect(res.snapshot.workflowId).toBe('wf_real');
+    expect(mockIsAppBlocksAuthorEnabled).not.toHaveBeenCalled();
+  });
+
+  it('the KILL-SWITCH still rejects a vanished viewer (UNAUTHORIZED, no orchestrator call)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockGetUserById.mockResolvedValue(null);
+    mockGetSessionUser.mockResolvedValue(null);
+    // Model the REAL flag rather than the suite's unconditional `true`: it is
+    // base-false and segment-gated, so a vanished subject (undefined user) is
+    // evaluated globally, matches no segment, and resolves false.
+    mockIsAppBlocksEnabled.mockImplementation(async (opts?: { user?: unknown }) => !!opts?.user);
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockGetWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('updateUserSettings STILL requires the authoring capability (the one surviving site)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    nonAuthorViewer();
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.updateUserSettings({ blockToken: 'tok', settings: { theme: 'dark' } })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    // ...and it is THIS gate that refused, not an incidental one.
+    expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalled();
   });
 });
 
@@ -5287,9 +5288,15 @@ describe('blocks workflow — buzz-type parity + spend-attribution currency', ()
 // Money page blocks read the VIEWER's OWN spendable balances via the block
 // token WITHOUT holding buzz:read:self. userId is derived from the self-bound
 // token sub, never client input — a page can only read its own session's user.
+// `getMyBuzzBalance` is no longer the scope-free convenience path it was: it now
+// requires the same `buzz:read:self` CONSENT its sibling self-reads require. The author
+// capability that used to be its only narrowing gate is gone from the runtime, and a
+// scope-free balance read would have been a widening.
+const BALANCE_READ = ['buzz:read:self'];
+
 describe('blocks.getMyBuzzBalance', () => {
   it('returns the three spendable balances for a valid token (from getUserBuzzAccounts)', async () => {
-    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: BALANCE_READ }));
     happyUser();
     // getUserBuzzAccounts returns every spend type; the proc projects to three.
     mockGetUserBuzzAccounts.mockResolvedValue({ blue: 100, green: 20, yellow: 5, red: 999 });
@@ -5303,7 +5310,7 @@ describe('blocks.getMyBuzzBalance', () => {
   });
 
   it('defaults missing account values to 0', async () => {
-    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: BALANCE_READ }));
     happyUser();
     mockGetUserBuzzAccounts.mockResolvedValue({ blue: 50 } as never);
     const caller = blocksRouter.createCaller(fakeCtx() as never);
@@ -5321,7 +5328,7 @@ describe('blocks.getMyBuzzBalance', () => {
   });
 
   it('rejects an anon subject with UNAUTHORIZED (no balance to read)', async () => {
-    mockVerifyBlockToken.mockResolvedValue(validClaims({ sub: 'anon' }));
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ sub: 'anon', scopes: BALANCE_READ }));
     const caller = blocksRouter.createCaller(fakeCtx() as never);
     await expect(caller.getMyBuzzBalance({ blockToken: 'tok' })).rejects.toMatchObject({
       code: 'UNAUTHORIZED',
@@ -5330,7 +5337,7 @@ describe('blocks.getMyBuzzBalance', () => {
   });
 
   it('rejects when the App Blocks flag is disabled (kill-switch)', async () => {
-    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: BALANCE_READ }));
     happyUser();
     mockIsAppBlocksEnabled.mockResolvedValue(false);
     const caller = blocksRouter.createCaller(fakeCtx() as never);
@@ -5341,24 +5348,42 @@ describe('blocks.getMyBuzzBalance', () => {
     expect(mockGetUserBuzzAccounts).not.toHaveBeenCalled();
   });
 
-  it('rejects a non-author subject with FORBIDDEN (author gate, no balance read)', async () => {
-    mockVerifyBlockToken.mockResolvedValue(validClaims());
-    // Enabled kill-switch passes, but the subject is not an app author.
-    mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: false, tier: 'free' });
-    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+  // REPLACES the old "rejects a non-author subject with FORBIDDEN (author gate)". The
+  // author gate is gone from this procedure; CONSENT is what narrows it now, and this is
+  // the test that keeps the removal from being a widening.
+  it('rejects a token lacking buzz:read:self with FORBIDDEN (no balance read)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: ['ai:write:budgeted'] }));
+    happyUser();
     const caller = blocksRouter.createCaller(fakeCtx() as never);
     await expect(caller.getMyBuzzBalance({ blockToken: 'tok' })).rejects.toMatchObject({
       code: 'FORBIDDEN',
+      message: 'block lacks buzz:read:self scope',
     });
     expect(mockGetUserBuzzAccounts).not.toHaveBeenCalled();
+  });
+
+  // The complement: a NON-AUTHOR carrying the consent scope is SERVED. Without this pair
+  // the FORBIDDEN above could equally be attributed to the subject rather than the scope.
+  it('SERVES a non-author subject whose token carries buzz:read:self', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: BALANCE_READ }));
+    mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: false, tier: 'free' });
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    mockGetUserBuzzAccounts.mockResolvedValue({ blue: 1, green: 2, yellow: 3 });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyBuzzBalance({ blockToken: 'tok' })).resolves.toEqual({
+      blue: 1,
+      green: 2,
+      yellow: 3,
+    });
   });
 });
 
 // ---- getMyViewer (host-mediated, token-bound viewer identity read) ----------
 // A page block reads the VIEWER's OWN identity ("who am I") via the block token,
 // backing the SDK useViewer() hook. userId is derived from the self-bound token
-// sub (never client input), gated on the `user:read:self` consent scope (unlike
-// the scope-free getMyBuzzBalance). Mirrors /api/v1/blocks/me: dbWrite ban/mute/
+// sub (never client input), gated on the `user:read:self` consent scope. (So is
+// getMyBuzzBalance now, on `buzz:read:self` — this used to contrast against it as the
+// scope-free read.) Mirrors /api/v1/blocks/me: dbWrite ban/mute/
 // deleted lookup, 404 on deleted, 403 on banned, `status:'muted'` for muted.
 const VIEWER_READ = ['user:read:self'];
 
@@ -5436,15 +5461,18 @@ describe('blocks.getMyViewer', () => {
     expect(mockDbWriteUserFindUnique).not.toHaveBeenCalled();
   });
 
-  it('rejects a non-author subject with FORBIDDEN (author gate, no db read)', async () => {
+  // REPLACES the old "rejects a non-author subject with FORBIDDEN (author gate)". The
+  // author gate no longer runs here; a non-author holding the CONSENT scope is served,
+  // which is the whole point of the change. The `user:read:self` requirement — asserted
+  // by the sibling test below — is what keeps this narrow.
+  it('SERVES a non-author subject whose token carries user:read:self', async () => {
     mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: VIEWER_READ }));
     mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: false, tier: 'free' });
     mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
     const caller = blocksRouter.createCaller(fakeCtx() as never);
-    await expect(caller.getMyViewer({ blockToken: 'tok' })).rejects.toMatchObject({
-      code: 'FORBIDDEN',
-    });
-    expect(mockDbWriteUserFindUnique).not.toHaveBeenCalled();
+    const result = await caller.getMyViewer({ blockToken: 'tok' });
+    expect(result).toMatchObject({ id: 42 });
+    expect(mockDbWriteUserFindUnique).toHaveBeenCalled();
   });
 
   it('rate-limits per blockInstanceId BEFORE the db read (TOO_MANY_REQUESTS)', async () => {
@@ -5562,7 +5590,7 @@ describe('blocks.listMyWorkflows (G6 — persistent output queue read)', () => {
 
 // ---- Buzz self-read bridges (getMyBuzz{Transactions,Accounts} + -----------
 // getMyDailyCompensation) — host-mediated, token-bound, buzz:read:self consent.
-// A `buzz:read:self` claim is REQUIRED (unlike the scope-free getMyBuzzBalance).
+// A `buzz:read:self` claim is REQUIRED (as it now is on getMyBuzzBalance too).
 // ---------------------------------------------------------------------------
 const BUZZ_READ = ['buzz:read:self'];
 
@@ -5882,6 +5910,9 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       expect(mockPersistCustomComfySettle).toHaveBeenCalledWith({
         workflowId: 'wf_cc_1',
         buzzCapKey: expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        // NULL: this viewer set no per-app consent budget, so no second reservation
+        // was taken and the settle has nothing extra to unwind.
+        consentBudgetKey: null,
         appSpendKey: 'system:blocks:app-spend-cap:apb_test:day',
         ceiling: 90,
         engine: 'zimage-turbo', // ccBody default engine (== recipe default)
@@ -6415,6 +6446,7 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       expect(mockPersistCustomComfySettle).toHaveBeenCalledWith({
         workflowId: 'wf_cc_1',
         buzzCapKey: expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        consentBudgetKey: null,
         appSpendKey: null,
         devSessionId: 'bki_dev',
         ceiling: 90,
@@ -6437,6 +6469,7 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       expect(mockPersistCustomComfySettle).toHaveBeenCalledWith({
         workflowId: 'wf_cc_1',
         buzzCapKey: expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        consentBudgetKey: null,
         appSpendKey: 'system:blocks:app-spend-cap:apb_test:day',
         devSessionId: 'bki_dev',
         ceiling: 90,

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -798,10 +798,11 @@ function buzzCapRedisKey(userId: number): `${typeof REDIS_SYS_KEYS.BLOCKS.BUZZ_C
  * until some later submit's `ttl < 0` branch re-arms it and extends the burn another
  * ~25h.
  *
- * MEASURED on this branch (adversarial audit round 1) against the CONSENT leg: an
- * `expire` rejection left `consent = 25` charged while the platform leg was correctly
- * refunded to 0 — the two counters diverging is precisely what
- * `refundBlockBuzzReservation` exists to prevent. The platform and run-for-real legs
+ * MEASURED on this branch (adversarial audit round 1) against the CONSENT leg: with
+ * `sysRedis.expire` made to reject for consent keys, the platform counter came back to
+ * its pre-attempt value and the consent counter stayed charged 25 for a submit that
+ * never happened — the two diverging is precisely what `refundBlockBuzzReservation`
+ * exists to prevent. The platform and run-for-real legs
  * had the identical shape, so all three are fixed here rather than at one call site:
  * open-coding this three times is what let the same defect sit in three places.
  *

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -2773,9 +2773,21 @@ export const blocksRouter = router({
       const alreadyGrantsSpend =
         !grantsSpend &&
         input.buzzBudgetPerDay !== undefined &&
-        (await getGrantedScopes({ userId: ctx.user!.id, appBlockId: input.appBlockId })).has(
-          'ai:write:budgeted'
-        );
+        // 🔴 `db: 'write'` — READ THE PRIMARY, because the write below goes to the
+        // primary. Off the replica this decision lags the grant it is asking about: a
+        // user who consents to `ai:write:budgeted` and then raises their limit lands
+        // inside the replication window, the check answers "no spend scope", and the
+        // budget they just set is silently ignored. Found by the seam test in
+        // blocks.router.getInstallConfig.test.ts — the scopes merged correctly (that
+        // path already used the primary) while the budget alone went missing, which is
+        // exactly how this would have presented in production.
+        (
+          await getGrantedScopes({
+            userId: ctx.user!.id,
+            appBlockId: input.appBlockId,
+            db: 'write',
+          })
+        ).has('ai:write:budgeted');
       const budgetIsMeaningful = grantsSpend || alreadyGrantsSpend;
       await recordScopeGrant({
         userId: ctx.user!.id,

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -16,7 +16,12 @@ import {
   verifyBlockToken,
   type BlockTokenClaims,
 } from '~/server/middleware/block-scope.middleware';
-import { REVIEW_RUN_FOR_REAL_BUZZ_CAP } from '~/shared/constants/block-scope.constants';
+import {
+  BLOCK_BUZZ_CAP_PER_DAY,
+  BLOCK_CONSENT_BUDGET_MAX_PER_DAY,
+  BLOCK_CONSENT_BUDGET_MIN_PER_DAY,
+  REVIEW_RUN_FOR_REAL_BUZZ_CAP,
+} from '~/shared/constants/block-scope.constants';
 import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { dailyBoostReward } from '~/server/rewards/active/dailyBoost.reward';
 import {
@@ -262,19 +267,29 @@ const enforceAppBlocksFlag = middleware(async ({ ctx, next, type }) => {
 });
 
 /**
- * AUTHZ gate for the BLOCK-TOKEN-authed runtime procs (estimate/submit/poll/
- * cancelWorkflow, updateUserSettings). These are `publicProcedure` authenticated
- * by a block JWT that resolves to a viewer userId rather than `ctx.user`, so the
- * `appDeveloperProcedure` middleware can't gate them — we re-assert the AUTHOR
- * capability against the RESOLVED subject here (defense-in-depth: don't trust
- * "only authors get block tokens" — the mint is gated too, but each call
- * re-checks).
+ * AUTHORING gate — the `appBlocksAuthor` capability (Flipt `app-blocks-author`,
+ * static fallback mod-only), asserted against a BLOCK-TOKEN-resolved subject.
  *
- * Developer soft-launch (Phase B): this replaced the old
- * `assertViewerIsModerator` — the subject must hold the `appBlocksAuthor`
- * capability (Flipt `app-blocks-author`, static fallback mod-only), so a curated
- * non-mod cohort can generate + spend Buzz from their OWN block while a random
- * non-author subject is still FORBIDDEN.
+ * 🔴 EXACTLY ONE CALL SITE REMAINS: `updateUserSettings`. Read that as the whole
+ * scope of this function, because it used to be fifteen.
+ *
+ * WHY IT SHRANK. This is an AUTHORING capability, and it was standing in front of
+ * RUNTIME procedures — generate, estimate, poll, cancel, read-my-balance,
+ * read-my-viewer. The effect was that a user who was not an app AUTHOR could not
+ * USE an app at all, which is not what an authoring capability is for and which
+ * blocked the whole non-author cohort. The platform enforces the user's own
+ * SCOPE GRANTS on those paths instead (`claims.scopes.includes(...)`, plus the
+ * per-(user, app) consent budget) — consent is the right authority for "may this
+ * app act on my behalf", and it is per-user rather than per-cohort.
+ *
+ * 🔴 THE REMAINING SITE IS A DELIBERATE EXCEPTION, NOT AN OVERSIGHT — do not
+ * "unify" it. `updateUserSettings` writes the block INSTALL's persisted settings,
+ * which is an authoring/publishing-shaped action rather than a runtime one, and
+ * no block scope expresses it.
+ *
+ * These procs are `publicProcedure` authenticated by a block JWT that resolves to
+ * a viewer userId rather than `ctx.user`, so the `appDeveloperProcedure`
+ * middleware cannot gate them — hence the explicit re-assert here.
  *
  * Hydrates the subject IDENTICALLY to `assertAppBlocksEnabledForTokenUser` (the
  * enabled kill-switch that runs right before this) — `sessionClient
@@ -285,7 +300,8 @@ const enforceAppBlocksFlag = middleware(async ({ ctx, next, type }) => {
  * segment) → FORBIDDEN (fail-closed).
  *
  * This is the AUTHZ half only; the `isAppBlocksEnabled` kill-switch
- * (`assertAppBlocksEnabledForTokenUser`) still runs first and is unchanged.
+ * (`assertAppBlocksEnabledForTokenUser`) still runs first and is unchanged — it
+ * is the kill-switch and it stays on EVERY block-token proc.
  */
 async function assertViewerIsAppDeveloper(userId: number): Promise<void> {
   const user = (await sessionClient.getSessionUserById(userId)) as SessionUser | null;
@@ -339,9 +355,10 @@ async function assertAppEditAccess(
  * mod-segmented flag resolves `true` only for a moderator subject; a non-mod or
  * anon (`sub:'anon'` → no resolvable user) subject still resolves `false` →
  * blocked. `verifyBlockToken` (caller) already rejected invalid/expired/revoked
- * tokens before this runs, and `assertViewerIsAppDeveloper` + every other belt
- * (budget cap, daily Buzz cap, reserveBlockBuzzSpend, getOrchestratorToken,
- * forced-SFW) are unchanged — this only swaps which identity the FLAG sees.
+ * tokens before this runs, and every other belt (the per-scope consent checks,
+ * budget cap, daily Buzz cap, the per-(user, app) consent budget,
+ * reserveBlockBuzzSpend, getOrchestratorToken, forced-SFW) is unchanged — this
+ * only swaps which identity the FLAG sees.
  *
  * Resolves the FULL server-side SessionUser via `sessionClient.getSessionUserById`
  * (the hub-backed resolver; never a client-supplied value) so the segment match
@@ -366,8 +383,9 @@ async function assertAppBlocksEnabledForTokenUser(userId: number): Promise<void>
   // Full, authoritative SessionUser (cached; tier derived from active
   // subscriptions) so buildFliptContext sees the user's REAL tier/isMember,
   // not type-defaults. A vanished user → undefined → global eval → flag false
-  // → blocked (fail-closed; the subsequent assertViewerIsAppDeveloper would also
-  // reject).
+  // → blocked (fail-closed). This is the LAST identity-shaped belt on most runtime
+  // procs now that the author gate is off them, so its fail-closed posture is not
+  // backed up by a second one — do not weaken it.
   // getSessionUserById returns the package SessionUser (loosely typed at this boundary — cast as bearer-token.ts
   // does) or null for a vanished user. null → undefined → isAppBlocksEnabled's global eval → flag false → blocked.
   const user = (await sessionClient.getSessionUserById(userId)) as SessionUser | null;
@@ -385,10 +403,14 @@ async function assertAppBlocksEnabledForTokenUser(userId: number): Promise<void>
  * carry the declared+granted `buzz:read:self` scope.
  *
  * Order (each step fail-closed): verify token → require consent scope → self-bind
- * the userId off `claims.sub` (never client input) → App-Blocks kill-switch +
- * author gate against the token subject → per-instance rate limit (keyed on the
- * stable `blockInstanceId`, BEFORE any db/ClickHouse work). Returns the
- * self-bound `userId` + verified `claims`.
+ * the userId off `claims.sub` (never client input) → App-Blocks kill-switch
+ * against the token subject → per-instance rate limit (keyed on the stable
+ * `blockInstanceId`, BEFORE any db/ClickHouse work). Returns the self-bound
+ * `userId` + verified `claims`.
+ *
+ * The consent scope — not an authoring capability — is the authority here: the
+ * author gate that used to follow the kill-switch is gone from every runtime
+ * proc (see `assertViewerIsAppDeveloper`).
  */
 async function authorizeBlockBuzzRead(
   blockToken: string
@@ -406,7 +428,6 @@ async function authorizeBlockBuzzRead(
     });
   }
   await assertAppBlocksEnabledForTokenUser(userId);
-  await assertViewerIsAppDeveloper(userId);
   // Per-instance rate limit (shared blocks limiter) — bounds a block hammering
   // these private reads (esp. daily-compensation → ClickHouse) onto the origin.
   // Runs BEFORE any service call. Fail-open on a redis incident.
@@ -510,10 +531,15 @@ function resolveBlockMaturity(claims: { maxBrowsingLevel?: number }): {
 // early-access / Private — it does not.
 //
 // Pass the REAL viewer context (their id + real isModerator + the request's
-// sfwOnly/wildcards flags) — never an elevated context. Today the viewer is
-// always an author (assertViewerIsAppDeveloper), so they see the appropriate
-// access; when GA opens further the same gate bounds them properly. Fail-closed:
-// a version missing from the result Map → FORBIDDEN.
+// sfwOnly/wildcards flags) — never an elevated context.
+//
+// 🔴 THE VIEWER IS NO LONGER ALWAYS AN APP AUTHOR. This comment used to say they
+// were, and leaned on it ("so they see the appropriate access"); the author gate
+// has since been removed from every runtime proc, so an ORDINARY consented viewer
+// reaches here. That is exactly why the gate must be passed the real viewer
+// context and must stay fail-closed — it is now the only thing standing between a
+// non-author viewer and an early-access / Private version. Fail-closed: a version
+// missing from the result Map → FORBIDDEN.
 //
 // Page-LoRA (Increment 1): generalized from 1→N versions. The checkpoint AND
 // every picked LoRA are gated in ONE `resolveCanGenerateForVersions` call (it
@@ -724,10 +750,16 @@ async function resolvePageLoraGates(opts: {
 // error on the reserve throws and fails the submit CLOSED, identical to the old
 // read path's fail-closed posture.
 //
-// The aggregate ceiling is a fixed platform default today. When the W5 consent
-// layer lands (app_user_scope_grants), the per-install/consent aggregate limit
-// should override this default — surfaced to the user at install/consent time.
-const BLOCK_BUZZ_CAP_PER_DAY = 50_000;
+// The aggregate ceiling is a fixed PLATFORM default and stays one. The W5 consent
+// layer (app_user_scope_grants) has since landed, and its per-(user, app) budget
+// does NOT override this — it is a SECOND, strictly-narrower reservation on top of
+// it (see `reserveBlockBuzzSpendForClaims`). The earlier plan to have consent
+// REPLACE the platform ceiling would have let a user consent their way OUT of the
+// abuse cap, so the two stack instead and the tighter one binds.
+//
+// The value itself now lives in `~/shared/constants/block-scope.constants` because
+// three places must agree on it: this enforcement, the zod bound on a user-set
+// consent budget, and the consent dialog that shows the user the ceiling.
 // 25h TTL: comfortably covers a UTC-day window plus clock skew; the key is
 // re-derived per day so a stale counter never bleeds into the next window.
 const BLOCK_BUZZ_CAP_TTL_SECONDS = 25 * 60 * 60;
@@ -836,27 +868,187 @@ async function reserveReviewRunForRealBuzzSpend(
   return { total, key };
 }
 
+// ---- CONSENT BUDGET — the per-(USER, APP BLOCK, UTC-day) ceiling the VIEWER set
+//      for THIS app at consent time (`app_user_scope_grants.buzz_budget_per_day`).
+//
+// The two caps above are PLATFORM caps: BLOCK_BUZZ_CAP_PER_DAY bounds one user
+// across ALL their apps (deliberately no appBlockId in the key), and the G8
+// per-app cap bounds one app across ALL users. Neither can express "I am happy for
+// THIS app to spend 500 of my Buzz a day and no more" — which is the thing a user
+// actually consents to. This is that third axis, and it is the ONLY one of the
+// three the user chooses.
+//
+// BOTH CAPS APPLY; THE TIGHTER ONE BINDS. The consent budget does not replace the
+// platform ceiling — it is bounded ABOVE by it (see BLOCK_CONSENT_BUDGET_MAX_PER_DAY),
+// so it can only ever narrow.
+//
+// A NULL budget writes NO key and takes NO reservation: behaviour is byte-identical
+// to before this existed, which is what makes shipping it without a backfill safe.
+const CONSENT_BUDGET_TTL_SECONDS = 25 * 60 * 60;
+
+function consentBudgetRedisKey(
+  userId: number,
+  appBlockId: string
+): `${typeof REDIS_SYS_KEYS.BLOCKS.CONSENT_BUDGET}:${string}` {
+  // PER-(user, app) — the appBlockId IS in the key, which is the whole difference
+  // from buzzCapRedisKey. Same UTC-day window so the two counters roll together.
+  return `${REDIS_SYS_KEYS.BLOCKS.CONSENT_BUDGET}:${userId}:${appBlockId}:${buzzCapWindowKey()}`;
+}
+
 /**
- * Picks the correct cumulative Buzz reservation for a submit given its verified
- * token claims: a RUN-FOR-REAL token (signed `reviewRunForReal:true`) reserves
- * against the tight per-(mod, publishRequestId) cumulative ceiling (rolling ~25h
- * window); every other token keeps the ordinary per-user daily cap —
- * BYTE-IDENTICAL to before. Returns the reserved `key` (all refund sites key off
- * it) plus the `cap` to compare the running `total` against. The run-for-real
- * reservation id is the token's `appBlockId` claim (the `pubreq_<ULID>` request id
- * the mint stamps).
+ * Atomically reserves `cost` against the (user, app, UTC-day) consent-budget
+ * counter. Identical atomic INCRBY + first-write-EX (+ ttl<0 re-arm) shape as
+ * `reserveBlockBuzzSpend`; fails CLOSED on a Redis error (throws).
+ */
+async function reserveConsentBudgetSpend(
+  userId: number,
+  appBlockId: string,
+  cost: number
+): Promise<{ total: number; key: ReturnType<typeof consentBudgetRedisKey> }> {
+  const key = consentBudgetRedisKey(userId, appBlockId);
+  const total = await sysRedis.incrBy(key, Math.ceil(cost));
+  if (total <= Math.ceil(cost)) {
+    await sysRedis.expire(key, CONSENT_BUDGET_TTL_SECONDS);
+  } else {
+    const ttl = await sysRedis.ttl(key);
+    if (ttl < 0) await sysRedis.expire(key, CONSENT_BUDGET_TTL_SECONDS);
+  }
+  return { total, key };
+}
+
+/**
+ * The reservation a spend path holds. `key`/`total`/`cap` are the PLATFORM
+ * cumulative reservation (daily per-user, or the run-for-real session ceiling) —
+ * unchanged names so every existing destructure still reads the same thing.
+ * `consent` is the SECOND reservation, present only when the viewer set a budget
+ * for this app; `null` means no consent budget applies and nothing extra was
+ * written.
+ */
+type BlockBuzzReservation = {
+  total: number;
+  key: string;
+  cap: number;
+  consent: { total: number; key: string; cap: number } | null;
+};
+
+/**
+ * Picks the correct cumulative Buzz reservation(s) for a submit given its verified
+ * token claims.
+ *
+ * PLATFORM leg (unchanged): a RUN-FOR-REAL token (signed `reviewRunForReal:true`)
+ * reserves against the tight per-(mod, publishRequestId) cumulative ceiling
+ * (rolling ~25h window); every other token keeps the ordinary per-user daily cap.
+ * Returns the reserved `key` (all refund sites key off it) plus the `cap` to
+ * compare the running `total` against. The run-for-real reservation id is the
+ * token's `appBlockId` claim (the `pubreq_<ULID>` request id the mint stamps).
+ *
+ * CONSENT leg (new): when the grant row for (userId, `claims.appBlockId`) carries a
+ * non-null `buzzBudgetPerDay`, ALSO reserve `cost` against a per-(user, app,
+ * UTC-day) counter capped at that value.
+ *
+ * 🔴 TWO SKIPS, EACH FOR ITS OWN REASON — they are not one condition wearing two
+ * hats:
+ *   - `claims.dev === true` — a dev/live-harness token is SELF-BOUND (only the
+ *     owner can spend, and only their own Buzz) and carries an appBlockId that is
+ *     frequently SYNTHETIC (`ephemeral-…`, `page_local_…`, `pubreq_…`) and joins to
+ *     no grant row at all. It is the same exclusion `reserveAppSpend` already
+ *     takes, for the same reason: an author iterating locally is not the audience a
+ *     consent budget exists to protect, and there is no consent to read.
+ *   - `claims.reviewRunForReal === true` — that arm deliberately SWAPS IN its own,
+ *     strictly tighter ceiling in place of the daily cap, and its `appBlockId` is a
+ *     `pubreq_<ULID>` publish-request id, not an AppBlock id. Layering a consent
+ *     budget on top would be reading a grant for an app that is not yet approved.
+ *
+ * FAIL-CLOSED, IN BOTH DIRECTIONS THAT MATTER. A Redis error on the consent leg
+ * refunds the platform leg and rethrows, so a failed reservation never leaves the
+ * user's daily allowance burned. A DB error reading the budget likewise throws
+ * rather than being treated as "no budget": absent means UNBOUNDED-within-50k, so
+ * swallowing the error would silently widen the ceiling the user consented to.
  */
 async function reserveBlockBuzzSpendForClaims(
   claims: BlockTokenClaims,
   userId: number,
   cost: number
-): Promise<{ total: number; key: string; cap: number }> {
+): Promise<BlockBuzzReservation> {
   if (claims.reviewRunForReal === true) {
     const { total, key } = await reserveReviewRunForRealBuzzSpend(userId, claims.appBlockId, cost);
-    return { total, key, cap: REVIEW_RUN_FOR_REAL_BUZZ_CAP };
+    return { total, key, cap: REVIEW_RUN_FOR_REAL_BUZZ_CAP, consent: null };
   }
   const { total, key } = await reserveBlockBuzzSpend(userId, cost);
-  return { total, key, cap: BLOCK_BUZZ_CAP_PER_DAY };
+  const platform = { total, key, cap: BLOCK_BUZZ_CAP_PER_DAY };
+  if (claims.dev === true) return { ...platform, consent: null };
+
+  // From here any throw must undo the platform reservation just taken — otherwise a
+  // failed attempt permanently burns the viewer's 50k/day allowance for a spend that
+  // never happened. Same rule the consent-DENY path below obeys.
+  let budget: number | null;
+  try {
+    const { getConsentBuzzBudget } = await import('~/server/services/blocks/scope-grant.service');
+    budget = await getConsentBuzzBudget({ userId, appBlockId: claims.appBlockId });
+  } catch (e) {
+    await refundBlockBuzzSpend(key, cost);
+    throw e;
+  }
+  if (budget == null) return { ...platform, consent: null };
+
+  try {
+    const consent = await reserveConsentBudgetSpend(userId, claims.appBlockId, cost);
+    return { ...platform, consent: { ...consent, cap: budget } };
+  } catch (e) {
+    await refundBlockBuzzSpend(key, cost);
+    throw e;
+  }
+}
+
+/**
+ * Refunds a reservation on EVERY key it holds — the platform cumulative counter
+ * and, when present, the consent budget.
+ *
+ * 🔴 THIS EXISTS SO THE TWO CAN NEVER DIVERGE. Every non-committed exit already had
+ * to refund the platform key; adding a second key meant either this helper or a
+ * second `refundBlockBuzzSpend(...)` line at each of the ~12 refund sites, and the
+ * second shape regenerates the same omission bug at every site (one such site would
+ * be enough: a denied attempt that refunds only one of two counters burns the other
+ * for the rest of the day). Callers pass the whole reservation, not a key.
+ *
+ * Best-effort per key, like `refundBlockBuzzSpend`: a lost refund OVER-counts, which
+ * makes a cap stricter — the safe direction. Never throws into the caller.
+ */
+async function refundBlockBuzzReservation(
+  reservation: BlockBuzzReservation,
+  cost: number
+): Promise<void> {
+  await refundBlockBuzzSpend(reservation.key, cost);
+  if (reservation.consent) await refundBlockBuzzSpend(reservation.consent.key, cost);
+}
+
+/** True when the reservation's CONSENT leg exists and its running total is over the
+ *  user's chosen budget. Separate from the platform check because the two produce
+ *  different messages and the platform one must be evaluated first (see below). */
+function consentBudgetExceeded(
+  reservation: BlockBuzzReservation
+): reservation is BlockBuzzReservation & {
+  consent: NonNullable<BlockBuzzReservation['consent']>;
+} {
+  return !!reservation.consent && reservation.consent.total > reservation.consent.cap;
+}
+
+/**
+ * Rejection copy for a consent-budget breach. Deliberately NUMBER-BEARING, unlike
+ * the per-app aggregate cap's message: that ceiling is a platform secret an app
+ * must not learn, while THIS one is the user's own setting — they chose it, they
+ * are the one being told, and hiding it would make the rejection unactionable.
+ * `costClause` differs per path (a fixed estimate vs a post-paid ceiling).
+ */
+function consentBudgetRejection(
+  consent: NonNullable<BlockBuzzReservation['consent']>,
+  cost: number,
+  costClause: string
+): string {
+  return (
+    `app Buzz limit reached: ${consent.total - Math.ceil(cost)} already spent today by ` +
+    `this app on your behalf, ${costClause}, your limit for this app is ${consent.cap}`
+  );
 }
 
 // RUN-FOR-REAL mint rate limit — per-mod fixed window. A privileged,
@@ -2503,6 +2695,26 @@ export const blocksRouter = router({
       z.object({
         appBlockId: z.string().min(1).max(64),
         scopes: z.array(z.string().min(1).max(64)).min(1).max(32),
+        /**
+         * The per-UTC-day Buzz ceiling the viewer sets for THIS app, captured at
+         * consent time. Bounded above by the platform's own per-user daily cap: a
+         * larger number could never bind, so accepting one would be storing a value
+         * that means nothing.
+         *
+         * THREE STATES, and they are all distinct:
+         *   - a number → set/replace the budget
+         *   - `null`   → explicitly clear it (back to platform-cap-only)
+         *   - OMITTED  → leave any stored budget untouched
+         * The last is what keeps a re-consent for an unrelated scope from silently
+         * wiping a limit the user set. See `recordScopeGrant`.
+         */
+        buzzBudgetPerDay: z
+          .number()
+          .int()
+          .min(BLOCK_CONSENT_BUDGET_MIN_PER_DAY)
+          .max(BLOCK_CONSENT_BUDGET_MAX_PER_DAY)
+          .nullable()
+          .optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -2536,14 +2748,58 @@ export const blocksRouter = router({
           message: 'none of the requested scopes are within the app’s approved manifest',
         });
       }
-      const { recordScopeGrant } = await import('~/server/services/blocks/scope-grant.service');
+      // ── The consent budget only means anything alongside `ai:write:budgeted`:
+      // that is the ONLY scope in the vocabulary that can spend Buzz, so a budget
+      // without it bounds nothing. When it is sent without that scope being GRANTED
+      // (neither in this call nor already on the row) we IGNORE it rather than
+      // erroring.
+      //
+      // WHY IGNORE AND NOT REJECT. The natural client shape is one consent dialog
+      // that always sends its budget field, and the scopes vary by what the app
+      // asked for. Erroring would make a perfectly reasonable client fail on a
+      // request that asks for nothing improper, and the failure mode of ignoring is
+      // benign: nothing is stored, so nothing later reads a budget that bounds
+      // nothing. It is NOT silently dropped from the user's point of view either —
+      // `listMyScopeGrants` reports the stored value, so a budget that was ignored
+      // simply does not appear.
+      //
+      // NOTE the ORDER: this reads the CURRENT grant, so consenting to a budget in
+      // the same call that grants `ai:write:budgeted` works (the scope is in
+      // `toGrant`), and so does raising a budget on an app that already holds it.
+      const { recordScopeGrant, getGrantedScopes } = await import(
+        '~/server/services/blocks/scope-grant.service'
+      );
+      const grantsSpend = toGrant.includes('ai:write:budgeted');
+      const alreadyGrantsSpend =
+        !grantsSpend &&
+        input.buzzBudgetPerDay !== undefined &&
+        (await getGrantedScopes({ userId: ctx.user!.id, appBlockId: input.appBlockId })).has(
+          'ai:write:budgeted'
+        );
+      const budgetIsMeaningful = grantsSpend || alreadyGrantsSpend;
       await recordScopeGrant({
         userId: ctx.user!.id,
         appBlockId: input.appBlockId,
         version: block.version ?? '',
         scopes: toGrant,
+        // Spread, NOT `buzzBudgetPerDay: input.buzzBudgetPerDay` — the service
+        // distinguishes an omitted key (leave the stored value alone) from an
+        // explicit `null` (clear it), and passing `undefined` through would collapse
+        // that distinction at the `in` test.
+        ...(input.buzzBudgetPerDay !== undefined && budgetIsMeaningful
+          ? { buzzBudgetPerDay: input.buzzBudgetPerDay }
+          : {}),
       });
-      return { ok: true, granted: toGrant };
+      return {
+        ok: true,
+        granted: toGrant,
+        // Echo what was actually stored so a client can tell an ignored budget from
+        // an applied one without a second round-trip.
+        buzzBudgetPerDay:
+          input.buzzBudgetPerDay !== undefined && budgetIsMeaningful
+            ? input.buzzBudgetPerDay
+            : undefined,
+      };
     }),
 
   /**
@@ -3198,7 +3454,6 @@ export const blocksRouter = router({
       }
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsAppDeveloper(userId);
       const token = await getOrchestratorToken(userId, ctx);
       const waitSeconds = resolveBlockPollWaitSeconds(input.waitSeconds);
       const workflow = await getWorkflow({
@@ -3323,7 +3578,6 @@ export const blocksRouter = router({
       }
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsAppDeveloper(userId);
       const { listMyBlockWorkflows } = await import(
         '~/server/services/blocks/block-workflows.service'
       );
@@ -3374,7 +3628,6 @@ export const blocksRouter = router({
       }
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsAppDeveloper(userId);
       const token = await getOrchestratorToken(userId, ctx);
       await cancelWorkflow({ workflowId: input.workflowId, token });
       const workflow = await getWorkflow({ token, path: { workflowId: input.workflowId } });
@@ -3443,8 +3696,9 @@ export const blocksRouter = router({
    * Order (each step fail-closed): verify token → require `ai:write:budgeted`
    * (same trust boundary as submit — an app that can submit gens can read its own
    * subqueue) → self-bind userId off `claims.sub` (UNAUTHORIZED for anon) →
-   * App-Blocks kill-switch + author gate against the TOKEN subject → per-instance
-   * rate limit → orchestrator LIST with the host-forced tag → project + return.
+   * App-Blocks kill-switch against the TOKEN subject → per-instance rate limit →
+   * orchestrator LIST with the host-forced tag → project + return. (The consent
+   * scope above is the authority; the author capability no longer gates runtime.)
    */
   queryAppWorkflows: publicProcedure
     // Block-JWT-authed (no session for dev:live) — flag evaluated against the
@@ -3473,7 +3727,6 @@ export const blocksRouter = router({
       }
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsAppDeveloper(userId);
       // Per-instance rate limit (shared blocks limiter), BEFORE the orchestrator
       // call. Bounds a block hammering the LIST onto the origin. Fail-open on a
       // redis incident (same posture as the buzz self-read bridges).
@@ -3566,7 +3819,6 @@ export const blocksRouter = router({
       }
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsAppDeveloper(userId);
       // Per-instance rate limit (shared blocks limiter), BEFORE any orchestrator
       // read/DELETE or DB query. Cancel is the HEAVIER path (2 orchestrator GETs +
       // 1 DELETE + 1 DB lookup per call), so it MUST be bounded exactly like the
@@ -3671,7 +3923,6 @@ export const blocksRouter = router({
         });
       }
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsAppDeveloper(userId);
       // Publish has its OWN (image-weighted) bucket — separate from the catalog
       // read bucket. Charge a base token per call up front (bounds call frequency
       // + the getWorkflow read); the per-image remainder is charged below, once
@@ -3936,7 +4187,6 @@ export const blocksRouter = router({
       }
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsAppDeveloper(userId);
       const ctxSlotId = (claims.ctx as { slotId?: unknown } | undefined)?.slotId;
       if (typeof ctxSlotId !== 'string' || ctxSlotId.length === 0) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'block token lacks slotId context' });
@@ -4188,7 +4438,6 @@ export const blocksRouter = router({
       }
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsAppDeveloper(userId);
       const ctxSlotId = (claims.ctx as { slotId?: unknown } | undefined)?.slotId;
       if (typeof ctxSlotId !== 'string' || ctxSlotId.length === 0) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'block token lacks slotId context' });
@@ -4370,8 +4619,11 @@ export const blocksRouter = router({
       // matching the old read path.
       // A RUN-FOR-REAL review token reserves against the tight per-(mod,
       // publishRequestId) cumulative ceiling (rolling ~25h window) instead of the
-      // per-user daily cap (reserveBlockBuzzSpendForClaims picks the right one;
-      // every refund site below keys off the returned `buzzCapKey`, unchanged).
+      // per-user daily cap (reserveBlockBuzzSpendForClaims picks the right one).
+      // The same call ALSO takes the viewer's per-(user, app) CONSENT BUDGET
+      // reservation when they set one, so a reservation can hold TWO keys — every
+      // refund site below therefore passes the whole `reservation` to
+      // `refundBlockBuzzReservation` rather than a single key.
       //
       // ── GEN IDEMPOTENCY CLAIM (audit 🔴-1). Taken BEFORE the cap reservation +
       //    orchestrator submit, so two CONCURRENT same-key submits (a double-click /
@@ -4426,9 +4678,12 @@ export const blocksRouter = router({
         if (genClaimKey) await releaseGenIdempotency(genClaimKey);
         throw e;
       }
-      const { total, key: buzzCapKey, cap: buzzCap } = reservation;
+      const { total, cap: buzzCap } = reservation;
       if (total > buzzCap) {
-        await refundBlockBuzzSpend(buzzCapKey, cost);
+        // 🔴 REFUND THE WHOLE RESERVATION, NOT JUST THE KEY THAT BREACHED. Both legs
+        // were INCRBY'd before either was checked, so refunding one leaves the other
+        // permanently charged for a generation that never ran.
+        await refundBlockBuzzReservation(reservation, cost);
         if (genClaimKey) await releaseGenIdempotency(genClaimKey);
         return {
           snapshot: {
@@ -4446,6 +4701,32 @@ export const blocksRouter = router({
             // #3520 exit 2 — quotes `cost` with no workflow. Additive + omitted
             // when empty, so this reply is byte-identical whenever nothing was
             // substituted.
+            ...(preflightSubstitutions?.length
+              ? { modelSubstitutions: preflightSubstitutions }
+              : {}),
+          },
+        };
+      }
+
+      // ── CONSENT BUDGET (the viewer's OWN per-app daily ceiling). Checked AFTER
+      // the platform cap on purpose: the platform cap is the one the user did not
+      // choose, so when both are breached at once the message that explains the
+      // situation is the platform one. 🔴 The refund is the load-bearing half —
+      // without it a denied attempt silently burns the user's 50k/day platform
+      // allowance for a generation the app was never allowed to run.
+      if (consentBudgetExceeded(reservation)) {
+        await refundBlockBuzzReservation(reservation, cost);
+        if (genClaimKey) await releaseGenIdempotency(genClaimKey);
+        return {
+          snapshot: {
+            workflowId: 'failed',
+            status: 'failed' as const,
+            cost: { total: cost },
+            error: consentBudgetRejection(
+              reservation.consent,
+              cost,
+              `this generation costs ${cost}`
+            ),
             ...(preflightSubstitutions?.length
               ? { modelSubstitutions: preflightSubstitutions }
               : {}),
@@ -4483,7 +4764,7 @@ export const blocksRouter = router({
           // Roll back the per-user reservation made above so a rejected submit
           // doesn't burn the viewer's own daily ceiling for a spend that never
           // happened.
-          await refundBlockBuzzSpend(buzzCapKey, cost);
+          await refundBlockBuzzReservation(reservation, cost);
           // No money moved → release the idempotency claim so a genuine retry can
           // re-run (the app cap may clear; the "retry shortly" messages are transient).
           if (genClaimKey) await releaseGenIdempotency(genClaimKey);
@@ -4549,7 +4830,7 @@ export const blocksRouter = router({
             // (the session reserve rolled ITSELF back on deny) and reject. Also
             // refund the G8 per-app reservation (present only for non-dev tokens;
             // a token with `dev !== true` can still have an active dev tunnel).
-            await refundBlockBuzzSpend(buzzCapKey, cost);
+            await refundBlockBuzzReservation(reservation, cost);
             if (appSpendReserve) {
               const { refundAppSpend } = await import(
                 '~/server/services/blocks/app-spend-cap.service'
@@ -4649,7 +4930,7 @@ export const blocksRouter = router({
         // No resolved submit → undo the reservation (net-equivalent to the old
         // "only record after a resolved submit" behavior) and propagate. Refund
         // against the pinned key, not a re-derived one (midnight-UTC race).
-        await refundBlockBuzzSpend(buzzCapKey, cost);
+        await refundBlockBuzzReservation(reservation, cost);
         // G8 — mirror the daily refund for the per-app aggregate reservation so a
         // failed submit doesn't permanently burn the app's daily ceiling.
         // Best-effort; present only for non-dev tokens.
@@ -4913,18 +5194,31 @@ export const blocksRouter = router({
    * NOTE: `buzz:read:self` is page-safe (PAGE_FORBIDDEN_SCOPES is empty — see
    * slot-registry.ts), and the richer self-reads (ledger / all-pool balances /
    * per-model earnings) live on the sibling `getMyBuzz{Transactions,Accounts}` /
-   * `getMyDailyCompensation` bridges, which REQUIRE that scope. This procedure
-   * stays the scope-free convenience path: the FIRST-PARTY host exposing the
-   * viewer's OWN spendable balance to their OWN page session, mediated by the
-   * proof-of-session block token — userId is derived from the token `sub`
-   * (self-bound), NEVER from client input, so a page can only ever read the
-   * balance of the exact user whose session minted the token.
+   * `getMyDailyCompensation` bridges, which require that scope via
+   * `authorizeBlockBuzzRead`.
    *
-   * Auth model is IDENTICAL to submitWorkflow's block-token gate: verify the
-   * token, require an authenticated (non-anon) subject, then the App-Blocks
-   * enabled kill-switch + author gate evaluated against the TOKEN subject. Only
-   * the three spendable types the UI needs are returned (blue/green/yellow) —
-   * internal types (red / creatorProgram / cash) are omitted.
+   * 🔴 THIS IS NO LONGER "the scope-free convenience path", AND THE CHANGE IS THE
+   * POINT. It used to carry no scope check at all, relying on
+   * `assertViewerIsAppDeveloper` — an AUTHORING capability — to keep it narrow.
+   * Removing that gate (so the non-author cohort can use apps at all) would have
+   * left this proc readable by ANY valid block token, i.e. a widening. The
+   * platform enforces SCOPE GRANTS instead, so this now requires the same
+   * `buzz:read:self` consent its sibling reads require. The self-binding is
+   * unchanged and still absolute: `userId` comes from the token `sub`, NEVER from
+   * client input, so a page can only read the balance of the exact user whose
+   * session minted the token.
+   *
+   * ⚠️ CONSEQUENCE FOR EXISTING APPS: a token that does not carry
+   * `buzz:read:self` now gets FORBIDDEN here where it previously got a balance.
+   * That is the intended tightening — the scope is the user's own consent — but it
+   * is a wire-visible behaviour change for any app that read the balance without
+   * declaring the scope.
+   *
+   * Auth model is otherwise IDENTICAL to submitWorkflow's block-token gate: verify
+   * the token, require the consent scope, require an authenticated (non-anon)
+   * subject, then the App-Blocks enabled kill-switch evaluated against the TOKEN
+   * subject. Only the three spendable types the UI needs are returned
+   * (blue/green/yellow) — internal types (red / creatorProgram / cash) are omitted.
    */
   getMyBuzzBalance: publicProcedure
     // Block-JWT-authed (no session for dev:live) — flag evaluated against the
@@ -4940,6 +5234,12 @@ export const blocksRouter = router({
     .mutation(async ({ input }) => {
       const claims = await verifyBlockToken(input.blockToken);
       if (!claims) throw new TRPCError({ code: 'UNAUTHORIZED', message: 'invalid block token' });
+      // CONSENT gate — the user's own grant is what authorizes this read now that
+      // the author capability no longer gates the runtime. Checked BEFORE the
+      // subject is resolved, matching authorizeBlockBuzzRead's order.
+      if (!claims.scopes.includes('buzz:read:self')) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'block lacks buzz:read:self scope' });
+      }
       // Derive the user from the SELF-BOUND token subject, never client input.
       const userId = parseSubjectUserId(claims.sub);
       if (userId == null) {
@@ -4948,10 +5248,9 @@ export const blocksRouter = router({
           message: 'buzz balance requires an authenticated viewer',
         });
       }
-      // Same gates as the other block-token procs, evaluated against the TOKEN
-      // subject: the enabled kill-switch AND the author capability.
+      // The App-Blocks kill-switch, evaluated against the TOKEN subject. (The
+      // author capability is deliberately NOT checked — see the docblock.)
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsAppDeveloper(userId);
       // getUserBuzzAccounts returns every spend type; project to just the three
       // spendable types the UI needs (omit red / creator-program / cash).
       const accounts = await getUserBuzzAccounts({ userId });
@@ -5044,12 +5343,14 @@ export const blocksRouter = router({
    *
    * CONSENT: requires the `user:read:self` scope — the least-privileged scope
    * that conveys "viewer identity" (audit I3; mirrors how /blocks/me gates via
-   * `withBlockScope({ requiredScope: 'user:read:self' })`). Unlike the scope-free
-   * getMyBuzzBalance, a block must declare+be-granted this scope.
+   * `withBlockScope({ requiredScope: 'user:read:self' })`). A block must
+   * declare+be-granted this scope. (`getMyBuzzBalance` now requires
+   * `buzz:read:self` for the same reason — it is no longer the scope-free path
+   * this line used to contrast against.)
    *
    * Order (each step fail-closed): verify token → require the consent scope →
    * self-bind the userId off `claims.sub` (never client input; UNAUTHORIZED for
-   * anon) → App-Blocks kill-switch + author gate against the TOKEN subject →
+   * anon) → App-Blocks kill-switch against the TOKEN subject →
    * per-instance rate limit (keyed on the stable `blockInstanceId`, BEFORE the
    * db read — the ban/mute lookup hits the PRIMARY, so a hammering block must be
    * bounded) → the /blocks/me identity read.
@@ -5083,12 +5384,10 @@ export const blocksRouter = router({
           message: 'viewer read requires an authenticated viewer',
         });
       }
-      // Same gates as the other block-token procs, evaluated against the TOKEN
-      // subject: the enabled kill-switch AND the author capability (pre-GA
-      // team-only gate — the router-side equivalent of /blocks/me's isModerator
-      // check).
+      // The App-Blocks kill-switch, evaluated against the TOKEN subject. The
+      // `user:read:self` consent scope checked above is what authorizes the read
+      // itself; the author capability is deliberately no longer checked here.
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsAppDeveloper(userId);
       // Per-instance rate limit (shared blocks limiter) — bounds a block
       // hammering the PRIMARY (the ban/mute lookup below reads dbWrite). Runs
       // BEFORE the db read. Fail-open on a redis incident.
@@ -6378,8 +6677,19 @@ function resolveCustomComfyRecipe(body: CustomComfyRecipeBody) {
 /**
  * customComfy ESTIMATE (plan §4). Do NOT run a real whatIf (returns 0 for
  * customComfy) — return the recipe's honest per-engine DISPLAY estimate. Same
- * page-only + developer gates as submit, so a model token / non-developer can't
- * even probe estimates. Fail-closed on an out-of-bounds param (ZodError).
+ * page-only + SCOPE gates as submit, so a model token / an unconsented token
+ * can't even probe estimates. Fail-closed on an out-of-bounds param (ZodError).
+ *
+ * 🔴 THE SCOPE CHECK HERE IS DEFENSE-IN-DEPTH, AND IT IS NOT REACHABLE TODAY —
+ * SAY SO RATHER THAN COUNTING IT AS COVERAGE. The only caller is the
+ * `estimateWorkflow` procedure, which rejects a token lacking
+ * `ai:write:budgeted` BEFORE it dispatches here, so no request can reach this
+ * line with the scope missing. It is written anyway because this helper takes
+ * `claims` and is one refactor away from a caller that does not pre-check (the
+ * `submitCustomComfyWorkflow` / `assertStepRequestAllowed` siblings carry the
+ * identical belt for the identical reason) — but a mutation of THIS line cannot
+ * be observed through the router, and a test asserting the FORBIDDEN would be
+ * graded by the outer proc's check, not this one.
  */
 async function estimateCustomComfyWorkflow(opts: { claims: BlockClaims; body: CustomComfyBody }) {
   const { claims, body } = opts;
@@ -6389,6 +6699,9 @@ async function estimateCustomComfyWorkflow(opts: { claims: BlockClaims; body: Cu
   if (!isPageToken(claims)) {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'customComfy recipes are page-only' });
   }
+  if (!claims.scopes.includes('ai:write:budgeted')) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'block lacks ai:write:budgeted scope' });
+  }
   const userId = parseSubjectUserId(claims.sub);
   if (userId == null) {
     throw new TRPCError({
@@ -6397,7 +6710,6 @@ async function estimateCustomComfyWorkflow(opts: { claims: BlockClaims; body: Cu
     });
   }
   await assertAppBlocksEnabledForTokenUser(userId);
-  await assertViewerIsAppDeveloper(userId);
 
   // ── INLINE arm. There is NO honest per-graph number to quote and no way to
   // derive one: the orchestrator forwards the graph opaquely and cannot price
@@ -6469,6 +6781,15 @@ async function submitCustomComfyWorkflow(opts: {
   if (!isPageToken(claims)) {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'customComfy recipes are page-only' });
   }
+  // ── CONSENT gate (DEFENSE-IN-DEPTH — see estimateCustomComfyWorkflow). The sole
+  // caller, the `submitWorkflow` procedure, already rejects a token without this
+  // scope before dispatching here, so this line is not reachable with the scope
+  // missing and must not be counted as the gate. It replaces the author-capability
+  // belt that used to sit in this slot, keeping the helper safe on its own terms
+  // if it ever gains a caller that does not pre-check.
+  if (!claims.scopes.includes('ai:write:budgeted')) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'block lacks ai:write:budgeted scope' });
+  }
   // The outer proc already gated this, but re-narrow here (defense-in-depth) so
   // `buzzBudget` is a positive number the static gate can compare against.
   if (typeof claims.buzzBudget !== 'number' || claims.buzzBudget <= 0) {
@@ -6482,7 +6803,6 @@ async function submitCustomComfyWorkflow(opts: {
     });
   }
   await assertAppBlocksEnabledForTokenUser(userId);
-  await assertViewerIsAppDeveloper(userId);
 
   // Narrow ONCE, into two mutually-exclusive locals. Exactly one is non-null for
   // any schema-valid body, which is what lets the shared belt below stay a single
@@ -6672,7 +6992,8 @@ async function submitCustomComfyWorkflow(opts: {
   }
   const { total, key: buzzCapKey, cap: buzzCap } = reservation;
   if (total > buzzCap) {
-    await refundBlockBuzzSpend(buzzCapKey, ceiling);
+    // Refund EVERY leg of the reservation — see the txt2img path for why.
+    await refundBlockBuzzReservation(reservation, ceiling);
     if (genClaimKey) await releaseGenIdempotency(genClaimKey);
     return {
       snapshot: {
@@ -6691,6 +7012,27 @@ async function submitCustomComfyWorkflow(opts: {
     };
   }
 
+  // ── CONSENT BUDGET. Post-paid, so the CEILING is what is reserved and therefore
+  // what is judged — a job that would settle cheaper is still refused if its
+  // worst case exceeds the user's limit. That is the conservative direction and
+  // the same one the platform cap already takes on this path.
+  if (consentBudgetExceeded(reservation)) {
+    await refundBlockBuzzReservation(reservation, ceiling);
+    if (genClaimKey) await releaseGenIdempotency(genClaimKey);
+    return {
+      snapshot: {
+        workflowId: 'failed',
+        status: 'failed' as const,
+        cost: { total: ceiling },
+        error: consentBudgetRejection(
+          reservation.consent,
+          ceiling,
+          `this generation may cost up to ${ceiling}`
+        ),
+      },
+    };
+  }
+
   // (3) Reserve the CEILING against the per-app aggregate cap (G8). Skipped for
   // DEV tokens (synthetic non-FK appBlockId) — matching the txt2img caps.
   let appSpendReserve: { key: AppSpendDailyKey; cost: number } | null = null;
@@ -6700,7 +7042,7 @@ async function submitCustomComfyWorkflow(opts: {
     if (!appSpend.allowed) {
       // Roll back the per-user reservation so a rejected submit doesn't burn the
       // viewer's own daily ceiling for a spend that never happened.
-      await refundBlockBuzzSpend(buzzCapKey, ceiling);
+      await refundBlockBuzzReservation(reservation, ceiling);
       // No money moved → release the idempotency claim so a genuine retry runs.
       if (genClaimKey) await releaseGenIdempotency(genClaimKey);
       return {
@@ -6752,7 +7094,7 @@ async function submitCustomComfyWorkflow(opts: {
         // above (the session reserve rolled ITSELF back on deny) and the G8
         // per-app reservation (present only for non-dev tokens; a token with
         // `dev !== true` can still have an active dev tunnel). Then fail-snapshot.
-        await refundBlockBuzzSpend(buzzCapKey, ceiling);
+        await refundBlockBuzzReservation(reservation, ceiling);
         if (appSpendReserve) {
           const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
           await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
@@ -6830,7 +7172,7 @@ async function submitCustomComfyWorkflow(opts: {
     snapshot = snapshotFromWorkflow(submitted);
     realizedTransactions = submitted.transactions;
   } catch (e) {
-    await refundBlockBuzzSpend(buzzCapKey, ceiling);
+    await refundBlockBuzzReservation(reservation, ceiling);
     if (appSpendReserve) {
       const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
       await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
@@ -6865,6 +7207,9 @@ async function submitCustomComfyWorkflow(opts: {
     await persistCustomComfySettle({
       workflowId: snapshot.workflowId,
       buzzCapKey,
+      // The consent-budget leg, when the viewer set a per-app budget. Absent
+      // otherwise, so the record shape is unchanged for everyone else.
+      consentBudgetKey: reservation.consent?.key ?? null,
       appSpendKey: appSpendReserve?.key ?? null,
       ...(devSessionReserve ? { devSessionId: devSessionReserve.sessionId } : {}),
       ceiling,
@@ -7078,12 +7423,20 @@ async function assertStepRequestAllowed(claims: BlockClaims): Promise<number> {
   if (!isPageToken(claims)) {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'registry steps are page-only' });
   }
+  // CONSENT gate — shared by estimate AND submit (that is this helper's whole
+  // reason to exist), so a caller can never probe a step price it may not run.
+  // DEFENSE-IN-DEPTH TODAY: both callers reach here only from procedures that have
+  // already rejected a token missing `ai:write:budgeted`, so this line is not
+  // reachable with the scope absent — see estimateCustomComfyWorkflow for why it
+  // is written anyway, and why it must not be reported as closing a gap.
+  if (!claims.scopes.includes('ai:write:budgeted')) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'block lacks ai:write:budgeted scope' });
+  }
   const userId = parseSubjectUserId(claims.sub);
   if (userId == null) {
     throw new TRPCError({ code: 'UNAUTHORIZED', message: 'step requires authenticated viewer' });
   }
   await assertAppBlocksEnabledForTokenUser(userId);
-  await assertViewerIsAppDeveloper(userId);
   return userId;
 }
 
@@ -7672,7 +8025,8 @@ async function submitStepWorkflow(opts: {
   }
   const { total, key: buzzCapKey, cap: buzzCap } = reservation;
   if (total > buzzCap) {
-    await refundBlockBuzzSpend(buzzCapKey, reserveBuzz);
+    // Refund EVERY leg of the reservation — see the txt2img path for why.
+    await refundBlockBuzzReservation(reservation, reserveBuzz);
     if (genClaimKey) await releaseGenIdempotency(genClaimKey);
     return {
       snapshot: {
@@ -7691,6 +8045,26 @@ async function submitStepWorkflow(opts: {
     };
   }
 
+  // ── CONSENT BUDGET — same belt, same refund-both-legs rule, on the registry-step
+  // money path. `kind:'step'` must not be a spend surface a guardrail cannot see
+  // (see THE MONEY RULE above this function).
+  if (consentBudgetExceeded(reservation)) {
+    await refundBlockBuzzReservation(reservation, reserveBuzz);
+    if (genClaimKey) await releaseGenIdempotency(genClaimKey);
+    return {
+      snapshot: {
+        workflowId: 'failed',
+        status: 'failed' as const,
+        cost: { total: reserveBuzz },
+        error: consentBudgetRejection(
+          reservation.consent,
+          reserveBuzz,
+          `this step costs ${reserveBuzz}`
+        ),
+      },
+    };
+  }
+
   // 🔴 (3) Reserve against the PER-APP aggregate cap (daily Buzz + velocity).
   // This is the guardrail the per-user cap structurally cannot provide — it is
   // keyed on `appBlockId` with the spender deliberately absent from the key, so
@@ -7704,7 +8078,7 @@ async function submitStepWorkflow(opts: {
     if (!appSpend.allowed) {
       // Roll back the per-user reservation so a rejected submit doesn't burn the
       // viewer's own daily ceiling for a spend that never happened.
-      await refundBlockBuzzSpend(buzzCapKey, reserveBuzz);
+      await refundBlockBuzzReservation(reservation, reserveBuzz);
       // No money moved → release the idempotency claim so a genuine retry runs.
       if (genClaimKey) await releaseGenIdempotency(genClaimKey);
       return {
@@ -7740,7 +8114,7 @@ async function submitStepWorkflow(opts: {
         devTunnel.spendCapBuzz
       );
       if (!reserved.allowed) {
-        await refundBlockBuzzSpend(buzzCapKey, reserveBuzz);
+        await refundBlockBuzzReservation(reservation, reserveBuzz);
         if (appSpendReserve) {
           const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
           await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
@@ -7788,7 +8162,7 @@ async function submitStepWorkflow(opts: {
     snapshot = snapshotFromWorkflow(submitted);
     realizedTransactions = submitted.transactions;
   } catch (e) {
-    await refundBlockBuzzSpend(buzzCapKey, reserveBuzz);
+    await refundBlockBuzzReservation(reservation, reserveBuzz);
     if (appSpendReserve) {
       const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
       await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
@@ -7882,6 +8256,12 @@ async function submitStepWorkflow(opts: {
         // a divergent submit inside a dev tunnel left that counter under-reading
         // by the overage: precisely the drift direction the same comment forbids.
         try {
+          // Corrects BOTH legs the original reservation held: the platform
+          // cumulative counter and, when the viewer set one, their consent budget.
+          // This is an ACCOUNTING CORRECTION for money already spent, not a gate —
+          // it deliberately has no deny path, so a consent budget that this pushes
+          // over its cap simply binds on the NEXT submit rather than retroactively
+          // refusing one that already billed.
           await reserveBlockBuzzSpendForClaims(claims, userId, capOverage);
         } catch {
           /* best-effort correction — a lost one under-counts by the overage only */
@@ -7935,6 +8315,9 @@ async function submitStepWorkflow(opts: {
     await persistCustomComfySettle({
       workflowId: snapshot.workflowId,
       buzzCapKey,
+      // The consent-budget leg, when the viewer set a per-app budget. Absent
+      // otherwise, so the record shape is unchanged for everyone else.
+      consentBudgetKey: reservation.consent?.key ?? null,
       appSpendKey: appSpendReserve?.key ?? null,
       ...(devSessionReserve ? { devSessionId: devSessionReserve.sessionId } : {}),
       ceiling: reserveBuzz,

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -23,6 +23,7 @@ import {
   REVIEW_RUN_FOR_REAL_BUZZ_CAP,
 } from '~/shared/constants/block-scope.constants';
 import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import type { RedisKeyTemplateSys } from '~/server/redis/client';
 import { dailyBoostReward } from '~/server/rewards/active/dailyBoost.reward';
 import {
   getDailyCompensationRewardByUser,
@@ -396,11 +397,17 @@ async function assertAppBlocksEnabledForTokenUser(userId: number): Promise<void>
 
 /**
  * Shared authorization gate for the buzz self-read bridges (`getMyBuzz*` below).
- * Mirrors `getMyBuzzBalance`'s gate but adds the `buzz:read:self` CONSENT check:
- * these reads (full ledger / all-pool balances incl. creator payout pools /
- * per-model earnings) are MORE sensitive than the spendable-balance convenience
- * read, so unlike the scope-free `getMyBuzzBalance` they require the token to
- * carry the declared+granted `buzz:read:self` scope.
+ * Verify token → require the `buzz:read:self` CONSENT scope → self-bind → kill-switch
+ * → rate limit.
+ *
+ * ⚠️ `getMyBuzzBalance` IS NOT SCOPE-FREE ANY MORE — this docblock said it was until
+ * the round-1 audit caught the contradiction with the one on `getMyBuzzBalance`
+ * itself. That proc now performs the SAME `buzz:read:self` check inline (it cannot
+ * call this helper: it is not rate-limited on `blockInstanceId` and its error copy
+ * differs). What still separates these bridges from it is SENSITIVITY, not the scope:
+ * the full ledger / all-pool balances incl. creator payout pools / per-model earnings,
+ * versus a spendable-balance read — which is why these three also carry the
+ * per-instance rate limit below.
  *
  * Order (each step fail-closed): verify token → require consent scope → self-bind
  * the userId off `claims.sub` (never client input) → App-Blocks kill-switch
@@ -776,25 +783,66 @@ function buzzCapRedisKey(userId: number): `${typeof REDIS_SYS_KEYS.BLOCKS.BUZZ_C
 }
 
 /**
+ * THE ONE reserve primitive behind every cumulative Buzz counter in this router
+ * (per-user daily, run-for-real session, consent budget). Atomic INCRBY, then arm
+ * the window's TTL on the (effectively) first write, with a `ttl < 0` re-arm for a
+ * key that somehow lost it.
+ *
+ * 🔴 IT SELF-UNWINDS ITS OWN INCRBY, AND THAT IS THE REASON IT IS ONE FUNCTION.
+ * Everything after the INCRBY is a SEPARATE Redis round-trip that can throw on its
+ * own, and by then `cost` is already ON the counter. The caller cannot clean that up
+ * — it never learns the key, because the throw happens before the return — so the
+ * reservation would leak for the rest of the window with nothing left holding a
+ * reference to it. Worse on the FIRST write of a window: the call that throws is the
+ * `expire` that would have armed the TTL, so the leaked counter has NO expiry at all
+ * until some later submit's `ttl < 0` branch re-arms it and extends the burn another
+ * ~25h.
+ *
+ * MEASURED on this branch (adversarial audit round 1) against the CONSENT leg: an
+ * `expire` rejection left `consent = 25` charged while the platform leg was correctly
+ * refunded to 0 — the two counters diverging is precisely what
+ * `refundBlockBuzzReservation` exists to prevent. The platform and run-for-real legs
+ * had the identical shape, so all three are fixed here rather than at one call site:
+ * open-coding this three times is what let the same defect sit in three places.
+ *
+ * Still fails CLOSED — the error is rethrown after the unwind, so the submit aborts.
+ * The unwind is best-effort (`refundBlockBuzzSpend` never throws); a lost unwind
+ * over-counts, which only makes the cap STRICTER.
+ */
+async function reserveCumulativeBuzzKey(
+  key: RedisKeyTemplateSys,
+  cost: number,
+  ttlSeconds: number
+): Promise<number> {
+  const amount = Math.ceil(cost);
+  const total = await sysRedis.incrBy(key, amount);
+  try {
+    if (total <= amount) {
+      await sysRedis.expire(key, ttlSeconds);
+    } else {
+      const ttl = await sysRedis.ttl(key);
+      if (ttl < 0) await sysRedis.expire(key, ttlSeconds);
+    }
+  } catch (e) {
+    await refundBlockBuzzSpend(key, amount);
+    throw e;
+  }
+  return total;
+}
+
+/**
  * Atomically reserves `cost` against this user's cumulative UTC-day counter and
  * returns the new running total. INCRBY is atomic, so concurrent submits
- * accumulate correctly with no read→check→record TOCTOU. Sets the TTL on the
- * (effectively) first write so the per-window key self-expires (the ttl<0 guard
- * also re-arms a key that somehow lost its TTL). No try/catch: a Redis error
- * throws and fails the submit CLOSED, identical to the old read path.
+ * accumulate correctly with no read→check→record TOCTOU. A Redis error throws and
+ * fails the submit CLOSED, identical to the old read path — see
+ * `reserveCumulativeBuzzKey` for the TTL arming and the self-unwind.
  */
 async function reserveBlockBuzzSpend(
   userId: number,
   cost: number
 ): Promise<{ total: number; key: ReturnType<typeof buzzCapRedisKey> }> {
   const key = buzzCapRedisKey(userId);
-  const total = await sysRedis.incrBy(key, Math.ceil(cost));
-  if (total <= Math.ceil(cost)) {
-    await sysRedis.expire(key, BLOCK_BUZZ_CAP_TTL_SECONDS);
-  } else {
-    const ttl = await sysRedis.ttl(key);
-    if (ttl < 0) await sysRedis.expire(key, BLOCK_BUZZ_CAP_TTL_SECONDS);
-  }
+  const total = await reserveCumulativeBuzzKey(key, cost, BLOCK_BUZZ_CAP_TTL_SECONDS);
   // Return the resolved key so the caller refunds against the EXACT same key it
   // reserved — see refundBlockBuzzSpend for why re-deriving is unsafe.
   return { total, key };
@@ -849,8 +897,9 @@ function reviewRunForRealBuzzCapKey(
 
 /**
  * Atomically reserves `cost` against the (mod, publishRequestId) run-for-real
- * cumulative counter. Identical atomic INCRBY + first-write-EX (+ ttl<0 re-arm)
- * shape as `reserveBlockBuzzSpend`; fails CLOSED on a Redis error (throws).
+ * cumulative counter. Same shared `reserveCumulativeBuzzKey` primitive as
+ * `reserveBlockBuzzSpend` (atomic INCRBY + first-write-EX + ttl<0 re-arm +
+ * self-unwind); fails CLOSED on a Redis error (throws).
  */
 async function reserveReviewRunForRealBuzzSpend(
   userId: number,
@@ -858,13 +907,7 @@ async function reserveReviewRunForRealBuzzSpend(
   cost: number
 ): Promise<{ total: number; key: ReturnType<typeof reviewRunForRealBuzzCapKey> }> {
   const key = reviewRunForRealBuzzCapKey(userId, publishRequestId);
-  const total = await sysRedis.incrBy(key, Math.ceil(cost));
-  if (total <= Math.ceil(cost)) {
-    await sysRedis.expire(key, REVIEW_RUN_FOR_REAL_BUZZ_CAP_TTL_SECONDS);
-  } else {
-    const ttl = await sysRedis.ttl(key);
-    if (ttl < 0) await sysRedis.expire(key, REVIEW_RUN_FOR_REAL_BUZZ_CAP_TTL_SECONDS);
-  }
+  const total = await reserveCumulativeBuzzKey(key, cost, REVIEW_RUN_FOR_REAL_BUZZ_CAP_TTL_SECONDS);
   return { total, key };
 }
 
@@ -897,8 +940,15 @@ function consentBudgetRedisKey(
 
 /**
  * Atomically reserves `cost` against the (user, app, UTC-day) consent-budget
- * counter. Identical atomic INCRBY + first-write-EX (+ ttl<0 re-arm) shape as
- * `reserveBlockBuzzSpend`; fails CLOSED on a Redis error (throws).
+ * counter. Same shared `reserveCumulativeBuzzKey` primitive as
+ * `reserveBlockBuzzSpend` (atomic INCRBY + first-write-EX + ttl<0 re-arm +
+ * self-unwind); fails CLOSED on a Redis error (throws).
+ *
+ * The self-unwind matters MOST here: this is the SECOND leg, so a throw after its
+ * INCRBY is caught by the caller, which refunds the PLATFORM key and rethrows. The
+ * caller has no handle on this key — it is created inside this function — so without
+ * the unwind the consent counter alone stays charged for a submit that never
+ * happened.
  */
 async function reserveConsentBudgetSpend(
   userId: number,
@@ -906,13 +956,7 @@ async function reserveConsentBudgetSpend(
   cost: number
 ): Promise<{ total: number; key: ReturnType<typeof consentBudgetRedisKey> }> {
   const key = consentBudgetRedisKey(userId, appBlockId);
-  const total = await sysRedis.incrBy(key, Math.ceil(cost));
-  if (total <= Math.ceil(cost)) {
-    await sysRedis.expire(key, CONSENT_BUDGET_TTL_SECONDS);
-  } else {
-    const ttl = await sysRedis.ttl(key);
-    if (ttl < 0) await sysRedis.expire(key, CONSENT_BUDGET_TTL_SECONDS);
-  }
+  const total = await reserveCumulativeBuzzKey(key, cost, CONSENT_BUDGET_TTL_SECONDS);
   return { total, key };
 }
 
@@ -8268,12 +8312,24 @@ async function submitStepWorkflow(opts: {
         // a divergent submit inside a dev tunnel left that counter under-reading
         // by the overage: precisely the drift direction the same comment forbids.
         try {
-          // Corrects BOTH legs the original reservation held: the platform
+          // Charges the overage on BOTH LEGS THIS CALL DERIVES — the platform
           // cumulative counter and, when the viewer set one, their consent budget.
-          // This is an ACCOUNTING CORRECTION for money already spent, not a gate —
-          // it deliberately has no deny path, so a consent budget that this pushes
-          // over its cap simply binds on the NEXT submit rather than retroactively
-          // refusing one that already billed.
+          //
+          // ⚠️ NOT the same keys the original reservation held, and the difference is
+          // observable. This takes a NEW reservation, so both keys are re-derived
+          // from `buzzCapWindowKey()` at correction time: a submit that STRADDLES
+          // midnight UTC charges its overage to the NEXT day's keys, leaving the day
+          // it actually spent on under-counted by the overage. It mirrors the
+          // pre-existing behaviour of the platform leg exactly (this call site
+          // predates the consent budget), and correcting it means threading the
+          // original keys down here — a change to how the reservation is carried, not
+          // to this comment. The window is one submit's duration per day, and the
+          // drift direction is "looser on the next day", never "spends more today".
+          //
+          // This is an ACCOUNTING CORRECTION for money already spent, not a gate — it
+          // deliberately has no deny path, so a consent budget that this pushes over
+          // its cap simply binds on the NEXT submit rather than retroactively refusing
+          // one that already billed.
           await reserveBlockBuzzSpendForClaims(claims, userId, capOverage);
         } catch {
           /* best-effort correction — a lost one under-counts by the overage only */

--- a/src/server/services/blocks/__tests__/custom-comfy-settle.service.test.ts
+++ b/src/server/services/blocks/__tests__/custom-comfy-settle.service.test.ts
@@ -59,6 +59,9 @@ import {
 const SETTLE_PREFIX = 'system:blocks:custom-comfy-settle';
 const BUZZ_KEY = 'system:blocks:buzz-cap:42:2026-07-17';
 const APP_KEY = 'system:blocks:app-spend-cap:app_test:2026-07-17';
+// The per-(user, app, UTC-day) CONSENT budget key — the ceiling the VIEWER set for
+// this one app. Present on the record only when they set one.
+const CONSENT_KEY = 'system:blocks:consent-budget:42:apb_test:2026-07-17';
 
 beforeEach(() => {
   for (const fn of [
@@ -89,6 +92,7 @@ function seedRecord(
     buzzCapKey: string;
     appSpendKey: string | null;
     devSessionId: string | null;
+    consentBudgetKey: string | null;
     ceiling: number;
     engine: string;
     recipe: string;
@@ -180,14 +184,24 @@ describe('persistCustomComfySettle', () => {
   });
 
   it('no-ops on an empty workflowId (never writes)', async () => {
-    await persistCustomComfySettle({ workflowId: '', buzzCapKey: BUZZ_KEY, appSpendKey: null, ceiling: 180 });
+    await persistCustomComfySettle({
+      workflowId: '',
+      buzzCapKey: BUZZ_KEY,
+      appSpendKey: null,
+      ceiling: 180,
+    });
     expect(mockSysRedis.set).not.toHaveBeenCalled();
   });
 
   it('swallows a Redis error (best-effort, degrades to reserve-without-settle)', async () => {
     mockSysRedis.set.mockRejectedValue(new Error('redis down'));
     await expect(
-      persistCustomComfySettle({ workflowId: 'wf_1', buzzCapKey: BUZZ_KEY, appSpendKey: null, ceiling: 180 })
+      persistCustomComfySettle({
+        workflowId: 'wf_1',
+        buzzCapKey: BUZZ_KEY,
+        appSpendKey: null,
+        ceiling: 180,
+      })
     ).resolves.toBeUndefined();
   });
 });
@@ -285,9 +299,83 @@ describe('settleCustomComfySpend', () => {
     expect(mockRefundDevSessionBuzz).not.toHaveBeenCalled();
   });
 
+  // ── CONSENT BUDGET leg. A post-paid job reserves the CEILING against the user's
+  // own per-app limit too, so the settle MUST give the over-reservation back there as
+  // well: without it a job that reserved 5,000 and billed 200 leaves the user's limit
+  // charged 5,000 for the rest of the day, which is exactly what the field's own
+  // comment says must not happen.
+  //
+  // 🔴 THESE ARE THE MUTATION-KILLING TESTS FOR M2 (audit round 1): deleting the
+  // `if (record.consentBudgetKey) … decrBy` block from settleCustomComfySpend survived
+  // the entire 5,214-test suite, because no test ever put a consentBudgetKey on a
+  // record.
+  it('refunds `ceiling - actual` on the CONSENT budget key too when one is present', async () => {
+    seedRecord({ consentBudgetKey: CONSENT_KEY, ceiling: 180 });
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 });
+    // Platform daily key…
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 150);
+    // …and the user's OWN per-app ceiling, same over-reservation.
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(CONSENT_KEY, 150);
+    expect(mockRefundAppSpend).toHaveBeenCalledWith(APP_KEY, 150);
+  });
+
+  it('refunds ALL FOUR counters for a submit that held every leg', async () => {
+    seedRecord({ consentBudgetKey: CONSENT_KEY, devSessionId: DEV_SESSION_ID, ceiling: 180 });
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 });
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 150);
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(CONSENT_KEY, 150);
+    expect(mockRefundAppSpend).toHaveBeenCalledWith(APP_KEY, 150);
+    expect(mockRefundDevSessionBuzz).toHaveBeenCalledWith(DEV_SESSION_ID, 150);
+  });
+
+  it('a record WITHOUT a consentBudgetKey never touches a consent-budget key', async () => {
+    seedRecord({ ceiling: 180 }); // the viewer set no budget
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 });
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 150);
+    const consentCalls = mockSysRedis.decrBy.mock.calls.filter((c) =>
+      String(c[0]).startsWith('system:blocks:consent-budget:')
+    );
+    expect(consentCalls).toHaveLength(0);
+  });
+
+  it('a full-ceiling spend refunds NOTHING on the consent budget either', async () => {
+    seedRecord({ consentBudgetKey: CONSENT_KEY, ceiling: 180 });
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 200 });
+    expect(mockSysRedis.decrBy).not.toHaveBeenCalled();
+  });
+
+  it('a consent-budget refund FAILURE never throws and never skips the other legs', async () => {
+    seedRecord({ consentBudgetKey: CONSENT_KEY, devSessionId: DEV_SESSION_ID, ceiling: 180 });
+    mockSysRedis.decrBy.mockImplementation(async (key: string) => {
+      if (key === CONSENT_KEY) throw new Error('redis down');
+      return 0;
+    });
+    await expect(
+      settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 })
+    ).resolves.toBeUndefined();
+    // The legs AFTER the failing one still ran — a lost refund over-counts on ONE
+    // counter (stricter), it does not abandon the rest of the settle.
+    expect(mockRefundDevSessionBuzz).toHaveBeenCalledWith(DEV_SESSION_ID, 150);
+    expect(mockRefundAppSpend).toHaveBeenCalledWith(APP_KEY, 150);
+  });
+
+  it('persists the consentBudgetKey onto the record verbatim', async () => {
+    await persistCustomComfySettle({
+      workflowId: 'wf_1',
+      buzzCapKey: BUZZ_KEY,
+      appSpendKey: APP_KEY,
+      consentBudgetKey: CONSENT_KEY,
+      ceiling: 180,
+    });
+    const [, value] = mockSysRedis.set.mock.calls[0] as [string, string, { EX: number }];
+    expect(JSON.parse(value)).toMatchObject({ consentBudgetKey: CONSENT_KEY });
+  });
+
   it('never throws when the GET fails (leaves the ceiling reserved — stricter)', async () => {
     mockSysRedis.get.mockRejectedValue(new Error('redis down'));
-    await expect(settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 })).resolves.toBeUndefined();
+    await expect(
+      settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 })
+    ).resolves.toBeUndefined();
     expect(mockSysRedis.decrBy).not.toHaveBeenCalled();
   });
 

--- a/src/server/services/blocks/__tests__/scope-grant.service.test.ts
+++ b/src/server/services/blocks/__tests__/scope-grant.service.test.ts
@@ -63,6 +63,161 @@ describe('scope-grant.service', () => {
     });
   });
 
+  describe('getConsentBuzzBudget', () => {
+    it('returns the stored budget for an active grant', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockResolvedValueOnce({
+        buzzBudgetPerDay: 500,
+        revokedAt: null,
+      });
+      const { getConsentBuzzBudget } = await import('../scope-grant.service');
+      expect(await getConsentBuzzBudget({ userId: 1, appBlockId: 'ab_x' })).toBe(500);
+    });
+
+    it('returns null when no grant row exists', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockResolvedValueOnce(null);
+      const { getConsentBuzzBudget } = await import('../scope-grant.service');
+      expect(await getConsentBuzzBudget({ userId: 1, appBlockId: 'ab_x' })).toBeNull();
+    });
+
+    it('returns null when the grant is revoked', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockResolvedValueOnce({
+        buzzBudgetPerDay: 500,
+        revokedAt: new Date(),
+      });
+      const { getConsentBuzzBudget } = await import('../scope-grant.service');
+      expect(await getConsentBuzzBudget({ userId: 1, appBlockId: 'ab_x' })).toBeNull();
+    });
+
+    // 🔴 GUARD THE VALUE, NOT ONLY ITS PRESENCE. A 0 would become a cap of 0 (deny
+    // everything); a NaN would become `total > NaN` — always false — i.e. a corrupt row
+    // would silently DISABLE the cap. Both must read as "no budget set".
+    it.each([
+      ['zero', 0],
+      ['negative', -5],
+      ['NaN', Number.NaN],
+    ])('returns null for a %s stored value', async (_label, value) => {
+      mockDb.appUserScopeGrant.findUnique.mockResolvedValueOnce({
+        buzzBudgetPerDay: value,
+        revokedAt: null,
+      });
+      const { getConsentBuzzBudget } = await import('../scope-grant.service');
+      expect(await getConsentBuzzBudget({ userId: 1, appBlockId: 'ab_x' })).toBeNull();
+    });
+
+    // Reads the PRIMARY by default: this runs on the spend path right after a consent
+    // write that may have LOWERED the budget, and a replica-lag read would spend against
+    // the older, looser ceiling.
+    it('reads the primary unless a read replica is explicitly requested', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockResolvedValue({
+        buzzBudgetPerDay: 5,
+        revokedAt: null,
+      });
+      const { getConsentBuzzBudget } = await import('../scope-grant.service');
+      await getConsentBuzzBudget({ userId: 1, appBlockId: 'ab_x' });
+      expect(mockDb.appUserScopeGrant.findUnique).toHaveBeenCalled();
+    });
+  });
+
+  describe('recordScopeGrant — buzzBudgetPerDay update semantics', () => {
+    // 🔴 THE OMITTED CASE IS THE ONE THAT MATTERS. A re-consent for an unrelated scope
+    // sends only `scopes`; if an omitted budget were written through as NULL, accepting
+    // one extra permission would silently wipe a spend limit the user set — a widening,
+    // performed by a dialog that never mentioned money.
+    it('leaves the stored budget untouched when the key is OMITTED', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockResolvedValueOnce({
+        id: 'augr_1',
+        grantedScopes: ['models:read:self'],
+      });
+      mockDb.appUserScopeGrant.update.mockResolvedValueOnce({});
+      const { recordScopeGrant } = await import('../scope-grant.service');
+      await recordScopeGrant({
+        userId: 1,
+        appBlockId: 'ab_x',
+        version: '1.0.0',
+        scopes: ['user:read:self'],
+      });
+      const data = mockDb.appUserScopeGrant.update.mock.calls[0][0].data;
+      expect(data).not.toHaveProperty('buzzBudgetPerDay');
+    });
+
+    it('OVERWRITES the stored budget when a number is supplied', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockResolvedValueOnce({
+        id: 'augr_1',
+        grantedScopes: [],
+      });
+      mockDb.appUserScopeGrant.update.mockResolvedValueOnce({});
+      const { recordScopeGrant } = await import('../scope-grant.service');
+      await recordScopeGrant({
+        userId: 1,
+        appBlockId: 'ab_x',
+        version: '1.0.0',
+        scopes: ['ai:write:budgeted'],
+        buzzBudgetPerDay: 250,
+      });
+      expect(mockDb.appUserScopeGrant.update.mock.calls[0][0].data).toMatchObject({
+        buzzBudgetPerDay: 250,
+      });
+    });
+
+    // An explicit NULL is the user REMOVING their limit — distinct from omitting it.
+    it('CLEARS the stored budget when null is supplied explicitly', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockResolvedValueOnce({
+        id: 'augr_1',
+        grantedScopes: [],
+      });
+      mockDb.appUserScopeGrant.update.mockResolvedValueOnce({});
+      const { recordScopeGrant } = await import('../scope-grant.service');
+      await recordScopeGrant({
+        userId: 1,
+        appBlockId: 'ab_x',
+        version: '1.0.0',
+        scopes: ['ai:write:budgeted'],
+        buzzBudgetPerDay: null,
+      });
+      expect(mockDb.appUserScopeGrant.update.mock.calls[0][0].data).toMatchObject({
+        buzzBudgetPerDay: null,
+      });
+    });
+
+    it('carries the budget onto a freshly CREATED grant row', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockResolvedValueOnce(null);
+      mockDb.appUserScopeGrant.create.mockResolvedValueOnce({});
+      const { recordScopeGrant } = await import('../scope-grant.service');
+      await recordScopeGrant({
+        userId: 1,
+        appBlockId: 'ab_x',
+        version: '1.0.0',
+        scopes: ['ai:write:budgeted'],
+        buzzBudgetPerDay: 250,
+      });
+      expect(mockDb.appUserScopeGrant.create.mock.calls[0][0].data).toMatchObject({
+        buzzBudgetPerDay: 250,
+      });
+    });
+
+    // The P2002 concurrent-first-write branch is a THIRD write site. It had to be updated
+    // too, and a guard that only covered the other two would read as coverage while
+    // leaving the racy path dropping the budget on the floor.
+    it('carries the budget through the P2002 concurrent-create retry', async () => {
+      mockDb.appUserScopeGrant.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: 'augr_1', grantedScopes: [] });
+      mockDb.appUserScopeGrant.create.mockRejectedValueOnce({ code: 'P2002' });
+      mockDb.appUserScopeGrant.update.mockResolvedValueOnce({});
+      const { recordScopeGrant } = await import('../scope-grant.service');
+      await recordScopeGrant({
+        userId: 1,
+        appBlockId: 'ab_x',
+        version: '1.0.0',
+        scopes: ['ai:write:budgeted'],
+        buzzBudgetPerDay: 250,
+      });
+      expect(mockDb.appUserScopeGrant.update.mock.calls[0][0].data).toMatchObject({
+        buzzBudgetPerDay: 250,
+      });
+    });
+  });
+
   describe('recordScopeGrant', () => {
     it('creates a fresh grant row when none exists', async () => {
       mockDb.appUserScopeGrant.findUnique.mockResolvedValueOnce(null);

--- a/src/server/services/blocks/__tests__/scope-grant.service.test.ts
+++ b/src/server/services/blocks/__tests__/scope-grant.service.test.ts
@@ -118,6 +118,109 @@ describe('scope-grant.service', () => {
     });
   });
 
+  // ── PRE-MIGRATION SAFETY. Migrations here are applied BY HAND, per environment, so
+  // an image can legitimately run against a database WITHOUT `buzz_budget_per_day`.
+  // MEASURED on this PR's own preview environment before these guards existed: Prisma
+  // raised P2022 and every install / subscribe / re-consent returned
+  // INTERNAL_SERVER_ERROR.
+  describe('a database WITHOUT the buzz_budget_per_day column (P2022)', () => {
+    /** The shape Prisma raises for "the column does not exist in the current database". */
+    function missingColumnError() {
+      return Object.assign(new Error('The column ... does not exist in the current database.'), {
+        code: 'P2022',
+      });
+    }
+
+    it('getConsentBuzzBudget returns null (= no budget can have been set — the TRUE state)', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockRejectedValueOnce(missingColumnError());
+      const { getConsentBuzzBudget } = await import('../scope-grant.service');
+      expect(await getConsentBuzzBudget({ userId: 1, appBlockId: 'ab_x' })).toBeNull();
+    });
+
+    // 🔴 THE OTHER HALF, AND THE ONE THAT MAKES THE CATCH SAFE. A bare catch here would
+    // turn a connection loss / timeout into "no budget", i.e. silently disable a money
+    // cap the user set — the exact fail-open this feature exists to prevent.
+    it('getConsentBuzzBudget RETHROWS any other Prisma error (never fails open)', async () => {
+      const other = Object.assign(new Error('connection refused'), { code: 'P1001' });
+      mockDb.appUserScopeGrant.findUnique.mockRejectedValueOnce(other);
+      const { getConsentBuzzBudget } = await import('../scope-grant.service');
+      await expect(getConsentBuzzBudget({ userId: 1, appBlockId: 'ab_x' })).rejects.toThrow(
+        /connection refused/
+      );
+    });
+
+    it('an error with NO code at all still throws', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockRejectedValueOnce(new Error('boom'));
+      const { getConsentBuzzBudget } = await import('../scope-grant.service');
+      await expect(getConsentBuzzBudget({ userId: 1, appBlockId: 'ab_x' })).rejects.toThrow(/boom/);
+    });
+
+    // 🔴 THE WRITE HALF. Prisma's DEFAULT selection is every scalar, so a create/update
+    // with no `select` emits `RETURNING … buzz_budget_per_day` and 500s on a database
+    // without the column — even though the write itself needs nothing back. These pin
+    // the explicit select on ALL THREE write sites (update, create, and the P2002
+    // concurrent-create retry); a guard covering only two would read as coverage while
+    // leaving a live 500 on the racy path.
+    it('the UPDATE write reads back only `id`', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockResolvedValueOnce({
+        id: 'augr_1',
+        grantedScopes: [],
+      });
+      mockDb.appUserScopeGrant.update.mockResolvedValueOnce({});
+      const { recordScopeGrant } = await import('../scope-grant.service');
+      await recordScopeGrant({
+        userId: 1,
+        appBlockId: 'ab_x',
+        version: '1.0.0',
+        scopes: ['user:read:self'],
+      });
+      expect(mockDb.appUserScopeGrant.update.mock.calls[0][0].select).toEqual({ id: true });
+    });
+
+    it('the CREATE write reads back only `id`', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockResolvedValueOnce(null);
+      mockDb.appUserScopeGrant.create.mockResolvedValueOnce({});
+      const { recordScopeGrant } = await import('../scope-grant.service');
+      await recordScopeGrant({
+        userId: 1,
+        appBlockId: 'ab_x',
+        version: '1.0.0',
+        scopes: ['user:read:self'],
+      });
+      expect(mockDb.appUserScopeGrant.create.mock.calls[0][0].select).toEqual({ id: true });
+    });
+
+    it('the P2002 concurrent-create RETRY update reads back only `id`', async () => {
+      mockDb.appUserScopeGrant.findUnique
+        .mockResolvedValueOnce(null) // first look-up: no row
+        .mockResolvedValueOnce({ id: 'augr_1', grantedScopes: [] }); // post-race re-read
+      mockDb.appUserScopeGrant.create.mockRejectedValueOnce({ code: 'P2002' });
+      mockDb.appUserScopeGrant.update.mockResolvedValueOnce({});
+      const { recordScopeGrant } = await import('../scope-grant.service');
+      await recordScopeGrant({
+        userId: 1,
+        appBlockId: 'ab_x',
+        version: '1.0.0',
+        scopes: ['user:read:self'],
+      });
+      expect(mockDb.appUserScopeGrant.update.mock.calls[0][0].select).toEqual({ id: true });
+    });
+
+    // The READ that mint depends on never touched the new column, and must not start.
+    it('getGrantedScopes still selects only the columns that predate the migration', async () => {
+      mockDb.appUserScopeGrant.findUnique.mockResolvedValueOnce({
+        grantedScopes: ['user:read:self'],
+        revokedAt: null,
+      });
+      const { getGrantedScopes } = await import('../scope-grant.service');
+      await getGrantedScopes({ userId: 1, appBlockId: 'ab_x' });
+      expect(mockDb.appUserScopeGrant.findUnique.mock.calls[0][0].select).toEqual({
+        grantedScopes: true,
+        revokedAt: true,
+      });
+    });
+  });
+
   describe('recordScopeGrant — buzzBudgetPerDay update semantics', () => {
     // 🔴 THE OMITTED CASE IS THE ONE THAT MATTERS. A re-consent for an unrelated scope
     // sends only `scopes`; if an omitted budget were written through as NULL, accepting

--- a/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
@@ -170,6 +170,103 @@ describe('listMyScopeGrants', () => {
     expect(result[0].buzzBudgetPerDay).toBeNull();
   });
 
+  // ── `spendScopeGranted` — whether the viewer's GRANT actually carries
+  // `ai:write:budgeted`. The budget editor on /apps/activity keys off this, and it is
+  // NOT derivable from `scopes` (which is the app's MANIFEST-declared set, i.e. what it
+  // ASKED for). Offering a limit control off the manifest would render a field the
+  // server silently drops, because `grantScopes` ignores a budget for an app that does
+  // not hold the spend scope.
+  it('spendScopeGranted is TRUE when the GRANT row carries ai:write:budgeted', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([pinnedSub()]);
+    mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([
+      {
+        appBlockId: 'apb_1',
+        buzzBudgetPerDay: 750,
+        revokedAt: null,
+        grantedScopes: ['user:read:self', 'ai:write:budgeted'],
+      },
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].spendScopeGranted).toBe(true);
+  });
+
+  // 🔴 THE DISCRIMINATING CASE: the app DECLARES the spend scope in its manifest, and
+  // the user has NOT granted it. Reading the manifest would answer `true` here.
+  it('spendScopeGranted is FALSE when only the MANIFEST declares the spend scope', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
+      pinnedSub({
+        appBlock: appBlock({
+          manifest: { name: 'Hello', scopes: ['ai:write:budgeted'] },
+          approvedScopes: ['ai:write:budgeted'],
+        }),
+      }),
+    ]);
+    mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([
+      {
+        appBlockId: 'apb_1',
+        buzzBudgetPerDay: null,
+        revokedAt: null,
+        grantedScopes: ['user:read:self'], // the user granted something else
+      },
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].scopes).toEqual(['ai:write:budgeted']); // manifest says yes…
+    expect(result[0].spendScopeGranted).toBe(false); // …the grant says no
+  });
+
+  it('spendScopeGranted is FALSE for a REVOKED grant (mirrors getGrantedScopes)', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([pinnedSub()]);
+    mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([
+      {
+        appBlockId: 'apb_1',
+        buzzBudgetPerDay: 750,
+        revokedAt: new Date(),
+        grantedScopes: ['ai:write:budgeted'],
+      },
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].spendScopeGranted).toBe(false);
+  });
+
+  it('spendScopeGranted is FALSE when the app has no grant row at all', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([pinnedSub()]);
+    mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].spendScopeGranted).toBe(false);
+  });
+
+  // ── PRE-MIGRATION. `buzz_budget_per_day` may not exist yet (migrations are applied by
+  // hand, per environment). The permissions page must still render: with no column, no
+  // budget can have been set, so "none" is the TRUE state and it is what the spend path
+  // enforces in that same database.
+  it('renders with NO budgets when the column does not exist yet (P2022)', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([pinnedSub()]);
+    mockDbRead.appUserScopeGrant.findMany.mockRejectedValue(
+      Object.assign(new Error('column does not exist'), { code: 'P2022' })
+    );
+    const result = await listMyScopeGrants(42);
+    expect(result).toHaveLength(1);
+    expect(result[0].buzzBudgetPerDay).toBeNull();
+    expect(result[0].spendScopeGranted).toBe(false);
+  });
+
+  // 🔴 And ONLY that code. A bare catch would render "no limits set" whenever the DB is
+  // unreachable — a lie about the user's own settings, on the page whose whole job is to
+  // report them.
+  it('RETHROWS any other DB error rather than reporting "no limits"', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([pinnedSub()]);
+    mockDbRead.appUserScopeGrant.findMany.mockRejectedValue(
+      Object.assign(new Error('connection refused'), { code: 'P1001' })
+    );
+    await expect(listMyScopeGrants(42)).rejects.toThrow(/connection refused/);
+  });
+
   it('reads scopes from the joined manifest.scopes', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
     mockDbRead.blockUserSubscription.findMany.mockResolvedValue([

--- a/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
@@ -23,6 +23,9 @@ const { mockDbRead, mockDbWrite } = vi.hoisted(() => ({
     blockBuzzAttribution: { findMany: vi.fn() },
     appBlockPublishRequest: { groupBy: vi.fn(), findFirst: vi.fn() },
     blockScopeInvocation: { findMany: vi.fn() },
+    // The consent BUDGET lives on the grant row, which `listMyScopeGrants` now reads to
+    // surface the viewer's per-app daily Buzz limit alongside the scopes.
+    appUserScopeGrant: { findMany: vi.fn() },
   },
   mockDbWrite: {
     blockUserSubscription: { update: vi.fn() },
@@ -55,6 +58,9 @@ beforeEach(() => {
   mockDbRead.appBlockPublishRequest.groupBy.mockResolvedValue([]);
   mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
   mockDbRead.blockScopeInvocation.findMany.mockResolvedValue([]);
+  // Default: no grant rows ⇒ every app reports `buzzBudgetPerDay: null`, which is the
+  // pre-column behaviour and what the existing expectations below assume.
+  mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([]);
   mockDbWrite.blockUserSubscription.update.mockResolvedValue({});
   mockDbWrite.blockScopeInvocation.create.mockResolvedValue({});
 });
@@ -113,6 +119,55 @@ describe('listMyScopeGrants', () => {
     expect(result[0].appBlockId).toBe('apb_1');
     expect(result[0].surfaces.modelInstallCount).toBe(2);
     expect(result[0].surfaces.subscriptionScopes).toEqual(['viewer_personal']);
+  });
+
+  // ── The CONSENT BUDGET the viewer set for this app. It lives on the grant row, not on
+  // the subscription rows this function aggregates, so it is a separate read — and its
+  // guards must mirror `getConsentBuzzBudget` exactly, or the permissions page would show
+  // a limit the SPEND path does not enforce (or hide one it does).
+  it('surfaces the consent budget from the grant row', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([pinnedSub()]);
+    mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([
+      { appBlockId: 'apb_1', buzzBudgetPerDay: 750, revokedAt: null },
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].buzzBudgetPerDay).toBe(750);
+    // Scoped to the apps actually in the result — never an unbounded scan.
+    expect(mockDbRead.appUserScopeGrant.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 42, appBlockId: { in: ['apb_1'] } } })
+    );
+  });
+
+  it('reports null when the app has no grant row', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([pinnedSub()]);
+    mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].buzzBudgetPerDay).toBeNull();
+  });
+
+  it('reports null for a REVOKED grant, matching what the spend path enforces', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([pinnedSub()]);
+    mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([
+      { appBlockId: 'apb_1', buzzBudgetPerDay: 750, revokedAt: new Date() },
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].buzzBudgetPerDay).toBeNull();
+  });
+
+  // A non-positive stored value would become a cap of 0 at the spend path, where
+  // `total > 0` denies everything. Both sides treat it as "no budget"; this pins that
+  // they agree rather than each guessing.
+  it('reports null for a non-positive stored budget', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([pinnedSub()]);
+    mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([
+      { appBlockId: 'apb_1', buzzBudgetPerDay: 0, revokedAt: null },
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].buzzBudgetPerDay).toBeNull();
   });
 
   it('reads scopes from the joined manifest.scopes', async () => {

--- a/src/server/services/blocks/custom-comfy-settle.service.ts
+++ b/src/server/services/blocks/custom-comfy-settle.service.ts
@@ -49,7 +49,9 @@ type BuzzCapKey = `${typeof REDIS_SYS_KEYS.BLOCKS.BUZZ_CAP}:${string}`;
 /** Same round-trip-and-cast reasoning as BuzzCapKey, for the consent-budget key. */
 type ConsentBudgetKey = `${typeof REDIS_SYS_KEYS.BLOCKS.CONSENT_BUDGET}:${string}`;
 
-function settleKey(workflowId: string): `${typeof REDIS_SYS_KEYS.BLOCKS.CUSTOM_COMFY_SETTLE}:${string}` {
+function settleKey(
+  workflowId: string
+): `${typeof REDIS_SYS_KEYS.BLOCKS.CUSTOM_COMFY_SETTLE}:${string}` {
   return `${REDIS_SYS_KEYS.BLOCKS.CUSTOM_COMFY_SETTLE}:${workflowId}`;
 }
 

--- a/src/server/services/blocks/custom-comfy-settle.service.ts
+++ b/src/server/services/blocks/custom-comfy-settle.service.ts
@@ -15,8 +15,9 @@ import type { AppSpendDailyKey } from '~/server/services/blocks/app-spend-cap.se
 // realizes at runtime. When the job reaches a TERMINAL status (observed by
 // `pollWorkflow` / `cancelWorkflow`) we refund the over-reservation
 // (`ceiling - actual`) back to EACH reservation counter (per-user daily, per-app
-// aggregate, and — when the submit came from an active on-site dev tunnel — the
-// per-dev-session cap), so every cap converges on the REAL accrued cost.
+// aggregate, the viewer's per-(user, app) CONSENT BUDGET when they set one, and —
+// when the submit came from an active on-site dev tunnel — the per-dev-session
+// cap), so every cap converges on the REAL accrued cost.
 //
 // This module owns the small durable link between the two: a per-workflow Redis
 // record of the exact reservation keys + the ceiling, written at submit and
@@ -45,6 +46,9 @@ const SETTLE_TTL_SECONDS = 25 * 60 * 60;
 // reserved, so the cast is sound — same key, same window).
 type BuzzCapKey = `${typeof REDIS_SYS_KEYS.BLOCKS.BUZZ_CAP}:${string}`;
 
+/** Same round-trip-and-cast reasoning as BuzzCapKey, for the consent-budget key. */
+type ConsentBudgetKey = `${typeof REDIS_SYS_KEYS.BLOCKS.CONSENT_BUDGET}:${string}`;
+
 function settleKey(workflowId: string): `${typeof REDIS_SYS_KEYS.BLOCKS.CUSTOM_COMFY_SETTLE}:${string}` {
   return `${REDIS_SYS_KEYS.BLOCKS.CUSTOM_COMFY_SETTLE}:${workflowId}`;
 }
@@ -54,6 +58,21 @@ type SettleRecord = {
   buzzCapKey: string;
   /** The per-app aggregate daily key; null for dev tokens (no per-app reserve). */
   appSpendKey: string | null;
+  /**
+   * The per-(user, app, UTC-day) CONSENT BUDGET key the ceiling was ALSO reserved
+   * against, when the viewer set a budget for this app. Absent for every submit
+   * where they did not (and for dev / run-for-real tokens, which take no consent
+   * reservation at all) — so that leg simply no-ops and the record is the exact
+   * shape it was before this field existed, which is what makes an in-flight
+   * pre-deploy record settle cleanly.
+   *
+   * 🔴 IT MUST BE SETTLED LIKE THE OTHERS. A post-paid job reserves the CEILING;
+   * without this leg the consent budget alone would stay charged at the ceiling
+   * while every other counter converged on the real accrued cost, so a user's own
+   * limit would exhaust far faster than their actual spend — visible to them, and
+   * wrong in the direction they would report as a bug.
+   */
+  consentBudgetKey?: string | null;
   /**
    * The dev-tunnel SESSION id the ceiling was ALSO reserved against, when the
    * submit came from an active on-site dev tunnel (F4). Absent for every non-dev
@@ -97,6 +116,8 @@ export async function persistCustomComfySettle(input: {
   workflowId: string;
   buzzCapKey: string;
   appSpendKey: string | null;
+  /** The consent-budget key, when the viewer set a per-app budget. */
+  consentBudgetKey?: string | null;
   devSessionId?: string | null;
   ceiling: number;
   /** Resolved engine + recipe id, for per-engine settle-time observability. */
@@ -109,6 +130,7 @@ export async function persistCustomComfySettle(input: {
     workflowId,
     buzzCapKey,
     appSpendKey,
+    consentBudgetKey = null,
     devSessionId = null,
     ceiling,
     engine,
@@ -120,6 +142,9 @@ export async function persistCustomComfySettle(input: {
   // Include the dev-session id ONLY when present, so a non-dev submit persists the
   // exact record shape it did before F4 (the dev-session refund leg then no-ops).
   if (devSessionId) record.devSessionId = devSessionId;
+  // Same rule for the consent-budget key: omitted when the viewer set no budget,
+  // so that record is byte-identical to a pre-consent-budget one.
+  if (consentBudgetKey) record.consentBudgetKey = consentBudgetKey;
   // Observability-only fields (never affect the refund). Present for every real
   // customComfy submit going forward; absent-safe at settle.
   if (engine) record.engine = engine;
@@ -138,7 +163,8 @@ export async function persistCustomComfySettle(input: {
  * Settle a customComfy workflow to its REAL accrued cost on the FIRST terminal
  * observation. Reads + atomically claims the settle record (GET then DEL, gated
  * on DEL===1 so only one caller refunds), then refunds `ceiling - actual` to
- * BOTH the per-user daily cap and the per-app aggregate cap.
+ * EVERY counter the record names — the per-user daily cap, the per-app aggregate
+ * cap, the viewer's consent budget, and the dev-session cap.
  *
  * Idempotent + self-scoping: a record exists ONLY for a customComfy submit and is
  * deleted on the first successful claim, so this can be called unconditionally on
@@ -231,6 +257,16 @@ export async function settleCustomComfySpend(input: {
   if (record.appSpendKey) {
     const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
     await refundAppSpend(record.appSpendKey as AppSpendDailyKey, refund);
+  }
+
+  // CONSENT BUDGET: present ONLY when the viewer set a per-app daily budget, which
+  // the submit reserved the same CEILING against. Refund the SAME over-reservation
+  // so the user's own limit converges on their real accrued spend like every other
+  // counter. Best-effort (a lost refund over-counts — stricter) and never throws.
+  if (record.consentBudgetKey) {
+    await sysRedis.decrBy(record.consentBudgetKey as ConsentBudgetKey, refund).catch(() => {
+      /* best-effort — a lost refund over-counts (stricter cap) */
+    });
   }
 
   // Dev-tunnel SESSION cap (F4): present ONLY when the submit came from an active

--- a/src/server/services/blocks/scope-grant.service.ts
+++ b/src/server/services/blocks/scope-grant.service.ts
@@ -54,7 +54,7 @@ export function isMissingColumnError(err: unknown): boolean {
  * migration is outstanding, and the operator has to be told.
  */
 let missingBudgetColumnLogged = false;
-function logMissingBudgetColumn(site: string, err: unknown): void {
+export function logMissingBudgetColumn(site: string, err: unknown): void {
   if (missingBudgetColumnLogged) return;
   missingBudgetColumnLogged = true;
   logToAxiom(

--- a/src/server/services/blocks/scope-grant.service.ts
+++ b/src/server/services/blocks/scope-grant.service.ts
@@ -21,7 +21,58 @@
  */
 
 import { dbRead, dbWrite } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
 import { newAppUserScopeGrantId } from '~/server/utils/app-block-ids';
+
+/**
+ * True for the ONE Prisma failure that means "this deploy is running ahead of its
+ * migration": P2022 — the column named in the query does not exist in the database.
+ *
+ * Migrations in this project are applied BY HAND, per environment, so the image and
+ * the schema are not deployed atomically and `buzz_budget_per_day` can legitimately
+ * be absent from a database the current code is talking to. Every OTHER Prisma error
+ * — connection loss, timeout, constraint violation — must still propagate: a bare
+ * `catch` here would swallow real DB failures and silently return "no budget", which
+ * is the fail-OPEN this whole feature exists to prevent.
+ *
+ * Narrow by CODE, not by message text. The message is a human string that upstream
+ * is free to reword; the code is the contract.
+ */
+export function isMissingColumnError(err: unknown): boolean {
+  return (err as { code?: unknown } | null)?.code === 'P2022';
+}
+
+/**
+ * ONCE PER PROCESS, not once per deploy and not once globally — this is a
+ * module-level boolean in one Node process, so a fleet of N pods emits up to N
+ * lines and a restart re-arms it. That is deliberate and sufficient: the signal
+ * wanted is "somebody is running ahead of the migration", which one line per pod
+ * carries, and the alternative (a line per spend attempt) would bury it.
+ *
+ * `error` level on purpose. Reading past a missing column is CORRECT (see
+ * `getConsentBuzzBudget`) but it is never an intended steady state — it means a
+ * migration is outstanding, and the operator has to be told.
+ */
+let missingBudgetColumnLogged = false;
+function logMissingBudgetColumn(site: string, err: unknown): void {
+  if (missingBudgetColumnLogged) return;
+  missingBudgetColumnLogged = true;
+  logToAxiom(
+    {
+      name: 'app-blocks-scope-grant',
+      type: 'error',
+      message:
+        `app_user_scope_grants.buzz_budget_per_day is MISSING from this database — ` +
+        `apply migration 20260910120000_app_user_scope_grant_buzz_budget. Consent budgets ` +
+        `read as "not set" until it lands; the platform per-user daily Buzz cap still applies.`,
+      site,
+      code: (err as { code?: unknown } | null)?.code,
+    },
+    'webhooks'
+  ).catch(() => {
+    /* logging must never break a spend path */
+  });
+}
 
 /**
  * Returns the set of block-scope strings the user currently has granted for
@@ -55,10 +106,29 @@ export async function getGrantedScopes(opts: {
  * for a budget to bound. Returning the stored number for a revoked row would be
  * enforcing a ceiling on spend that cannot happen.
  *
+ * ⚠️ THE REVOKED BRANCH IS AN INVARIANT GUARD, NOT REGRESSION COVERAGE, BECAUSE THE
+ * STATE IS CURRENTLY UNREACHABLE. Nothing in this codebase ever SETS
+ * `app_user_scope_grants.revoked_at` — grep it: every write is `revokedAt: null`
+ * (re-granting un-revokes). A revoked row therefore only exists if an operator writes
+ * one by hand. The `!row || row.revokedAt` tests here, in `getGrantedScopes`, and in
+ * `listMyScopeGrants` are pinning an invariant against a future revoke path, and the
+ * tests that exercise them by constructing a revoked row are testing that invariant —
+ * they are NOT evidence that a bug was ever possible on this path.
+ *
  * 🔴 READS THE PRIMARY BY DEFAULT. This runs on the spend path, immediately after a
  * consent write that may have just LOWERED the budget: served off the replica, a
  * lag window would spend against the OLD, looser ceiling — the one direction a
  * money cap must never drift. The read is a single unique-index lookup.
+ *
+ * 🔴 A MISSING COLUMN (P2022) RETURNS `null`, AND THAT IS THE TRUE ANSWER, NOT A
+ * FALLBACK. Migrations here are applied by hand, so an image can legitimately run
+ * against a database that does not yet have `buzz_budget_per_day`. If the column
+ * does not exist then no user can ever have set a budget — "no budget set" is not a
+ * degraded guess, it is the only state the database can be in — and `null` routes to
+ * exactly the same behaviour every pre-column grant already had: the platform's own
+ * `BLOCK_BUZZ_CAP_PER_DAY` ceiling keeps enforcing, unchanged. Only P2022 is caught;
+ * any other Prisma failure still throws, because for those the budget is UNKNOWN
+ * rather than absent, and treating unknown as "no budget" would be a fail-open.
  */
 export async function getConsentBuzzBudget(opts: {
   userId: number;
@@ -66,10 +136,17 @@ export async function getConsentBuzzBudget(opts: {
   db?: 'read' | 'write';
 }): Promise<number | null> {
   const client = opts.db === 'read' ? dbRead : dbWrite;
-  const row = (await client.appUserScopeGrant.findUnique({
-    where: { userId_appBlockId: { userId: opts.userId, appBlockId: opts.appBlockId } },
-    select: { buzzBudgetPerDay: true, revokedAt: true },
-  })) as { buzzBudgetPerDay: number | null; revokedAt: Date | null } | null;
+  let row: { buzzBudgetPerDay: number | null; revokedAt: Date | null } | null;
+  try {
+    row = (await client.appUserScopeGrant.findUnique({
+      where: { userId_appBlockId: { userId: opts.userId, appBlockId: opts.appBlockId } },
+      select: { buzzBudgetPerDay: true, revokedAt: true },
+    })) as { buzzBudgetPerDay: number | null; revokedAt: Date | null } | null;
+  } catch (err) {
+    if (!isMissingColumnError(err)) throw err;
+    logMissingBudgetColumn('getConsentBuzzBudget', err);
+    return null;
+  }
   if (!row || row.revokedAt) return null;
   const budget = row.buzzBudgetPerDay;
   // Guard the VALUE, not just its presence: a non-positive or non-finite number
@@ -114,6 +191,21 @@ export async function getConsentBuzzBudget(opts: {
  * permission would silently wipe a spend limit the user had deliberately set —
  * a widening, performed by a dialog that said nothing about money.
  */
+/**
+ * 🔴 THE WRITES BELOW MUST NEVER READ A COLUMN BACK. Prisma's DEFAULT selection is
+ * "every scalar", so a `create`/`update` with no `select` emits
+ * `RETURNING … buzz_budget_per_day` — which makes an ordinary install / subscribe /
+ * re-consent throw P2022 against a database that has not had the migration applied
+ * yet, i.e. a 500 on every grant write from a deploy that lands first. MEASURED on
+ * this PR's own preview environment before this select existed.
+ *
+ * `id` is picked because it is the primary key: it predates this feature, it can
+ * never be the column a future migration is racing, and no caller uses the return
+ * value (both writers return `void`). Do NOT widen this to include a column added by
+ * a pending migration — the whole point is that these writes read nothing new.
+ */
+const WRITE_RETURN_SELECT = { id: true } as const;
+
 export async function recordScopeGrant(opts: {
   userId: number;
   appBlockId: string;
@@ -141,6 +233,7 @@ export async function recordScopeGrant(opts: {
     await dbWrite.appUserScopeGrant.update({
       where: { id: existing.id },
       data: { grantedScopes: merged, version, revokedAt: null, ...budgetData },
+      select: WRITE_RETURN_SELECT,
     });
     return;
   }
@@ -155,6 +248,7 @@ export async function recordScopeGrant(opts: {
         grantedScopes: incoming,
         ...budgetData,
       },
+      select: WRITE_RETURN_SELECT,
     });
   } catch (err) {
     // Concurrent first-write race on the (user, app_block) unique index →
@@ -170,6 +264,7 @@ export async function recordScopeGrant(opts: {
     await dbWrite.appUserScopeGrant.update({
       where: { id: row.id },
       data: { grantedScopes: merged, version, revokedAt: null, ...budgetData },
+      select: WRITE_RETURN_SELECT,
     });
   }
 }

--- a/src/server/services/blocks/scope-grant.service.ts
+++ b/src/server/services/blocks/scope-grant.service.ts
@@ -43,6 +43,44 @@ export async function getGrantedScopes(opts: {
 }
 
 /**
+ * Reads the per-(user, app) CONSENT BUDGET — the daily Buzz ceiling the viewer
+ * themselves set for this app when they consented. `null` means the user set no
+ * budget, in which case the app spends under the platform's own per-user daily
+ * ceiling (`BLOCK_BUZZ_CAP_PER_DAY`) alone — the behaviour of every grant written
+ * before the column existed.
+ *
+ * 🔴 A REVOKED GRANT RETURNS `null`, AND THAT IS NOT A LOOSENING. `getGrantedScopes`
+ * already treats a revoked row as an empty grant, so a revoked user's token carries
+ * no `ai:write:budgeted` and can reach no spend path at all — there is nothing left
+ * for a budget to bound. Returning the stored number for a revoked row would be
+ * enforcing a ceiling on spend that cannot happen.
+ *
+ * 🔴 READS THE PRIMARY BY DEFAULT. This runs on the spend path, immediately after a
+ * consent write that may have just LOWERED the budget: served off the replica, a
+ * lag window would spend against the OLD, looser ceiling — the one direction a
+ * money cap must never drift. The read is a single unique-index lookup.
+ */
+export async function getConsentBuzzBudget(opts: {
+  userId: number;
+  appBlockId: string;
+  db?: 'read' | 'write';
+}): Promise<number | null> {
+  const client = opts.db === 'read' ? dbRead : dbWrite;
+  const row = (await client.appUserScopeGrant.findUnique({
+    where: { userId_appBlockId: { userId: opts.userId, appBlockId: opts.appBlockId } },
+    select: { buzzBudgetPerDay: true, revokedAt: true },
+  })) as { buzzBudgetPerDay: number | null; revokedAt: Date | null } | null;
+  if (!row || row.revokedAt) return null;
+  const budget = row.buzzBudgetPerDay;
+  // Guard the VALUE, not just its presence: a non-positive or non-finite number
+  // read back from the DB would otherwise become a cap of 0 or NaN, and `total >
+  // NaN` is false — i.e. a corrupt row would silently DISABLE the cap. Treat any
+  // unusable value as "no budget set" (the platform cap still applies).
+  if (typeof budget !== 'number' || !Number.isFinite(budget) || budget <= 0) return null;
+  return Math.floor(budget);
+}
+
+/**
  * Records (or extends) a user's consent for an app block. ADDITIVE — scopes
  * the user already granted persist; the supplied scopes are unioned in. Writing
  * a grant also clears any prior `revoked_at` (re-granting un-revokes), and
@@ -56,14 +94,38 @@ export async function getGrantedScopes(opts: {
  * (install/subscribe already resolve the AppBlock manifest) — this service does
  * NOT re-derive the ceiling; it stores exactly what it is told the user
  * consented to. Unknown/garbage scopes simply never match at mint.
+ *
+ * ## `buzzBudgetPerDay` semantics — NOT additive, and deliberately not
+ *
+ * The scope set unions because "I already let you read my models" and "now also
+ * spend my Buzz" are both true at once. A budget is a single number and cannot
+ * union; it can only be kept or replaced. So:
+ *
+ *   - `buzzBudgetPerDay: <number>` → OVERWRITES the stored value. The user just
+ *     told us what they want; the newest statement wins.
+ *   - `buzzBudgetPerDay: null`     → OVERWRITES with "no budget" (an explicit
+ *     clear — the user removed their limit).
+ *   - key OMITTED (`undefined`)    → LEAVES the stored value untouched.
+ *
+ * That third case is the one that matters, and it is why this is `'buzzBudgetPerDay'
+ * in opts` rather than a `!== undefined` test on the value. A re-consent for a NEW
+ * scope (the host surfaces `needs_consent`, the user clicks Allow) sends only the
+ * scopes; if an omitted budget were written through as NULL, accepting one extra
+ * permission would silently wipe a spend limit the user had deliberately set —
+ * a widening, performed by a dialog that said nothing about money.
  */
 export async function recordScopeGrant(opts: {
   userId: number;
   appBlockId: string;
   version: string;
   scopes: string[];
+  /** Omit to leave any stored budget untouched; `null` explicitly clears it. */
+  buzzBudgetPerDay?: number | null;
 }): Promise<void> {
   const { userId, appBlockId, version } = opts;
+  // Presence of the KEY, not truthiness of the value — see the doc above.
+  const budgetSupplied = 'buzzBudgetPerDay' in opts;
+  const budgetData = budgetSupplied ? { buzzBudgetPerDay: opts.buzzBudgetPerDay ?? null } : {};
   // Dedup + drop empties so the stored array stays clean.
   const incoming = Array.from(new Set(opts.scopes.filter((s) => typeof s === 'string' && s.length > 0)));
 
@@ -76,7 +138,7 @@ export async function recordScopeGrant(opts: {
     const merged = Array.from(new Set([...(existing.grantedScopes ?? []), ...incoming]));
     await dbWrite.appUserScopeGrant.update({
       where: { id: existing.id },
-      data: { grantedScopes: merged, version, revokedAt: null },
+      data: { grantedScopes: merged, version, revokedAt: null, ...budgetData },
     });
     return;
   }
@@ -89,6 +151,7 @@ export async function recordScopeGrant(opts: {
         appBlockId,
         version,
         grantedScopes: incoming,
+        ...budgetData,
       },
     });
   } catch (err) {
@@ -104,7 +167,7 @@ export async function recordScopeGrant(opts: {
     const merged = Array.from(new Set([...(row.grantedScopes ?? []), ...incoming]));
     await dbWrite.appUserScopeGrant.update({
       where: { id: row.id },
-      data: { grantedScopes: merged, version, revokedAt: null },
+      data: { grantedScopes: merged, version, revokedAt: null, ...budgetData },
     });
   }
 }

--- a/src/server/services/blocks/scope-grant.service.ts
+++ b/src/server/services/blocks/scope-grant.service.ts
@@ -127,7 +127,9 @@ export async function recordScopeGrant(opts: {
   const budgetSupplied = 'buzzBudgetPerDay' in opts;
   const budgetData = budgetSupplied ? { buzzBudgetPerDay: opts.buzzBudgetPerDay ?? null } : {};
   // Dedup + drop empties so the stored array stays clean.
-  const incoming = Array.from(new Set(opts.scopes.filter((s) => typeof s === 'string' && s.length > 0)));
+  const incoming = Array.from(
+    new Set(opts.scopes.filter((s) => typeof s === 'string' && s.length > 0))
+  );
 
   const existing = (await dbWrite.appUserScopeGrant.findUnique({
     where: { userId_appBlockId: { userId, appBlockId } },

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -1111,6 +1111,35 @@ describe('block step registry — billing-mode dispatch', () => {
     }
   });
 
+  // 🔴 TRIPWIRE, NOT COVERAGE — and it exists because a mutant survived here.
+  //
+  // The router's step branch has a POST-PAID arm (`if (plan.postPaidSettle …)
+  // persistCustomComfySettle({ …, consentBudgetKey: reservation.consent?.key ?? null })`)
+  // that NO registered step can reach: `prepaidFixed` is the only implemented billing
+  // mode and it hardcodes `postPaidSettle: false`. Audit round 1 mutated that
+  // `consentBudgetKey` line to `null` and it SURVIVED the whole suite — correctly, in
+  // the sense that no input exists that could have caught it. The customComfy twin of
+  // that line IS behaviourally covered (blocks.router.workflow.test.ts → "CONSENT
+  // BUDGET"); this one cannot be, until the arm is reachable.
+  //
+  // So this asserts the UNREACHABILITY itself. The moment someone registers a
+  // post-paid step this test goes red, and the fix is not to delete it — it is to add
+  // the router-level settle-record coverage the arm has never had (the customComfy
+  // "persists that key on the settle record" test is the template).
+  it('NO registered step is post-paid — the router post-paid arm is unreachable, so it is UNTESTED', () => {
+    for (const [id, step] of listRegisteredSteps()) {
+      for (const variant of step.variants) {
+        const params = step.paramSchema.parse(step.canonicalParamsFor(variant));
+        expect(
+          planStepSpend(step, params).postPaidSettle,
+          `step '${id}' is now POST-PAID. The router's post-paid settle arm — including ` +
+            `the consentBudgetKey it puts on the settle record — has no behavioural test. ` +
+            `Add one before shipping this step.`
+        ).toBe(false);
+      }
+    }
+  });
+
   // 🔴 STRUCTURAL PROOF that dispatch is on `billingMode`, not on the step id and
   // not on the wire `kind`. A fixture declaring a DIFFERENT mode is routed to
   // that mode's handler — reaching it needs no change to the router, the schema,

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -190,8 +190,11 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
       // what the spend path enforces in that same database. Any other error still
       // throws: a permissions page that quietly renders "no limits" because the DB is
       // unreachable would be a lie about the user's own settings.
-      const { isMissingColumnError } = await import('~/server/services/blocks/scope-grant.service');
+      const { isMissingColumnError, logMissingBudgetColumn } = await import(
+        '~/server/services/blocks/scope-grant.service'
+      );
       if (!isMissingColumnError(err)) throw err;
+      logMissingBudgetColumn('listMyScopeGrants', err);
     }
     for (const g of grants) {
       // Mirror getConsentBuzzBudget's guards EXACTLY — revoked → null, and a

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -59,8 +59,23 @@ export type ScopeGrantSurface = {
    *
    * A REVOKED grant reports `null`, matching `getConsentBuzzBudget`: a revoked
    * grant carries no spend scope, so there is no spend for a budget to bound.
+   * ⚠️ That branch is an INVARIANT guard over a state nothing in this codebase can
+   * produce — no code path ever writes a non-null `revoked_at` — see
+   * `getConsentBuzzBudget`.
    */
   buzzBudgetPerDay: number | null;
+  /**
+   * True when the viewer's LIVE (non-revoked) grant row for this app actually carries
+   * `ai:write:budgeted` — the one scope in the vocabulary that can spend their Buzz.
+   *
+   * 🔴 THIS IS NOT DERIVABLE FROM `scopes` ABOVE, and that is why it exists. `scopes`
+   * is the app's MANIFEST-declared set (what it asks for); this is the USER'S GRANT
+   * (what they agreed to). The budget editor on /apps/activity keys off this one: a
+   * budget only bounds something when the spend scope is granted, and `grantScopes`
+   * IGNORES a budget sent for an app that does not hold it — so offering the control
+   * off the manifest set would render a field whose value the server silently drops.
+   */
+  spendScopeGranted: boolean;
   surfaces: {
     modelInstallCount: number;
     subscriptionScopes: string[];
@@ -148,11 +163,36 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
   // an N+1 per row. Apps with no grant row simply do not appear in the map and
   // report `null`, which is the same thing "no budget set" means everywhere else.
   const budgetByAppBlock = new Map<string, number | null>();
+  const spendGrantedByAppBlock = new Set<string>();
   if (byAppBlock.size > 0) {
-    const grants = (await dbRead.appUserScopeGrant.findMany({
-      where: { userId, appBlockId: { in: Array.from(byAppBlock.keys()) } },
-      select: { appBlockId: true, buzzBudgetPerDay: true, revokedAt: true },
-    })) as Array<{ appBlockId: string; buzzBudgetPerDay: number | null; revokedAt: Date | null }>;
+    type GrantRow = {
+      appBlockId: string;
+      buzzBudgetPerDay: number | null;
+      revokedAt: Date | null;
+      grantedScopes: string[];
+    };
+    let grants: GrantRow[] = [];
+    try {
+      grants = (await dbRead.appUserScopeGrant.findMany({
+        where: { userId, appBlockId: { in: Array.from(byAppBlock.keys()) } },
+        select: {
+          appBlockId: true,
+          buzzBudgetPerDay: true,
+          revokedAt: true,
+          grantedScopes: true,
+        },
+      })) as GrantRow[];
+    } catch (err) {
+      // 🔴 P2022 ONLY — the deploy is running ahead of its migration and
+      // `buzz_budget_per_day` does not exist yet. See `isMissingColumnError`. With no
+      // column there is no budget any user could have set, so an empty map is the TRUE
+      // state and every app reports `null` (= "platform cap only"), which is exactly
+      // what the spend path enforces in that same database. Any other error still
+      // throws: a permissions page that quietly renders "no limits" because the DB is
+      // unreachable would be a lie about the user's own settings.
+      const { isMissingColumnError } = await import('~/server/services/blocks/scope-grant.service');
+      if (!isMissingColumnError(err)) throw err;
+    }
     for (const g of grants) {
       // Mirror getConsentBuzzBudget's guards EXACTLY — revoked → null, and a
       // non-positive stored value → null — so this display can never disagree with
@@ -162,6 +202,10 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
           ? Math.floor(g.buzzBudgetPerDay)
           : null;
       budgetByAppBlock.set(g.appBlockId, usable);
+      // Mirror `getGrantedScopes`: a revoked row grants nothing.
+      if (!g.revokedAt && (g.grantedScopes ?? []).includes('ai:write:budgeted')) {
+        spendGrantedByAppBlock.add(g.appBlockId);
+      }
     }
   }
 
@@ -192,6 +236,7 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
       iconUrl,
       scopes: manifestScopes,
       buzzBudgetPerDay: budgetByAppBlock.get(appBlockId) ?? null,
+      spendScopeGranted: spendGrantedByAppBlock.has(appBlockId),
       surfaces: {
         modelInstallCount: entry.modelInstallCount,
         subscriptionScopes: Array.from(entry.subscriptionScopes).sort(),

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -50,6 +50,17 @@ export type ScopeGrantSurface = {
   name: string;
   iconUrl?: string;
   scopes: string[];
+  /**
+   * The per-UTC-day Buzz ceiling the VIEWER set for this app at consent time, or
+   * `null` when they set none (in which case only the platform's own per-user daily
+   * cap applies). Read from `app_user_scope_grants.buzz_budget_per_day` — the same
+   * row + the same NULL semantics the SPEND path enforces against, so the
+   * permissions surface cannot show a limit the enforcement does not honour.
+   *
+   * A REVOKED grant reports `null`, matching `getConsentBuzzBudget`: a revoked
+   * grant carries no spend scope, so there is no spend for a budget to bound.
+   */
+  buzzBudgetPerDay: number | null;
   surfaces: {
     modelInstallCount: number;
     subscriptionScopes: string[];
@@ -132,6 +143,28 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
     }
   }
 
+  // The consent BUDGET lives on the grant row, not on the subscription rows this
+  // function aggregates — one indexed read for every app in the result, rather than
+  // an N+1 per row. Apps with no grant row simply do not appear in the map and
+  // report `null`, which is the same thing "no budget set" means everywhere else.
+  const budgetByAppBlock = new Map<string, number | null>();
+  if (byAppBlock.size > 0) {
+    const grants = (await dbRead.appUserScopeGrant.findMany({
+      where: { userId, appBlockId: { in: Array.from(byAppBlock.keys()) } },
+      select: { appBlockId: true, buzzBudgetPerDay: true, revokedAt: true },
+    })) as Array<{ appBlockId: string; buzzBudgetPerDay: number | null; revokedAt: Date | null }>;
+    for (const g of grants) {
+      // Mirror getConsentBuzzBudget's guards EXACTLY — revoked → null, and a
+      // non-positive stored value → null — so this display can never disagree with
+      // what the spend path enforces.
+      const usable =
+        !g.revokedAt && typeof g.buzzBudgetPerDay === 'number' && g.buzzBudgetPerDay > 0
+          ? Math.floor(g.buzzBudgetPerDay)
+          : null;
+      budgetByAppBlock.set(g.appBlockId, usable);
+    }
+  }
+
   const result: ScopeGrantSurface[] = [];
   for (const [appBlockId, entry] of byAppBlock.entries()) {
     const manifest = (entry.appBlock.manifest ?? {}) as {
@@ -158,6 +191,7 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
       name: manifestName,
       iconUrl,
       scopes: manifestScopes,
+      buzzBudgetPerDay: budgetByAppBlock.get(appBlockId) ?? null,
       surfaces: {
         modelInstallCount: entry.modelInstallCount,
         subscriptionScopes: Array.from(entry.subscriptionScopes).sort(),

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -159,9 +159,43 @@ export const BLOCK_BUZZ_CAP_PER_DAY = 50_000;
  * expresses — so zero is rejected at the input rather than stored as a
  * confusing dead grant. Mirrored by the `app_user_scope_grants_buzz_budget_bounds`
  * CHECK constraint (migration 20260910120000).
+ *
+ * 🔴 MIN = 1 WAS RE-EXAMINED (audit round 1) AND DELIBERATELY KEPT. The objection
+ * was that a floor of 1 lets a user store a budget that refuses every generation.
+ * That is TRUE — 1 is below every registered per-engine ceiling — but it stopped
+ * being a TRAP once the limit became editable: the budget is now rendered and
+ * raise/lower/clearable on /apps/activity (`AppBudgetControl`), so a too-low value
+ * is one click from recoverable IN the product, and the editor shows an explicit
+ * warning below `BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY` saying what a low number
+ * does. Raising the floor instead would silently overrule a user who deliberately
+ * wants a tiny allowance for a step-priced app (`convert-image` costs 1 Buzz), which
+ * is a real and legitimate setting. Recoverability + a warning beats a floor that
+ * decides for them.
  */
 export const BLOCK_CONSENT_BUDGET_MIN_PER_DAY = 1;
 export const BLOCK_CONSENT_BUDGET_MAX_PER_DAY = BLOCK_BUZZ_CAP_PER_DAY;
+
+/**
+ * Pre-filled suggestion when a user turns a limit ON (consent modal + the editor on
+ * /apps/activity). Deliberately far below the platform ceiling: the default should be
+ * a limit, not a formality.
+ */
+export const BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY = 1000;
+
+/**
+ * Below this, the UI warns that the limit is low enough to refuse ordinary
+ * generations. NOT a validation bound — anything from MIN up is storable and
+ * enforced exactly as given.
+ *
+ * The number is the LOWEST per-engine post-paid ceiling any registered recipe
+ * declares today: `STARTER_BUDGET.maxBuzz` = 90 and `seamless-pano`'s cheapest engine
+ * (`zimage-turbo`) = 90. A budget under it cannot fund a single customComfy
+ * generation, so an app using one will appear broken. Registry steps can be far
+ * cheaper (`convert-image` = 1 Buzz), which is why this warns instead of blocking.
+ * If a cheaper recipe engine is ever registered this number is free to drop — it
+ * changes copy, never enforcement.
+ */
+export const BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY = 90;
 
 /**
  * Membership test against the authoritative scope vocabulary.

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -134,6 +134,36 @@ export type BlockScopeString = keyof typeof BLOCK_SCOPE_TO_OAUTH_BIT;
 export const REVIEW_RUN_FOR_REAL_BUZZ_CAP = 5000;
 
 /**
+ * PLATFORM per-(USER, UTC-day) cumulative Buzz-spend ceiling across ALL the apps
+ * a viewer has installed. The abuse ceiling nobody consents to — a per-call
+ * `buzzBudget` alone cannot bound an app looping sub-budget submits, so this is
+ * the aggregate that actually binds. Enforced in `blocks.router.ts`
+ * (`reserveBlockBuzzSpend`, keyed WITHOUT appBlockId so N installed apps share
+ * ONE ceiling rather than multiplying it).
+ *
+ * Lives HERE, in the client-safe shared module, because it is now read by three
+ * places that must agree: the server enforcement, the `blocks.grantScopes` zod
+ * bound on a user-set consent budget, and the consent dialog that shows the user
+ * what the ceiling is. It is also the upper bound on
+ * `app_user_scope_grants.buzz_budget_per_day` — a consent budget ABOVE the
+ * platform cap could never bind, so storing one would be storing a number that
+ * means nothing.
+ */
+export const BLOCK_BUZZ_CAP_PER_DAY = 50_000;
+
+/**
+ * Bounds for a user-set per-app consent budget
+ * (`app_user_scope_grants.buzz_budget_per_day`). MIN is 1 rather than 0: a
+ * budget of zero would be a way to consent to `ai:write:budgeted` and
+ * simultaneously make it unusable, which is what DECLINING the scope already
+ * expresses — so zero is rejected at the input rather than stored as a
+ * confusing dead grant. Mirrored by the `app_user_scope_grants_buzz_budget_bounds`
+ * CHECK constraint (migration 20260910120000).
+ */
+export const BLOCK_CONSENT_BUDGET_MIN_PER_DAY = 1;
+export const BLOCK_CONSENT_BUDGET_MAX_PER_DAY = BLOCK_BUZZ_CAP_PER_DAY;
+
+/**
  * Membership test against the authoritative scope vocabulary.
  *
  * 🔴 OWN-PROPERTY ONLY — deliberately `hasOwnProperty`, never `in`. `in` walks


### PR DESCRIPTION
## What moved

The App Blocks runtime was gated by `assertViewerIsAppDeveloper` — an **authoring** capability — standing in front of **runtime** actions: generate, estimate, poll, cancel, read-my-balance, read-my-viewer. The effect was that a viewer who is not an app author could not *use* an app at all. This replaces that with the user's own **scope grants**, plus a per-(user, app) daily Buzz budget the viewer sets at consent time.

**`await assertViewerIsAppDeveloper(userId)` in `blocks.router.ts`: 15 → 1.**

The survivor is `updateUserSettings`, which writes the install's persisted settings — an authoring/publishing-shaped action that no block scope expresses. It is a deliberate exception, documented at the function and pinned by a test.

`claims.scopes.includes(...)` checks in that file: 10 → 15.
`await submitWorkflow({` call sites: **7 → 7** (the `no-unguarded-billable-submit` ratchet is untouched).

### Group A — 10 sites that already had a scope check (gate removed only)

`authorizeBlockBuzzRead`, `pollWorkflow`, `listMyWorkflows`, `cancelWorkflow`, `queryAppWorkflows`, `cancelAppWorkflow`, `publishGenerationOutputs`, `estimateWorkflow`, `submitWorkflow`, `getMyViewer`. `assertAppBlocksEnabledForTokenUser` (the kill-switch) stays on every one of them.

### Group B — 4 sites with no scope check (gate removed, scope added)

| site | scope added | reachable widening? |
|---|---|---|
| `getMyBuzzBalance` (procedure) | `buzz:read:self` | **Yes** — this is the one that mattered |
| `estimateCustomComfyWorkflow` (helper) | `ai:write:budgeted` | No |
| `submitCustomComfyWorkflow` (helper) | `ai:write:budgeted` | No |
| `assertStepRequestAllowed` (helper) | `ai:write:budgeted` | No |

🔴 **Reviewer-relevant honesty about the three "No" rows.** Those helpers are only ever reached from `estimateWorkflow` / `submitWorkflow`, both of which reject a token missing `ai:write:budgeted` *before* they dispatch. So no request can reach those lines with the scope absent: they are defense-in-depth, they close no gap today, and **a mutation of them cannot be observed through the router**. They are commented as such in the code so a future reader does not mistake them for the gate. `getMyBuzzBalance` is the genuine case — it had no scope check at all, so removing the author gate without adding one would have exposed the viewer's balance to any valid block token.

⚠️ **Wire-visible behaviour change:** `getMyBuzzBalance` was documented as "the scope-free convenience path". It now returns `FORBIDDEN` to a token that does not carry `buzz:read:self`. That is the intended tightening — the scope *is* the user's consent — but any app that read the balance without declaring the scope will need to declare it. The docblock has been rewritten to say so rather than left asserting the old contract.

### Group C — untouched

`updateUserSettings` keeps `assertViewerIsAppDeveloper`, per the operator's decision. Not unified.

## The consent budget

New nullable column `app_user_scope_grants.buzz_budget_per_day`. When a grant carries a non-null value, every spend path *also* reserves the cost against a per-(user, app, UTC-day) Redis counter capped at that value. **Both caps apply; the tighter binds.** A NULL budget writes no key and takes no reservation — byte-identical to today, so there is no backfill and nobody is silently tightened.

- Single chokepoint: `reserveBlockBuzzSpendForClaims`, used by all four spend paths.
- **Skipped for `claims.dev === true`** (self-bound token, frequently synthetic `appBlockId` that joins to no grant row — the same exclusion `reserveAppSpend` already takes) and **for `claims.reviewRunForReal === true`** (that arm swaps in its own strictly-tighter ceiling and its `appBlockId` is a `pubreq_<ULID>`, not an AppBlock id). Both skips are commented at the branch.
- Key added under `REDIS_SYS_KEYS.BLOCKS.CONSENT_BUDGET`, not hand-typed.
- **Fails closed** on a Redis error *and* on a DB error reading the budget: absent means "unbounded within the 50k platform cap", so swallowing a read error would silently widen the ceiling the user consented to.

### 🔴 The correctness requirement

**If the consent reservation rejects, the platform daily reservation already taken is refunded.** Without it, a denied attempt silently burns the viewer's 50,000/day allowance for a generation that never ran.

Rather than adding a second refund line at each of ~12 refund sites (which regenerates the same omission bug at every site), `reserveBlockBuzzSpendForClaims` now returns **both** reservations and every refund site calls `refundBlockBuzzReservation(reservation, cost)`. Callers pass the whole reservation, never a key.

The post-paid `customComfy` settle record carries the consent key too, so a ceiling reservation converges on real accrued cost on that counter as well — otherwise a user's own limit would exhaust far faster than their actual spend.

## Schema + migration

- `packages/civitai-db-schema/prisma/schema.full.prisma` — `buzzBudgetPerDay Int? @map("buzz_budget_per_day")` on `AppUserScopeGrant`.
- `packages/civitai-db-schema/prisma/migrations/20260910120000_app_user_scope_grant_buzz_budget/migration.sql` — `ADD COLUMN IF NOT EXISTS ... INTEGER NULL` plus a positive-if-present CHECK bounded at 50,000 (a budget above the platform cap could never bind).
- The committed `src/kysely/types.ts` and `src/models.ts` deltas are the generated artifacts for that one field, nothing else.

**Note on the brief's premise:** there is only **one** tracked Prisma schema in this repo, `schema.full.prisma`. `packages/civitai-db-schema/prisma/schema.prisma` is *generated* by `postinstall` and gitignored, and there is no `prisma/schema.prisma` at the repo root. It picked up the field automatically.

### 🔴 DEPLOY ORDER

**The migration is NOT applied here, and nothing in CI or the deploy applies it.** Migrations against this DB are applied by hand, per environment.

The column is additive and nullable, so applying it **early is a no-op** for the currently-running code — but it **must be applied BEFORE the new image rolls**. Once the image is live, every Prisma read of `AppUserScopeGrant` selects `buzz_budget_per_day`; without the column those reads fail with a missing-column error, which is a 500 on the consent and permissions surfaces and a fail-closed rejection on the spend path.

Safe order: **apply the SQL → verify → then roll the image.**

## Consent write path + UI

- `blocks.grantScopes` accepts an optional `buzzBudgetPerDay` (positive int, max 50,000, nullable).
- **Sent without `ai:write:budgeted` being granted (in this call or already on the row) it is IGNORED, not an error.** The natural client shape is one dialog that always sends its budget field while the scopes vary; erroring would fail a request that asks for nothing improper. Nothing is stored, so nothing later reads a budget that bounds nothing — and the response echoes what was actually stored, so a client can tell an ignored budget from an applied one without a second round-trip. Documented at the call site.
- **`recordScopeGrant` budget semantics** — a number **overwrites**, an explicit `null` **clears**, an **omitted key leaves the stored value untouched**. The third case is the load-bearing one and is why the implementation tests `'buzzBudgetPerDay' in opts` rather than `!== undefined`: a re-consent for an unrelated scope sends only `scopes`, and writing an omitted budget through as NULL would silently wipe a spend limit the user set — a widening performed by a dialog that never mentioned money. The `P2002` concurrent-create retry is a third write site and carries the budget too.
- `BlockConsentModal` grows a spend-limit control, shown **only** when `ai:write:budgeted` is being consented to. Off by default (stores NULL = what every already-consented user has). Off ⇒ the key is **omitted**, never sent as `null`.
- `blocks.listMyScopeGrants` surfaces `buzzBudgetPerDay`, with guards that mirror `getConsentBuzzBudget` exactly (revoked → null, non-positive → null) so the permissions page can never show a limit the spend path does not enforce.

## Test matrix

Every test below was run against the **base commit** (`origin/main` @ `61a6b068aa`, in a clean worktree with the two symbols this PR adds substituted for their literal values so the file collects — otherwise an import error would report every test red for the wrong reason) and against **HEAD**.

### Regression coverage — RED at base, GREEN at HEAD

| test | file |
|---|---|
| a NON-AUTHOR holding a validly-scoped token can `submitWorkflow` | `blocks.router.scopeEnforcement.test.ts` |
| `getMyBuzzBalance` REJECTS a token lacking `buzz:read:self` | ″ |
| `getMyBuzzBalance` SERVES a non-author whose token carries `buzz:read:self` | ″ |
| a spend over the consented per-app budget is REJECTED | ″ |
| **a consent-budget denial REFUNDS the platform daily reservation** | ″ |
| a spend landing EXACTLY on the consented budget SUCCEEDS (boundary) | ″ |
| a spend within the consented budget SUCCEEDS and charges both counters | ″ |
| a DB error reading the budget fails the submit CLOSED and refunds the platform leg | ″ |
| the limit control appears when the spend scope is being consented to | `BlockConsentModal.browser.test.tsx` |
| with the limit ON, Allow sends the entered budget | ″ |
| an out-of-range budget blocks Allow | ″ |
| `grantScopes` PERSISTS the budget when the spend scope is granted | `blocks.router.getInstallConfig.test.ts` |
| `grantScopes` IGNORES a budget sent without a spend scope (without erasing a stored one) | ″ |
| `grantScopes` HONOURS a budget for an app that already holds the scope | ″ |
| `grantScopes` OMITTING the budget leaves a stored one untouched | ″ |
| `grantScopes` rejects a budget above the platform cap / a zero budget | ″ |

### Invariant guards — GREEN at base AND at HEAD (**not** regression coverage)

| test | note |
|---|---|
| `submitWorkflow` rejects a token without `ai:write:budgeted` | the check already existed |
| `estimateWorkflow` rejects a token without `ai:write:budgeted` | ″ |
| NULL budget writes no consent key, and the platform counter still moves | also the positive control for the counter model |
| NULL budget still binds at the 50k platform cap | pins that the second reservation did not relax the first |
| a dev token takes NO consent reservation even when a budget exists | passes **vacuously** at base — no consent key exists there to find |
| a REVOKED grant contributes no consent budget | vacuous at base, same reason |
| the limit control is absent when no spend scope is consented to | vacuous at base — no control exists there |
| with the limit OFF, Allow OMITS `buzzBudgetPerDay` entirely | vacuous at base; at HEAD it pins omitted-vs-null |

Method note: the consent-budget block holds the author capability **constant** (granted) so that base-vs-HEAD varies only the budget. Without that, every test in it would go red at base for a reason that has nothing to do with a budget, and the matrix would attribute the wrong cause.

The Redis counters are modelled **statefully** (an in-memory map keyed by the real key strings the router builds), not stubbed to a constant — the refund assertion has to be "the counter came back to its pre-attempt value", which needs a counter. The NULL-budget test is the positive control that the map moves at all.

### Mutation check

Five mutations, each applied to the narrowest expression that can be wrong, run, and reverted. **Every one died, and each died on its own assertion:**

| # | mutation | what died |
|---|---|---|
| M1 | `consentBudgetExceeded` → `return false` | over-budget submit returned `'pending'` instead of `'failed'` |
| M2 | `total > cap` → `total >= cap` | the exact-boundary spend was refused (`'failed'` instead of `'wf_real'`) |
| M3 | consent-deny refunds only the consent leg | **platform daily counter read `325`, expected `300`** — the exact 25 that would have been burned |
| M4 | DB read error → treat budget as absent (fail open) | the submit resolved instead of rejecting |
| M5 | drop `disabled={budgetBlocksSubmit}` on Allow | `expect(element).toBeDisabled()` did not succeed |

Reachability: M1/M2/M3 all executed the consent guard — the platform cap sat at 25–125 against 50,000, so no earlier check short-circuits, and flipping *only* the consent guard changed the outcome. M2 exists because without a boundary fixture it would have survived a fully green suite: every other test sits well clear of the cap.

## Verification

| gate | base | HEAD |
|---|---|---|
| `pnpm typecheck` | **0 errors** | **0 errors** — delta **0** |
| unit project | — | **1740 files / 39,633 tests passed**, 0 failed, 3 files + 33 tests skipped |
| `pnpm test:lint-rules` | — | **36 files / 501 tests passed** |
| component (`BlockConsentModal`) | 3 failed / 4 passed | **7 passed** |
| eslint on changed source files | 3 errors | **same 3 errors** — all pre-existing, zero delta |
| prettier on added files (blocking) | — | **clean** |
| all CI checks on the branch | — | **all terminal, zero failures** |

The typecheck instrument was negative-controlled: a deliberate `string`-to-`number` assignment made it report `1 type error(s)` and exit 2, so the two `0` verdicts are real rather than a harness reporting nothing.

## Known, and not caused by this change

`src/server/__tests__/eventloop-watchdog.capture.test.ts` is load-flaky on this host. Reproduced on **unmodified `origin/main`**: 3 consecutive base runs failed (3, 3, 1 failures) against HEAD's (2, 2, 1), with the failure count tracking wall time exactly (39 s → 3, 30 s → 2, 20 s → 1). It passed in the clean full-suite run above. Not investigated further here — it touches no code in this PR.


---

## Follow-up commits on this branch

**`style:`** — prettier. CI's `ESLint + Prettier (changed files)` is *blocking on added files*, and the new test file was not formatted. Caught by CI, not locally: I had run `eslint` on the changed files but not `prettier`. Four modified files were formatted alongside it (warn-only for those). No behaviour change; the affected suites and typecheck were re-run after.

**`fix:`** — a defect this PR introduced, found by a test written *after* the first push, and worth reading as the most interesting part of the change.

The enforcement tests mock the grant READ; the service tests mock the DB. Both are hermetic, both pass whether or not the two halves are wired together, and **neither ever builds the combined state** — so nothing proved a budget set through `blocks.grantScopes` could actually reach `getConsentBuzzBudget` on the spend path. Adding that seam test failed on its first run.

`grantScopes` decides whether a budget is meaningful by asking whether the app already holds `ai:write:budgeted` — and that read went to the **replica** while the write goes to the **primary**. A user who consents to the spend scope and then raises their limit lands inside the replication window: the check answers "no spend scope" and the budget they just set is silently dropped. Now reads with `db: 'write'`.

It presented exactly as it would have in production: the **scopes merged correctly** (that path already used the primary) while the **budget alone went missing** — i.e. it would have been reported as "my limit doesn't stick sometimes", not as a consent bug.

That failing-then-passing run is the mutation evidence for the fix (M6): reverting `db: 'write'` reproduces it, and the assertion that dies is the budget's own.
