### PR TITLE
fix(filters): render a visible border on a checked filter chip

### DIFF
--- a/src/components/Buzz/WithdrawalRequest/BuzzWithdrawalRequestFiltersDropdown.module.scss
+++ b/src/components/Buzz/WithdrawalRequest/BuzzWithdrawalRequestFiltersDropdown.module.scss
@@ -2,16 +2,17 @@
   font-size: 12px;
   font-weight: 600;
 
+  // Mantine puts `data-variant` on the Chip ROOT, not on this label, so a
+  // `&[data-variant='filled']` clause here matches nothing and the filled
+  // background survives, hiding the border below.
   &[data-checked] {
-
     &,
     &:hover {
-      color: light-dark(var(--mantine-color-white), var(--mantine-color-black));
-      border: 1px solid var(--mantine-color-primary);
-    }
-
-    &[data-variant='filled'] {
       background-color: transparent;
+      // Mantine's checked colour is white, for the filled background this rule removes.
+      color: var(--mantine-color-text);
+      border: 1px solid var(--mantine-primary-color-filled);
+      --chip-icon-color: var(--mantine-primary-color-filled);
     }
   }
 }

--- a/src/components/Buzz/WithdrawalRequest/BuzzWithdrawalRequestFiltersDropdown.module.scss
+++ b/src/components/Buzz/WithdrawalRequest/BuzzWithdrawalRequestFiltersDropdown.module.scss
@@ -5,7 +5,9 @@
   // Mantine puts `data-variant` on the Chip ROOT, not on this label, so a
   // `&[data-variant='filled']` clause here matches nothing and the filled
   // background survives, hiding the border below.
