### PR TITLE
fix(generation): cancel abandoned resource-picker searches and stop r…

### DIFF
--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/useResourceSelectInfinite.ts
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/useResourceSelectInfinite.ts
@@ -5,7 +5,7 @@ import { useResourceSelectContext } from '~/components/ImageGeneration/Generatio
 import { useGetTextToImageRequests } from '~/components/ImageGeneration/utils/generationRequestHooks';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import type { ModelType } from '~/shared/utils/prisma/enums';
-import { trpc } from '~/utils/trpc';
+import { queryRetry, trpc } from '~/utils/trpc';
 import { isDefined } from '~/utils/type-guards';
 
 const limit = 50;
@@ -56,6 +56,11 @@ export function useResourceSelectInfinite({ query }: { query: string }) {
       enabled,
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       placeholderData: keepPreviousData,
+      // A batched request can't abort one operation, so the abort needs skipBatch.
+      trpc: { abortOnUnmount: true, context: { skipBatch: true } },
+      // A 503 here is the server's Meili timeout; a retry queues a second search behind the first.
+      retry: (failureCount, error) =>
+        error.data?.code !== 'SERVICE_UNAVAILABLE' && queryRetry(failureCount, error),
     }
   );
 

--- a/src/server/meilisearch/__tests__/client.test.ts
+++ b/src/server/meilisearch/__tests__/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MeiliSearch } from 'meilisearch';
 
 // Tests for the fail-fast safety net on fetchDocumentsAbortable. Goal: prove
 // that (a) the function rejects within ~timeoutMs when upstream is slow,
@@ -28,6 +29,7 @@ vi.mock('~/env/server', () => ({
     MEILI_CALL_TIMEOUT_MS: 2500,
     MEILI_CALL_CONCURRENCY: 50,
     MEILI_RESOURCE_SELECT_CONCURRENCY: 500,
+    MEILI_RESOURCE_SELECT_TIMEOUT_MS: 100,
     MEILI_CIRCUIT_TRIP_THRESHOLD: 10,
     MEILI_CIRCUIT_WINDOW_SECONDS: 30,
     MEILI_CIRCUIT_COOLDOWN_SECONDS: 30,
@@ -1264,5 +1266,114 @@ describe('service-catch → meiliFetchFailfastTotal{route, reason} on a transien
 
     expect(reThrown).toBe(apiError500);
     expect(incMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('withMeiliResourceSelect cancellation', () => {
+  function abortableCall(signal: AbortSignal) {
+    if (signal.aborted) return Promise.reject(signal.reason);
+    return new Promise<never>((_, reject) =>
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+    );
+  }
+
+  it('aborts the signal handed to the call when the timeout fires', async () => {
+    const { withMeiliResourceSelect, MeiliCallTimeoutError } = await import(
+      '~/server/meilisearch/client'
+    );
+    let seen: AbortSignal | undefined;
+
+    const call = withMeiliResourceSelect((signal) => {
+      seen = signal;
+      return new Promise<never>(() => undefined);
+    });
+
+    await expect(call).rejects.toBeInstanceOf(MeiliCallTimeoutError);
+    expect(seen?.aborted).toBe(true);
+  });
+
+  it('aborts the signal handed to the call when the caller aborts', async () => {
+    const { withMeiliResourceSelect } = await import('~/server/meilisearch/client');
+    const caller = new AbortController();
+    let seen: AbortSignal | undefined;
+
+    const call = withMeiliResourceSelect(
+      (signal) => {
+        seen = signal;
+        return abortableCall(signal);
+      },
+      { signal: caller.signal }
+    );
+    caller.abort();
+
+    await expect(call).rejects.toMatchObject({ name: 'AbortError' });
+    expect(seen?.aborted).toBe(true);
+  });
+});
+
+describe('searchWithSignal', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  // A 200 whose body stalls after a partial chunk, then fails on abort or after
+  // `failAfterMs` — the shape that makes meilisearch-js resolve `undefined`.
+  function stallingBodyFetch(failAfterMs = 1000) {
+    const seen: { signal?: AbortSignal } = {};
+    const fetchFn = (_input: unknown, init?: { signal?: AbortSignal }) => {
+      seen.signal = init?.signal;
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"hits":['));
+          const timer = setTimeout(
+            () => controller.error(new Error('socket hang up')),
+            failAfterMs
+          );
+          init?.signal?.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(timer);
+              controller.error(init.signal?.reason);
+            },
+            { once: true }
+          );
+        },
+      });
+      return Promise.resolve(
+        new Response(body, { status: 200, headers: { 'content-type': 'application/json' } })
+      );
+    };
+    return { fetchFn: fetchFn as unknown as typeof fetch, seen };
+  }
+
+  it('rejects with the abort, not an empty result, when aborted mid-body', async () => {
+    const { searchWithSignal } = await import('~/server/meilisearch/client');
+    const { fetchFn, seen } = stallingBodyFetch();
+    global.fetch = fetchFn;
+    const ctrl = new AbortController();
+    const index = new MeiliSearch({ host: 'http://meili-search.example' }).index('models');
+
+    const call = searchWithSignal(index, '', {}, ctrl.signal);
+    setTimeout(() => ctrl.abort(), 10);
+
+    await expect(call).rejects.toMatchObject({ name: 'AbortError' });
+    expect(seen.signal).toBeDefined();
+  });
+
+  it('treats a body that never arrives as a transient upstream failure', async () => {
+    const { searchWithSignal, isTransientMeiliError, MeilisearchFetchError } = await import(
+      '~/server/meilisearch/client'
+    );
+    global.fetch = stallingBodyFetch(10).fetchFn;
+    const index = new MeiliSearch({ host: 'http://meili-search.example' }).index('models');
+
+    const err = await searchWithSignal(index, '', {}, new AbortController().signal).catch(
+      (e: unknown) => e
+    );
+
+    expect(err).toBeInstanceOf(MeilisearchFetchError);
+    expect(isTransientMeiliError(err)).toBe(true);
   });
 });

