### PR TITLE
feat(metabase-skill): add snippet verbs, --query-file, and two write guards

### DIFF
--- a/.claude/skills/metabase/SKILL.md
+++ b/.claude/skills/metabase/SKILL.md
@@ -91,10 +91,15 @@ node .claude/skills/metabase/metabase.mjs update-question --id 123 --display lin
 shell argument intact, and a swallowed value is parsed as boolean `true` — which writes a card with no
 query and reports success. `create-question` takes `--query-file` too.
 
-🔴 **A comment line that is exactly `--` breaks parameter binding for the whole query** on the
+🔴 **A comment line whose only content is `--` breaks parameter binding for the whole query** on the
 ClickHouse driver: every variable fails with *"we got more parameters than we can handle"*, which points
-at neither the line nor the cause. One trailing space per line is the fix, and both write commands now
-refuse SQL that contains one.
+at neither the line nor the cause. **Indentation does not save it** — an indented `--`, the usual form
+inside a CTE, breaks binding the same way. A trailing space or tab is the fix.
+
+`create-question`, `update-question`, `run-query`, `create-snippet` and `update-snippet` all refuse text
+containing one. **No test can catch this**: the query runs clean until a variable is *bound*, so an
+unparameterised run and a card that merely exists both look correct. The guard is the only check that
+reaches it.
 
 **Display types:** `table`, `bar`, `line`, `area`, `pie`, `scalar`, `row`, `funnel`, `map`, `scatter`, `waterfall`, `combo`, `smartscalar`, `progress`, `gauge`, `pivot`
 
@@ -225,11 +230,21 @@ A snippet is text pasted into `{{snippet: <name>}}` at run time, so several card
 expression instead of each carrying a copy that drifts.
 
 ```bash
-node .claude/skills/metabase/metabase.mjs list-snippets
-node .claude/skills/metabase/metabase.mjs create-snippet --name "image engine" --file engine.sql \
-  --description "what it derives, and what must not be added to it"
-node .claude/skills/metabase/metabase.mjs update-snippet --id 1 --file engine.sql
+node .claude/skills/metabase/metabase.mjs list-snippets [--json]
+node .claude/skills/metabase/metabase.mjs create-snippet --name "image engine" \
+  (--file engine.sql | --content "SQL") [--description "..."]
+node .claude/skills/metabase/metabase.mjs update-snippet --id 1 \
+  [--file engine.sql | --content "SQL"] [--name "..."] [--description "..."]
 ```
+
+Each write reads the snippet back and reports only on the fields it actually sent — a metadata-only
+update says "stored description matches", never "content matches", because it did not send content and
+did not check it.
+
+🔴 **Snippet text is the one place the `--` guard could not otherwise reach.** A snippet is substituted
+verbatim into every card that references it, and those cards' own SQL may contain nothing but
+`{{snippet: name}}` — so a bare `--` inside a snippet body breaks binding everywhere it is used and no
+per-card check can see it. `create-snippet` and `update-snippet` guard their content for that reason.
 
 **A snippet takes no parameters** — it is literal substitution, not a function. So a fragment can only
 reference bare column names, and a card using it must select from the table with **no alias** on those

--- a/.claude/skills/metabase/SKILL.md
+++ b/.claude/skills/metabase/SKILL.md
@@ -91,6 +91,13 @@ node .claude/skills/metabase/metabase.mjs update-question --id 123 --display lin
 shell argument intact, and a swallowed value is parsed as boolean `true` — which writes a card with no
 query and reports success. `create-question` takes `--query-file` too.
 
+An empty or whitespace-only `--query-file` is refused, because a file's emptiness is invisible to the
+caller — the program opened it, not them. An inline `--query "   "` is still accepted: it was typed
+deliberately by someone who can see what they typed.
+
+A write that contains a `{{snippet: ...}}` reference also verifies the snippet tag landed, not just the
+SQL. The two fail independently: a dropped tag leaves the query byte-identical and the card unrunnable.
+
 🔴 **A comment line whose only content is `--` breaks parameter binding for the whole query** on the
 ClickHouse driver: every variable fails with *"we got more parameters than we can handle"*, which points
 at neither the line nor the cause. **Indentation does not save it** — an indented `--`, the usual form

--- a/.claude/skills/metabase/SKILL.md
+++ b/.claude/skills/metabase/SKILL.md
@@ -87,6 +87,15 @@ node .claude/skills/metabase/metabase.mjs update-question --id 123 --display lin
   --visualization '{"graph.dimensions":["date"],"graph.metrics":["count"]}'
 ```
 
+**Pass real SQL as `--query-file`, not `--query`.** A query with a comment header does not survive a
+shell argument intact, and a swallowed value is parsed as boolean `true` — which writes a card with no
+query and reports success. `create-question` takes `--query-file` too.
+
+🔴 **A comment line that is exactly `--` breaks parameter binding for the whole query** on the
+ClickHouse driver: every variable fails with *"we got more parameters than we can handle"*, which points
+at neither the line nor the cause. One trailing space per line is the fix, and both write commands now
+refuse SQL that contains one.
+
 **Display types:** `table`, `bar`, `line`, `area`, `pie`, `scalar`, `row`, `funnel`, `map`, `scatter`, `waterfall`, `combo`, `smartscalar`, `progress`, `gauge`, `pivot`
 
 ### create-dashboard — New dashboard
@@ -209,6 +218,28 @@ node .claude/skills/metabase/metabase.mjs search --query "challenge" --type ques
 node .claude/skills/metabase/metabase.mjs get --type question --id 101
 node .claude/skills/metabase/metabase.mjs get --type dashboard --id 456
 ```
+
+### Snippets — one derivation shared by many cards
+
+A snippet is text pasted into `{{snippet: <name>}}` at run time, so several cards can share one
+expression instead of each carrying a copy that drifts.
+
+```bash
+node .claude/skills/metabase/metabase.mjs list-snippets
+node .claude/skills/metabase/metabase.mjs create-snippet --name "image engine" --file engine.sql \
+  --description "what it derives, and what must not be added to it"
+node .claude/skills/metabase/metabase.mjs update-snippet --id 1 --file engine.sql
+```
+
+**A snippet takes no parameters** — it is literal substitution, not a function. So a fragment can only
+reference bare column names, and a card using it must select from the table with **no alias** on those
+columns.
+
+Referencing one from a card is handled for you: both `create-question` and `update-question` scan the
+SQL for `{{snippet: ...}}` and add the matching template tag, because a card missing that tag fails at
+run time with `missing required parameters` and the auto-detect for ordinary `{{variable}}` syntax does
+not match a name containing a colon. A reference to a snippet that does not exist is refused before
+anything is written.
 
 ### list-collections / list-databases
 

