### PR TITLE
test(app-blocks): freeze the clock in two more time-bucket suites

### DIFF
--- a/src/server/services/blocks/__tests__/app-bounty-cap.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-bounty-cap.service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Per-APP spend-BOUNTY accrual cap (audit 🟡-2 / App-Blocks Sybil-economics
@@ -65,7 +65,26 @@ import {
 
 const APP_BLOCK_ID = 'apb_test';
 
+/**
+ * Mid-day on purpose: 12 hours from either UTC midnight. This cap is DAILY-only
+ * — there is no short velocity window here — so the boundary that matters is
+ * the UTC day rollover, and the freeze parks well clear of it.
+ */
+const FROZEN_CLOCK = new Date('2026-07-31T12:00:30Z');
+
 beforeEach(() => {
+  // 🔴 FIRST, before anything derives a key. The accrual key is a UTC-day
+  // string, and the cases below accumulate in a loop and then RE-DERIVE `today`
+  // to read the counter back. If the day rolls between the loop and the read —
+  // or inside the loop — the counter is split across two keys and the read
+  // lands on the wrong one.
+  //
+  // MEASURED at this file's base: with the clock stepped 100ms per read and UTC
+  // midnight landing ~500 calls into the 1,000-iteration loop, the `SYBIL CASE`
+  // fails `expected 50000 to be 25000`. Freezing takes it to 0. Rarer than the
+  // sibling 60s-bucket flake (a 24h boundary, not a 60s one) and the same class.
+  vi.useFakeTimers();
+  vi.setSystemTime(FROZEN_CLOCK);
   store.clear();
   ttls.clear();
   mockSysRedis.incrBy.mockClear();
@@ -75,6 +94,11 @@ beforeEach(() => {
   mockSysRedis.ttl.mockImplementation(async (key: string) =>
     ttls.has(key) ? ttls.get(key)! : 1000
   );
+});
+
+afterEach(() => {
+  // Hand the clock back so a fake timer cannot leak into a later file.
+  vi.useRealTimers();
 });
 
 describe('BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY', () => {

--- a/src/server/services/blocks/__tests__/app-bounty-cap.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-bounty-cap.service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Per-APP spend-BOUNTY accrual cap (audit 🟡-2 / App-Blocks Sybil-economics
@@ -65,26 +65,7 @@ import {
 
 const APP_BLOCK_ID = 'apb_test';
 
-/**
- * Mid-day on purpose: 12 hours from either UTC midnight. This cap is DAILY-only
- * — there is no short velocity window here — so the boundary that matters is
- * the UTC day rollover, and the freeze parks well clear of it.
- */
-const FROZEN_CLOCK = new Date('2026-07-31T12:00:30Z');
-
 beforeEach(() => {
-  // 🔴 FIRST, before anything derives a key. The accrual key is a UTC-day
-  // string, and the cases below accumulate in a loop and then RE-DERIVE `today`
-  // to read the counter back. If the day rolls between the loop and the read —
-  // or inside the loop — the counter is split across two keys and the read
-  // lands on the wrong one.
-  //
-  // MEASURED at this file's base: with the clock stepped 100ms per read and UTC
-  // midnight landing ~500 calls into the 1,000-iteration loop, the `SYBIL CASE`
-  // fails `expected 50000 to be 25000`. Freezing takes it to 0. Rarer than the
-  // sibling 60s-bucket flake (a 24h boundary, not a 60s one) and the same class.
-  vi.useFakeTimers();
-  vi.setSystemTime(FROZEN_CLOCK);
   store.clear();
   ttls.clear();
   mockSysRedis.incrBy.mockClear();
@@ -94,11 +75,6 @@ beforeEach(() => {
   mockSysRedis.ttl.mockImplementation(async (key: string) =>
     ttls.has(key) ? ttls.get(key)! : 1000
   );
-});
-
-afterEach(() => {
-  // Hand the clock back so a fake timer cannot leak into a later file.
-  vi.useRealTimers();
 });
 
 describe('BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY', () => {

--- a/src/server/services/blocks/__tests__/app-spend-cap-rejection-signal.test.ts
+++ b/src/server/services/blocks/__tests__/app-spend-cap-rejection-signal.test.ts
@@ -104,6 +104,18 @@ import { reserveAppSpend } from '../app-spend-cap.service';
 
 const APP_BLOCK_ID = 'apb_reject_test';
 
+/**
+ * ⚠️ DISCLOSED, NOT FIXED: this derives the expected day with
+ * `new Date().toISOString().slice(0, 10)` — byte-identical to the
+ * implementation's own `spendCapWindowKey` (`../app-spend-cap.service`). The
+ * sibling `block-tip-rate-limit.test.ts` replaced exactly this pattern with an
+ * independent literal in the same change, so the rule is asserted there and not
+ * followed here. It is left alone deliberately: a distinct-constant mutation of
+ * `spendCapWindowKey` is still killed (2 failed / 13), so nothing is currently
+ * uncovered, and changing it is a separate edit with its own justification
+ * rather than something to slip into a de-flaking PR. Named here so the
+ * inconsistency is visible rather than accidental.
+ */
 function dailyKey(app = APP_BLOCK_ID): string {
   const today = new Date().toISOString().slice(0, 10);
   return `${SPEND_CAP_PREFIX}:${app}:${today}`;
@@ -124,7 +136,9 @@ const FROZEN_CLOCK = new Date('2026-07-31T12:00:30Z');
 
 beforeEach(() => {
   // 🔴 FIRST, before anything derives a key. `reserveAppSpend`'s velocity key is
-  // `floor(Date.now()/1000/60)` — a FIXED 60s window — and the denial-count
+  // `floor(Date.now()/1000/BLOCK_APP_SPEND_VELOCITY_WINDOW_SECONDS)` — a FIXED
+  // window whose width DEFAULTS to 60s but is env-overridable, so do not write
+  // the 60 as though it were a constant — and the denial-count
   // cases below loop to a ceiling and then assert an EXACT total. That is only
   // sound while the bucket holds still for the whole loop: a boundary inside it
   // restarts the counter, more submits are allowed, and the total comes up

--- a/src/server/services/blocks/__tests__/app-spend-cap-rejection-signal.test.ts
+++ b/src/server/services/blocks/__tests__/app-spend-cap-rejection-signal.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * OBSERVABILITY of the per-app spend-cap REJECTION path.
@@ -114,7 +114,29 @@ function reasons(): string[] {
   return mockRecordRejection.mock.calls.map((c) => c[0] as string);
 }
 
+/**
+ * Mid-bucket AND mid-day on purpose: 30s into a 60s velocity window and 12
+ * hours from either UTC midnight, so neither boundary is anywhere near.
+ * Matches the instant `app-spend-cap.service.test.ts` freezes at, deliberately
+ * — these two files exercise the same service and the same key shapes.
+ */
+const FROZEN_CLOCK = new Date('2026-07-31T12:00:30Z');
+
 beforeEach(() => {
+  // 🔴 FIRST, before anything derives a key. `reserveAppSpend`'s velocity key is
+  // `floor(Date.now()/1000/60)` — a FIXED 60s window — and the denial-count
+  // cases below loop to a ceiling and then assert an EXACT total. That is only
+  // sound while the bucket holds still for the whole loop: a boundary inside it
+  // restarts the counter, more submits are allowed, and the total comes up
+  // short for a reason that has nothing to do with the code.
+  //
+  // MEASURED at this file's base: with the clock advanced 100ms per read and a
+  // bucket boundary landing ~25 calls into the 50-iteration loop, the
+  // `counts AFFECTED GENERATIONS` case fails `expected 44 to be 47` — 3 submits
+  // allowed in each of two buckets instead of 3 in one. Freezing takes it to 0.
+  // Same defect and same fix as civitai#4742 on the sibling suite.
+  vi.useFakeTimers();
+  vi.setSystemTime(FROZEN_CLOCK);
   store.clear();
   ttls.clear();
   for (const fn of [
@@ -152,6 +174,12 @@ beforeEach(() => {
   mockRecordRejection.mockReset();
   mockRecordRejection.mockImplementation(() => undefined);
   metricsModule.brokenExport = false;
+});
+
+afterEach(() => {
+  // Hand the clock back — a leaked fake timer would silently change how every
+  // later file in the same worker behaves.
+  vi.useRealTimers();
 });
 
 describe('spend-cap rejection signal — every deny is counted, with the reason that applied', () => {

--- a/src/server/utils/__tests__/block-tip-rate-limit.test.ts
+++ b/src/server/utils/__tests__/block-tip-rate-limit.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Direct unit coverage for the tip cap/limit REDIS PRIMITIVES
@@ -34,14 +34,12 @@ const { sysStore, sysTtls, mockSys, cacheStore, cacheTtls, mockCache } = vi.hois
       const v = sysStore.get(k);
       return v == null ? null : String(v);
     }),
-    set: vi.fn(
-      async (k: string, val: string, opts?: { NX?: boolean; EX?: number }) => {
-        if (opts?.NX && sysStore.has(k)) return null; // NX: only set when absent
-        sysStore.set(k, val);
-        if (opts?.EX != null) sysTtls.set(k, opts.EX);
-        return 'OK';
-      }
-    ),
+    set: vi.fn(async (k: string, val: string, opts?: { NX?: boolean; EX?: number }) => {
+      if (opts?.NX && sysStore.has(k)) return null; // NX: only set when absent
+      sysStore.set(k, val);
+      if (opts?.EX != null) sysTtls.set(k, opts.EX);
+      return 'OK';
+    }),
     del: vi.fn(async (k: string) => {
       const had = sysStore.has(k);
       sysStore.delete(k);
@@ -86,9 +84,42 @@ import {
   reserveBlockTipSpend,
 } from '../block-tip-rate-limit';
 
-const TODAY = new Date().toISOString().slice(0, 10);
+/**
+ * Mid-day on purpose: 12 hours from either UTC midnight. The tip cap's key is a
+ * UTC-day string, so the day rollover is the only boundary that matters here.
+ */
+const FROZEN_CLOCK = new Date('2026-07-31T12:00:30Z');
+
+/**
+ * 🔴 DERIVED AT CALL TIME, NOT AT IMPORT — and that is the whole fix for this
+ * file, not a style preference.
+ *
+ * This used to be a module-level constant evaluated once when the module was
+ * imported. Two consequences, and the second is why freezing alone is not
+ * enough here:
+ *
+ *   1. At base it is a genuine (if rare) flake: the constant is captured at
+ *      import while the service derives its key at CALL time, so a UTC-day
+ *      rollover in between makes the two disagree and the key assertions fail.
+ *   2. A `beforeEach` freeze CANNOT fix that on its own — worse, it BREAKS the
+ *      file. The constant is already computed by the time `beforeEach` runs, so
+ *      it keeps the real date while the service starts returning the frozen one.
+ *      MEASURED: adding only the freeze fails 2 of 29 cases with
+ *      `expected 'system:blocks:tip-cap:42:2026-07-31' to be
+ *      'system:blocks:tip-cap:42:2026-09-10'`.
+ *
+ * So both halves are required: the freeze below pins what the SERVICE derives,
+ * and this function makes the TEST read the same clock instead of a stale copy.
+ */
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
 
 beforeEach(() => {
+  // 🔴 FIRST, before anything derives a key — see `todayKey` above for why
+  // this freeze and that function only work as a PAIR.
+  vi.useFakeTimers();
+  vi.setSystemTime(FROZEN_CLOCK);
   vi.clearAllMocks();
   sysStore.clear();
   sysTtls.clear();
@@ -96,11 +127,16 @@ beforeEach(() => {
   cacheTtls.clear();
 });
 
+afterEach(() => {
+  // Hand the clock back so a fake timer cannot leak into a later file.
+  vi.useRealTimers();
+});
+
 describe('reserveBlockTipSpend', () => {
   it('reserves the amount, returns a UTC-day-scoped key, and SETS the TTL on the first write', async () => {
     const { total, key } = await reserveBlockTipSpend(42, 100);
     expect(total).toBe(100);
-    expect(key).toBe(`system:blocks:tip-cap:42:${TODAY}`);
+    expect(key).toBe(`system:blocks:tip-cap:42:${todayKey()}`);
     // TTL armed on first write (~25h).
     expect(mockSys.expire).toHaveBeenCalledWith(key, 25 * 60 * 60);
     expect(sysStore.get(key)).toBe(100);
@@ -148,7 +184,7 @@ describe('refundBlockTipSpend', () => {
     expect(mockSys.decrBy).toHaveBeenCalledWith(yesterdayKey, 500);
     expect(sysStore.get(yesterdayKey)).toBe(0);
     // The current-day key is untouched.
-    expect(sysStore.get(`system:blocks:tip-cap:42:${TODAY}`)).toBeUndefined();
+    expect(sysStore.get(`system:blocks:tip-cap:42:${todayKey()}`)).toBeUndefined();
   });
 
   it('is best-effort — a failed DECRBY never throws (a lost refund only over-counts)', async () => {
@@ -195,7 +231,7 @@ describe('readBlockTipAllowance (item 4)', () => {
   it('reads the CURRENT-day key (same key the reserve path mutates)', async () => {
     await reserveBlockTipSpend(7, 100);
     await readBlockTipAllowance(7);
-    expect(mockSys.get).toHaveBeenCalledWith(`system:blocks:tip-cap:7:${TODAY}`);
+    expect(mockSys.get).toHaveBeenCalledWith(`system:blocks:tip-cap:7:${todayKey()}`);
   });
 
   it('CLAMPS remaining at 0 when a straddling over-cap reservation pushed spent past the cap', async () => {
@@ -308,12 +344,7 @@ describe('tip idempotency (item 2, tip half)', () => {
       const a = await claimTipIdempotency(42, 'apb_appA', 'tip1', FP);
       expect(a.state).toBe('acquired');
       if (a.state !== 'acquired') throw new Error('unreachable');
-      await finalizeTipIdempotency(
-        a.key,
-        200,
-        { ok: true, tip: { toUserId: 5, amount: 25 } },
-        FP
-      );
+      await finalizeTipIdempotency(a.key, 200, { ok: true, tip: { toUserId: 5, amount: 25 } }, FP);
 
       // App B hardcodes the SAME literal key. It must NOT receive app A's cached
       // body (which would leak A's recipient + amount) and its own tip must run.
@@ -361,7 +392,9 @@ describe('tip idempotency (item 2, tip half)', () => {
       );
       expect(
         computeTipFingerprint({ toUserId: 5, amount: 25, entityType: 'Image', entityId: 1 })
-      ).not.toBe(computeTipFingerprint({ toUserId: 5, amount: 25, entityType: 'Image', entityId: 2 }));
+      ).not.toBe(
+        computeTipFingerprint({ toUserId: 5, amount: 25, entityType: 'Image', entityId: 2 })
+      );
       // Stable for the SAME payload (a retry must replay, not 422).
       expect(computeTipFingerprint({ toUserId: 5, amount: 25 })).toBe(base);
     });

--- a/src/server/utils/__tests__/block-tip-rate-limit.test.ts
+++ b/src/server/utils/__tests__/block-tip-rate-limit.test.ts
@@ -96,10 +96,25 @@ const FROZEN_CLOCK = new Date('2026-07-31T12:00:30Z');
  * It is deliberately NOT computed as `new Date().toISOString().slice(0, 10)`.
  * That is byte-identical to the expression the implementation uses
  * (`tipCapWindowKey` in `../block-tip-rate-limit`), so an expectation built that
- * way moves WITH the implementation and can never catch it changing — the
- * "never derive a test's expectation from the implementation it tests" trap. A
- * literal is an independent expectation: switch production to a LOCAL-date
- * derivation and this still pins the UTC answer.
+ * way moves WITH the implementation — the "never derive a test's expectation
+ * from the implementation it tests" trap. The literal is an INDEPENDENT
+ * expectation, and it is also simply less machinery.
+ *
+ * 🔴 BE PRECISE ABOUT WHAT THAT BUYS — AN EARLIER VERSION OF THIS COMMENT
+ * OVERSOLD IT AND WAS FALSE. It claimed that switching production to a
+ * LOCAL-date derivation would still be caught here. MEASURED, mutating
+ * `tipCapWindowKey` to `toLocaleDateString('en-CA')`: the literal SURVIVES
+ * under `TZ=UTC` and `America/Winnipeg` (29/29) and dies only at UTC+13/+14.
+ * `FROZEN_CLOCK` is 12:00:30Z, so the local and UTC dates agree at every offset
+ * inside ±12h — every deployment TZ, CI's UTC included. The control that
+ * settles it: a FROZEN-but-DERIVED expectation survives that same mutant
+ * (29/29 at both TZs), so against it the two forms are EQUIVALENT, not
+ * better-and-worse. (The unfrozen base did catch it — but only through the
+ * import-vs-call-time skew that is the bug being fixed, so that is not
+ * coverage worth preserving.)
+ *
+ * Choose the literal for INDEPENDENCE and simplicity, which are real. Do not
+ * claim a detection property it does not have.
  *
  * ⚠️ A second, separate trap, recorded in case anyone reintroduces a derived
  * value here: this day string used to be a module-level `const`, evaluated at

--- a/src/server/utils/__tests__/block-tip-rate-limit.test.ts
+++ b/src/server/utils/__tests__/block-tip-rate-limit.test.ts
@@ -91,33 +91,31 @@ import {
 const FROZEN_CLOCK = new Date('2026-07-31T12:00:30Z');
 
 /**
- * 🔴 DERIVED AT CALL TIME, NOT AT IMPORT — and that is the whole fix for this
- * file, not a style preference.
+ * 🔴 A LITERAL, NOT A DERIVATION — the UTC day of `FROZEN_CLOCK`, written out.
  *
- * This used to be a module-level constant evaluated once when the module was
- * imported. Two consequences, and the second is why freezing alone is not
- * enough here:
+ * It is deliberately NOT computed as `new Date().toISOString().slice(0, 10)`.
+ * That is byte-identical to the expression the implementation uses
+ * (`tipCapWindowKey` in `../block-tip-rate-limit`), so an expectation built that
+ * way moves WITH the implementation and can never catch it changing — the
+ * "never derive a test's expectation from the implementation it tests" trap. A
+ * literal is an independent expectation: switch production to a LOCAL-date
+ * derivation and this still pins the UTC answer.
  *
- *   1. At base it is a genuine (if rare) flake: the constant is captured at
- *      import while the service derives its key at CALL time, so a UTC-day
- *      rollover in between makes the two disagree and the key assertions fail.
- *   2. A `beforeEach` freeze CANNOT fix that on its own — worse, it BREAKS the
- *      file. The constant is already computed by the time `beforeEach` runs, so
- *      it keeps the real date while the service starts returning the frozen one.
- *      MEASURED: adding only the freeze fails 2 of 29 cases with
- *      `expected 'system:blocks:tip-cap:42:2026-07-31' to be
- *      'system:blocks:tip-cap:42:2026-09-10'`.
- *
- * So both halves are required: the freeze below pins what the SERVICE derives,
- * and this function makes the TEST read the same clock instead of a stale copy.
+ * ⚠️ A second, separate trap, recorded in case anyone reintroduces a derived
+ * value here: this day string used to be a module-level `const`, evaluated at
+ * IMPORT. A `beforeEach` freeze cannot move such a constant — it is already
+ * computed — so it keeps the real date while the service returns the frozen one.
+ * MEASURED: freeze-only fails 2 of 29 with `expected
+ * 'system:blocks:tip-cap:42:2026-07-31' to be
+ * 'system:blocks:tip-cap:42:2026-09-10'`. A literal sidesteps that entirely,
+ * because it reads no clock at all.
  */
-function todayKey(): string {
-  return new Date().toISOString().slice(0, 10);
-}
+const FROZEN_DAY = '2026-07-31';
 
 beforeEach(() => {
-  // 🔴 FIRST, before anything derives a key — see `todayKey` above for why
-  // this freeze and that function only work as a PAIR.
+  // 🔴 FIRST, before the service derives any key. This pins what the SERVICE
+  // computes; `FROZEN_DAY` above is the independent literal the assertions
+  // compare against. Both are needed, and neither derives from the other.
   vi.useFakeTimers();
   vi.setSystemTime(FROZEN_CLOCK);
   vi.clearAllMocks();
@@ -136,7 +134,7 @@ describe('reserveBlockTipSpend', () => {
   it('reserves the amount, returns a UTC-day-scoped key, and SETS the TTL on the first write', async () => {
     const { total, key } = await reserveBlockTipSpend(42, 100);
     expect(total).toBe(100);
-    expect(key).toBe(`system:blocks:tip-cap:42:${todayKey()}`);
+    expect(key).toBe(`system:blocks:tip-cap:42:${FROZEN_DAY}`);
     // TTL armed on first write (~25h).
     expect(mockSys.expire).toHaveBeenCalledWith(key, 25 * 60 * 60);
     expect(sysStore.get(key)).toBe(100);
@@ -184,7 +182,7 @@ describe('refundBlockTipSpend', () => {
     expect(mockSys.decrBy).toHaveBeenCalledWith(yesterdayKey, 500);
     expect(sysStore.get(yesterdayKey)).toBe(0);
     // The current-day key is untouched.
-    expect(sysStore.get(`system:blocks:tip-cap:42:${todayKey()}`)).toBeUndefined();
+    expect(sysStore.get(`system:blocks:tip-cap:42:${FROZEN_DAY}`)).toBeUndefined();
   });
 
   it('is best-effort — a failed DECRBY never throws (a lost refund only over-counts)', async () => {
@@ -231,7 +229,7 @@ describe('readBlockTipAllowance (item 4)', () => {
   it('reads the CURRENT-day key (same key the reserve path mutates)', async () => {
     await reserveBlockTipSpend(7, 100);
     await readBlockTipAllowance(7);
-    expect(mockSys.get).toHaveBeenCalledWith(`system:blocks:tip-cap:7:${todayKey()}`);
+    expect(mockSys.get).toHaveBeenCalledWith(`system:blocks:tip-cap:7:${FROZEN_DAY}`);
   });
 
   it('CLAMPS remaining at 0 when a straddling over-cap reservation pushed spent past the cap', async () => {


### PR DESCRIPTION
## What

Follow-up to #4742. That PR fixed a wall-clock flake in `app-spend-cap.service.test.ts` and disclosed that sibling suites carried the same shape.

🔴 **This PR was originally three files. Round 0 of the audit cut it to two** — see the correction note at the bottom; the earlier description is wrong and is corrected here rather than quietly rewritten.

Both remaining files derive a key from the wall clock and then assert an **exact** count. A boundary landing inside a loop makes the assertion wrong for a reason that has nothing to do with the code.

## Every claim here is a measurement

Each file was made to **fail at its own base first**, with a probe that advances the clock a fixed step per read and parks the boundary inside the loop — the CI-slowness condition, made deterministic.

| file | boundary | red at base | after |
|---|---|---|---|
| `app-spend-cap-rejection-signal.test.ts` | 60 s velocity bucket | `expected 44 to be 47` | 13/13, probe-immune |
| `block-tip-rate-limit.test.ts` | UTC midnight, via an import-time constant | freezing **alone** fails 2/29 | 29/29, probe-immune |

- **rejection-signal** is the same service and the same 60 s bucket as #4742. With the boundary ~25 calls into the 50-iteration loop, 3 submits are allowed in *each* of two buckets instead of 3 in one, so the denial total comes up short.
- **block-tip** held its day string in a **module-level `const` evaluated at import**. A `beforeEach` freeze cannot move it — the constant is already computed — so it keeps the real date while the service returns the frozen one. Measured: freeze-only fails 2 of 29 with `expected 'system:blocks:tip-cap:42:2026-07-31' to be 'system:blocks:tip-cap:42:2026-09-10'`.

## The expectation is now a literal, and that is a defect fix

The first version of this PR replaced that constant with a `todayKey()` function computing `new Date().toISOString().slice(0, 10)` — **byte-identical to the expression the implementation uses** (`tipCapWindowKey`, `block-tip-rate-limit.ts:100`). An expectation built that way moves *with* the implementation and can never catch it changing: the "never derive a test's expectation from the implementation it tests" trap.

It is now `const FROZEN_DAY = '2026-07-31'` — an **independent** expectation, and simply less machinery. 29/29 with the literal at all three call sites.

🔴 **This paragraph previously claimed the literal would catch production switching to a local-date derivation, "which the derived form never could". That was FALSE and is retracted** (audit round 1). Measured, mutating `tipCapWindowKey` to `toLocaleDateString('en-CA')`: the literal **survives** under `TZ=UTC` and `America/Winnipeg` (29/29) and dies only at UTC+13/+14 — `FROZEN_CLOCK` is 12:00:30Z, so local and UTC dates agree at every offset inside ±12 h, which is every deployment TZ including CI's. And the control that settles it: a **frozen-but-derived** expectation survives that mutant too (29/29 at both TZs), so the two forms are **equivalent** against it. The unfrozen base did catch it — but only via the import-vs-call-time skew that is the bug being fixed, so that is not coverage worth keeping. The literal stays for independence and simplicity; it does not buy a detection property.

## What was dropped, and why

`app-bounty-cap.service.test.ts` is **no longer touched**. Round 0 measured its exposure at roughly **1 in 7.2 million per run** — a 12 ms test against a 24 h boundary, and the ordering is unchanged even at a generous 50× slow-CI factor. That does not justify ~25 lines of comment, a clock pin, and an `afterEach` whose only job is to undo the pin.

The requirement that pulled it in was never stated by anyone — *"all four suites should be internally consistent"* — and the audit named it. The reverts were taken against the **branch point**, not current `main`, and the file was verified unchanged upstream in between, so nothing of anyone else's rode in.

## Scope and collateral

Test-only; no production file is touched. The frozen instant matches #4742 (mid-bucket **and** mid-day) for the 60 s-bucket file.

Both touched files gain an `afterEach` handing the clock back — neither had one. To rule out a leaked fake timer changing a neighbouring file, the whole of `src/server/services/blocks/__tests__` plus `src/server/utils/__tests__` was run: **241 files / 4,984 tests green** (measured on the three-file version; the current diff is a strict subset of it).

`block-tip-rate-limit.test.ts` did not satisfy `prettier --check` at base, so formatting it rewrapped one pre-existing block.

---

### 🔴 Correction to this description

The original version of this description claimed **three** files and presented `todayKey()` as *"the interesting part"* of the fix. Both are now wrong: the third file was dropped, and that function was removed as a defect. Corrected in place rather than deleted, because a reviewer may already have read it.

