### PR TITLE
fix(notifications): close the drawer on tap, and put the close button on the title line

### DIFF
--- a/src/components/Notifications/NotificationList.browser.test.tsx
+++ b/src/components/Notifications/NotificationList.browser.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, test, vi } from 'vitest';
+import type * as NotificationThumbnails from '~/components/Notifications/notification-thumbnails';
+
+// The thumbnail hook is the only tRPC caller in this tree; the id normaliser
+// beside it stays real, since the list keys its lookups with it.
+vi.mock('~/components/Notifications/notification-thumbnails', async (importOriginal) => ({
+  ...(await importOriginal<typeof NotificationThumbnails>()),
+  useNotificationThumbnails: () => new Map(),
+}));
+
+import { NotificationList } from './NotificationList';
+import { IsClientProvider } from '~/providers/IsClientProvider';
+import { renderWithProviders } from '../../../test/component-setup';
+
+// A reaction milestone: the shape the notifications DB actually stores. Its url
+// exists nowhere in `details` — `getNotificationMessage` derives it.
+const reactionMilestone = {
+  id: 1,
+  type: 'image-reaction-milestone',
+  category: 'Milestone',
+  createdAt: new Date('2026-09-10T00:00:00Z'),
+  read: false,
+  details: {
+    version: 2,
+    imageId: 123,
+    postId: 456,
+    models: ['Some Checkpoint'],
+    reactionCount: 10,
+  },
+} as any;
+
+async function renderRow(onItemClick: (...args: any[]) => void) {
+  // `DaysFromNow` throws without it, and React unmounts the whole root on an
+  // uncaught render error — so the symptom is an empty body, not a stack.
+  renderWithProviders(
+    <IsClientProvider>
+      <NotificationList items={[reactionMilestone]} searchText="" onItemClick={onItemClick} />
+    </IsClientProvider>
+  );
+
+  // Without this the row is read before React has committed and every assertion
+  // below reports `Cannot read properties of null` instead of its own numbers.
+  await vi.waitFor(() => {
+    expect(
+      document.body.querySelector('a[href]'),
+      `no notification row rendered; body was: ${document.body.textContent}`
+    ).toBeTruthy();
+  });
+
+  return document.body.querySelector('a[href]') as HTMLElement;
+}
+
+// Reported 2026-09-10 while reproducing ClickUp 868m2ay0a: on mobile, tapping a
+// notification navigates but leaves the full-screen drawer covering the page.
+// `NotificationsComposed` gated its `onClose()` on `notification.details.url`,
+// which only announcements carry, so the panel closed for announcements alone.
+describe('NotificationList click payload', () => {
+  test('hands back the derived url, so the panel knows it navigated', async () => {
+    const onItemClick = vi.fn();
+    const row = await renderRow(onItemClick);
+
+    row.click();
+
+    // `objectContaining`, because the list hands back the item with the resolved
+    // message attached; the second argument is what this file is about.
+    expect(onItemClick).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), {
+      keepOpened: false,
+      url: '/images/123?postId=456',
+    });
+  });
+
+  test('keeps the panel open on a middle click', async () => {
+    const onItemClick = vi.fn();
+    const row = await renderRow(onItemClick);
+
+    row.dispatchEvent(new MouseEvent('auxclick', { bubbles: true, button: 1 }));
+
+    expect(onItemClick).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), {
+      keepOpened: true,
+      url: '/images/123?postId=456',
+    });
+  });
+});