--- a/.claude/skills/metabase/SKILL.md
+++ b/.claude/skills/metabase/SKILL.md
@@ -98,9 +98,11 @@ deliberately by someone who can see what they typed.
 A write that contains a `{{snippet: ...}}` reference also verifies the snippet tag landed, not just the
 SQL. The two fail independently: a dropped tag leaves the query byte-identical and the card unrunnable.
 
-Write a reference as `{{snippet: name}}`. `{{snippet:name}}` is fine — Metabase normalises it — but a
-space *before* the colon is not normalised and needs a tag named literally `snippet : name`, so a card
-written that way cannot run. That spelling is refused rather than written.
+Write a reference as `{{snippet: name}}`, lowercase. `{{snippet:name}}` is fine — Metabase normalises the
+missing space — but it does **not** normalise a space *before* the colon, and it **preserves the case of
+the prefix**. Both `{{snippet : name}}` and `{{SNIPPET: name}}` are references Metabase demands a tag for
+under that exact spelling, which this tool does not write, so the card cannot run. Both are refused rather
+than written.
 
 🔴 **A comment line whose only content is `--` breaks parameter binding for the whole query** on the
 ClickHouse driver: every variable fails with *"we got more parameters than we can handle"*, which points

--- a/.claude/skills/metabase/SKILL.md
+++ b/.claude/skills/metabase/SKILL.md
@@ -89,7 +89,7 @@ node .claude/skills/metabase/metabase.mjs update-question --id 123 --display lin
 
 **Pass real SQL as `--query-file`, not `--query`.** A query with a comment header does not survive a
 shell argument intact, and a swallowed value is parsed as boolean `true` — which writes a card with no
-query and reports success. `create-question` takes `--query-file` too.
+query and reports success. `create-question` and `run-query` take `--query-file` too.
 
 An empty or whitespace-only `--query-file` is refused, because a file's emptiness is invisible to the
 caller — the program opened it, not them. An inline `--query "   "` is still accepted: it was typed
@@ -97,6 +97,10 @@ deliberately by someone who can see what they typed.
 
 A write that contains a `{{snippet: ...}}` reference also verifies the snippet tag landed, not just the
 SQL. The two fail independently: a dropped tag leaves the query byte-identical and the card unrunnable.
+
+Write a reference as `{{snippet: name}}`. `{{snippet:name}}` is fine — Metabase normalises it — but a
+space *before* the colon is not normalised and needs a tag named literally `snippet : name`, so a card
+written that way cannot run. That spelling is refused rather than written.
 
 🔴 **A comment line whose only content is `--` breaks parameter binding for the whole query** on the
 ClickHouse driver: every variable fails with *"we got more parameters than we can handle"*, which points

