### PR TITLE
fix(images): serve a 2x variant on post detail and the model showcase

### DIFF
--- a/src/client-utils/__tests__/cf-images-utils.test.ts
+++ b/src/client-utils/__tests__/cf-images-utils.test.ts
@@ -11,7 +11,11 @@ vi.mock('~/env/client', () => ({
 
 import {
   COMMON_IMAGE_WIDTHS,
+  MAX_EDGE_WIDTH,
+  SRCSET_DPR,
   getEdgeUrl,
+  getEdgeUrlSrcSet,
+  resolveOptimized,
   snapWidthToCommonSize,
 } from '~/client-utils/cf-images-utils';
 
@@ -77,5 +81,78 @@ describe('getEdgeUrl width snapping', () => {
   it('does not snap height', () => {
     const url = getEdgeUrl(SRC, { height: 451 });
     expect(url).toContain('height=451');
+  });
+});
+
+describe('getEdgeUrlSrcSet', () => {
+  const SRC = 'abc-image-uuid';
+
+  const descriptors = (srcSet: string | undefined) =>
+    (srcSet ?? '').split(', ').map((entry) => {
+      const [url, descriptor] = entry.split(' ');
+      return { width: Number(url.match(/width=(\d+)/)?.[1]), descriptor };
+    });
+
+  it('pairs the requested width with a variant one ladder-snapped doubling up', () => {
+    // Post detail renders an 800 CSS px box; a 2x display needs 1600 real pixels.
+    expect(descriptors(getEdgeUrlSrcSet(SRC, { width: 800 }))).toEqual([
+      { width: 800, descriptor: '1x' },
+      { width: 1600, descriptor: `${SRCSET_DPR}x` },
+    ]);
+  });
+
+  it('snaps both descriptors onto the ladder', () => {
+    // 451 -> 512; 902 -> 1200. Neither number appears verbatim.
+    expect(descriptors(getEdgeUrlSrcSet(SRC, { width: 451 }))).toEqual([
+      { width: 512, descriptor: '1x' },
+      { width: 1200, descriptor: `${SRCSET_DPR}x` },
+    ]);
+  });
+
+  it('carries every other option onto BOTH variants', () => {
+    // The 2x URL losing `optimized` is the expensive failure: unoptimized, the 1600px
+    // variant of a detailed image measures ~1MB against ~305kB.
+    const srcSet = getEdgeUrlSrcSet(SRC, { width: 800, optimized: true, anim: false });
+    const urls = (srcSet ?? '').split(', ');
+    expect(urls).toHaveLength(2);
+    for (const url of urls) {
+      expect(url).toContain('optimized=true');
+      expect(url).toContain('anim=false');
+    }
+  });
+
+  it('omits the attribute when the 2x variant cannot exceed the 1x one', () => {
+    // Both clamp to MAX_EDGE_WIDTH, so a srcSet here would list the same URL twice.
+    expect(getEdgeUrlSrcSet(SRC, { width: MAX_EDGE_WIDTH })).toBeUndefined();
+  });
+
+  it('omits the attribute for original and for width-less requests', () => {
+    expect(getEdgeUrlSrcSet(SRC, { width: 800, original: true })).toBeUndefined();
+    expect(getEdgeUrlSrcSet(SRC, {})).toBeUndefined();
+  });
+
+  it('omits the attribute for a src the edge does not serve', () => {
+    expect(getEdgeUrlSrcSet('https://example.test/a.png', { width: 800 })).toBeUndefined();
+    expect(getEdgeUrlSrcSet('blob:whatever', { width: 800 })).toBeUndefined();
+  });
+});
+
+describe('resolveOptimized', () => {
+  it('forces the optimized format for a hi-DPI request whatever the preference', () => {
+    expect(resolveOptimized({ width: 800, hiDpi: true, imageFormat: 'metadata' })).toBe(true);
+  });
+
+  it('leaves a plain wide request on the user preference', () => {
+    expect(resolveOptimized({ width: 800, imageFormat: 'metadata' })).toBe(false);
+    expect(resolveOptimized({ width: 800, imageFormat: 'optimized' })).toBe(true);
+  });
+
+  it('still forces it below the small-preview threshold', () => {
+    expect(resolveOptimized({ width: 450, imageFormat: 'metadata' })).toBe(true);
+  });
+
+  it('leaves an original request on the user preference', () => {
+    // hiDpi never reaches an original request, so the lightbox and downloads keep honouring it.
+    expect(resolveOptimized({ imageFormat: 'metadata' })).toBe(false);
   });
 });

--- a/src/client-utils/__tests__/cf-images-utils.test.ts
+++ b/src/client-utils/__tests__/cf-images-utils.test.ts
@@ -121,6 +121,24 @@ describe('getEdgeUrlSrcSet', () => {
     }
   });
 
+  it('escapes whitespace in a name so the candidate is not silently dropped', () => {
+    // A raw space TERMINATES a srcset URL: the rest of the filename is read as the
+    // descriptor, found invalid, and the candidate is dropped — leaving the browser on
+    // `src`, i.e. 1x, with no error. Image names routinely contain spaces.
+    const srcSet = getEdgeUrlSrcSet(SRC, { width: 800, name: 'Unstable Bastard_312879214.png' });
+    // Every candidate must be `<url><space><descriptor>` with no space inside the url.
+    for (const candidate of (srcSet ?? '').split(', ')) {
+      const [url, descriptor, ...extra] = candidate.split(' ');
+      expect(extra).toEqual([]);
+      expect(descriptor).toMatch(/^\dx$/);
+      expect(url).toContain('%20');
+    }
+    expect(descriptors(srcSet)).toEqual([
+      { width: 800, descriptor: '1x' },
+      { width: 1600, descriptor: `${SRCSET_DPR}x` },
+    ]);
+  });
+
   it('omits the attribute when the 2x variant cannot exceed the 1x one', () => {
     // Both clamp to MAX_EDGE_WIDTH, so a srcSet here would list the same URL twice.
     expect(getEdgeUrlSrcSet(SRC, { width: MAX_EDGE_WIDTH })).toBeUndefined();

--- a/src/client-utils/cf-images-utils.ts
+++ b/src/client-utils/cf-images-utils.ts
@@ -3,8 +3,9 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useBrowsingSettings } from '~/providers/BrowserSettingsProvider';
 import {
   getEdgeUrl,
+  getEdgeUrlSrcSet,
   getInferredMediaType,
-  shouldForceOptimized,
+  resolveOptimized,
   type EdgeUrlProps,
 } from '~/client-utils/edge-url';
 
@@ -14,20 +15,28 @@ import {
 export {
   COMMON_IMAGE_WIDTHS,
   OPTIMIZED_WIDTH_THRESHOLD,
+  SRCSET_DPR,
   getEdgeUrl,
+  getEdgeUrlSrcSet,
   getInferredMediaType,
+  resolveOptimized,
   shouldForceOptimized,
   snapWidthToCommonSize,
 } from '~/client-utils/edge-url';
 export type { EdgeUrlProps } from '~/client-utils/edge-url';
 
-export function useEdgeUrl(src: string, options: Omit<EdgeUrlProps, 'src'> | undefined) {
+/** @param hiDpi emit a 2x `srcSet` variant, and force the optimized format — see `resolveOptimized`. */
+export function useEdgeUrl(
+  src: string,
+  options: Omit<EdgeUrlProps, 'src'> | undefined,
+  hiDpi?: boolean
+) {
   const currentUser = useCurrentUser();
   const inferredType = getInferredMediaType(src, options);
   let type = options?.type ?? inferredType;
 
   if (!src || src.startsWith('http') || src.startsWith('blob'))
-    return { url: src, type: inferredType };
+    return { url: src, srcSet: undefined, type: inferredType };
 
   let { anim, transcode } = options ?? {};
 
@@ -40,22 +49,26 @@ export function useEdgeUrl(src: string, options: Omit<EdgeUrlProps, 'src'> | und
   }
 
   if (!anim) type = 'image';
-  // Threshold lives in `edge-url` so anything that has to reproduce this decision
-  // outside React (the announcement banner health monitor) cannot drift from it.
-  const shouldOptimize = shouldForceOptimized(options?.width);
-  const optimized =
-    options?.optimized ||
-    shouldOptimize ||
-    currentUser?.filePreferences?.imageFormat === 'optimized';
+  // Decided in `edge-url` so anything that has to reproduce this outside React (the
+  // announcement banner health monitor) cannot drift from it.
+  const optimized = resolveOptimized({
+    optimized: options?.optimized,
+    width: options?.width,
+    hiDpi,
+    imageFormat: currentUser?.filePreferences?.imageFormat,
+  });
+
+  const resolved = {
+    ...options,
+    anim,
+    transcode,
+    type,
+    optimized: optimized ? true : undefined,
+  };
 
   return {
-    url: getEdgeUrl(src, {
-      ...options,
-      anim,
-      transcode,
-      type,
-      optimized: optimized ? true : undefined,
-    }),
+    url: getEdgeUrl(src, resolved),
+    srcSet: hiDpi ? getEdgeUrlSrcSet(src, resolved) : undefined,
     type,
   };
 }

--- a/src/client-utils/edge-url.ts
+++ b/src/client-utils/edge-url.ts
@@ -69,6 +69,30 @@ export function shouldForceOptimized(width?: number | null) {
 }
 
 /**
+ * The `optimized` flag the render path emits.
+ *
+ * `hiDpi` forces it because the 2x variant is where the format choice stops being free:
+ * unoptimized, a 1600px variant of a detailed image measures ~1MB against ~305kB optimized.
+ * Nothing a user picked is lost — a resized variant is re-encoded, so the generation
+ * parameters carried in the source PNG's `tEXt` chunk are absent from it in either format.
+ * `original` requests never reach here with `hiDpi`, so the preference still governs the
+ * lightbox and downloads.
+ */
+export function resolveOptimized({
+  optimized,
+  width,
+  hiDpi,
+  imageFormat,
+}: {
+  optimized?: boolean;
+  width?: number | null;
+  hiDpi?: boolean;
+  imageFormat?: string | null;
+}) {
+  return !!(optimized || shouldForceOptimized(width) || hiDpi || imageFormat === 'optimized');
+}
+
+/**
  * Snap a requested width up to the next value in `COMMON_IMAGE_WIDTHS`.
  *
  * Behavior matches `ServeImageMiddleware.cs` in civitai-image-cacher:
@@ -76,7 +100,7 @@ export function shouldForceOptimized(width?: number | null) {
  *  - Otherwise, return the first ladder value strictly greater than `width`.
  *  - If no ladder value is greater (i.e. the request exceeds the ladder top),
  *    return the original width unchanged so callers that explicitly oversized
- *    aren't capped here. The existing 1800 cap in `getEdgeUrl` still applies.
+ *    aren't capped here. `clampEdgeWidth` still applies.
  */
 export function snapWidthToCommonSize(width: number): number {
   for (const size of COMMON_IMAGE_WIDTHS) {
@@ -84,6 +108,48 @@ export function snapWidthToCommonSize(width: number): number {
     if (size > width) return size;
   }
   return width;
+}
+
+/** Ceiling `getEdgeUrl` applies to a requested width, after the ladder snap. */
+export const MAX_EDGE_WIDTH = 1800;
+
+export function clampEdgeWidth(width: number) {
+  return Math.min(width, MAX_EDGE_WIDTH);
+}
+
+/**
+ * Device-pixel-ratio the hi-DPI `srcSet` targets.
+ *
+ * 3x is deliberately not offered: at the widths these surfaces request it clears the ladder
+ * top and lands on `MAX_EDGE_WIDTH`, so a 3x candidate would buy 1800px over 1600px — 12%
+ * more pixels for a whole extra variant to generate, cache and download.
+ */
+export const SRCSET_DPR = 2;
+
+/**
+ * `srcSet` pairing the 1x variant with one sized for a `SRCSET_DPR` display.
+ *
+ * x-descriptors rather than a `devicePixelRatio` read: the ratio is unknown during SSR, so
+ * choosing a width from it would emit different markup on server and client — a hydration
+ * mismatch, and a second download of whichever variant lost. The browser resolves a
+ * descriptor list itself, before React runs.
+ *
+ * Returns undefined when the 2x variant would land on the same rung as the 1x one, so the
+ * attribute is omitted rather than listing one URL twice.
+ */
+export function getEdgeUrlSrcSet(src: string, options: Omit<EdgeUrlProps, 'src'> = {}) {
+  const { width, original } = options;
+  if (!src || src.startsWith('http') || src.startsWith('blob')) return undefined;
+  if (!width || original) return undefined;
+
+  const base = clampEdgeWidth(snapWidthToCommonSize(width));
+  const scaled = clampEdgeWidth(snapWidthToCommonSize(width * SRCSET_DPR));
+  if (scaled <= base) return undefined;
+
+  return [
+    `${getEdgeUrl(src, { ...options, width: base })} 1x`,
+    `${getEdgeUrl(src, { ...options, width: scaled })} ${SRCSET_DPR}x`,
+  ].join(', ');
 }
 
 export function getEdgeUrl(
@@ -118,8 +184,7 @@ export function getEdgeUrl(
   // Snap width to the cacher's CommonSizes ladder *before* the 1800 cap so the cap
   // remains the final word for over-ladder values. Height is not snapped — the
   // cacher only snaps width.
-  if (width) width = snapWidthToCommonSize(width);
-  if (width && width > 1800) width = 1800;
+  if (width) width = clampEdgeWidth(snapWidthToCommonSize(width));
   if (height && height > 1000) height = 1000;
 
   const modifiedParams = {

--- a/src/client-utils/edge-url.ts
+++ b/src/client-utils/edge-url.ts
@@ -147,9 +147,28 @@ export function getEdgeUrlSrcSet(src: string, options: Omit<EdgeUrlProps, 'src'>
   if (scaled <= base) return undefined;
 
   return [
-    `${getEdgeUrl(src, { ...options, width: base })} 1x`,
-    `${getEdgeUrl(src, { ...options, width: scaled })} ${SRCSET_DPR}x`,
+    `${srcSetSafe(getEdgeUrl(src, { ...options, width: base }))} 1x`,
+    `${srcSetSafe(getEdgeUrl(src, { ...options, width: scaled }))} ${SRCSET_DPR}x`,
   ].join(', ');
+}
+
+/**
+ * A delivery URL ends in the image's `name`, which routinely contains spaces
+ * ("..._Unstable Bastard_312879214.png"). `src` tolerates that — the browser encodes it — but
+ * in `srcset` whitespace TERMINATES the URL, so the rest of the filename is read as the
+ * descriptor, found invalid, and the candidate is silently dropped. Every candidate drops and
+ * the browser falls back to `src`, i.e. the 1x variant, with no error anywhere.
+ *
+ * Only ASCII whitespace needs escaping, and each character is encoded as itself: the srcset
+ * parser ends a URL at whitespace alone, so the commas `getEdgeUrl` puts in the params segment
+ * are already safe where they sit, and a non-breaking space is not a terminator — rewriting one
+ * to %20 would request a different object than `src` does.
+ */
+function srcSetSafe(url: string) {
+  return url.replace(
+    /[\t\n\f\r ]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0')}`
+  );
 }
 
 export function getEdgeUrl(

--- a/src/components/EdgeMedia/EdgeImage.tsx
+++ b/src/components/EdgeMedia/EdgeImage.tsx
@@ -12,17 +12,23 @@ export type EdgeImageProps = React.ImgHTMLAttributes<HTMLImageElement> & {
   options: Omit<EdgeUrlProps, 'src'>;
   /** Database image ID — included in drag data so drop targets can look up metadata server-side */
   imageId?: number;
+  /** Also serve a variant sized for a 2x display. See `useEdgeUrl`. */
+  hiDpi?: boolean;
 };
 
 export const EdgeImage = forwardRef<HTMLImageElement, EdgeImageProps>(
   (
-    { className, fadeIn, src, options, style, onLoad, onError, imageId, ...props },
+    { className, fadeIn, src, options, style, onLoad, onError, imageId, hiDpi, ...props },
     forwardedRef
   ) => {
     // const ref = useRef<HTMLImageElement>(null);
     // TODO - determine how we can animate cosmetics
     const { anim, ...rest } = options ?? {};
-    const { url } = useEdgeUrl(src, anim !== false ? rest : { ...rest, anim: false });
+    const { url, srcSet } = useEdgeUrl(
+      src,
+      anim !== false ? rest : { ...rest, anim: false },
+      hiDpi
+    );
 
     // useImperativeHandle(forwardedRef, () => ref.current as HTMLImageElement);
 
@@ -47,6 +53,7 @@ export const EdgeImage = forwardRef<HTMLImageElement, EdgeImageProps>(
         onLoad={handleLoad}
         onError={handleError}
         src={url}
+        srcSet={srcSet}
         style={{ maxWidth: options?.width ? options.width : undefined, ...style }}
         onDragStart={(e) => {
           setMediaDragData(e.dataTransfer, { url, mediaId: imageId || undefined, type: 'image' });

--- a/src/components/EdgeMedia/EdgeMedia.tsx
+++ b/src/components/EdgeMedia/EdgeMedia.tsx
@@ -34,6 +34,8 @@ export type EdgeMediaProps = EdgeUrlProps &
     imageProps?: React.HTMLAttributes<HTMLImageElement>;
     /** Database image ID — forwarded to EdgeImage for drag-and-drop metadata lookup */
     imageId?: number;
+    /** Also serve a variant sized for a 2x display. Images only. See `useEdgeUrl`. */
+    hiDpi?: boolean;
   };
 
 export function EdgeMedia({
@@ -71,6 +73,7 @@ export function EdgeMedia({
   imageProps,
   optimized,
   imageId,
+  hiDpi,
   ...imgProps
 }: EdgeMediaProps) {
   const imgRef = useRef<HTMLImageElement>(null);
@@ -109,6 +112,7 @@ export function EdgeMedia({
           className={className}
           style={style}
           imageId={imageId}
+          hiDpi={hiDpi}
           {...imgProps}
           {...imageProps}
         />

--- a/src/components/Model/ModelCarousel/ModelCarousel.tsx
+++ b/src/components/Model/ModelCarousel/ModelCarousel.tsx
@@ -167,7 +167,7 @@ function ModelCarouselContent({ modelId, modelVersionId, modelUserId, limit = 10
                               >
                                 <ImagePreview
                                   image={image}
-                                  edgeImageProps={{ width: 800 }}
+                                  edgeImageProps={{ width: 800, hiDpi: features.hiDpiPreviews }}
                                   aspectRatio={(image.width ?? 1) / (image.height ?? 1)}
                                   // radius="md"
                                   style={{ width: '100%' }}

--- a/src/components/Post/Detail/PostImages.tsx
+++ b/src/components/Post/Detail/PostImages.tsx
@@ -182,6 +182,7 @@ export function PostImages({
                               type={image.type}
                               imageId={image.id}
                               width={width < maxWidth ? width : maxWidth}
+                              hiDpi={features.hiDpiPreviews}
                               original={image.type === 'video'}
                               anim={safe}
                               html5Controls={showsControlStrip}

--- a/src/components/ResourceReview/ResourceReviewCarousel.tsx
+++ b/src/components/ResourceReview/ResourceReviewCarousel.tsx
@@ -9,6 +9,7 @@ import { ImageContextMenu } from '~/components/Image/ContextMenu/ImageContextMen
 import { useQueryImages } from '~/components/Image/image.utils';
 import { ImageMetaPopover2 } from '~/components/Image/Meta/ImageMetaPopover';
 import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 
 import { MediaHash } from '~/components/ImageHash/ImageHash';
 import { Reactions } from '~/components/Reaction/Reactions';
@@ -28,6 +29,7 @@ export function ResourceReviewCarousel({
   reviewId: number;
 }) {
   const mobile = useContainerSmallerThan('md');
+  const features = useFeatureFlags();
 
   // today, typescript was not cool.
   // functions will only check extra parameters if it's fresh
@@ -87,6 +89,7 @@ export function ResourceReviewCarousel({
                                 alt={image.name ?? undefined}
                                 type={image.type}
                                 width={800}
+                                hiDpi={features.hiDpiPreviews}
                                 placeholder="empty"
                                 style={{ width: '100%', objectPosition: 'top' }}
                               />

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -191,6 +191,24 @@ const featureFlags = createFeatureFlags({
   // with `enabled: false` and no rollout hides the bar for everyone, moderators included.
   // Until that flag exists, evaluation returns null and static evaluation keeps it on.
   feedTagBar: { availability: ['public'], fliptKey: 'feed-tag-bar' },
+  // Serve post-detail and model-page showcase images a `srcSet` carrying a 2x variant, and
+  // force the optimized format there whatever the user's `imageFormat` preference. Without
+  // it those surfaces request a width in CSS pixels and every DPR>=2 display upscales:
+  // measured 1.82x on post detail at DPR 2, 1.38x on an iPhone (ClickUp 868m36wyd).
+  //
+  // `['public']` and NOT `[]`: the 2x variant is also the OPTIMIZED one, so for a user on
+  // the default `imageFormat: 'metadata'` it is FEWER bytes than the unoptimized JPEG shipped
+  // today (measured 305kB vs 421kB), and the Flipt-down fallback should be the cheaper,
+  // sharper path. So DO NOT create `hi-dpi-previews` in flipt-state to ship this: while it
+  // does not exist, evaluation returns null and static evaluation keeps it on. Creating it as
+  // a boolean with `enabled: false` and no rollout IS the kill switch — Flipt's answer
+  // overrides static evaluation in both directions.
+  //
+  // Deliberately NOT applied to card feeds (`/images`, the model-page gallery). Those request
+  // 450, whose 2x doubles to 900 and then snaps to the 1200 rung — ~3.7x the bytes (60kB ->
+  // 221kB) on an infinitely scrolling surface, for a box that only renders ~318 CSS px. Wants a
+  // ~900 rung in civitai-image-cacher's `CommonSizes` before it can be turned on there.
+  hiDpiPreviews: { availability: ['public'], fliptKey: 'hi-dpi-previews' },
   // `availability: []` is the Flipt-down fallback, and off is the right one here: the search
   // refinement is useless until the gated documents carry `hasActivePaidAccess`, which is a backfill
   // and an index-settings change, not a deploy.


### PR DESCRIPTION
Closes the blur half of [868m36wyd](https://app.clickup.com/t/868m36wyd) (Freshdesk #71618, reported by RisingV).

## The bug

Every image URL carries a width in **CSS** pixels and nothing else. `srcSet` is explicitly excluded from `EdgeMediaProps`, and the only `devicePixelRatio` reads in `src/` are an audio waveform and the 3D viewer. So on a DPR≥2 display the browser upscales by DPR — everywhere, by construction. It is invisible at DPR 1, which is why it survives local testing and reads to users as "shown at ~2× its stored size".

Measured on prod with Playwright at real device-pixel ratios, on RisingV's own image:

| Surface | Viewport @ DPR | CSS px | Device px | Served | Upscale |
|---|---|---|---|---|---|
| **Post detail** | 1440 @2x | 728 | 1456 | 800 | **1.82×** |
| **Post detail** | 393 @3x (iPhone) | 369 | 1107 | 800 | **1.38×** |
| Model showcase carousel | 1440 @2x | 351 | 702 | 800 | 0.88× ✅ |
| Card feeds (`/images`, model gallery) | 1440 @2x | ~318 | ~636 | 450 | 1.41–1.85× |
| Image-detail lightbox | any | — | — | `original` | 1.00× ✅ |

457c96cc69 raised two call sites 450 → 800 by hand. That works for the showcase carousel because its box is small; it cannot help post detail, whose box **is** 800 CSS px.

## The fix

`EdgeImage` emits `srcSet` x-descriptors when a call site opts in with `hiDpi`.

**x-descriptors rather than reading `devicePixelRatio`**: the ratio is unknown during SSR, so picking a width from it would emit different markup on server and client — a hydration mismatch plus a second download of whichever variant lost. The browser resolves the list itself, before React runs.

**`hiDpi` also forces the optimized format**, whatever the user's `imageFormat` preference. That is what pays for the extra pixels:

| Variant (same image) | Bytes | Type |
|---|---|---|
| `width=800` — what post detail serves today | **421 kB** | JPEG q90 |
| `width=800,optimized=true` | 136 kB | WebP |
| `width=1600` | 1 018 kB | JPEG q90 |
| **`width=1600,optimized=true`** | **305 kB** | WebP |

The default `imageFormat` is `'metadata'` (unoptimized), so for most users the **2× variant is fewer bytes than what ships today** — 305 kB against 421 kB.

Nothing the user chose is lost. A resized variant is re-encoded, so the generation parameters in the source PNG's `tEXt` chunk are absent from it either way: the unoptimized 800 px JPEG carries 188 bytes of encoder boilerplate (resolution, ColorSpace, ExifVersion) and **no prompt**. `original` requests never set `hiDpi`, so the lightbox and downloads still honour the preference.

## Scope, and what is deliberately left out

Opted in: **post detail**, **model showcase carousel**, **resource review carousel**.

**Card feeds are deliberately excluded** (`/images`, the model-page gallery). They request 450, which doubles to 900 and then snaps to the **1200** rung — the ladder has nothing between 512 and 800 — for a box that renders ~318 CSS px. That is ~3.7× the bytes (60 kB → 221 kB) on an infinitely scrolling surface. It wants a ~900 rung in civitai-image-cacher's `CommonSizes` first.

**The showcase carousel keeps its 800.** I was going to walk it back to 450 as double-counted DPR compensation, then measured the box across viewports: it is 427 CSS px on desktop but **744 px at a 768 viewport**, because below the `@md` container breakpoint the slide is `flex-[0_0_100%]`. Desktop therefore over-serves (1600 px for an 854 device-px box). `sizes` + `w` descriptors would fix that, but the breakpoint is a **container** query and `sizes` cannot express one.

**AVIF is not in this PR.** The image cacher does no content negotiation and has no AVIF path — `Accept: image/avif,…` still returns WebP, and a `format=avif` URL segment is silently ignored. RisingV's AVIF recommendation is a civitai-image-cacher change, and his own caveat about encode compute is the open question there.

**The crop half of the ticket is not in this PR either.** `ImagePreview` clamps `aspectRatio ??= Math.max(w/h, 9/16)` with `objectFit: 'cover'`, so anything taller than 9:16 is centre-cropped. `ModelCarousel` passes an explicit unclamped ratio and is exempt; other call sites are not. Worth deciding per call site whether that crop is intended.

## Flag

`hiDpiPreviews` / `hi-dpi-previews`, `availability: ['public']`.

🔴 **Do not create `hi-dpi-previews` in flipt-state to ship this.** While it does not exist, evaluation returns null and static evaluation keeps it on. Creating it as a boolean with `enabled: false` and no rollout **is** the kill switch — Flipt's answer overrides static evaluation in both directions. Same shape as `feedTagBar`.

## Verification

Measured on a local dev server, before → after:

| Surface | DPR | Before | After |
|---|---|---|---|
| Post detail | 1x | 0.91× (421 kB JPEG) | 0.91× (34 kB WebP) |
| **Post detail** | **2x** | **1.82×** | **0.91×** |
| Post detail | 3x | 2.73× | 1.36× |
| Model showcase | 2x | 1.07× | 0.53× |

- `pnpm run typecheck` — 0 errors
- `cf-images-utils` suite — 19 tests. Mutation-checked both ways that matter: dropping `hiDpi` from `resolveOptimized`, and dropping the options spread from the 1x URL, each fail with a readable assertion rather than passing quietly.
- `pnpm run test:lint-rules` — 36 files / 501 tests
- feature-flag suites (lazy-equivalence, early-adopter seam) — 33 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AHshP7h4ng3mi6dkePEas