--- a/src/components/Notifications/NotificationList.tsx
+++ b/src/components/Notifications/NotificationList.tsx
@@ -106,7 +106,13 @@ export function NotificationList({
 
         const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
           e.preventDefault();
-          onItemClick(notification, false);
+          // The url is derived here by `getNotificationMessage`; the raw `notification.details`
+          // carries one for announcements only, so a consumer reading it off there sees
+          // `undefined` for every other type.
+          onItemClick(notification, {
+            keepOpened: details.target === '_blank',
+            url: details.url,
+          });
           if (!details.url) return;
           if (details.target === '_blank') return window.open(details.url, '_blank');
           const toModal = details.url.includes('?dialog=');
@@ -130,7 +136,7 @@ export function NotificationList({
         };
 
         const handleMiddleClick = () => {
-          onItemClick(notification, true);
+          onItemClick(notification, { keepOpened: true, url: details.url });
         };
 
         return (
@@ -191,7 +197,10 @@ export function NotificationList({
 
 type Props = {
   items: NotificationGetAll['items'];
-  onItemClick: (notification: NotificationGetAll['items'][number], keepOpened: boolean) => void;
+  onItemClick: (
+    notification: NotificationGetAll['items'][number],
+    options: { keepOpened: boolean; url?: string }
+  ) => void;
   textSize?: MantineSize;
   truncate?: boolean;
   searchText: string;

--- a/src/components/Notifications/NotificationTabs.browser.test.tsx
+++ b/src/components/Notifications/NotificationTabs.browser.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, test, vi } from 'vitest';
+import type * as NotificationsUtils from '~/components/Notifications/notifications.utils';
+
+// Both halves of this layout are inert unless a test imports them: Tailwind
+// supplies `shrink-0`, Mantine supplies the tab padding these assertions measure
+// against. Without them the tabs never shrink here and the file passes over the
+// broken code — verified by reverting `shrink-0` with these imports removed.
+import '~/styles/globals.css';
+import '@mantine/core/styles.layer.css';
+
+// A count wide enough to matter. `all` is the tab the drawer opens on, so it is
+// the one a reader sees selected.
+const counts = { all: 1330, comments: 2200, milestones: 0, updates: 0, bounties: 0, buzz: 0 };
+
+vi.mock('~/components/Notifications/notifications.utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof NotificationsUtils>()),
+  useQueryNotificationsCount: () => counts,
+}));
+vi.mock('~/components/Notifications/useNotificationSettings', () => ({
+  useNotificationSettings: () => ({
+    isLoading: false,
+    hasCategory: { Comments: true, Update: true, Milestone: true, Bounty: true, Buzz: true },
+  }),
+}));
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 1, onboarding: 0 }) }));
+
+import { NotificationTabs } from './NotificationTabs';
+import { renderWithProviders } from '../../../test/component-setup';
+
+// Narrower than the tabs need, which is the drawer's normal state on a phone —
+// the row is a horizontal scroller precisely because they do not fit.
+const NARROW = 300;
+
+async function renderTabs() {
+  renderWithProviders(
+    <div style={{ width: NARROW }}>
+      <NotificationTabs onTabChange={() => undefined} />
+    </div>
+  );
+
+  await vi.waitFor(() => {
+    expect(document.body.querySelector('.mantine-Tabs-tab')).toBeTruthy();
+  });
+}
+
+function allTab() {
+  return document.body.querySelector('.mantine-Tabs-tab') as HTMLElement;
+}
+
+// Reported 2026-09-10: with `1.33K` in the badge, the selected pill had no right
+// padding — the badge sat flush with its edge. `Tabs.List` is `nowrap`, so the
+// tabs shrank below their content width; `tabSection` is `shrink-0`, so the
+// badge was the part that spilled.
+describe('NotificationTabs with a large count', () => {
+  test('keeps the count badge inside the tab padding', async () => {
+    await renderTabs();
+
+    const tab = allTab();
+    const badge = tab.querySelector('.mantine-Badge-root') as HTMLElement;
+    expect(badge, 'no count badge rendered').toBeTruthy();
+
+    // Measured on the broken layout the badge ends 15.6px past this edge, i.e.
+    // flush with the pill. A revert prints both numbers.
+    const paddingRightEdge =
+      tab.getBoundingClientRect().right - parseFloat(getComputedStyle(tab).paddingRight);
+    expect(badge.getBoundingClientRect().right).toBeLessThanOrEqual(paddingRightEdge + 1);
+  });
+});