--- a/src/server/meilisearch/client.ts
+++ b/src/server/meilisearch/client.ts
@@ -1,5 +1,12 @@
 import { createHash } from 'crypto';
-import type { EnqueuedTask, DocumentsQuery, ResourceResults } from 'meilisearch';
+import type {
+  EnqueuedTask,
+  DocumentsQuery,
+  Index,
+  ResourceResults,
+  SearchParams,
+  SearchResponse,
+} from 'meilisearch';
 import { MeiliSearch } from 'meilisearch';
 import pLimit from 'p-limit';
 import { env } from '~/env/server';
@@ -844,14 +851,11 @@ function recordCallOutcome(backend: MeiliBackend, isTrial: boolean, failed: bool
  *   - Background / job / indexing callers (updateDocs and friends) are NOT
  *     wrapped — they have their own retry loops and slowness there is fine.
  *
- * AbortSignal: meilisearch-js 0.x doesn't accept AbortSignal on .search() /
- * .getDocuments(), so the loser of the Promise.race below continues running
- * in the background. The orphan SDK promise will eventually settle when the
- * backend responds (or RSTs the connection) — at that point we've already
- * released the limiter slot, so the orphan does not block new callers.
- * fetchDocumentsAbortable() (above) is the cancellable path for the slow-
- * fetch flow; we don't try to force-cancel SDK calls from here — out of
- * scope.
+ * Cancellation: `fn` receives a signal that aborts on `opts.signal` or on the
+ * timeout. Only a call that hands it to its request (`search(q, params,
+ * { signal })`) is cancelled; any other call loses the race and settles in the
+ * background. Either way the limiter slot is released at the race, and a
+ * search Meili has already started runs to completion regardless.
  *
  * The queue is intentionally unbounded: a saturated queue means every call
  * will time out at MEILI_CALL_TIMEOUT_MS and reject naturally — the timeout
@@ -861,8 +865,8 @@ function recordCallOutcome(backend: MeiliBackend, isTrial: boolean, failed: bool
 async function runWithLimiter<T>(
   key: LimiterKey,
   backendLabel: string,
-  fn: () => Promise<T>,
-  opts: { useTimeout?: boolean; timeoutMs?: number } = {}
+  fn: (signal: AbortSignal) => Promise<T>,
+  opts: { useTimeout?: boolean; timeoutMs?: number; signal?: AbortSignal } = {}
 ): Promise<T> {
   const useTimeout = opts.useTimeout ?? true;
   const timeoutMs = opts.timeoutMs ?? env.MEILI_CALL_TIMEOUT_MS;
@@ -890,13 +894,14 @@ async function runWithLimiter<T>(
   return limiters[key](async () => {
     let timer: NodeJS.Timeout | undefined;
     let failedForCircuit = false;
-    // Capture the SDK call so we can absorb a late rejection if the timeout
-    // wins the race. meilisearch-js doesn't accept AbortSignal here, so the
-    // SDK call keeps running and will eventually settle (success or RST).
-    // Without this catch, a late rejection bubbles to `unhandledRejection` —
-    // Node ≥15's default exit-on-unhandled would turn our brownout protection
-    // into pod-crash amplification.
-    const sdkCall = fn();
+    const timeoutCtrl = new AbortController();
+    const signal = opts.signal
+      ? AbortSignal.any([opts.signal, timeoutCtrl.signal])
+      : timeoutCtrl.signal;
+    // Absorb a late rejection after the timeout wins the race. Without this
+    // catch it bubbles to `unhandledRejection`, and Node's exit-on-unhandled
+    // turns brownout protection into pod-crash amplification.
+    const sdkCall = fn(signal);
     sdkCall.catch(() => undefined);
     try {
       if (!useTimeout) {
@@ -926,6 +931,7 @@ async function runWithLimiter<T>(
                 `Meilisearch call exceeded ${timeoutMs}ms timeout`
               )
             );
+            timeoutCtrl.abort();
           }, timeoutMs);
           // Don't keep the event loop alive for this timer; the surrounding
           // Promise.race resolves either way.
@@ -983,10 +989,28 @@ export function withMeiliHealthProbe<T>(fn: () => Promise<T>): Promise<T> {
  * (generous, not removed) so a hung backend still can't hold event-loop slots
  * to Traefik's 30s router timeout — the 2026-05-29 SIGKILL path.
  */
-export function withMeiliResourceSelect<T>(fn: () => Promise<T>): Promise<T> {
+export function withMeiliResourceSelect<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  { signal }: { signal?: AbortSignal } = {}
+): Promise<T> {
   return runWithLimiter('resourceSelect', 'resourceSelect', fn, {
     timeoutMs: env.MEILI_RESOURCE_SELECT_TIMEOUT_MS,
+    signal,
   });
+}
+
+// meilisearch-js swallows a failed body read and resolves `undefined`, so an abort
+// (or a dropped connection) mid-body would otherwise look like a successful search.
+export async function searchWithSignal<D extends Record<string, any>>(
+  index: Index,
+  query: string,
+  params: SearchParams,
+  signal: AbortSignal
+): Promise<SearchResponse<D>> {
+  const res = await index.search<D>(query, params, { signal });
+  signal.throwIfAborted();
+  if (!res) throw new MeilisearchFetchError(502, 'response body did not arrive');
+  return res;
 }
 
 // Methods on a Meilisearch index that issue a network call to the backend and

--- a/src/server/routers/model.router.ts
+++ b/src/server/routers/model.router.ts
@@ -266,7 +266,9 @@ export const modelRouter = router({
   getResourceSelect: publicProcedure
     .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getResourceSelectSchema)
-    .query(({ ctx, input }) => getResourceSelectModels(input, { user: ctx.user })),
+    .query(({ ctx, input }) =>
+      getResourceSelectModels(input, { user: ctx.user, signal: ctx.signal })
+    ),
   upsert: guardedProcedure
     .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(modelUpsertSchema)

--- a/src/server/services/resource-select.service.ts
+++ b/src/server/services/resource-select.service.ts
@@ -6,6 +6,7 @@ import { dbRead } from '~/server/db/client';
 import {
   isTransientMeiliError,
   searchClient,
+  searchWithSignal,
   withMeiliResourceSelect,
 } from '~/server/meilisearch/client';
 import { REDIS_KEYS } from '~/server/redis/client';
@@ -186,14 +187,22 @@ function buildFilter({
 
 async function searchModels(
   query: string,
-  request: SearchParams
+  request: SearchParams,
+  signal?: AbortSignal
 ): Promise<SearchResponse<ModelSearchIndexRecord>> {
   if (!searchClient)
     return { hits: [], estimatedTotalHits: 0 } as unknown as SearchResponse<ModelSearchIndexRecord>;
   const client = searchClient;
   try {
-    return await withMeiliResourceSelect(() =>
-      client.index(MODELS_SEARCH_INDEX).search<ModelSearchIndexRecord>(query, request)
+    return await withMeiliResourceSelect(
+      (searchSignal) =>
+        searchWithSignal<ModelSearchIndexRecord>(
+          client.index(MODELS_SEARCH_INDEX),
+          query,
+          request,
+          searchSignal
+        ),
+      { signal }
     );
   } catch (err) {
     if (isTransientMeiliError(err)) {
@@ -239,7 +248,7 @@ async function getOfficialModelIds() {
 
 export async function getResourceSelectModels(
   input: GetResourceSelectInput,
-  { user }: { user: ServiceUser }
+  { user, signal }: { user: ServiceUser; signal?: AbortSignal }
 ) {
   const { tab, query = '', sort, cursor, limit, filterTypes, filterBaseModels, tagName } = input;
 
@@ -283,12 +292,16 @@ export async function getResourceSelectModels(
     excludeIds: officialIdsForType,
   });
 
-  const results = await searchModels(query, {
-    filter: filter ?? undefined,
-    sort: meiliSortFor(sort),
-    offset,
-    limit: take,
-  });
+  const results = await searchModels(
+    query,
+    {
+      filter: filter ?? undefined,
+      sort: meiliSortFor(sort),
+      offset,
+      limit: take,
+    },
+    signal
+  );
 
   let items = transformModelHits(results.hits);
 


### PR DESCRIPTION
…etrying its timeouts

The picker's Meili searches time out ~9k times a day at our 10s cap. Each timeout was retried once by the client, and nothing was ever cancelled: our timeout lost the race but left the HTTP request open, and closing the modal or typing a new query left the old request running end to end.

- The picker query sets abortOnUnmount + skipBatch, and does not retry a SERVICE_UNAVAILABLE (the server's Meili timeout).
- The router passes ctx.signal through to search(); runWithLimiter hands its call a signal that also aborts on the timeout. meilisearch-js 0.33 spreads search()'s config into fetch, so the signal closes the request.
- searchWithSignal rethrows an abort that lands mid-body, and turns a body that never arrives into a transient 502, because meilisearch-js swallows a failed body read and resolves undefined.

A search Meili has already started still runs to completion; this frees our pods and drops searches still waiting in Meili's queue.