--- a/.claude/skills/metabase/metabase.mjs
+++ b/.claude/skills/metabase/metabase.mjs
@@ -92,6 +92,7 @@ async function api(method, path, body) {
 
 async function runQuery(opts) {
   const { database, query, timeout } = opts;
+  if (typeof query === 'string') assertNoBareSqlComment(query);
   const dbId = parseInt(database, 10);
   if (!dbId || !query) {
     console.error('Usage: run-query --database <id> --query "SQL"');
@@ -138,6 +139,12 @@ async function createQuestion(opts) {
       query = readFileSync(resolve(process.cwd(), queryFile), 'utf-8');
     } catch (e) {
       console.error(`Error: cannot read --query-file ${queryFile}: ${e.message}`);
+      process.exit(1);
+    }
+    // An empty file is falsy and would skip the write AND its verification while exiting 0; a
+    // whitespace-only one is truthy and writes a card that opens blank, then "verifies" it.
+    if (!query.trim()) {
+      console.error(`Error: --query-file ${queryFile} is empty. Refusing to write a card with no query.`);
       process.exit(1);
     }
   }
@@ -482,15 +489,18 @@ async function runCard(opts) {
   console.log(`\n${result.data.rows.length} row(s)`);
 }
 
-// A comment line that is exactly `--` breaks parameter binding for the WHOLE query on Metabase's
+// A comment line whose only content is `--` breaks parameter binding for the WHOLE query on Metabase's
 // ClickHouse driver: every variable fails with "we got more parameters than we can handle", which names
-// neither the line nor the cause and reads as "you have too many variables". One trailing space is the
-// entire fix, so refusing here is cheaper than diagnosing it from the error.
-function assertNoBareSqlComment(sql) {
+// neither the line nor the cause and reads as "you have too many variables".
+//
+// Leading whitespace does NOT save it -- an indented `--`, the common form inside a CTE, breaks binding
+// exactly the same way -- while a trailing space or tab IS the fix. Measured against the live driver, so
+// trim only the start: trimming the end would reject the very form that works.
+function assertNoBareSqlComment(sql, what = 'SQL') {
   const lines = sql.split('\n').map((l) => (l.endsWith('\r') ? l.slice(0, -1) : l));
-  const bad = lines.map((l, i) => (l === '--' ? i + 1 : 0)).filter(Boolean);
+  const bad = lines.map((l, i) => (l.trimStart() === '--' ? i + 1 : 0)).filter(Boolean);
   if (bad.length) {
-    console.error(`Error: ${bad.length} bare "--" comment line(s) at line ${bad.join(', ')}.`);
+    console.error(`Error: ${what} has ${bad.length} bare "--" comment line(s) at line ${bad.join(', ')}.`);
     console.error('They break parameter binding on the ClickHouse driver. Add a trailing space to each.');
     process.exit(1);
   }
@@ -509,10 +519,20 @@ async function syncSnippetTags(tags, sql) {
   const existing = new Set((isArray ? tags : Object.values(tags)).map((t) => t.name));
 
   const added = [];
+  const repointed = [];
   for (const name of names) {
     const tagName = `snippet: ${name}`;
-    if (existing.has(tagName)) continue;
     const snippet = byName.get(name);
+    if (existing.has(tagName)) {
+      // Skipping by name alone leaves a stale `snippet-id` behind when a snippet was deleted and
+      // recreated, and the card then fails at run time. The id is already in hand, so reconcile it.
+      const current = (isArray ? tags : Object.values(tags)).find((t) => t.name === tagName);
+      if (snippet && current && current['snippet-id'] !== snippet.id) {
+        current['snippet-id'] = snippet.id;
+        repointed.push(`${tagName} -> id ${snippet.id}`);
+      }
+      continue;
+    }
     if (!snippet) {
       console.error(`Error: the SQL references {{snippet: ${name}}} but no snippet of that name exists.`);
       console.error(`Existing snippets: ${all.map((sn) => sn.name).join(', ') || '(none)'}`);
@@ -539,6 +559,7 @@ async function syncSnippetTags(tags, sql) {
     }
     added.push(tagName);
   }
+  if (repointed.length) console.log(`  Snippet tags re-pointed: ${repointed.join(', ')}`);
   return added;
 }
 
@@ -579,26 +600,42 @@ function snippetContent(opts) {
     console.error('Error: pass --content or --file, not both');
     process.exit(1);
   }
-  if (!opts.file) return opts.content;
-  try {
-    return readFileSync(resolve(process.cwd(), opts.file), 'utf-8');
-  } catch (e) {
-    console.error(`Error: cannot read --file ${opts.file}: ${e.message}`);
-    process.exit(1);
+  let content = opts.content;
+  if (opts.file) {
+    try {
+      content = readFileSync(resolve(process.cwd(), opts.file), 'utf-8');
+    } catch (e) {
+      console.error(`Error: cannot read --file ${opts.file}: ${e.message}`);
+      process.exit(1);
+    }
+    if (!content.trim()) {
+      console.error(`Error: --file ${opts.file} is empty. Refusing to write an empty snippet.`);
+      process.exit(1);
+    }
   }
+  // Snippet text is substituted verbatim into every card that references it, so a bare `--` here breaks
+  // binding in cards whose own SQL contains nothing but `{{snippet: name}}` -- where no guard can see it.
+  if (content) assertNoBareSqlComment(content, 'snippet content');
+  return content;
 }
 
-function reportSnippetWrite(label, stored, sent) {
+// `expected` holds only the fields this call actually sent. A verification line printed for a field that
+// was never sent is a claim about a check that did not happen, which is worse than no line at all.
+function reportSnippetWrite(stored, expected) {
+  const fields = Object.keys(expected);
   if (stored === null) {
-    console.log('  WARNING: could not read it back. Verify by hand.');
+    console.error('  WARNING: could not read it back. Verify by hand.');
     process.exitCode = 1;
-  } else if (sent && stored.content !== sent) {
-    console.log('  WARNING: stored content DIFFERS from what was sent. Stored:');
-    console.log(stored.content);
-    process.exitCode = 1;
-  } else {
-    console.log('  Verified: the stored content matches what was sent');
+    return;
   }
+  const wrong = fields.filter((f) => stored[f] !== expected[f]);
+  if (wrong.length) {
+    console.error(`  WARNING: stored ${wrong.join(', ')} DIFFERS from what was sent.`);
+    for (const f of wrong) console.error(`    ${f}: ${JSON.stringify(stored[f])}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`  Verified: stored ${fields.join(', ')} match${fields.length === 1 ? 'es' : ''} what was sent`);
 }
 
 async function createSnippet(opts) {
@@ -614,7 +651,7 @@ async function createSnippet(opts) {
   });
   console.log(`Snippet created: ${snippet.name} (id ${snippet.id})`);
   console.log(`  Reference it as: {{snippet: ${snippet.name}}}`);
-  reportSnippetWrite('create', await readSnippet(snippet.id), content);
+  reportSnippetWrite(await readSnippet(snippet.id), { name: opts.name, content });
 }
 
 async function updateSnippet(opts) {
@@ -630,7 +667,7 @@ async function updateSnippet(opts) {
   if (opts.description !== undefined) body.description = opts.description;
   await api('PUT', `/native-query-snippet/${snippetId}`, body);
   console.log(`Snippet ${snippetId} updated`);
-  reportSnippetWrite('update', await readSnippet(snippetId), content);
+  reportSnippetWrite(await readSnippet(snippetId), body);
 }
 
 async function updateQuestion(opts) {
@@ -649,6 +686,12 @@ async function updateQuestion(opts) {
       query = readFileSync(resolve(process.cwd(), queryFile), 'utf-8');
     } catch (e) {
       console.error(`Error: cannot read --query-file ${queryFile}: ${e.message}`);
+      process.exit(1);
+    }
+    // An empty file is falsy and would skip the write AND its verification while exiting 0; a
+    // whitespace-only one is truthy and writes a card that opens blank, then "verifies" it.
+    if (!query.trim()) {
+      console.error(`Error: --query-file ${queryFile} is empty. Refusing to write a card with no query.`);
       process.exit(1);
     }
   }
@@ -916,6 +959,10 @@ Commands:
   list                 List items in a collection
   search               Search for questions/dashboards
   get                  Get details of an item
+  run-card             Run a SAVED question with its parameters
+  list-snippets        List native query snippets
+  create-snippet       Create a native query snippet
+  update-snippet       Update a snippet's content, name or description
   list-collections     List all collections
   list-databases       List all databases
 

--- a/.claude/skills/metabase/metabase.mjs
+++ b/.claude/skills/metabase/metabase.mjs
@@ -528,24 +528,22 @@ function assertNoBareSqlComment(sql, what = 'SQL') {
   }
 }
 
-// Metabase normalises `{{snippet:name}}` to a tag named `snippet: name`, but does NOT normalise a space
-// BEFORE the colon, and it preserves the CASE of the prefix -- `{{SNIPPET: x}}` is a working reference
-// whose tag is named `SNIPPET: x`. The reference regex below matches a lowercase prefix only, so an
-// uppercase one is invisible to it exactly as a space-before-colon is. The checker matches
-// case-insensitively so both are refused rather than written; the reference regex stays case-sensitive,
-// so the only accepted spelling is the one it can see.
-// BEFORE the colon: `{{snippet : name}}` requires a tag named literally `snippet : name`. That spelling
-// is invisible to the reference regex below, so the card is written with no tag, cannot run, and the tag
-// verification stays silent because it has nothing to expect. Refusing it here is the cheap close --
-// it costs an odd spelling nobody wants and removes the one path where the verification is vacuous.
+// Metabase normalises `{{snippet:name}}` to a tag named `snippet: name`, but it does NOT normalise a
+// space before the colon, and it preserves the CASE of the prefix -- `{{snippet : x}}` and `{{SNIPPET: x}}`
+// are references it demands a tag for under that exact spelling. Both are invisible to the reference regex
+// below, which matches a lowercase prefix with no leading space, so a card written with either gets no
+// tag, cannot run, and the tag verification stays silent because it has nothing to expect. The checker
+// matches case-insensitively so both are refused rather than written; the reference regex stays
+// case-sensitive, so the only accepted spelling is the one it can see.
 function assertCanonicalSnippetRefs(sql) {
   const bad = [...sql.matchAll(/\{\{\s*(snippet[^:}]*:[^}]*?)\s*\}\}/gi)]
     .map((m) => m[1].trim())
     .filter((ref) => !/^snippet:\s*\S/.test(ref));
   if (bad.length) {
     console.error(`Error: unusable snippet reference(s): ${bad.map((r) => `{{${r}}}`).join(', ')}`);
-    console.error('Write them as {{snippet: name}}. A space before the colon, an uppercase prefix, or an');
-    console.error('empty name gives a card this tool cannot tag, and Metabase then cannot run it.');
+    console.error('Write them as {{snippet: name}}. A space before the colon, an uppercase prefix, an');
+    console.error('empty name, or a prefix that is not exactly `snippet` gives a card this tool cannot');
+    console.error('tag, and Metabase then cannot run it.');
     process.exit(1);
   }
 }

--- a/.claude/skills/metabase/metabase.mjs
+++ b/.claude/skills/metabase/metabase.mjs
@@ -110,6 +110,10 @@ async function runQuery(opts) {
       process.exit(1);
     }
   }
+  if (queryFile && typeof query === 'string' && !query.trim()) {
+    console.error(`Error: --query-file ${queryFile} is empty.`);
+    process.exit(1);
+  }
   if (typeof query === 'string') assertNoBareSqlComment(query);
   const dbId = parseInt(database, 10);
   if (!dbId || !query) {
@@ -524,10 +528,28 @@ function assertNoBareSqlComment(sql, what = 'SQL') {
   }
 }
 
+// Metabase normalises `{{snippet:name}}` to a tag named `snippet: name`, but does NOT normalise a space
+// BEFORE the colon: `{{snippet : name}}` requires a tag named literally `snippet : name`. That spelling
+// is invisible to the reference regex below, so the card is written with no tag, cannot run, and the tag
+// verification stays silent because it has nothing to expect. Refusing it here is the cheap close --
+// it costs an odd spelling nobody wants and removes the one path where the verification is vacuous.
+function assertCanonicalSnippetRefs(sql) {
+  const bad = [...sql.matchAll(/\{\{\s*(snippet[^:}]*:[^}]*?)\s*\}\}/g)]
+    .map((m) => m[1].trim())
+    .filter((ref) => !/^snippet:\s*\S/.test(ref));
+  if (bad.length) {
+    console.error(`Error: unusable snippet reference(s): ${bad.map((r) => `{{${r}}}`).join(', ')}`);
+    console.error('Write them as {{snippet: name}} -- a space before the colon, or an empty name, gives');
+    console.error('a card Metabase cannot run.');
+    process.exit(1);
+  }
+}
+
 // A `{{snippet: name}}` reference needs its own entry in the card's template-tags, or the card fails to
 // run with `missing required parameters`. The UI writes that entry; a programmatic PUT does not. Tags
 // arrive as an object in the `native` shape and an array in the `stages` one.
 async function syncSnippetTags(tags, sql) {
+  assertCanonicalSnippetRefs(sql);
   const names = [...new Set([...sql.matchAll(/\{\{\s*snippet:\s*([^}]+?)\s*\}\}/g)].map((m) => m[1]))];
   if (!names.length) return [];
 
@@ -598,6 +620,14 @@ async function syncSnippetTags(tags, sql) {
 // a write's own response -- a server that echoes what it did not persist would otherwise verify itself.
 function verifySnippetTags(card, expectedNames) {
   if (!expectedNames.length) return;
+  // A failed GET is not a failed write. Falling through would report every expected tag as missing and
+  // tell the operator the card is broken when the write may have been fine -- the distinction readCard
+  // exists to preserve.
+  if (!card) {
+    console.error('  WARNING: could not read the card back, so its snippet tags are unverified.');
+    process.exitCode = 1;
+    return;
+  }
   const stage = card?.dataset_query?.native ?? card?.dataset_query?.stages?.[0];
   const raw = stage?.['template-tags'] ?? stage?.template_tags ?? {};
   const stored = new Set((Array.isArray(raw) ? raw : Object.values(raw)).map((t) => t.name));

--- a/.claude/skills/metabase/metabase.mjs
+++ b/.claude/skills/metabase/metabase.mjs
@@ -13,6 +13,10 @@ import { parseOpts } from './parse-opts.mjs';
  *   list            List questions/dashboards in a collection
  *   search          Search for questions/dashboards by name
  *   get             Get details of a question or dashboard
+ *   run-card        Run a saved question with its parameters
+ *   list-snippets   List native query snippets
+ *   create-snippet  Create a native query snippet
+ *   update-snippet  Update a snippet's content, name or description
  *   set-dropdown     Configure a template tag variable as a dropdown list
  *   set-date-picker  Configure a template tag variable as a date picker
  *   set-parameters   Set all parameters on a question (full JSON)
@@ -133,6 +137,7 @@ async function createQuestion(opts) {
     console.error('Error: pass --query or --query-file, not both');
     process.exit(1);
   }
+  let snippetTagNames = [];
   let query = opts.query;
   if (queryFile) {
     try {
@@ -178,8 +183,7 @@ async function createQuestion(opts) {
     }
   }
 
-  const addedTags = await syncSnippetTags(templateTags, query);
-  if (addedTags.length) console.log(`Snippet tags added: ${addedTags.join(', ')}`);
+  await syncSnippetTags(templateTags, query);
 
   const body = {
     name,
@@ -523,20 +527,24 @@ async function syncSnippetTags(tags, sql) {
   for (const name of names) {
     const tagName = `snippet: ${name}`;
     const snippet = byName.get(name);
-    if (existing.has(tagName)) {
-      // Skipping by name alone leaves a stale `snippet-id` behind when a snippet was deleted and
-      // recreated, and the card then fails at run time. The id is already in hand, so reconcile it.
-      const current = (isArray ? tags : Object.values(tags)).find((t) => t.name === tagName);
-      if (snippet && current && current['snippet-id'] !== snippet.id) {
-        current['snippet-id'] = snippet.id;
-        repointed.push(`${tagName} -> id ${snippet.id}`);
-      }
-      continue;
-    }
+    // Existence is checked before the already-tagged branch on purpose. Checking it after let a
+    // reference to a DELETED snippet through whenever the card already carried a tag of that name --
+    // which is exactly the case the id reconcile below exists for.
     if (!snippet) {
       console.error(`Error: the SQL references {{snippet: ${name}}} but no snippet of that name exists.`);
       console.error(`Existing snippets: ${all.map((sn) => sn.name).join(', ') || '(none)'}`);
       process.exit(1);
+    }
+    if (existing.has(tagName)) {
+      // Skipping by name alone leaves a stale `snippet-id` behind when a snippet was deleted and
+      // recreated, and the card then fails at run time. The id is already in hand, so reconcile it.
+      const current = (isArray ? tags : Object.values(tags)).find((t) => t.name === tagName);
+      if (current && current['snippet-id'] !== snippet.id) {
+        current['snippet-id'] = snippet.id;
+        repointed.push(`${tagName} -> id ${snippet.id}`);
+      }
+      if (current && current['snippet-name'] !== name) current['snippet-name'] = name;
+      continue;
     }
     if (isArray) {
       tags.push({
@@ -560,7 +568,7 @@ async function syncSnippetTags(tags, sql) {
     added.push(tagName);
   }
   if (repointed.length) console.log(`  Snippet tags re-pointed: ${repointed.join(', ')}`);
-  return added;
+  return names.map((name) => `snippet: ${name}`);
 }
 
 // A snippet is literal text substitution into `{{snippet: <name>}}` and takes NO parameters, so a fragment
@@ -651,7 +659,12 @@ async function createSnippet(opts) {
   });
   console.log(`Snippet created: ${snippet.name} (id ${snippet.id})`);
   console.log(`  Reference it as: {{snippet: ${snippet.name}}}`);
-  reportSnippetWrite(await readSnippet(snippet.id), { name: opts.name, content });
+  // Every field this call sends, so the report cannot be a field short of what it wrote.
+  reportSnippetWrite(await readSnippet(snippet.id), {
+    name: opts.name,
+    content,
+    description: opts.description ?? null,
+  });
 }
 
 async function updateSnippet(opts) {
@@ -680,6 +693,7 @@ async function updateQuestion(opts) {
     console.error('Error: pass --query or --query-file, not both');
     process.exit(1);
   }
+  let snippetTagNames = [];
   let query = opts.query;
   if (queryFile) {
     try {
@@ -725,8 +739,7 @@ async function updateQuestion(opts) {
         process.exit(1);
       }
     }
-    const addedTags = await syncSnippetTags(templateTags, query);
-    if (addedTags.length) console.log(`  Snippet tags added: ${addedTags.join(', ')}`);
+    snippetTagNames = await syncSnippetTags(templateTags, query);
     body.dataset_query = {
       database: existing.database_id ?? existing.dataset_query?.database,
       type: 'native',
@@ -753,6 +766,21 @@ async function updateQuestion(opts) {
       process.exit(1);
     }
     console.log('  Verified: the stored query matches what was sent');
+
+    // The tags are the half nothing used to check. A snippet reference whose tag the server dropped
+    // still leaves the SQL byte-identical, so verifying the query alone cannot see it.
+    const storedStage = card.dataset_query?.native ?? card.dataset_query?.stages?.[0];
+    const storedRaw = storedStage?.['template-tags'] ?? {};
+    const storedTagNames = new Set(
+      (Array.isArray(storedRaw) ? storedRaw : Object.values(storedRaw)).map((t) => t.name)
+    );
+    const missing = snippetTagNames.filter((n) => !storedTagNames.has(n));
+    if (missing.length) {
+      console.error(`  WARNING: snippet tag(s) NOT stored: ${missing.join(', ')}. The card will fail to run.`);
+      process.exitCode = 1;
+    } else if (snippetTagNames.length) {
+      console.log(`  Verified: snippet tag(s) stored (${snippetTagNames.join(', ')})`);
+    }
   }
   if (body.archived !== undefined) console.log(`  Archived: ${card.archived}`);
   console.log(`  URL: ${METABASE_URL}/question/${cardId}`);

--- a/.claude/skills/metabase/metabase.mjs
+++ b/.claude/skills/metabase/metabase.mjs
@@ -95,11 +95,25 @@ async function api(method, path, body) {
 // ── Commands ──────────────────────────────────────────────────────────────────
 
 async function runQuery(opts) {
-  const { database, query, timeout } = opts;
+  const { database, timeout } = opts;
+  const queryFile = opts['query-file'];
+  if (opts.query && queryFile) {
+    console.error('Error: pass --query or --query-file, not both');
+    process.exit(1);
+  }
+  let query = opts.query;
+  if (queryFile) {
+    try {
+      query = readFileSync(resolve(process.cwd(), queryFile), 'utf-8');
+    } catch (e) {
+      console.error(`Error: cannot read --query-file ${queryFile}: ${e.message}`);
+      process.exit(1);
+    }
+  }
   if (typeof query === 'string') assertNoBareSqlComment(query);
   const dbId = parseInt(database, 10);
   if (!dbId || !query) {
-    console.error('Usage: run-query --database <id> --query "SQL"');
+    console.error('Usage: run-query --database <id> (--query "SQL" | --query-file <path>)');
     process.exit(1);
   }
 
@@ -137,7 +151,6 @@ async function createQuestion(opts) {
     console.error('Error: pass --query or --query-file, not both');
     process.exit(1);
   }
-  let snippetTagNames = [];
   let query = opts.query;
   if (queryFile) {
     try {
@@ -183,7 +196,7 @@ async function createQuestion(opts) {
     }
   }
 
-  await syncSnippetTags(templateTags, query);
+  const snippetTagNames = await syncSnippetTags(templateTags, query);
 
   const body = {
     name,
@@ -237,6 +250,7 @@ async function createQuestion(opts) {
   console.log(`  Name: ${card.name}`);
   console.log(`  URL: ${METABASE_URL}/question/${card.id}`);
   console.log(`  Verified: the stored query matches what was sent`);
+  verifySnippetTags(stored, snippetTagNames);
   if (Object.keys(templateTags).length > 0) {
     console.log(`  Variables: ${Object.keys(templateTags).join(', ')}`);
   }
@@ -514,61 +528,86 @@ function assertNoBareSqlComment(sql, what = 'SQL') {
 // run with `missing required parameters`. The UI writes that entry; a programmatic PUT does not. Tags
 // arrive as an object in the `native` shape and an array in the `stages` one.
 async function syncSnippetTags(tags, sql) {
-  const names = [...sql.matchAll(/\{\{\s*snippet:\s*([^}]+?)\s*\}\}/g)].map((m) => m[1]);
+  const names = [...new Set([...sql.matchAll(/\{\{\s*snippet:\s*([^}]+?)\s*\}\}/g)].map((m) => m[1]))];
   if (!names.length) return [];
 
   const all = await api('GET', '/native-query-snippet');
   const byName = new Map(all.map((sn) => [sn.name, sn]));
   const isArray = Array.isArray(tags);
-  const existing = new Set((isArray ? tags : Object.values(tags)).map((t) => t.name));
+  const find = (tagName) => (isArray ? tags : Object.values(tags)).find((t) => t.name === tagName);
 
   const added = [];
   const repointed = [];
   for (const name of names) {
     const tagName = `snippet: ${name}`;
     const snippet = byName.get(name);
-    // Existence is checked before the already-tagged branch on purpose. Checking it after let a
-    // reference to a DELETED snippet through whenever the card already carried a tag of that name --
-    // which is exactly the case the id reconcile below exists for.
+    const current = find(tagName);
+
+    // Metabase resolves a snippet by `snippet-id`, never by name -- a card whose SQL names a snippet
+    // that was since RENAMED keeps working. So an unknown name is only fatal when the card has no tag
+    // to resolve through; otherwise refusing here would block an unrelated edit to a card that runs.
     if (!snippet) {
+      if (current && current['snippet-id'] != null) {
+        console.error(
+          `  WARNING: {{snippet: ${name}}} names no existing snippet, but the card's tag points at ` +
+            `id ${current['snippet-id']}, which is what Metabase resolves. Left as is -- rename the ` +
+            `reference in the SQL when convenient.`
+        );
+        continue;
+      }
       console.error(`Error: the SQL references {{snippet: ${name}}} but no snippet of that name exists.`);
       console.error(`Existing snippets: ${all.map((sn) => sn.name).join(', ') || '(none)'}`);
       process.exit(1);
     }
-    if (existing.has(tagName)) {
-      // Skipping by name alone leaves a stale `snippet-id` behind when a snippet was deleted and
-      // recreated, and the card then fails at run time. The id is already in hand, so reconcile it.
-      const current = (isArray ? tags : Object.values(tags)).find((t) => t.name === tagName);
-      if (current && current['snippet-id'] !== snippet.id) {
+
+    if (current) {
+      // A stale id fails LOUDLY at run time ("Snippet 99999 does not exist"), so reconciling it is the
+      // load-bearing half. `snippet-name` is ignored by resolution, but it is what a human reads.
+      const fixes = [];
+      if (current['snippet-id'] !== snippet.id) {
         current['snippet-id'] = snippet.id;
-        repointed.push(`${tagName} -> id ${snippet.id}`);
+        fixes.push(`id ${snippet.id}`);
       }
-      if (current && current['snippet-name'] !== name) current['snippet-name'] = name;
+      if (current['snippet-name'] !== name) {
+        current['snippet-name'] = name;
+        fixes.push(`name "${name}"`);
+      }
+      if (fixes.length) repointed.push(`${tagName} -> ${fixes.join(', ')}`);
       continue;
     }
-    if (isArray) {
-      tags.push({
-        id: randomUUID(),
-        name: tagName,
-        'display-name': tagName,
-        type: 'snippet',
-        'snippet-name': name,
-        'snippet-id': snippet.id,
-      });
-    } else {
-      tags[tagName] = {
-        id: randomUUID(),
-        name: tagName,
-        'display-name': tagName,
-        type: 'snippet',
-        'snippet-name': name,
-        'snippet-id': snippet.id,
-      };
-    }
+
+    const tag = {
+      id: randomUUID(),
+      name: tagName,
+      'display-name': tagName,
+      type: 'snippet',
+      'snippet-name': name,
+      'snippet-id': snippet.id,
+    };
+    if (isArray) tags.push(tag);
+    else tags[tagName] = tag;
     added.push(tagName);
   }
+  if (added.length) console.log(`  Snippet tags added: ${added.join(', ')}`);
   if (repointed.length) console.log(`  Snippet tags re-pointed: ${repointed.join(', ')}`);
   return names.map((name) => `snippet: ${name}`);
+}
+
+// Announcing a tag is not the same as it having landed: a tag the server dropped leaves the query
+// byte-identical, so verifying the SQL alone cannot see it. `card` must come from a fresh read, not from
+// a write's own response -- a server that echoes what it did not persist would otherwise verify itself.
+function verifySnippetTags(card, expectedNames) {
+  if (!expectedNames.length) return;
+  const stage = card?.dataset_query?.native ?? card?.dataset_query?.stages?.[0];
+  const raw = stage?.['template-tags'] ?? stage?.template_tags ?? {};
+  const stored = new Set((Array.isArray(raw) ? raw : Object.values(raw)).map((t) => t.name));
+  const missing = expectedNames.filter((n) => !stored.has(n));
+  if (missing.length) {
+    console.error(`  WARNING: snippet tag(s) NOT stored: ${missing.join(', ')}. The card will fail to run.`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`  Verified: snippet tag(s) stored (${expectedNames.join(', ')})`);
 }
 
 // A snippet is literal text substitution into `{{snippet: <name>}}` and takes NO parameters, so a fragment
@@ -685,6 +724,7 @@ async function updateSnippet(opts) {
 
 async function updateQuestion(opts) {
   const { id, display, visualization, description, archived, variables } = opts;
+  let snippetTagNames = [];
 
   // SQL long enough to carry a comment header does not survive a shell argument intact, and the parser
   // degrades a swallowed value to `true`, which writes a card with no query and reports success.
@@ -693,7 +733,6 @@ async function updateQuestion(opts) {
     console.error('Error: pass --query or --query-file, not both');
     process.exit(1);
   }
-  let snippetTagNames = [];
   let query = opts.query;
   if (queryFile) {
     try {
@@ -766,21 +805,7 @@ async function updateQuestion(opts) {
       process.exit(1);
     }
     console.log('  Verified: the stored query matches what was sent');
-
-    // The tags are the half nothing used to check. A snippet reference whose tag the server dropped
-    // still leaves the SQL byte-identical, so verifying the query alone cannot see it.
-    const storedStage = card.dataset_query?.native ?? card.dataset_query?.stages?.[0];
-    const storedRaw = storedStage?.['template-tags'] ?? {};
-    const storedTagNames = new Set(
-      (Array.isArray(storedRaw) ? storedRaw : Object.values(storedRaw)).map((t) => t.name)
-    );
-    const missing = snippetTagNames.filter((n) => !storedTagNames.has(n));
-    if (missing.length) {
-      console.error(`  WARNING: snippet tag(s) NOT stored: ${missing.join(', ')}. The card will fail to run.`);
-      process.exitCode = 1;
-    } else if (snippetTagNames.length) {
-      console.log(`  Verified: snippet tag(s) stored (${snippetTagNames.join(', ')})`);
-    }
+    verifySnippetTags(await readCard(cardId), snippetTagNames);
   }
   if (body.archived !== undefined) console.log(`  Archived: ${card.archived}`);
   console.log(`  URL: ${METABASE_URL}/question/${cardId}`);

--- a/.claude/skills/metabase/metabase.mjs
+++ b/.claude/skills/metabase/metabase.mjs
@@ -529,18 +529,23 @@ function assertNoBareSqlComment(sql, what = 'SQL') {
 }
 
 // Metabase normalises `{{snippet:name}}` to a tag named `snippet: name`, but does NOT normalise a space
+// BEFORE the colon, and it preserves the CASE of the prefix -- `{{SNIPPET: x}}` is a working reference
+// whose tag is named `SNIPPET: x`. The reference regex below matches a lowercase prefix only, so an
+// uppercase one is invisible to it exactly as a space-before-colon is. The checker matches
+// case-insensitively so both are refused rather than written; the reference regex stays case-sensitive,
+// so the only accepted spelling is the one it can see.
 // BEFORE the colon: `{{snippet : name}}` requires a tag named literally `snippet : name`. That spelling
 // is invisible to the reference regex below, so the card is written with no tag, cannot run, and the tag
 // verification stays silent because it has nothing to expect. Refusing it here is the cheap close --
 // it costs an odd spelling nobody wants and removes the one path where the verification is vacuous.
 function assertCanonicalSnippetRefs(sql) {
-  const bad = [...sql.matchAll(/\{\{\s*(snippet[^:}]*:[^}]*?)\s*\}\}/g)]
+  const bad = [...sql.matchAll(/\{\{\s*(snippet[^:}]*:[^}]*?)\s*\}\}/gi)]
     .map((m) => m[1].trim())
     .filter((ref) => !/^snippet:\s*\S/.test(ref));
   if (bad.length) {
     console.error(`Error: unusable snippet reference(s): ${bad.map((r) => `{{${r}}}`).join(', ')}`);
-    console.error('Write them as {{snippet: name}} -- a space before the colon, or an empty name, gives');
-    console.error('a card Metabase cannot run.');
+    console.error('Write them as {{snippet: name}}. A space before the colon, an uppercase prefix, or an');
+    console.error('empty name gives a card this tool cannot tag, and Metabase then cannot run it.');
     process.exit(1);
   }
 }

--- a/.claude/skills/metabase/metabase.mjs
+++ b/.claude/skills/metabase/metabase.mjs
@@ -21,6 +21,7 @@ import { parseOpts } from './parse-opts.mjs';
  */
 
 import { readFileSync } from 'fs';
+import { randomUUID } from 'crypto';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -123,12 +124,29 @@ async function runQuery(opts) {
 }
 
 async function createQuestion(opts) {
-  const { name, database, query, collection, description, variables } = opts;
+  const { name, database, collection, description, variables } = opts;
   const dbId = parseInt(database, 10);
-  if (!name || !dbId || !query) {
-    console.error('Usage: create-question --name "Name" --database <id> --query "SQL" [--collection <id>] [--description "..."] [--variables \'{"name":{"type":"text","display-name":"Name"}}\']');
+
+  const queryFile = opts['query-file'];
+  if (opts.query && queryFile) {
+    console.error('Error: pass --query or --query-file, not both');
     process.exit(1);
   }
+  let query = opts.query;
+  if (queryFile) {
+    try {
+      query = readFileSync(resolve(process.cwd(), queryFile), 'utf-8');
+    } catch (e) {
+      console.error(`Error: cannot read --query-file ${queryFile}: ${e.message}`);
+      process.exit(1);
+    }
+  }
+
+  if (!name || !dbId || !query) {
+    console.error('Usage: create-question --name "Name" --database <id> (--query "SQL" | --query-file <path>) [--collection <id>] [--description "..."] [--variables \'{"name":{"type":"text","display-name":"Name"}}\']');
+    process.exit(1);
+  }
+  assertNoBareSqlComment(query);
 
   // Parse template tags from variables JSON or auto-detect {{variable}} patterns
   let templateTags = {};
@@ -152,6 +170,9 @@ async function createQuestion(opts) {
       };
     }
   }
+
+  const addedTags = await syncSnippetTags(templateTags, query);
+  if (addedTags.length) console.log(`Snippet tags added: ${addedTags.join(', ')}`);
 
   const body = {
     name,
@@ -461,8 +482,177 @@ async function runCard(opts) {
   console.log(`\n${result.data.rows.length} row(s)`);
 }
 
+// A comment line that is exactly `--` breaks parameter binding for the WHOLE query on Metabase's
+// ClickHouse driver: every variable fails with "we got more parameters than we can handle", which names
+// neither the line nor the cause and reads as "you have too many variables". One trailing space is the
+// entire fix, so refusing here is cheaper than diagnosing it from the error.
+function assertNoBareSqlComment(sql) {
+  const lines = sql.split('\n').map((l) => (l.endsWith('\r') ? l.slice(0, -1) : l));
+  const bad = lines.map((l, i) => (l === '--' ? i + 1 : 0)).filter(Boolean);
+  if (bad.length) {
+    console.error(`Error: ${bad.length} bare "--" comment line(s) at line ${bad.join(', ')}.`);
+    console.error('They break parameter binding on the ClickHouse driver. Add a trailing space to each.');
+    process.exit(1);
+  }
+}
+
+// A `{{snippet: name}}` reference needs its own entry in the card's template-tags, or the card fails to
+// run with `missing required parameters`. The UI writes that entry; a programmatic PUT does not. Tags
+// arrive as an object in the `native` shape and an array in the `stages` one.
+async function syncSnippetTags(tags, sql) {
+  const names = [...sql.matchAll(/\{\{\s*snippet:\s*([^}]+?)\s*\}\}/g)].map((m) => m[1]);
+  if (!names.length) return [];
+
+  const all = await api('GET', '/native-query-snippet');
+  const byName = new Map(all.map((sn) => [sn.name, sn]));
+  const isArray = Array.isArray(tags);
+  const existing = new Set((isArray ? tags : Object.values(tags)).map((t) => t.name));
+
+  const added = [];
+  for (const name of names) {
+    const tagName = `snippet: ${name}`;
+    if (existing.has(tagName)) continue;
+    const snippet = byName.get(name);
+    if (!snippet) {
+      console.error(`Error: the SQL references {{snippet: ${name}}} but no snippet of that name exists.`);
+      console.error(`Existing snippets: ${all.map((sn) => sn.name).join(', ') || '(none)'}`);
+      process.exit(1);
+    }
+    if (isArray) {
+      tags.push({
+        id: randomUUID(),
+        name: tagName,
+        'display-name': tagName,
+        type: 'snippet',
+        'snippet-name': name,
+        'snippet-id': snippet.id,
+      });
+    } else {
+      tags[tagName] = {
+        id: randomUUID(),
+        name: tagName,
+        'display-name': tagName,
+        type: 'snippet',
+        'snippet-name': name,
+        'snippet-id': snippet.id,
+      };
+    }
+    added.push(tagName);
+  }
+  return added;
+}
+
+// A snippet is literal text substitution into `{{snippet: <name>}}` and takes NO parameters, so a fragment
+// can only reference bare column names -- a consuming card must not alias the table they come from.
+
+async function listSnippets(opts) {
+  const snippets = await api('GET', '/native-query-snippet');
+  if (opts.json) {
+    console.log(JSON.stringify(snippets, null, 2));
+    return;
+  }
+  if (!snippets.length) {
+    console.log('No snippets on this instance.');
+    return;
+  }
+  for (const sn of snippets) {
+    console.log(`  ${sn.id}  ${sn.name}${sn.archived ? '  (archived)' : ''}`);
+    console.log(`      ${(sn.content || '').replace(/\s+/g, ' ').slice(0, 100)}`);
+  }
+}
+
+// Read without `api()`'s exit-on-failure, for the reason `readCard` exists: a failed read-back must not be
+// reported as a failed write, because the two call for different next actions.
+async function readSnippet(id) {
+  try {
+    const res = await fetch(`${METABASE_URL}/api/native-query-snippet/${id}`, {
+      headers: { 'x-api-key': METABASE_API_KEY },
+    });
+    return res.ok ? await res.json() : null;
+  } catch {
+    return null;
+  }
+}
+
+function snippetContent(opts) {
+  if (opts.content && opts.file) {
+    console.error('Error: pass --content or --file, not both');
+    process.exit(1);
+  }
+  if (!opts.file) return opts.content;
+  try {
+    return readFileSync(resolve(process.cwd(), opts.file), 'utf-8');
+  } catch (e) {
+    console.error(`Error: cannot read --file ${opts.file}: ${e.message}`);
+    process.exit(1);
+  }
+}
+
+function reportSnippetWrite(label, stored, sent) {
+  if (stored === null) {
+    console.log('  WARNING: could not read it back. Verify by hand.');
+    process.exitCode = 1;
+  } else if (sent && stored.content !== sent) {
+    console.log('  WARNING: stored content DIFFERS from what was sent. Stored:');
+    console.log(stored.content);
+    process.exitCode = 1;
+  } else {
+    console.log('  Verified: the stored content matches what was sent');
+  }
+}
+
+async function createSnippet(opts) {
+  const content = snippetContent(opts);
+  if (!opts.name || !content) {
+    console.error('Usage: create-snippet --name "Name" (--content "SQL" | --file <path>) [--description "..."]');
+    process.exit(1);
+  }
+  const snippet = await api('POST', '/native-query-snippet', {
+    name: opts.name,
+    content,
+    description: opts.description ?? null,
+  });
+  console.log(`Snippet created: ${snippet.name} (id ${snippet.id})`);
+  console.log(`  Reference it as: {{snippet: ${snippet.name}}}`);
+  reportSnippetWrite('create', await readSnippet(snippet.id), content);
+}
+
+async function updateSnippet(opts) {
+  const snippetId = parseInt(opts.id, 10);
+  const content = snippetContent(opts);
+  if (!snippetId || (!content && !opts.name && opts.description === undefined)) {
+    console.error('Usage: update-snippet --id <id> [--content "SQL" | --file <path>] [--name "Name"] [--description "..."]');
+    process.exit(1);
+  }
+  const body = {};
+  if (content) body.content = content;
+  if (opts.name) body.name = opts.name;
+  if (opts.description !== undefined) body.description = opts.description;
+  await api('PUT', `/native-query-snippet/${snippetId}`, body);
+  console.log(`Snippet ${snippetId} updated`);
+  reportSnippetWrite('update', await readSnippet(snippetId), content);
+}
+
 async function updateQuestion(opts) {
-  const { id, display, visualization, query, description, archived, variables } = opts;
+  const { id, display, visualization, description, archived, variables } = opts;
+
+  // SQL long enough to carry a comment header does not survive a shell argument intact, and the parser
+  // degrades a swallowed value to `true`, which writes a card with no query and reports success.
+  const queryFile = opts['query-file'];
+  if (opts.query && queryFile) {
+    console.error('Error: pass --query or --query-file, not both');
+    process.exit(1);
+  }
+  let query = opts.query;
+  if (queryFile) {
+    try {
+      query = readFileSync(resolve(process.cwd(), queryFile), 'utf-8');
+    } catch (e) {
+      console.error(`Error: cannot read --query-file ${queryFile}: ${e.message}`);
+      process.exit(1);
+    }
+  }
+  if (query) assertNoBareSqlComment(query);
   const cardId = parseInt(id, 10);
   if (!cardId) {
     console.error('Usage: update-question --id <id> [--display <type>] [--visualization \'{"key":"value"}\'] [--query "SQL"] [--variables \'{...}\'] [--description "..."] [--archived true|false]');
@@ -492,6 +682,8 @@ async function updateQuestion(opts) {
         process.exit(1);
       }
     }
+    const addedTags = await syncSnippetTags(templateTags, query);
+    if (addedTags.length) console.log(`  Snippet tags added: ${addedTags.join(', ')}`);
     body.dataset_query = {
       database: existing.database_id ?? existing.dataset_query?.database,
       type: 'native',
@@ -747,6 +939,9 @@ const commands = {
   'create-question': createQuestion,
   'update-question': updateQuestion,
   'run-card': runCard,
+  'list-snippets': listSnippets,
+  'create-snippet': createSnippet,
+  'update-snippet': updateSnippet,
   'create-dashboard': createDashboard,
   'add-to-dashboard': addToDashboard,
   'add-dashboard-filter': addDashboardFilter,


### PR DESCRIPTION
Eight Metabase cards (630, 859, 1073, 628, 1420, 2575, 1717, 2577) each hand-list orchestration job types, and the lists go stale without anyone noticing. Card 630's `wan` column read **0** for the week of 2026-09-01 against a real **452,969**: its list has `fal-wan27-image`, which was retired on 2026-07-28, and never gained `alibaba-wan-image`. `qwen` was understated 6.8x the same way.

The fix is one shared derivation living in a Metabase snippet rather than eight copies of a `CASE`. The skill had no way to create one, so this adds it.

## What changed

- **`list-snippets` / `create-snippet` / `update-snippet`** — each verifies by reading the stored content back rather than trusting the write.
- **`--query-file` on `create-question` and `update-question`.** SQL with a comment header does not survive a shell argument intact, and `parseOpts` degrades a swallowed value to boolean `true` — which writes a card with no query and reports success.
- **Refuse SQL containing a line that is exactly `--`.** On the ClickHouse driver that breaks parameter binding for the *whole* query, and the error — "we got more parameters than we can handle" — names neither the line nor the cause. My own first draft of card 630 had nine of them.
- **Add the template tag a `{{snippet: name}}` reference needs.** Without it the card fails at run time with `missing required parameters`; the existing auto-detect is `\w+` only, so it never matches a name containing a colon. A reference to a snippet that does not exist is refused before anything is written.

## Verification

Nothing in the repo's checks covers this path — `.claude/**` is outside tsconfig's `include` and no vitest project collects it — so the evidence is behaviour against the live instance:

- Created the snippet `image engine` (the instance's first), applied it to card 630 via `--query-file`, and ran the card back through `run-card`: 261 rows, 28 engines, `wan` **635,815** where it read 0.
- Both guards checked **in both directions**: a bare `--` and an unknown snippet are refused with a named reason, and the same SQL without them passes the guard and fails later for a different reason.
- Tag sync proven end to end on a throwaway card, since card 630 already carried the tag by then — created, ran, and archived (3367).

## Note for the reviewer

The first version of this commit was written against a local `main` that was 11 commits stale and would have reverted #4744's `run-card`, `--query`, `--archived` and `--variables` work. It was caught before it left the worktree by `SKILL.md` documenting verbs the file I had edited did not contain. This diff is additive on top of current `origin/main` — 229 insertions, 3 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013B28QvFKbzEhb5iFZiksh7