--- a/src/components/Notifications/NotificationTabs.tsx
+++ b/src/components/Notifications/NotificationTabs.tsx
@@ -53,7 +53,11 @@ export function NotificationTabs({ onTabChange, enabled = true, ...tabsProps }: 
               <Tabs.Tab
                 key={tab}
                 value={tab}
-                className="flex px-4 py-2"
+                // `shrink-0` because the list is `nowrap` inside a horizontal
+                // scroller: without it the tabs shrink below their content and a
+                // four-character count (`1.33K`) spills over the padding to sit
+                // flush with the pill's edge.
+                className="flex shrink-0 px-4 py-2"
                 classNames={{
                   tabLabel: 'flex items-center gap-1.5 capitalize font-semibold',
                   tabSection: 'shrink-0',

--- a/src/components/Notifications/NotificationTabs.tsx
+++ b/src/components/Notifications/NotificationTabs.tsx
@@ -53,9 +53,9 @@ export function NotificationTabs({ onTabChange, enabled = true, ...tabsProps }: 
               <Tabs.Tab
                 key={tab}
                 value={tab}
-                className="flex px-3 py-2"
+                className="flex px-4 py-2"
                 classNames={{
-                  tabLabel: 'flex items-center gap-2 capitalize font-semibold',
+                  tabLabel: 'flex items-center gap-1.5 capitalize font-semibold',
                   tabSection: 'shrink-0',
                 }}
                 rightSection={

--- a/src/components/Notifications/NotificationsComposed.tsx
+++ b/src/components/Notifications/NotificationsComposed.tsx
@@ -112,17 +112,11 @@ export const NotificationsComposed = forwardRef<HTMLDivElement, { onClose?: () =
     return (
       <>
         <div className="flex flex-col gap-4 p-4">
-          <Group justify="space-between">
+          <Group justify="space-between" wrap="nowrap">
             <Title className="text-[21px] sm:text-[34px]" order={1}>
               Notifications
             </Title>
-            <Group gap={8}>
-              <Switch
-                label="Hide Read"
-                labelPosition="left"
-                checked={hideRead}
-                onChange={(e) => setHideRead(e.currentTarget.checked)}
-              />
+            <Group gap={8} wrap="nowrap">
               <Tooltip label={`Mark ${categoryName} as read`} position="bottom">
                 {/* Disabled until the followed set has landed: an empty list dismisses
                     nothing, so an early click would clear the platform half and leave a
@@ -161,6 +155,13 @@ export const NotificationsComposed = forwardRef<HTMLDivElement, { onClose?: () =
                 </LegacyActionIcon>
               }
             />
+            <Switch
+              className="shrink-0"
+              label="Hide Read"
+              labelPosition="left"
+              checked={hideRead}
+              onChange={(e) => setHideRead(e.currentTarget.checked)}
+            />
             {creatorAnnouncementsEnabled && selectedTab === 'announcements' && (
               <Chip.Group
                 multiple
@@ -193,7 +194,7 @@ export const NotificationsComposed = forwardRef<HTMLDivElement, { onClose?: () =
                   <NotificationList
                     items={notifications}
                     searchText={searchText}
-                    onItemClick={(notification, keepOpened) => {
+                    onItemClick={(notification, { keepOpened, url }) => {
                       if (notification.type === 'announcement' && !notification.read) {
                         dismissAnnouncements(notification.id);
                       } else if (!notification.read)
@@ -201,7 +202,7 @@ export const NotificationsComposed = forwardRef<HTMLDivElement, { onClose?: () =
                           id: notification.id,
                           category: notification.category,
                         });
-                      if (!keepOpened && notification.details.url) onClose?.();
+                      if (!keepOpened && url) onClose?.();
                     }}
                   />
                   {hasNextPage && (


### PR DESCRIPTION
Found while investigating [868m2ay0a](https://app.clickup.com/t/868m2ay0a) (the iOS 404 from a reaction notification). Separate defect, reported by @manuelurenah while debugging: on mobile, tapping a notification navigates but the drawer stays over the page — and since the mobile drawer is full-screen, the page it just loaded is invisible.

## The drawer never closed

`NotificationsComposed` gated its `onClose()` on `notification.details.url`:

```tsx
if (!keepOpened && notification.details.url) onClose?.();
```

That url does not exist. The notifications DB stores a reaction milestone as:

```
type:    'image-reaction-milestone'
details: { models: [...], postId: 30694953, imageId: 141187280, version: 2, reactionCount: 10 }
```

The url is *derived* by `getNotificationMessage` into the enriched item `NotificationList` builds. Only announcements carry a url on `details` itself — so announcements were the only notifications that closed the panel. The line dates to `2b1d6bb5df` (Oct 2024); the details shape changed under it.

`NotificationList` now hands the resolved url back through the callback, so a consumer that needs it can't silently read `undefined` off the raw details:

```ts
onItemClick: (
  notification: NotificationGetAll['items'][number],
  options: { keepOpened: boolean; url?: string }
) => void;
```

`keepOpened` also covers `target: '_blank'` (one type, `user-journey`) — that opens a new tab, so the panel should stay put.

## Three UI fixes on the same screenshot

**Header wrapped at phone width.** `Group justify="space-between"` put the title on line 1 and mark-as-read / settings / close on line 2. The Hide Read switch moves down to the filter row — where the other filter already lives — and the three controls now sit beside the title at every width.

**Tab pills were cramped.** 12px horizontal padding against an 8px label/badge gap, so the count badge crowded the right edge of the selected pill. Now 16px and 6px; measured, the "All" pill goes 61px → 69px.

**A large count had no padding at all.** With `1.33K` in the badge the pill's right padding vanished — the badge sat flush with the edge. `Tabs.List` is `nowrap` inside a horizontal scroller, so the tabs shrank below their content width; `tabSection` was already `shrink-0`, so the badge was the part that spilled. Measured at 402px: badge ending **15.6px past** a 16px padding edge, tab held at 69.4px against the 100.6px its content needs. `shrink-0` on the tab, so the row scrolls — which is what `TwScrollX` exists for — instead of compressing.

## Verified

Real Chromium, drawer opened in-app:

| viewport | result |
|---|---|
| 402px (iPhone) | one line, X level with the title |
| 710px (desktop drawer) | one line |
| `/user/notifications` | title + 2 icons — that call site passes no `onClose`, so there is no X to place |

Two browser test files, 3 tests, both mutation-checked against a revert.

`NotificationList.browser.test.tsx` — reading the url off raw `details` again prints:

```
- "url": "/images/123?postId=456",
+ "url": undefined,
```

`NotificationTabs.browser.test.tsx` — dropping `shrink-0` prints `expected 65.34375 to be less than or equal to 54.390625`.

⚠️ The stylesheet imports at the top of the tabs test are load-bearing. Written without them it **passed over the broken code**: the component project loads no global stylesheet, so Tailwind's `shrink-0` and Mantine's tab padding are both absent and nothing shrinks in the first place. Confirmed by reverting under each condition. A second test asserting the tab keeps its content width went in and came back out — `column-gap` computes to `normal` there, so the expected width was `NaN` and it could not fail for the right reason.

⚠️ That test runs in **no blocking CI job** — `lint.yml` keeps the unit job Node-only — so it is red only in the preview pipeline's report-only `component-tests`.

## Not in this PR

- **The 404 itself.** Could not reproduce on `main` in Chromium or WebKit at iPhone size, nor with the routing files reverted to their 2026-08-12 state. Ticket was filed 2026-08-12; `b785c97571` (#4039) landed 2026-08-17 and its own message describes this exact symptom — *"left `/images/[imageId]` with no `imageId` and rendered its not-found branch."* Tracking that separately on the ClickUp task.
- **Focus trap.** The drawer autofocuses **Mark all as read** (visible as the blue ring in the screenshots). Pre-existing — it was already that element before this reorder — but Enter right after opening marks the tab read. Left alone deliberately; happy to move autofocus to the close button if you want it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FCvNCov1q2m1rhRQM9Wwz