-  &[data-checked] {
+  // `:not([data-disabled])` mirrors how Mantine scopes its own checked rules: without it a
+  // disabled checked chip loses its greyed fill and reads as enabled.
+  &[data-checked]:not([data-disabled]) {
     &,
     &:hover {
       background-color: transparent;

--- a/src/components/CosmeticShop/CosmeticsFiltersDropdown.module.scss
+++ b/src/components/CosmeticShop/CosmeticsFiltersDropdown.module.scss
@@ -2,16 +2,17 @@
   font-size: 12px;
   font-weight: 600;
 
+  // Mantine puts `data-variant` on the Chip ROOT, not on this label, so a
+  // `&[data-variant='filled']` clause here matches nothing and the filled
+  // background survives, hiding the border below.
   &[data-checked] {
-
     &,
     &:hover {
-      color: light-dark(var(--mantine-color-white), var(--mantine-color-black));
-      border: 1px solid var(--mantine-color-primary);
-    }
-
-    &[data-variant='filled'] {
       background-color: transparent;
+      // Mantine's checked colour is white, for the filled background this rule removes.
+      color: var(--mantine-color-text);
+      border: 1px solid var(--mantine-primary-color-filled);
+      --chip-icon-color: var(--mantine-primary-color-filled);
     }
   }
 }

--- a/src/components/CosmeticShop/CosmeticsFiltersDropdown.module.scss
+++ b/src/components/CosmeticShop/CosmeticsFiltersDropdown.module.scss
@@ -5,7 +5,9 @@
   // Mantine puts `data-variant` on the Chip ROOT, not on this label, so a
   // `&[data-variant='filled']` clause here matches nothing and the filled
   // background survives, hiding the border below.
-  &[data-checked] {
+  // `:not([data-disabled])` mirrors how Mantine scopes its own checked rules: without it a
+  // disabled checked chip loses its greyed fill and reads as enabled.
+  &[data-checked]:not([data-disabled]) {
     &,
     &:hover {
       background-color: transparent;

--- a/src/components/CosmeticShop/ShopFiltersDropdown.module.scss
+++ b/src/components/CosmeticShop/ShopFiltersDropdown.module.scss
@@ -5,7 +5,9 @@
   // Mantine puts `data-variant` on the Chip ROOT, not on this label, so a
   // `&[data-variant='filled']` clause here matches nothing and the filled
   // background survives, hiding the border below.
-  &[data-checked] {
+  // `:not([data-disabled])` mirrors how Mantine scopes its own checked rules: without it a
+  // disabled checked chip loses its greyed fill and reads as enabled.
+  &[data-checked]:not([data-disabled]) {
     &,
     &:hover {
       background-color: transparent;

--- a/src/components/CosmeticShop/ShopFiltersDropdown.module.scss
+++ b/src/components/CosmeticShop/ShopFiltersDropdown.module.scss
@@ -2,16 +2,17 @@
   font-size: 12px;
   font-weight: 600;
 
+  // Mantine puts `data-variant` on the Chip ROOT, not on this label, so a
+  // `&[data-variant='filled']` clause here matches nothing and the filled
+  // background survives, hiding the border below.
   &[data-checked] {
-
     &,
     &:hover {
-      color: var(--mantine-color-white);
-      border: 1px solid var(--mantine-color-primary);
-    }
-
-    &[data-variant='filled'] {
       background-color: transparent;
+      // Mantine's checked colour is white, for the filled background this rule removes.
+      color: var(--mantine-color-text);
+      border: 1px solid var(--mantine-primary-color-filled);
+      --chip-icon-color: var(--mantine-primary-color-filled);
     }
   }
 }

--- a/src/components/Cosmetics/CosmeticsFiltersDropdown.module.scss
+++ b/src/components/Cosmetics/CosmeticsFiltersDropdown.module.scss
@@ -2,16 +2,17 @@
   font-size: 12px;
   font-weight: 600;
 
+  // Mantine puts `data-variant` on the Chip ROOT, not on this label, so a
+  // `&[data-variant='filled']` clause here matches nothing and the filled
+  // background survives, hiding the border below.
   &[data-checked] {
-
     &,
     &:hover {
-      color: light-dark(var(--mantine-color-white), var(--mantine-color-black));
-      border: 1px solid var(--mantine-color-primary);
-    }
-
-    &[data-variant='filled'] {
       background-color: transparent;
+      // Mantine's checked colour is white, for the filled background this rule removes.
+      color: var(--mantine-color-text);
+      border: 1px solid var(--mantine-primary-color-filled);
+      --chip-icon-color: var(--mantine-primary-color-filled);
     }
   }
 }

--- a/src/components/Cosmetics/CosmeticsFiltersDropdown.module.scss
+++ b/src/components/Cosmetics/CosmeticsFiltersDropdown.module.scss
@@ -5,7 +5,9 @@
   // Mantine puts `data-variant` on the Chip ROOT, not on this label, so a
   // `&[data-variant='filled']` clause here matches nothing and the filled
   // background survives, hiding the border below.
-  &[data-checked] {
+  // `:not([data-disabled])` mirrors how Mantine scopes its own checked rules: without it a
+  // disabled checked chip loses its greyed fill and reads as enabled.
+  &[data-checked]:not([data-disabled]) {
     &,
     &:hover {
       background-color: transparent;

--- a/src/components/Filters/AdaptiveFiltersDropdown.module.scss
+++ b/src/components/Filters/AdaptiveFiltersDropdown.module.scss
@@ -1,21 +1,3 @@
-.label {
-  font-size: 12px;
-  font-weight: 600;
-
-  &[data-checked] {
-
-    &,
-    &:hover {
-      color: light-dark(var(--mantine-color-white), var(--mantine-color-black));
-      border: 1px solid var(--mantine-color-primary);
-    }
-
-    &[data-variant='filled'] {
-      background-color: transparent;
-    }
-  }
-}
-
 .opened {
   transform: rotate(180deg);
   transition: transform 200ms ease;

--- a/src/components/Filters/FilterChip.module.scss
+++ b/src/components/Filters/FilterChip.module.scss
@@ -2,15 +2,17 @@
   font-size: 12px;
   font-weight: 600;
 
+  // Mantine puts `data-variant` on the Chip ROOT, not on this label, so a
+  // `&[data-variant='filled']` clause here matches nothing and the filled
+  // background survives, hiding the border below.
   &[data-checked] {
     &,
     &:hover {
-      color: var(--mantine-color-white);
-      border: 1px solid var(--mantine-color-primary);
-    }
-
-    &[data-variant="filled"] {
       background-color: transparent;
+      // Mantine's checked colour is white, for the filled background this rule removes.
+      color: var(--mantine-color-text);
+      border: 1px solid var(--mantine-primary-color-filled);
+      --chip-icon-color: var(--mantine-primary-color-filled);
     }
   }
 }

--- a/src/components/Filters/FilterChip.module.scss
+++ b/src/components/Filters/FilterChip.module.scss
@@ -5,7 +5,9 @@
   // Mantine puts `data-variant` on the Chip ROOT, not on this label, so a
   // `&[data-variant='filled']` clause here matches nothing and the filled
   // background survives, hiding the border below.
-  &[data-checked] {
+  // `:not([data-disabled])` mirrors how Mantine scopes its own checked rules: without it a
+  // disabled checked chip loses its greyed fill and reads as enabled.
+  &[data-checked]:not([data-disabled]) {
     &,
     &:hover {
       background-color: transparent;

--- a/src/components/Filters/__tests__/filterChipCheckedState.test.ts
+++ b/src/components/Filters/__tests__/filterChipCheckedState.test.ts
@@ -31,26 +31,32 @@ import { describe, expect, it } from 'vitest';
  * `--chip-icon-color` does the same job for the check mark, which Mantine also draws white.
  *
  * WHY THIS IS A SOURCE GUARD, MEASURED RATHER THAN ASSUMED. A rendered version was
- * written and run in the browser `component` project, and it cannot work: that harness
- * loads neither `@mantine/core/styles.css` nor Mantine's runtime theme variables. With
- * the fix in place, a checked `FilterChip` there computes `border-top-width: 0px`,
- * `border-top-style: none`, and BOTH `--mantine-primary-color-filled` and
- * `--mantine-color-text` read as the empty string on `:root` and on the label. So the
- * rendered assertion fails identically whether the fix is present or absent — it
- * distinguishes nothing. (`test/component-setup.tsx` injects only the `:root` custom
- * properties parsed out of `globals.css`.) The browser evidence for this change is the
- * manual measurement recorded above, not a suite.
+ * written and run in the browser `component` project, and it cannot work: with the fix in
+ * place a checked `FilterChip` there computes `border-top-width: 0px` and
+ * `border-top-style: none`, and both `--mantine-primary-color-filled` and
+ * `--mantine-color-text` read as the EMPTY STRING on `:root` and on the label — so the
+ * assertion fails identically whether the fix is present or absent. `MantineProvider`
+ * does inject theme variables, but `deduplicateCssVariables` (default true) strips every
+ * variable matching Mantine's default on the assumption `styles.css` is loaded, and the
+ * harness loads only the `:root` properties parsed out of `globals.css`
+ * (`test/component-setup.tsx`). The browser evidence for this change is the manual
+ * measurement recorded above, not a suite.
+ *
+ * 🔴 EVERY ASSERTION HERE IS TEXTUAL. It reads source, not rendered CSS, so it can be
+ * satisfied by text that does not have the claimed effect and can refuse a valid edit it
+ * does not recognise. Where a message below sounds definite, it is describing what the
+ * source says, not what a browser computed.
  */
 
 const REPO_ROOT = path.resolve(__dirname, '../../../..');
-// Resolved through node rather than joined onto REPO_ROOT: pnpm's layout is a symlink
-// farm, and a hand-built path is the thing that goes stale when a worktree is laid out
-// differently from the primary checkout.
-// `styles.layer.css`, not `styles.css`: that is the build the app imports
-// (`src/pages/_app.tsx`), and the layered one is what the cascade claim below rests on.
-const MANTINE_CSS = createRequire(__filename).resolve('@mantine/core/styles.layer.css');
 
-/** The modules whose `.label` class is actually handed to a Mantine `Chip`. */
+/**
+ * The modules in THIS change's scope — five of the seven `.label` modules handed to a
+ * Mantine `Chip`. NOT an inventory: `ImageGeneration/GenerationForm/ResourceSelectFilters`
+ * and `PurchasableRewards/PurchasableRewardsModeratorFiltersDropdown` are the same copied
+ * rule and are deliberately not listed, so a checked chip there still renders as a filled
+ * pill. Add them here when they are brought into line.
+ */
 const CHIP_LABEL_MODULES = [
   'src/components/Filters/FilterChip.module.scss',
   'src/components/CosmeticShop/ShopFiltersDropdown.module.scss',
@@ -70,7 +76,7 @@ function read(file: string): string {
  * Strip comments — every token searched for below is also discussed in the file it is
  * sought in. Trailing `//` comments are stripped too, not just full-line ones: a trailing
  * comment can otherwise satisfy a positive assertion whose declaration was deleted, and
- * can trip the negative one with prose.
+ * can trip a negative one with prose.
  */
 function code(src: string): string {
   return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|\s)\/\/.*$/gm, '$1');
@@ -90,33 +96,68 @@ function blockAt(src: string, at: number): string | null {
 }
 
 /**
- * The `&[data-checked]` body inside the `.label` rule.
+ * The `.label` rule body.
  *
- * 🔴 SCOPED TO `.label` FIRST, DELIBERATELY. Searching the whole file for the first
- * `&[data-checked]` would read a decoy in any rule above it — and if that decoy happened
- * to be compliant while `.label`'s own copy rotted, the pass would be silent. This is the
- * one failure mode in the file that would not be loud.
+ * 🔴 EVERYTHING BELOW IS SCOPED THROUGH THIS, DELIBERATELY. Searching a whole module for a
+ * selector or a declaration reads decoys in unrelated rules — and a decoy that happens to
+ * be compliant while `.label`'s own copy rots is the one failure mode in this file that
+ * would not be loud.
  */
-function checkedBlock(src: string): string | null {
-  const label = blockAt(src, src.search(/^\.label\s*\{/m));
-  if (label === null) return null;
-  return blockAt(label, label.indexOf('&[data-checked]'));
+function labelBlock(src: string): string | null {
+  return blockAt(src, src.search(/^\.label\s*\{/m));
 }
 
-/** How many times a property is declared — `color:` must not match `background-color:`. */
-function declarationCount(block: string, property: string): number {
-  const re = new RegExp(`(^|[;{}\\s])${property.replace(/-/g, '\\-')}\\s*:`, 'g');
-  return (block.match(re) ?? []).length;
+/**
+ * The declarations that apply to a checked chip: the body of the `&, &:hover` group inside
+ * `&[data-checked]`. Scoped to that group rather than to the whole checked block so a
+ * sibling rule — `&:focus-visible`, a `@media` — is not counted as an override of it.
+ */
+function checkedDeclarations(label: string): string | null {
+  const checked = blockAt(label, label.indexOf('&[data-checked]'));
+  if (checked === null) return null;
+  return blockAt(checked, checked.search(/&\s*,\s*\n?\s*&:hover/));
+}
+
+/**
+ * How many times any member of a shorthand family is declared.
+ *
+ * 🔴 THE FAMILY, NOT THE PROPERTY. `border: 1px solid …; border-width: 0;` overrides the
+ * pinned value while leaving exactly one `border:` — and longhand override of a chip
+ * border is a live idiom here (`StickerPlacementTray.tsx` does it inline, on purpose).
+ * Counting only the exact property would miss the very shape this check exists for.
+ */
+function declarationCount(block: string, family: readonly string[]): number {
+  return family.reduce((total, property) => {
+    const re = new RegExp(`(^|[;{}\\s])${property.replace(/-/g, '\\-')}\\s*:`, 'g');
+    return total + (block.match(re) ?? []).length;
+  }, 0);
 }
 
 describe('filter chips render a visible border when checked', () => {
   it.each(CHIP_LABEL_MODULES)('%s', (relative) => {
     const src = code(read(path.join(REPO_ROOT, relative)));
-    const block = checkedBlock(src);
+    const label = labelBlock(src);
+    expect(
+      label,
+      `${relative} no longer has a top-level \`.label\` rule — re-point this guard deliberately ` +
+        'rather than letting it pass over a renamed selector.'
+    ).not.toBeNull();
+
+    // Asserted against the selector text, not against the file: the same substring appearing
+    // on some unrelated rule would otherwise satisfy this while the scoping had moved.
+    expect(
+      /&\[data-checked\]:not\(\[data-disabled\]\)\s*\{/.test(label as string),
+      `${relative} no longer excludes disabled chips from the checked rule. Mantine scopes every ` +
+        'one of its own checked rules that way; unscoped, this clears the greyed disabled ' +
+        'background too and a disabled checked chip reads as enabled. Keep the `:not()` on the ' +
+        'checked selector rather than on `.label`, or the chip typography gets scoped behind it too.'
+    ).toBe(true);
+
+    const block = checkedDeclarations(label as string);
     expect(
       block,
-      `${relative} no longer has a \`&[data-checked]\` block inside its \`.label\` rule — ` +
-        're-point this guard deliberately rather than letting it pass over a renamed selector.'
+      `${relative} no longer has an \`&, &:hover\` group inside \`&[data-checked]\` — the ` +
+        'declarations below are read from that group, so this guard now checks nothing. Re-point it.'
     ).not.toBeNull();
     const checked = block as string;
 
@@ -150,25 +191,24 @@ describe('filter chips render a visible border when checked', () => {
     ).toBe(true);
 
     // 🔴 A SECOND DECLARATION IS HOW A REPAIRED RULE GOES BACK TO BEING INEFFECTIVE, and a
-    // fragment match cannot see the cascade: `border: 1px solid var(…); border: none;`
-    // satisfies every assertion above while drawing nothing. That is this bug's own history
-    // — a declaration present and overridden — so it is checked by count, not by presence.
-    for (const property of ['border', 'background-color', 'color'] as const) {
-      const count = declarationCount(checked, property);
+    // fragment match cannot see the cascade: `border: 1px solid var(…); border-width: 0;`
+    // satisfies every assertion above while drawing nothing. That is this bug's own history —
+    // a declaration present and overridden — so it is checked by count across the family.
+    const families = {
+      border: ['border', 'border-width', 'border-style', 'border-color'],
+      background: ['background', 'background-color'],
+      color: ['color'],
+    } as const;
+    for (const [name, family] of Object.entries(families)) {
+      const count = declarationCount(checked, family);
       expect(
         count,
-        `${relative} declares \`${property}\` ${count} times in the checked block. The later one ` +
-          'wins, so the pinned value above may not be what renders. Keep one declaration per ' +
-          'property here.'
+        `${relative} declares ${name} ${count} times in the checked group (counting ` +
+          `${family.join(', ')}). The later one wins, so the pinned value above may not be what ` +
+          'renders. Keep one declaration per family here; a legitimate second one belongs in its ' +
+          'own nested rule, which this count does not read.'
       ).toBe(1);
     }
-
-    expect(
-      /:not\(\[data-disabled\]\)/.test(src),
-      `${relative} no longer excludes disabled chips from the checked rule. Mantine scopes every ` +
-        'one of its own checked rules with `:not([data-disabled])`; unscoped, this clears the ' +
-        'greyed disabled background too and a disabled checked chip reads as enabled.'
-    ).toBe(true);
 
     // 🔴 The dead selector, kept out by name. It is the plausible "fix" someone re-adds.
     expect(
@@ -180,17 +220,20 @@ describe('filter chips render a visible border when checked', () => {
   });
 
   /**
-   * The LIBRARY half: the property the source half names has to exist, and has to exist
-   * UNCONDITIONALLY. Pinned against the installed package so a Mantine upgrade that drops it,
-   * or moves it behind a colour scheme, is caught HERE with an explanation.
+   * The LIBRARY half: the property the source half names has to exist. Pinned against the
+   * installed package so a Mantine upgrade that drops it is caught HERE with an explanation.
+   *
+   * Scope note, so this claims no more than it proves: only the FIRST hop is asserted to be
+   * unconditional. `--mantine-primary-color-filled` resolves to `--mantine-color-blue-filled`,
+   * which Mantine defines per colour scheme and never unconditionally — that is by design
+   * (`ColorSchemeScript` always sets the attribute), and it is not what this pins.
    */
   it('`--mantine-primary-color-filled` is defined on Mantine’s unconditional `:root`', () => {
-    const css = read(MANTINE_CSS);
+    // Resolved here rather than at module scope: a tree without `node_modules` then fails this
+    // one test with its own message instead of taking the whole file down as a collection error.
+    const mantineCss = createRequire(__filename).resolve('@mantine/core/styles.layer.css');
+    const css = read(mantineCss);
     const root = blockAt(css, css.search(/:root\s*\{/));
-    // The control is real only because the assertion below reads THIS slice: an unscoped
-    // search over the whole file would stay green if the definition moved into a
-    // scheme-specific or @media rule, which is the failure that would cost light mode its
-    // border again.
     expect(
       root,
       "Mantine no longer ships a bare `:root` rule — this guard's extraction is stale, not the claim."
@@ -205,24 +248,30 @@ describe('filter chips render a visible border when checked', () => {
   });
 
   /**
-   * 🔴 THE WHOLE FIX RESTS ON CASCADE LAYERS, AND SPECIFICITY IS A TIE UNDERNEATH.
-   * `.label[data-checked]` and Mantine's `.m_fa109255:not([data-disabled]):where([data-checked])`
-   * are both (0,2,0). What makes the module win is that `postcss.config.js` wraps every
-   * `*.module.scss` in `@layer modules`, `_app.tsx` imports Mantine's `styles.layer.css`
-   * (`@layer mantine`), and `_document.tsx` declares `modules` AFTER `mantine`. Remove or
-   * reorder that declaration and these five rules lose to Mantine on source order — a coin
-   * flip that would restore the filled background with nothing else changing.
+   * 🔴 THE FIX RESTS ON CASCADE LAYERS, AND A LAYER BEATS ANY SPECIFICITY.
+   * `postcss.config.js` wraps every `*.module.scss` in `@layer modules`, `_app.tsx` imports
+   * Mantine's `styles.layer.css` (`@layer mantine`), and `_document.tsx` declares `modules`
+   * AFTER `mantine`. The module rule also out-specifies Mantine's since it gained
+   * `:not([data-disabled])` — (0,3,0) against (0,2,0) — but that is no defence: reorder the
+   * declaration and the `mantine` layer wins regardless of specificity, restoring the filled
+   * background with nothing else changing.
    */
   it('the `modules` layer still outranks `mantine`, which is why these rules apply at all', () => {
     const doc = read(path.join(REPO_ROOT, 'src/pages/_document.tsx'));
-    const order = /@layer ([a-z-]+(?:,\s*[a-z-]+)*);/.exec(doc);
+    // Matched on the string that SHIPS, not on the first `@layer` in the file: the comment above
+    // that line quotes the declaration, and prose would otherwise satisfy this.
+    const order = /__html:\s*'@layer ([^']+);'/.exec(doc);
     expect(
       order,
-      'src/pages/_document.tsx no longer declares a `@layer` order. Without it the checked-chip ' +
-        'rules below fall back to source order against Mantine, which is not something anything ' +
-        'in this repo controls.'
+      'src/pages/_document.tsx no longer emits a `@layer` order via `__html`. Without that ' +
+        'declaration the checked-chip rules fall back to layer order as encountered, which is not ' +
+        'something anything in this repo controls.'
     ).not.toBeNull();
     const names = (order as RegExpExecArray)[1].split(',').map((n) => n.trim());
+    // Membership before comparison: `indexOf` returns -1 for an absent name, so an ordering
+    // assertion alone passes when `mantine` is simply gone.
+    expect(names, `the declared layer order is [${names.join(', ')}]`).toContain('mantine');
+    expect(names, `the declared layer order is [${names.join(', ')}]`).toContain('modules');
     expect(
       names.indexOf('modules'),
       `the declared layer order is [${names.join(
@@ -231,7 +280,23 @@ describe('filter chips render a visible border when checked', () => {
         "or every checked filter chip goes back to Mantine's filled background and the border " +
         'becomes invisible again.'
     ).toBeGreaterThan(names.indexOf('mantine'));
-    expect(names).toContain('mantine');
+  });
+
+  /**
+   * The other half of that: Mantine has to be IN a layer for the order to bind. Swapping this
+   * one import for `@mantine/core/styles.css` leaves Mantine unlayered, and unlayered
+   * declarations beat every named layer — so the filled background returns and the border goes
+   * invisible again, with nothing else in the repo changing. It is a one-word edit of exactly
+   * the kind someone makes while debugging a layer problem.
+   */
+  it('Mantine is imported as its LAYERED build', () => {
+    const app = code(read(path.join(REPO_ROOT, 'src/pages/_app.tsx')));
+    expect(
+      /@mantine\/core\/styles\.layer\.css/.test(app),
+      'src/pages/_app.tsx no longer imports `@mantine/core/styles.layer.css`. The unlayered ' +
+        '`styles.css` build beats every layered rule, including the checked-chip rules in ' +
+        '`*.module.scss`, so the filled background comes back and the border becomes invisible.'
+    ).toBe(true);
   });
 
   /**
@@ -244,7 +309,8 @@ describe('filter chips render a visible border when checked', () => {
     const relative = 'src/components/Filters/AdaptiveFiltersDropdown.module.scss';
     const src = code(read(path.join(REPO_ROOT, relative)));
     // Matches the class wherever a selector could reintroduce it — grouped (`.label, .x`),
-    // qualified (`.label:not(…)`) or nested — rather than the one spelling it had.
+    // qualified (`.label:not(…)`) or nested — rather than the one spelling it had. A descendant
+    // form (`.wrap .label`) is not matched and would be equally unreachable style.
     expect(
       /(^|[,{}])\s*\.label\b/m.test(src),
       `${relative} has a \`.label\` rule again. Nothing applies it — the component passes only ` +

--- a/src/components/Filters/__tests__/filterChipCheckedState.test.ts
+++ b/src/components/Filters/__tests__/filterChipCheckedState.test.ts
@@ -107,15 +107,23 @@ function labelBlock(src: string): string | null {
   return blockAt(src, src.search(/^\.label\s*\{/m));
 }
 
+/** The whole `&[data-checked]…` body, sibling rules included. */
+function checkedBlock(label: string): string | null {
+  return blockAt(label, label.indexOf('&[data-checked]'));
+}
+
 /**
- * The declarations that apply to a checked chip: the body of the `&, &:hover` group inside
- * `&[data-checked]`. Scoped to that group rather than to the whole checked block so a
- * sibling rule — `&:focus-visible`, a `@media` — is not counted as an override of it.
+ * The `&, &:hover` group inside it — where the pinned declarations live.
+ *
+ * 🔴 THE TWO SCOPES ARE NOT INTERCHANGEABLE, AND USING THIS ONE FOR THE COUNTS WAS A BUG.
+ * Presence is asserted here, because this is where the declarations belong. Overrides are
+ * counted over the whole checked body, because a SIBLING rule is a real override: a
+ * `&:hover { background-color: var(--chip-bg); }` beside this group has the same specificity
+ * and comes later, so it restores the filled background on hover — the headline bug of this
+ * change, with every presence assertion still green.
  */
-function checkedDeclarations(label: string): string | null {
-  const checked = blockAt(label, label.indexOf('&[data-checked]'));
-  if (checked === null) return null;
-  return blockAt(checked, checked.search(/&\s*,\s*\n?\s*&:hover/));
+function checkedGroup(checked: string): string | null {
+  return blockAt(checked, checked.search(/&\s*,\s*&:hover/));
 }
 
 /**
@@ -153,16 +161,24 @@ describe('filter chips render a visible border when checked', () => {
         'checked selector rather than on `.label`, or the chip typography gets scoped behind it too.'
     ).toBe(true);
 
-    const block = checkedDeclarations(label as string);
+    const body = checkedBlock(label as string);
     expect(
-      block,
+      body,
+      `${relative} no longer has an \`&[data-checked]\` block inside \`.label\` — re-point this ` +
+        'guard deliberately rather than letting it pass over a renamed selector.'
+    ).not.toBeNull();
+    const checked = body as string;
+
+    const group = checkedGroup(checked);
+    expect(
+      group,
       `${relative} no longer has an \`&, &:hover\` group inside \`&[data-checked]\` — the ` +
         'declarations below are read from that group, so this guard now checks nothing. Re-point it.'
     ).not.toBeNull();
-    const checked = block as string;
+    const pinned = group as string;
 
     expect(
-      /border:\s*1px solid var\(--mantine-primary-color-filled\)\s*;/.test(checked),
+      /border:\s*1px solid var\(--mantine-primary-color-filled\)\s*;/.test(pinned),
       `${relative} no longer draws the checked border from \`--mantine-primary-color-filled\`. ` +
         'If it names a different custom property, check that property is actually DEFINED: ' +
         '`--mantine-color-primary` was not, which made the whole shorthand invalid and drew no ' +
@@ -170,32 +186,54 @@ describe('filter chips render a visible border when checked', () => {
     ).toBe(true);
 
     expect(
-      /background-color:\s*transparent\s*;/.test(checked),
-      `${relative} lets the checked chip keep Mantine's filled background. The border above is ` +
-        'the same colour as that background, so it renders and cannot be seen — the chip looks ' +
-        'exactly as it did when the border was missing entirely.'
+      /background-color:\s*transparent\s*;/.test(pinned),
+      `${relative} has no \`background-color: transparent\` in the checked group. If the fill is ` +
+        'still there, the border above is the same colour as it and cannot be seen — the chip looks ' +
+        'exactly as it did when the border was missing entirely. If you wrote the `background` ' +
+        'shorthand instead, this guard pins the longhand spelling and needs updating deliberately.'
     ).toBe(true);
 
     expect(
-      /(^|[;{}\s])color:\s*var\(--mantine-color-text\)\s*;/.test(checked),
+      /(^|[;{}\s])color:\s*var\(--mantine-color-text\)\s*;/.test(pinned),
       `${relative} no longer pins the checked label colour. Mantine's own value is white, for ` +
         'the filled background this rule removes; without the override a checked chip in light ' +
         'mode is white text on transparent — an empty outlined pill.'
     ).toBe(true);
 
     expect(
-      /--chip-icon-color:\s*var\(--mantine-primary-color-filled\)\s*;/.test(checked),
+      /--chip-icon-color:\s*var\(--mantine-primary-color-filled\)\s*;/.test(pinned),
       `${relative} no longer pins the check mark's colour. Mantine draws it from ` +
         '`--chip-color`, i.e. white — invisible once the fill is gone, exactly like the label ' +
         'colour above.'
     ).toBe(true);
+
+    // 🔴 The dead selector, kept out by name. It is the plausible "fix" someone re-adds, and the
+    // natural place to re-add it is as a SIBLING of the group above — so this reads the whole
+    // checked body, not the group.
+    expect(
+      /\[data-variant/.test(checked),
+      `${relative} matches on \`data-variant\` again. Mantine puts that attribute on the Chip ` +
+        'ROOT, not on the label — such a clause matches nothing, which is exactly how the filled ' +
+        'background survived here for as long as it did.'
+    ).toBe(false);
 
     // 🔴 A SECOND DECLARATION IS HOW A REPAIRED RULE GOES BACK TO BEING INEFFECTIVE, and a
     // fragment match cannot see the cascade: `border: 1px solid var(…); border-width: 0;`
     // satisfies every assertion above while drawing nothing. That is this bug's own history —
     // a declaration present and overridden — so it is checked by count across the family.
     const families = {
-      border: ['border', 'border-width', 'border-style', 'border-color'],
+      border: [
+        'border',
+        'border-width',
+        'border-style',
+        'border-color',
+        'border-top',
+        'border-right',
+        'border-bottom',
+        'border-left',
+        'border-block',
+        'border-inline',
+      ],
       background: ['background', 'background-color'],
       color: ['color'],
     } as const;
@@ -203,20 +241,13 @@ describe('filter chips render a visible border when checked', () => {
       const count = declarationCount(checked, family);
       expect(
         count,
-        `${relative} declares ${name} ${count} times in the checked group (counting ` +
-          `${family.join(', ')}). The later one wins, so the pinned value above may not be what ` +
-          'renders. Keep one declaration per family here; a legitimate second one belongs in its ' +
-          'own nested rule, which this count does not read.'
+        `${relative} declares ${name} ${count} times anywhere in the \`&[data-checked]\` block ` +
+          `(counting ${family.join(', ')}), sibling rules included. The later one wins, so the ` +
+          'pinned value above may not be what renders — a sibling `&:hover { background-color: … }` ' +
+          'restores on hover exactly the fill this change removes. A second declaration may well be ' +
+          'legitimate; if it is, widen this guard deliberately rather than deleting it.'
       ).toBe(1);
     }
-
-    // 🔴 The dead selector, kept out by name. It is the plausible "fix" someone re-adds.
-    expect(
-      /\[data-variant/.test(checked),
-      `${relative} matches on \`data-variant\` again. Mantine puts that attribute on the Chip ` +
-        'ROOT, not on the label — such a clause matches nothing, which is exactly how the filled ' +
-        'background survived here for as long as it did.'
-    ).toBe(false);
   });
 
   /**
@@ -229,8 +260,9 @@ describe('filter chips render a visible border when checked', () => {
    * (`ColorSchemeScript` always sets the attribute), and it is not what this pins.
    */
   it('`--mantine-primary-color-filled` is defined on Mantine’s unconditional `:root`', () => {
-    // Resolved here rather than at module scope: a tree without `node_modules` then fails this
-    // one test with its own message instead of taking the whole file down as a collection error.
+    // Resolved here rather than at module scope: a tree without `node_modules` then fails this one
+    // test instead of taking the whole file down as a collection error. The message in that case is
+    // node's `MODULE_NOT_FOUND`, not `read`'s — the throw happens before the existence check.
     const mantineCss = createRequire(__filename).resolve('@mantine/core/styles.layer.css');
     const css = read(mantineCss);
     const root = blockAt(css, css.search(/:root\s*\{/));
@@ -255,9 +287,16 @@ describe('filter chips render a visible border when checked', () => {
    * `:not([data-disabled])` — (0,3,0) against (0,2,0) — but that is no defence: reorder the
    * declaration and the `mantine` layer wins regardless of specificity, restoring the filled
    * background with nothing else changing.
+   *
+   * That contract is repo-wide, not a filter-chip one — `globals.css` documents it as governing
+   * every `*.module.scss`. This test and the one below it are currently its ONLY guards. The next
+   * module-level fix that leans on it should MOVE them into a shared guard, not copy them.
    */
   it('the `modules` layer still outranks `mantine`, which is why these rules apply at all', () => {
-    const doc = read(path.join(REPO_ROOT, 'src/pages/_document.tsx'));
+    // Comment-stripped: `_document.tsx` already carries a commented-out element
+    // (`{/* <InlineStylesHead /> */}`), so commenting this one out — what someone does while
+    // debugging a layer problem — would otherwise leave a dead declaration satisfying this.
+    const doc = code(read(path.join(REPO_ROOT, 'src/pages/_document.tsx')));
     // Matched on the string that SHIPS, not on the first `@layer` in the file: the comment above
     // that line quotes the declaration, and prose would otherwise satisfy this.
     const order = /__html:\s*'@layer ([^']+);'/.exec(doc);
@@ -297,6 +336,15 @@ describe('filter chips render a visible border when checked', () => {
         '`styles.css` build beats every layered rule, including the checked-chip rules in ' +
         '`*.module.scss`, so the filled background comes back and the border becomes invisible.'
     ).toBe(true);
+    // 🔴 ADDING the unlayered build breaks this exactly as REPLACING it does, and a paste from
+    // Mantine's docs adds rather than replaces. Anchored on `@mantine/core/` so the unrelated
+    // `mantine-react-table/styles.css` import in the same file does not trip it.
+    expect(
+      /@mantine\/core\/styles\.css/.test(app),
+      'src/pages/_app.tsx imports the UNLAYERED `@mantine/core/styles.css` as well. Unlayered ' +
+        'declarations beat every named layer, so this restores the filled background on checked ' +
+        'chips even with the layered build still imported beside it.'
+    ).toBe(false);
   });
 
   /**

--- a/src/components/Filters/__tests__/filterChipCheckedState.test.ts
+++ b/src/components/Filters/__tests__/filterChipCheckedState.test.ts
@@ -1,0 +1,157 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * A CHECKED FILTER CHIP IS AN OUTLINE, NOT A FILLED PILL — AND THE BORDER HAS TO BE
+ * VISIBLE, WHICH TAKES BOTH HALVES OF THIS FILE.
+ *
+ * Measured 2026-09-10 on `/models` → Filters → Time period, before the fix: the checked
+ * chip drew NO border at all. The rule asked for `var(--mantine-color-primary)`, which is
+ * defined nowhere — not in this repo and not in `@mantine/core` — so the `border`
+ * shorthand was invalid at computed-value time, both longhands fell back to their initial
+ * values (`border-style: none`, used width 0), and the checked chip rendered 2px narrower
+ * than the unchecked one.
+ *
+ * 🔴 CORRECTING THE VARIABLE ALONE IS NOT ENOUGH, AND LOOKS LIKE IT IS. Beside the broken
+ * line every module also carried `&[data-checked] { &[data-variant='filled'] {…} }`, and
+ * Mantine puts `data-variant` on the Chip ROOT, not on the label these modules style — so
+ * that clause never matched, the filled background survived, and a repaired border came
+ * out `rgb(25,113,194)` on a background of exactly the same colour. A border that renders
+ * and cannot be seen reads as a finished ticket while changing nothing anyone can
+ * perceive. Hence the background assertion below: it is what makes the border assertion
+ * mean something.
+ *
+ * 🔴 AND THE TEXT COLOUR IS LOAD-BEARING, NOT TIDYING. Mantine's checked rule sets
+ * `color: var(--chip-color)` — white, chosen for the filled background this file removes.
+ * Leave it and a checked chip in LIGHT mode is white text on a transparent background:
+ * measured, an empty outlined pill with its label and check mark invisible. The explicit
+ * `--mantine-color-text` is what keeps it readable (15.78:1 light, 8.48:1 dark).
+ *
+ * WHY A SOURCE GUARD RATHER THAN A RENDERED ONE. The browser `component` project loads
+ * only the `:root` custom properties parsed out of `globals.css` (`test/component-setup.tsx`),
+ * NOT `@mantine/core/styles.css` — so `--mantine-primary-color-filled` does not resolve
+ * there and every Mantine class is styleless. A computed-colour assertion in that harness
+ * would compare one unresolved value to another and pass while observing nothing. Same
+ * split, and the same reasoning, as `AppBlocks/__tests__/chromeCrumbLinkStyle.test.ts`:
+ * the source half is checked here, the library half against the installed package.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const MANTINE_CSS = path.join(REPO_ROOT, 'node_modules/@mantine/core/styles.css');
+
+/** The modules whose `.label` class is actually handed to a Mantine `Chip`. */
+const CHIP_LABEL_MODULES = [
+  'src/components/Filters/FilterChip.module.scss',
+  'src/components/CosmeticShop/ShopFiltersDropdown.module.scss',
+  'src/components/CosmeticShop/CosmeticsFiltersDropdown.module.scss',
+  'src/components/Cosmetics/CosmeticsFiltersDropdown.module.scss',
+  'src/components/Buzz/WithdrawalRequest/BuzzWithdrawalRequestFiltersDropdown.module.scss',
+];
+
+function read(file: string): string {
+  // Prove the path before trusting a "no match": a search over an absent operand reports
+  // CLEAN, not MISSING, so a moved file would turn every assertion below into a vacuous pass.
+  expect(fs.existsSync(file), `${file} does not exist`).toBe(true);
+  return fs.readFileSync(file, 'utf8');
+}
+
+/** Strip comments — every token searched for below is also discussed in the file it is sought in. */
+function code(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/** The body of the `&[data-checked]` block inside `.label`. */
+function checkedBlock(src: string): string | null {
+  const at = src.indexOf('&[data-checked]');
+  if (at === -1) return null;
+  const open = src.indexOf('{', at);
+  if (open === -1) return null;
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(open + 1, i);
+  }
+  return null;
+}
+
+describe('filter chips render a visible border when checked', () => {
+  it.each(CHIP_LABEL_MODULES)('%s', (relative) => {
+    const src = code(read(path.join(REPO_ROOT, relative)));
+    const block = checkedBlock(src);
+    expect(
+      block,
+      `${relative} no longer has a \`&[data-checked]\` block in its \`.label\` rule — ` +
+        're-point this guard deliberately rather than letting it pass over a renamed selector.'
+    ).not.toBeNull();
+
+    expect(
+      /border:\s*1px solid var\(--mantine-primary-color-filled\)/.test(block as string),
+      `${relative} no longer draws the checked border from \`--mantine-primary-color-filled\`. ` +
+        'If it names a different custom property, check that property is actually DEFINED: ' +
+        '`--mantine-color-primary` was not, which made the whole shorthand invalid and drew no ' +
+        'border at all.'
+    ).toBe(true);
+
+    expect(
+      /background-color:\s*transparent/.test(block as string),
+      `${relative} lets the checked chip keep Mantine's filled background. The border above is ` +
+        'the same colour as that background, so it renders and cannot be seen — the chip looks ' +
+        'exactly as it did when the border was missing entirely.'
+    ).toBe(true);
+
+    expect(
+      /color:\s*var\(--mantine-color-text\)/.test(block as string),
+      `${relative} no longer pins the checked label colour. Mantine's own value is white, for ` +
+        'the filled background this rule removes; without the override a checked chip in light ' +
+        'mode is white text on transparent — an empty outlined pill.'
+    ).toBe(true);
+
+    // 🔴 The dead selector, kept out by name. It is the plausible "fix" someone re-adds.
+    expect(
+      /\[data-variant/.test(block as string),
+      `${relative} matches on \`data-variant\` again. Mantine puts that attribute on the Chip ` +
+        'ROOT, not on the label — such a clause matches nothing, which is exactly how the filled ' +
+        'background survived here for as long as it did.'
+    ).toBe(false);
+  });
+
+  /**
+   * The LIBRARY half: the property the source half names has to exist, or the shorthand is
+   * invalid again and the border silently disappears. Pinned against the installed package
+   * so a Mantine upgrade that drops it is caught HERE, with an explanation.
+   */
+  it('`--mantine-primary-color-filled` is a property Mantine actually defines', () => {
+    const css = read(MANTINE_CSS);
+    // Positive control on the extraction: if `:root` changed shape, the lookup below returns
+    // nothing and the failure would name the property rather than the parse.
+    expect(
+      /:root\s*\{/.test(css),
+      "Mantine no longer ships a bare `:root` rule — this guard's extraction is stale, not the claim."
+    ).toBe(true);
+    expect(
+      /--mantine-primary-color-filled:\s*[^;]+;/.test(css),
+      'Mantine no longer defines `--mantine-primary-color-filled`. Every checked filter chip now ' +
+        'asks for an undefined custom property, which invalidates the whole `border` shorthand and ' +
+        'draws no border — the original bug, returning through the library rather than the source.'
+    ).toBe(true);
+  });
+
+  /**
+   * `AdaptiveFiltersDropdown.module.scss` carried a sixth copy of the same broken rule, on a
+   * `.label` class NOTHING reads — that file hands Mantine only `indicatorRoot`, `indicator`,
+   * `actionButton` and `opened`. It was deleted rather than repaired. This pins that: an
+   * unreachable copy of a rule is how the same mistake reached six files.
+   */
+  it('the dropdown shell keeps no unreachable copy of the chip rule', () => {
+    const relative = 'src/components/Filters/AdaptiveFiltersDropdown.module.scss';
+    const src = code(read(path.join(REPO_ROOT, relative)));
+    expect(
+      /^\.label\s*\{/m.test(src),
+      `${relative} has a \`.label\` rule again. Nothing applies it — the component passes only ` +
+        'indicator/actionButton/opened classes to Mantine — so it is style that cannot render, and ' +
+        'the last copy sat there broken alongside five live ones. If a chip in this file genuinely ' +
+        'needs the class now, wire it up in the component in the same change.'
+    ).toBe(false);
+  });
+});

--- a/src/components/Filters/__tests__/filterChipCheckedState.test.ts
+++ b/src/components/Filters/__tests__/filterChipCheckedState.test.ts
@@ -1,10 +1,11 @@
 import fs from 'fs';
+import { createRequire } from 'module';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 
 /**
  * A CHECKED FILTER CHIP IS AN OUTLINE, NOT A FILLED PILL — AND THE BORDER HAS TO BE
- * VISIBLE, WHICH TAKES BOTH HALVES OF THIS FILE.
+ * VISIBLE, WHICH TAKES ALL THREE DECLARATIONS THIS FILE PINS.
  *
  * Measured 2026-09-10 on `/models` → Filters → Time period, before the fix: the checked
  * chip drew NO border at all. The rule asked for `var(--mantine-color-primary)`, which is
@@ -19,26 +20,35 @@ import { describe, expect, it } from 'vitest';
  * that clause never matched, the filled background survived, and a repaired border came
  * out `rgb(25,113,194)` on a background of exactly the same colour. A border that renders
  * and cannot be seen reads as a finished ticket while changing nothing anyone can
- * perceive. Hence the background assertion below: it is what makes the border assertion
- * mean something.
+ * perceive. Hence the background assertion: it is what makes the border assertion mean
+ * something.
  *
  * 🔴 AND THE TEXT COLOUR IS LOAD-BEARING, NOT TIDYING. Mantine's checked rule sets
  * `color: var(--chip-color)` — white, chosen for the filled background this file removes.
  * Leave it and a checked chip in LIGHT mode is white text on a transparent background:
  * measured, an empty outlined pill with its label and check mark invisible. The explicit
- * `--mantine-color-text` is what keeps it readable (15.78:1 light, 8.48:1 dark).
+ * `--mantine-color-text` is what keeps it readable (15.78:1 light, 8.48:1 dark), and
+ * `--chip-icon-color` does the same job for the check mark, which Mantine also draws white.
  *
- * WHY A SOURCE GUARD RATHER THAN A RENDERED ONE. The browser `component` project loads
- * only the `:root` custom properties parsed out of `globals.css` (`test/component-setup.tsx`),
- * NOT `@mantine/core/styles.css` — so `--mantine-primary-color-filled` does not resolve
- * there and every Mantine class is styleless. A computed-colour assertion in that harness
- * would compare one unresolved value to another and pass while observing nothing. Same
- * split, and the same reasoning, as `AppBlocks/__tests__/chromeCrumbLinkStyle.test.ts`:
- * the source half is checked here, the library half against the installed package.
+ * WHY THIS IS A SOURCE GUARD, MEASURED RATHER THAN ASSUMED. A rendered version was
+ * written and run in the browser `component` project, and it cannot work: that harness
+ * loads neither `@mantine/core/styles.css` nor Mantine's runtime theme variables. With
+ * the fix in place, a checked `FilterChip` there computes `border-top-width: 0px`,
+ * `border-top-style: none`, and BOTH `--mantine-primary-color-filled` and
+ * `--mantine-color-text` read as the empty string on `:root` and on the label. So the
+ * rendered assertion fails identically whether the fix is present or absent — it
+ * distinguishes nothing. (`test/component-setup.tsx` injects only the `:root` custom
+ * properties parsed out of `globals.css`.) The browser evidence for this change is the
+ * manual measurement recorded above, not a suite.
  */
 
 const REPO_ROOT = path.resolve(__dirname, '../../../..');
-const MANTINE_CSS = path.join(REPO_ROOT, 'node_modules/@mantine/core/styles.css');
+// Resolved through node rather than joined onto REPO_ROOT: pnpm's layout is a symlink
+// farm, and a hand-built path is the thing that goes stale when a worktree is laid out
+// differently from the primary checkout.
+// `styles.layer.css`, not `styles.css`: that is the build the app imports
+// (`src/pages/_app.tsx`), and the layered one is what the cascade claim below rests on.
+const MANTINE_CSS = createRequire(__filename).resolve('@mantine/core/styles.layer.css');
 
 /** The modules whose `.label` class is actually handed to a Mantine `Chip`. */
 const CHIP_LABEL_MODULES = [
@@ -56,14 +66,18 @@ function read(file: string): string {
   return fs.readFileSync(file, 'utf8');
 }
 
-/** Strip comments — every token searched for below is also discussed in the file it is sought in. */
+/**
+ * Strip comments — every token searched for below is also discussed in the file it is
+ * sought in. Trailing `//` comments are stripped too, not just full-line ones: a trailing
+ * comment can otherwise satisfy a positive assertion whose declaration was deleted, and
+ * can trip the negative one with prose.
+ */
 function code(src: string): string {
-  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|\s)\/\/.*$/gm, '$1');
 }
 
-/** The body of the `&[data-checked]` block inside `.label`. */
-function checkedBlock(src: string): string | null {
-  const at = src.indexOf('&[data-checked]');
+/** The body of `rule { … }` starting at `at`, brace-matched. Null when unbalanced. */
+function blockAt(src: string, at: number): string | null {
   if (at === -1) return null;
   const open = src.indexOf('{', at);
   if (open === -1) return null;
@@ -75,18 +89,39 @@ function checkedBlock(src: string): string | null {
   return null;
 }
 
+/**
+ * The `&[data-checked]` body inside the `.label` rule.
+ *
+ * 🔴 SCOPED TO `.label` FIRST, DELIBERATELY. Searching the whole file for the first
+ * `&[data-checked]` would read a decoy in any rule above it — and if that decoy happened
+ * to be compliant while `.label`'s own copy rotted, the pass would be silent. This is the
+ * one failure mode in the file that would not be loud.
+ */
+function checkedBlock(src: string): string | null {
+  const label = blockAt(src, src.search(/^\.label\s*\{/m));
+  if (label === null) return null;
+  return blockAt(label, label.indexOf('&[data-checked]'));
+}
+
+/** How many times a property is declared — `color:` must not match `background-color:`. */
+function declarationCount(block: string, property: string): number {
+  const re = new RegExp(`(^|[;{}\\s])${property.replace(/-/g, '\\-')}\\s*:`, 'g');
+  return (block.match(re) ?? []).length;
+}
+
 describe('filter chips render a visible border when checked', () => {
   it.each(CHIP_LABEL_MODULES)('%s', (relative) => {
     const src = code(read(path.join(REPO_ROOT, relative)));
     const block = checkedBlock(src);
     expect(
       block,
-      `${relative} no longer has a \`&[data-checked]\` block in its \`.label\` rule — ` +
+      `${relative} no longer has a \`&[data-checked]\` block inside its \`.label\` rule — ` +
         're-point this guard deliberately rather than letting it pass over a renamed selector.'
     ).not.toBeNull();
+    const checked = block as string;
 
     expect(
-      /border:\s*1px solid var\(--mantine-primary-color-filled\)/.test(block as string),
+      /border:\s*1px solid var\(--mantine-primary-color-filled\)\s*;/.test(checked),
       `${relative} no longer draws the checked border from \`--mantine-primary-color-filled\`. ` +
         'If it names a different custom property, check that property is actually DEFINED: ' +
         '`--mantine-color-primary` was not, which made the whole shorthand invalid and drew no ' +
@@ -94,22 +129,50 @@ describe('filter chips render a visible border when checked', () => {
     ).toBe(true);
 
     expect(
-      /background-color:\s*transparent/.test(block as string),
+      /background-color:\s*transparent\s*;/.test(checked),
       `${relative} lets the checked chip keep Mantine's filled background. The border above is ` +
         'the same colour as that background, so it renders and cannot be seen — the chip looks ' +
         'exactly as it did when the border was missing entirely.'
     ).toBe(true);
 
     expect(
-      /color:\s*var\(--mantine-color-text\)/.test(block as string),
+      /(^|[;{}\s])color:\s*var\(--mantine-color-text\)\s*;/.test(checked),
       `${relative} no longer pins the checked label colour. Mantine's own value is white, for ` +
         'the filled background this rule removes; without the override a checked chip in light ' +
         'mode is white text on transparent — an empty outlined pill.'
     ).toBe(true);
 
+    expect(
+      /--chip-icon-color:\s*var\(--mantine-primary-color-filled\)\s*;/.test(checked),
+      `${relative} no longer pins the check mark's colour. Mantine draws it from ` +
+        '`--chip-color`, i.e. white — invisible once the fill is gone, exactly like the label ' +
+        'colour above.'
+    ).toBe(true);
+
+    // 🔴 A SECOND DECLARATION IS HOW A REPAIRED RULE GOES BACK TO BEING INEFFECTIVE, and a
+    // fragment match cannot see the cascade: `border: 1px solid var(…); border: none;`
+    // satisfies every assertion above while drawing nothing. That is this bug's own history
+    // — a declaration present and overridden — so it is checked by count, not by presence.
+    for (const property of ['border', 'background-color', 'color'] as const) {
+      const count = declarationCount(checked, property);
+      expect(
+        count,
+        `${relative} declares \`${property}\` ${count} times in the checked block. The later one ` +
+          'wins, so the pinned value above may not be what renders. Keep one declaration per ' +
+          'property here.'
+      ).toBe(1);
+    }
+
+    expect(
+      /:not\(\[data-disabled\]\)/.test(src),
+      `${relative} no longer excludes disabled chips from the checked rule. Mantine scopes every ` +
+        'one of its own checked rules with `:not([data-disabled])`; unscoped, this clears the ' +
+        'greyed disabled background too and a disabled checked chip reads as enabled.'
+    ).toBe(true);
+
     // 🔴 The dead selector, kept out by name. It is the plausible "fix" someone re-adds.
     expect(
-      /\[data-variant/.test(block as string),
+      /\[data-variant/.test(checked),
       `${relative} matches on \`data-variant\` again. Mantine puts that attribute on the Chip ` +
         'ROOT, not on the label — such a clause matches nothing, which is exactly how the filled ' +
         'background survived here for as long as it did.'
@@ -117,24 +180,58 @@ describe('filter chips render a visible border when checked', () => {
   });
 
   /**
-   * The LIBRARY half: the property the source half names has to exist, or the shorthand is
-   * invalid again and the border silently disappears. Pinned against the installed package
-   * so a Mantine upgrade that drops it is caught HERE, with an explanation.
+   * The LIBRARY half: the property the source half names has to exist, and has to exist
+   * UNCONDITIONALLY. Pinned against the installed package so a Mantine upgrade that drops it,
+   * or moves it behind a colour scheme, is caught HERE with an explanation.
    */
-  it('`--mantine-primary-color-filled` is a property Mantine actually defines', () => {
+  it('`--mantine-primary-color-filled` is defined on Mantine’s unconditional `:root`', () => {
     const css = read(MANTINE_CSS);
-    // Positive control on the extraction: if `:root` changed shape, the lookup below returns
-    // nothing and the failure would name the property rather than the parse.
+    const root = blockAt(css, css.search(/:root\s*\{/));
+    // The control is real only because the assertion below reads THIS slice: an unscoped
+    // search over the whole file would stay green if the definition moved into a
+    // scheme-specific or @media rule, which is the failure that would cost light mode its
+    // border again.
     expect(
-      /:root\s*\{/.test(css),
+      root,
       "Mantine no longer ships a bare `:root` rule — this guard's extraction is stale, not the claim."
-    ).toBe(true);
+    ).not.toBeNull();
     expect(
-      /--mantine-primary-color-filled:\s*[^;]+;/.test(css),
-      'Mantine no longer defines `--mantine-primary-color-filled`. Every checked filter chip now ' +
-        'asks for an undefined custom property, which invalidates the whole `border` shorthand and ' +
-        'draws no border — the original bug, returning through the library rather than the source.'
+      /--mantine-primary-color-filled:\s*[^;]+;/.test(root as string),
+      'Mantine no longer defines `--mantine-primary-color-filled` on its unconditional `:root`. ' +
+        'Every checked filter chip now asks for a property that may not resolve, which invalidates ' +
+        'the whole `border` shorthand and draws no border — the original bug, returning through the ' +
+        'library rather than the source.'
     ).toBe(true);
+  });
+
+  /**
+   * 🔴 THE WHOLE FIX RESTS ON CASCADE LAYERS, AND SPECIFICITY IS A TIE UNDERNEATH.
+   * `.label[data-checked]` and Mantine's `.m_fa109255:not([data-disabled]):where([data-checked])`
+   * are both (0,2,0). What makes the module win is that `postcss.config.js` wraps every
+   * `*.module.scss` in `@layer modules`, `_app.tsx` imports Mantine's `styles.layer.css`
+   * (`@layer mantine`), and `_document.tsx` declares `modules` AFTER `mantine`. Remove or
+   * reorder that declaration and these five rules lose to Mantine on source order — a coin
+   * flip that would restore the filled background with nothing else changing.
+   */
+  it('the `modules` layer still outranks `mantine`, which is why these rules apply at all', () => {
+    const doc = read(path.join(REPO_ROOT, 'src/pages/_document.tsx'));
+    const order = /@layer ([a-z-]+(?:,\s*[a-z-]+)*);/.exec(doc);
+    expect(
+      order,
+      'src/pages/_document.tsx no longer declares a `@layer` order. Without it the checked-chip ' +
+        'rules below fall back to source order against Mantine, which is not something anything ' +
+        'in this repo controls.'
+    ).not.toBeNull();
+    const names = (order as RegExpExecArray)[1].split(',').map((n) => n.trim());
+    expect(
+      names.indexOf('modules'),
+      `the declared layer order is [${names.join(
+        ', '
+      )}]. \`modules\` must come after \`mantine\`, ` +
+        "or every checked filter chip goes back to Mantine's filled background and the border " +
+        'becomes invisible again.'
+    ).toBeGreaterThan(names.indexOf('mantine'));
+    expect(names).toContain('mantine');
   });
 
   /**
@@ -146,8 +243,10 @@ describe('filter chips render a visible border when checked', () => {
   it('the dropdown shell keeps no unreachable copy of the chip rule', () => {
     const relative = 'src/components/Filters/AdaptiveFiltersDropdown.module.scss';
     const src = code(read(path.join(REPO_ROOT, relative)));
+    // Matches the class wherever a selector could reintroduce it — grouped (`.label, .x`),
+    // qualified (`.label:not(…)`) or nested — rather than the one spelling it had.
     expect(
-      /^\.label\s*\{/m.test(src),
+      /(^|[,{}])\s*\.label\b/m.test(src),
       `${relative} has a \`.label\` rule again. Nothing applies it — the component passes only ` +
         'indicator/actionButton/opened classes to Mantine — so it is style that cannot render, and ' +
         'the last copy sat there broken alongside five live ones. If a chip in this file genuinely ' +

--- a/src/components/Filters/__tests__/filterChipCheckedState.test.ts
+++ b/src/components/Filters/__tests__/filterChipCheckedState.test.ts
@@ -53,9 +53,14 @@ const REPO_ROOT = path.resolve(__dirname, '../../../..');
 /**
  * The modules in THIS change's scope — five of the seven `.label` modules handed to a
  * Mantine `Chip`. NOT an inventory: `ImageGeneration/GenerationForm/ResourceSelectFilters`
- * and `PurchasableRewards/PurchasableRewardsModeratorFiltersDropdown` are the same copied
- * rule and are deliberately not listed, so a checked chip there still renders as a filled
- * pill. Add them here when they are brought into line.
+ * and `PurchasableRewards/PurchasableRewardsModeratorFiltersDropdown` are deliberately not
+ * listed, so a checked chip there still renders as a filled pill.
+ *
+ * They are the AFTER-STATE OF A HALF-FIX, not untouched copies: both already name
+ * `--mantine-primary-color-filled` correctly, so their border draws — and is then hidden by
+ * the fill that the same dead `&[data-variant='filled']` clause fails to remove. Anyone
+ * fixing them should not go looking for the undefined variable; it is not there. Their label
+ * colours also differ from each other. Add them here when they are brought into line.
  */
 const CHIP_LABEL_MODULES = [
   'src/components/Filters/FilterChip.module.scss',
@@ -233,8 +238,12 @@ describe('filter chips render a visible border when checked', () => {
         'border-left',
         'border-block',
         'border-inline',
+        // Single-EDGE longhands (`border-top-width`, `border-inline-start`, …) are deliberately
+        // out of scope: each removes one edge rather than the border, so none reproduces this
+        // bug. Prefix-matching `border*` instead would sweep in `border-radius`, which is
+        // ordinary CSS on a chip, and refuse it.
       ],
-      background: ['background', 'background-color'],
+      background: ['background', 'background-color', 'background-image'],
       color: ['color'],
     } as const;
     for (const [name, family] of Object.entries(families)) {
@@ -289,8 +298,11 @@ describe('filter chips render a visible border when checked', () => {
    * background with nothing else changing.
    *
    * That contract is repo-wide, not a filter-chip one — `globals.css` documents it as governing
-   * every `*.module.scss`. This test and the one below it are currently its ONLY guards. The next
-   * module-level fix that leans on it should MOVE them into a shared guard, not copy them.
+   * every `*.module.scss`. This test and the one below it are the only guards that READ the
+   * declaration; `src/tests/geometry/geometryHarness.geometry.test.tsx` asserts a hand-copied
+   * literal of the same order against its own CSSOM, so a reorder of `_document.tsx` reddens these
+   * two and leaves that one green on the stale order. The next module-level fix that leans on this
+   * contract should MOVE all three into one shared guard rather than adding a fourth copy.
    */
   it('the `modules` layer still outranks `mantine`, which is why these rules apply at all', () => {
     // Comment-stripped: `_document.tsx` already carries a commented-out element

--- a/src/components/Filters/__tests__/filterChipCheckedState.test.ts
+++ b/src/components/Filters/__tests__/filterChipCheckedState.test.ts
@@ -132,18 +132,28 @@ function checkedGroup(checked: string): string | null {
 }
 
 /**
- * How many times any member of a shorthand family is declared.
+ * How many times anything in a property family is declared.
  *
  * 🔴 THE FAMILY, NOT THE PROPERTY. `border: 1px solid …; border-width: 0;` overrides the
  * pinned value while leaving exactly one `border:` — and longhand override of a chip
  * border is a live idiom here (`StickerPlacementTray.tsx` does it inline, on purpose).
- * Counting only the exact property would miss the very shape this check exists for.
+ * Counting only the exact property would miss the very shape this check exists for, and an
+ * enumerated list misses it too: the sided and logical longhands (`border-top-width`,
+ * `border-inline-start-width`, …) are 18 more names and each one does the same job.
+ *
+ * 🔴 THE EXCLUSIONS ARE WHAT MAKE A PREFIX SAFE. `border-radius` is ordinary CSS on a chip —
+ * these five modules are pill-shaped — so a bare `border[a-z-]*` prefix would refuse a
+ * perfectly good edit. A false red on ordinary CSS is how a guard gets deleted rather than
+ * fixed, which this file has already been through once.
  */
-function declarationCount(block: string, family: readonly string[]): number {
-  return family.reduce((total, property) => {
-    const re = new RegExp(`(^|[;{}\\s])${property.replace(/-/g, '\\-')}\\s*:`, 'g');
-    return total + (block.match(re) ?? []).length;
-  }, 0);
+const FAMILY_PATTERNS = {
+  border: /(^|[;{}\s])border(-(?!radius|collapse|spacing|image)[a-z-]+)?\s*:/g,
+  background: /(^|[;{}\s])background(-color|-image)?\s*:/g,
+  color: /(^|[;{}\s])color\s*:/g,
+} as const;
+
+function declarationCount(block: string, pattern: RegExp): number {
+  return (block.match(new RegExp(pattern.source, 'g')) ?? []).length;
 }
 
 describe('filter chips render a visible border when checked', () => {
@@ -226,32 +236,12 @@ describe('filter chips render a visible border when checked', () => {
     // fragment match cannot see the cascade: `border: 1px solid var(…); border-width: 0;`
     // satisfies every assertion above while drawing nothing. That is this bug's own history —
     // a declaration present and overridden — so it is checked by count across the family.
-    const families = {
-      border: [
-        'border',
-        'border-width',
-        'border-style',
-        'border-color',
-        'border-top',
-        'border-right',
-        'border-bottom',
-        'border-left',
-        'border-block',
-        'border-inline',
-        // Single-EDGE longhands (`border-top-width`, `border-inline-start`, …) are deliberately
-        // out of scope: each removes one edge rather than the border, so none reproduces this
-        // bug. Prefix-matching `border*` instead would sweep in `border-radius`, which is
-        // ordinary CSS on a chip, and refuse it.
-      ],
-      background: ['background', 'background-color', 'background-image'],
-      color: ['color'],
-    } as const;
-    for (const [name, family] of Object.entries(families)) {
-      const count = declarationCount(checked, family);
+    for (const [name, pattern] of Object.entries(FAMILY_PATTERNS)) {
+      const count = declarationCount(checked, pattern);
       expect(
         count,
         `${relative} declares ${name} ${count} times anywhere in the \`&[data-checked]\` block ` +
-          `(counting ${family.join(', ')}), sibling rules included. The later one wins, so the ` +
+          `(matching ${pattern.source}), sibling rules included. The later one wins, so the ` +
           'pinned value above may not be what renders — a sibling `&:hover { background-color: … }` ' +
           'restores on hover exactly the fill this change removes. A second declaration may well be ' +
           'legitimate; if it is, widen this guard deliberately rather than deleting it.'

--- a/src/components/Sticker/StickerPlacementTray.tsx
+++ b/src/components/Sticker/StickerPlacementTray.tsx
@@ -337,28 +337,27 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
                     onChange={setMineOnlyRequested}
                     /**
                      * 🔴 ALL FOUR OF THESE PIN GEOMETRY, AND NONE IS DECORATION.
-                     * Mantine restyles a checked chip: padding drops 16px -> 7.5px,
-                     * the border WIDTH goes 1px -> 0, and a check icon appears.
-                     * Those do not cancel — measured 105.08px unchecked against
-                     * 102.73px checked — so the control visibly jumped as you
-                     * toggled it, next to two inputs that do not move. Pinning the
-                     * three that vary, and dropping the icon, makes the box the
-                     * same in both states by construction rather than by
-                     * arithmetic; the filled background still says which state it
-                     * is in.
+                     * Mantine restyles a checked chip: padding drops 16px -> 7.5px
+                     * and a check icon appears. Those do not cancel — measured
+                     * 105.08px unchecked against 102.73px checked — so the control
+                     * visibly jumped as you toggled it, next to two inputs that do
+                     * not move. Pinning what varies, and dropping the icon, makes
+                     * the box the same in both states by construction rather than
+                     * by arithmetic.
                      *
-                     * `borderWidth`/`borderStyle` are NOT a duplicate of
-                     * FilterChip.module.scss. That file sets the whole shorthand
-                     * for the checked state — but it names
-                     * `--mantine-color-primary`, which nothing defines (Mantine
-                     * ships `--mantine-primary-color-filled`; six module files
-                     * copy the undefined name). An unresolvable `var()` is invalid
-                     * at computed-value time, so the shorthand is dropped entirely
-                     * and the checked border computes to `none`. These two
-                     * longhands put the width back; the white that shows is
-                     * `currentColor` from the `color` beside it, not a colour
-                     * anyone set. Measured: 1px solid transparent unchecked, 1px
-                     * solid white checked, 105.08px both.
+                     * Dropping the icon costs this chip a cue the other filter
+                     * chips keep: FilterChip.module.scss draws a checked chip as a
+                     * primary border on a cleared background, and with the icon
+                     * hidden that border is the only thing here saying which state
+                     * it is in.
+                     *
+                     * `borderWidth`/`borderStyle` duplicate what that file already
+                     * sets for the checked state, and are kept deliberately: they
+                     * hold the box steady whatever the shared module does to the
+                     * border later. The shorthand there resolved to nothing until
+                     * PR #4749 (it named `--mantine-color-primary`, which nothing
+                     * defines), and these two longhands are why this chip did not
+                     * jump while it did.
                      *
                      * The height fallback is load-bearing separately:
                      * `--input-height-xs` is scoped to an Input, so unqualified it


### PR DESCRIPTION
Closes the ClickUp item "Filter chips render no checked border" (868m3rut8).

## The bug, and the half of it the ticket did not have

`--mantine-color-primary` is defined nowhere — not in this repo, and not in `@mantine/core`. Six filter modules named it in a checked-state `border` shorthand, so the declaration was invalid at computed-value time, both longhands fell back to their initial values (`border-style: none`, used width `0`), and a checked chip drew no border at all.

**Correcting the property alone would have looked like a fix and changed nothing anyone can see.** Beside the broken line, every module also carried:

```scss
&[data-checked] {
  &[data-variant='filled'] { background-color: transparent; }
}
```

Mantine puts `data-variant` on the Chip **root**, not on the label these modules style — confirmed by dumping the DOM, not by reading the selector — so that clause never matched either. The filled background survived, and a repaired border came out `rgb(25,113,194)` on a background of exactly the same colour: a border that renders and cannot be seen.

Both dead rules together describe the intended state, so both are fixed: transparent background, primary border, primary check icon.

The explicit `color: var(--mantine-color-text)` is not tidying. Mantine's checked colour is white, chosen for the fill this change removes; without the override a checked chip in **light** mode is white text and a white check mark on transparent — an empty outlined pill.

`AdaptiveFiltersDropdown.module.scss` held a sixth copy of the rule on a `.label` class **nothing applies** (that component hands Mantine only `indicator`/`actionButton`/`opened`). It is deleted rather than repaired — an unreachable copy of a rule is how the same mistake reached six files.

## Measured in a browser, not in the stylesheet

`/models` → Filters → Time period, chip "Day", same chip toggled in one session:

| | before | after |
|---|---|---|
| unchecked | w 62.98, h 28, `1px solid transparent` | unchanged |
| checked | w **60.98**, h 28, `0px none` | w **62.98**, h 28, `1px solid` primary |

The geometry worry inverts: the border that never drew was making the **checked** chip 2px narrower. This removes a shift rather than introducing one, so the ~15 `FilterChip` call sites do not move.

Contrast against the dropdown surface, measured after the change: light **3.53:1** border / **15.78:1** text; dark **3.01:1** / **8.48:1**. The border clears WCAG 1.4.11's 3:1 for a non-text UI component in both schemes, and the check icon is a second, non-colour cue.

## The guard, and why it is a source guard

`src/components/Filters/__tests__/filterChipCheckedState.test.ts` pins all three halves — the property is one Mantine actually defines, the background is cleared so the border can be seen, and the label colour is pinned — plus the dead `data-variant` selector by name, because that is the plausible "fix" someone re-adds.

It is a source-plus-installed-library assertion rather than a rendered one for the same reason `AppBlocks/__tests__/chromeCrumbLinkStyle.test.ts` is: the browser `component` harness loads only the `:root` custom properties parsed out of `globals.css`, not `@mantine/core/styles.css`, so a computed-colour assertion there would compare two unresolved values and pass while observing nothing.

Each assertion was broken on its own to prove it can fail, with the tree restored and diffed clean after each:

- revert `FilterChip.module.scss` to its previous state → `Tests 2 failed | 5 passed (7)`, exit 1
- remove only `background-color: transparent` → `Tests 1 failed | 6 passed (7)`, exit 1
- remove only the `color:` line → `Tests 1 failed | 6 passed (7)`, exit 1

## Verification

- `pnpm run typecheck` — OK, 0 type errors
- `pnpm run lint` — exits 1 on 358 pre-existing errors, **none in these files**; controlled by planting a lint error in the new test and watching eslint report it, so the silence is real rather than an ignored path
- `pnpm run test:unit:run` — `Test Files 1 failed | 1745 passed | 3 skipped (1749)`, exit 1. The one failure is `src/server/integrations/__tests__/moderation-cache-probe.test.ts`, which **passes 22/22 in isolation** and shares no import with this diff. `blocks.router.workflow.test.ts` collected **370** tests, so the submodule is present and the run means something.
- Nothing in typecheck, eslint or any vitest project covers SCSS. Stated plainly rather than implied by a green list.

## The one call site where the dark-mode colour is load-bearing

`StickerPlacementTray.tsx` hides its chip's check icon (`iconWrapper: { display: 'none' }`) so the control cannot change size beside two fixed-height inputs. With the fill gone, **the border is that chip's only checked cue** — every other call site still has the fill inversion and the tick to fall back on. It sits on `dark-7` and measures **3.43:1**, which passes WCAG 1.4.11.

Worth knowing before anyone revisits the border colour: the dropdown surface elsewhere is `dark-6`, where blue-8 measures **2.99:1** and does not pass 1.4.11 on its own. That is survivable everywhere the fill inverts, and it is exactly the case this tray does not have. Naming `--mantine-color-blue-6` in dark would take it to 4.21:1 without touching light mode; not done here, deliberately, because it is a design decision rather than part of this fix.

## Verification of the suite failure

The full unit suite exits 1 on this branch with one failing file, `src/server/integrations/__tests__/moderation-cache-probe.test.ts`. That is **pre-existing and measured, not inferred** — `origin/main` at `4a5b4db6ec` fails the same test with the same assertion:

| | result |
|---|---|
| `origin/main` @ `4a5b4db6ec` | `Test Files 1 failed \| 1748 passed \| 3 skipped (1752)`, exit 1 |
| this branch | `Test Files 1 failed \| 1745 passed \| 3 skipped (1749)`, exit 1 |

(The totals differ because `main` is three test files ahead of this branch's base.) It passes 22/22 in isolation.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HkSNTzjwFVUctwzRKGpm9
