### PR TITLE
fix(model-files): read a packaging scheme from the file name when no dtype can state it

### DIFF
--- a/src/components/Resource/FilesProvider.precision-autofill.browser.test.tsx
+++ b/src/components/Resource/FilesProvider.precision-autofill.browser.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import type * as TrpcModule from '~/utils/trpc';
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * The wiring, not the rule. `resolveUploadPrecision` is covered by
+ * `src/utils/__tests__/file-helpers.precision-filename-fallback.test.ts`; what nothing else
+ * reaches is the three lines in `onDrop` that carry its answer into the file record.
+ *
+ * 🔑 The name reaches it with its ORIGINAL case on purpose. The extension check just above
+ * lowercases into a local, and passing that local instead — which reads like an obvious tidy —
+ * silently kills every camelCase match, because the word-start rule needs the hump. A unit test
+ * calling the helper directly cannot see that; this one can, which is the reason it exists.
+ *
+ * No `version` is passed, so the auto-start upload effect returns early: this test transfers no
+ * bytes and touches no S3.
+ *
+ * Each case waits for the field to STOP being empty and then asserts the value synchronously,
+ * rather than polling for the right value. Both arrive on the same tick, so polling for the value
+ * would burn the full 15 s matcher budget on every wrong answer and report it as a slow test —
+ * `expected nvfp4, received fp32` in 15 s reads like an environment problem. This way a wrong
+ * value fails in under a second, saying the same thing.
+ */
+
+const noMutation = vi.hoisted(() => () => ({
+  mutateAsync: vi.fn(),
+  mutate: vi.fn(),
+  isLoading: false,
+}));
+
+// Only the `trpc` client is overridden; the module's other exports are kept via importOriginal
+// so a consumer elsewhere in the tree doesn't get `undefined` and silently collect zero tests.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    useUtils: () => ({ modelFile: { hasOfficialFileOfSize: { fetch: vi.fn() } } }),
+    // Undefined data makes useModelFileOptions fall back to constants.modelFileFp, which is the
+    // real list this runs against in production until the query resolves.
+    modelFile: {
+      getOptions: { useQuery: () => ({ data: undefined }) },
+      create: { useMutation: noMutation },
+    },
+    modelVersion: {
+      setLinkedComponents: { useMutation: noMutation },
+      linkOfficialFileByHash: { useMutation: noMutation },
+      addLinkedComponent: { useMutation: noMutation },
+      publish: { useMutation: noMutation },
+    },
+    model: { publish: { useMutation: noMutation } },
+  },
+}));
+vi.mock('~/hooks/useFileHash', () => ({ useFileHash: () => ({ hashFile: vi.fn() }) }));
+vi.mock('~/components/Resource/official-match', () => ({ resolveOfficialFileHash: vi.fn() }));
+
+import { FilesProvider, useFilesContext } from '~/components/Resource/FilesProvider';
+
+/** Real production header of ModelFile 3157252, MNeMiC's own NVFP4 checkpoint. */
+const NVFP4_HEADER: Array<[string, number, number]> = [
+  ['U8', 448, 6_077_550_752],
+  ['F32', 239, 1_280_582_832],
+  ['F8_E4M3', 224, 759_693_312],
+  ['BF16', 191, 689_669_120],
+];
+
+function safetensorsFile(name: string, dtypes: Array<[string, number, number]>) {
+  const header: Record<string, { dtype: string; data_offsets: [number, number] }> = {};
+  let offset = 0;
+  for (const [dtype, count, bytes] of dtypes) {
+    const per = Math.floor(bytes / count);
+    for (let i = 0; i < count; i++) {
+      header[`${dtype}.${i}`] = { dtype, data_offsets: [offset, offset + per] };
+      offset += per;
+    }
+  }
+  const json = new TextEncoder().encode(JSON.stringify(header));
+  const len = new Uint8Array(8);
+  new DataView(len.buffer).setBigUint64(0, BigInt(json.byteLength), true);
+  return new File([len, json], name);
+}
+
+function Harness({ file }: { file: File }) {
+  const { files, onDrop } = useFilesContext();
+  return (
+    <div>
+      <button onClick={() => onDrop([file])}>drop</button>
+      <span data-testid="fp">{files[0]?.fp ?? 'none'}</span>
+    </div>
+  );
+}
+
+function renderHarness(file: File) {
+  renderWithProviders(
+    <FilesProvider model={{ type: 'Checkpoint' }}>
+      <Harness file={file} />
+    </FilesProvider>
+  );
+}
+
+/** Drop the file, wait for detection to settle, and return whatever it settled on. */
+async function dropAndReadPrecision() {
+  await page.getByRole('button', { name: 'drop' }).click();
+  const field = page.getByTestId('fp');
+  await expect.element(field).not.toHaveTextContent('none');
+  return field.element().textContent;
+}
+
+describe('FilesProvider auto-fills precision from the name when the header cannot state it', () => {
+  test("MNeMiC's NVFP4 checkpoint lands as nvfp4, not the fp32 its header votes for", async () => {
+    renderHarness(safetensorsFile('KREAtivity_5.0_NVFP4.safetensors', NVFP4_HEADER));
+
+    expect(await dropAndReadPrecision()).toBe('nvfp4');
+  });
+
+  test('a camelCase name still matches, which is what breaks if the lowercased local is passed', async () => {
+    renderHarness(safetensorsFile('RawGirlKreaNVFP4.safetensors', NVFP4_HEADER));
+
+    expect(await dropAndReadPrecision()).toBe('nvfp4');
+  });
+
+  test('a header that can speak still wins over a name claiming a dtype-stateable precision', async () => {
+    renderHarness(safetensorsFile('some_model_fp8.safetensors', [['BF16', 4, 4_000_000]]));
+
+    expect(await dropAndReadPrecision()).toBe('bf16');
+  });
+});

--- a/src/components/Resource/FilesProvider.tsx
+++ b/src/components/Resource/FilesProvider.tsx
@@ -22,7 +22,9 @@ import {
   getModelFileFormat,
   inferGgufQuantType,
   inferSafetensorsPrecision,
+  resolveUploadPrecision,
 } from '~/utils/file-helpers';
+import { useModelFileOptions } from '~/hooks/useModelFileOptions';
 import { resolveOfficialFileHash } from '~/components/Resource/official-match';
 import { useFileHash } from '~/hooks/useFileHash';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -117,6 +119,7 @@ export const useFilesContext = () => {
 
 export function FilesProvider({ model, version, children }: FilesProviderProps) {
   const queryUtils = trpc.useUtils();
+  const { precisions } = useModelFileOptions();
   const { hashFile } = useFileHash();
   const upload = useS3UploadStore((state) => state.upload);
   const setItems = useS3UploadStore((state) => state.setItems);
@@ -570,7 +573,12 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
       const fileName = item.file.name.toLowerCase();
       if (fileName.endsWith('.safetensors') || fileName.endsWith('.sft')) {
         inferSafetensorsPrecision(item.file)
-          .then((fp) => {
+          .then((headerFp) => {
+            const fp = resolveUploadPrecision({
+              fileName: item.name,
+              headerFp,
+              precisions,
+            });
             if (fp) handleUpdateFile(item.uuid, { fp });
           })
           .catch(() => null);

--- a/src/utils/__tests__/file-helpers.precision-filename-fallback.test.ts
+++ b/src/utils/__tests__/file-helpers.precision-filename-fallback.test.ts
@@ -75,6 +75,18 @@ describe('upload precision: filename fallback under the header', () => {
     expect(resolveUploadPrecision({ fileName: file.name, headerFp, precisions })).toBe('bf16');
   });
 
+  // Both production headers happen to have their tensor COUNT order agree with their BYTE
+  // order, so they cannot tell the byte weighting from one-point-per-tensor. This one disagrees:
+  // scoring per tensor reads fp32.
+  it('decides the header vote on bytes, not on how many tensors carry a dtype', async () => {
+    const file = safetensorsFile('plain.safetensors', [
+      ['BF16', 2, 20_000_000],
+      ['F32', 50, 50_000],
+    ]);
+
+    expect(await inferSafetensorsPrecision(file)).toBe('bf16');
+  });
+
   it('keeps a scheme the header observed directly over a contradicting name', async () => {
     const file = safetensorsFile('something_nf4.safetensors', [
       ['F8_E4M3', 8, 8_000_000],
@@ -88,7 +100,7 @@ describe('upload precision: filename fallback under the header', () => {
 });
 
 describe('inferPrecisionFromFileName', () => {
-  it('prefers the longest option, so fp8_scaled is not read as fp8', () => {
+  it('reads a separator inside an option as optional', () => {
     expect(inferPrecisionFromFileName('mymodel_fp8_scaled.safetensors', precisions)).toBe(
       'fp8_scaled'
     );
@@ -97,8 +109,41 @@ describe('inferPrecisionFromFileName', () => {
     );
   });
 
+  // The live list cannot exercise the longest-first sort: no option in it is a word-start-legal
+  // prefix of another, and `fp4` inside `nvfp4` is refused by the word-start rule rather than by
+  // the ordering. It becomes load-bearing the moment a mod adds a variant of an existing option,
+  // which is what this pins — without the sort, `fp8_scaled` wins because it is listed first.
+  it('prefers the longest option when a shorter one is a legal prefix of it', () => {
+    expect(
+      inferPrecisionFromFileName('mymodel_fp8_scaled_v2.safetensors', [
+        ...precisions,
+        'fp8_scaled_v2',
+      ])
+    ).toBe('fp8_scaled_v2');
+  });
+
+  // `modelFileOptions` is trimmed but never lowercased, so a mod can add `FP8`. Without a
+  // case-folded filter it escapes the dtype-stateable check and overrides a correct header.
+  it('does not offer a dtype-stateable option a mod typed in capitals', () => {
+    expect(inferPrecisionFromFileName('mymodel_fp8.safetensors', [...precisions, 'FP8'])).toBe(
+      null
+    );
+  });
+
   it('accepts a camelCase hump as a word start', () => {
     expect(inferPrecisionFromFileName('RawGirlKreaNVFP4.safetensors', precisions)).toBe('nvfp4');
+  });
+
+  // Real prod names. A version number between the lowercase hump and the token is the common
+  // shape and must survive the rule that refuses job ids.
+  it('accepts a version number between the hump and the token', () => {
+    expect(inferPrecisionFromFileName('TzigoAnimeFlux_v2NF4.safetensors', precisions)).toBe('nf4');
+    expect(
+      inferPrecisionFromFileName('fluxedUpFluxNSFW_51NVFP4-Nunchaku.safetensors', precisions)
+    ).toBe('nvfp4');
+    expect(
+      inferPrecisionFromFileName('projectGaiaFlux1D_v20NF4Uncensored.safetensors', precisions)
+    ).toBe('nf4');
   });
 
   it('offers a precision a mod added at runtime and the constants do not carry', () => {
@@ -118,11 +163,20 @@ describe('inferPrecisionFromFileName', () => {
     expect(inferPrecisionFromFileName('lora_int4.safetensors', precisions)).toBe('int4');
   });
 
+  // 🔴 The digit-preceded ids are the ones that matter. Base32 is uppercase letters AND digits,
+  // so a rule that accepted any [a-z0-9] before an uppercase token minted `nf4` for 12 real prod
+  // job ids while every fixture here passed. Keep at least one digit-preceded id in this list.
   it('does not read a precision out of a trained-file job id', () => {
     expect(inferPrecisionFromFileName('PW2MQDNF4ZXWSGYEHXWCGH8B60.safetensors', precisions)).toBe(
       null
     );
     expect(inferPrecisionFromFileName('AGAGENF442Q05F8KABM73JT1C0.safetensors', precisions)).toBe(
+      null
+    );
+    expect(inferPrecisionFromFileName('F2NF4J1W4CGCKYETAEQJT9B5A0.safetensors', precisions)).toBe(
+      null
+    );
+    expect(inferPrecisionFromFileName('3HAF53NF4S8FDQMV8HC9Z8C300.safetensors', precisions)).toBe(
       null
     );
   });
@@ -137,5 +191,11 @@ describe('inferPrecisionFromFileName', () => {
     expect(inferPrecisionFromFileName('SM-FinetunePaint40Art-Remake.safetensors', precisions)).toBe(
       null
     );
+  });
+
+  // The only case `endsWord` decides on its own: a separator satisfies `startsWord`, so
+  // nothing else can refuse it.
+  it('does not read int4 out of a longer number at a word start', () => {
+    expect(inferPrecisionFromFileName('model_int40_fix.safetensors', precisions)).toBe(null);
   });
 });

--- a/src/utils/__tests__/file-helpers.precision-filename-fallback.test.ts
+++ b/src/utils/__tests__/file-helpers.precision-filename-fallback.test.ts
@@ -181,6 +181,19 @@ describe('inferPrecisionFromFileName', () => {
     );
   });
 
+  // Known-accepted, pinned so nobody reads the rule above as total coverage. Both shapes reach a
+  // word start with nothing in front to judge: the token at index 0, and the token behind a digit
+  // run that reaches the start of the name. 1 row in 40,351 job-id names, which is not worth a
+  // special case — if it becomes one, change these assertions, not the rule.
+  it('does accept a job id that begins with a precision token', () => {
+    expect(inferPrecisionFromFileName('NF4J1W4CGCKYETAEQJT9B5A0XY.safetensors', precisions)).toBe(
+      'nf4'
+    );
+    expect(inferPrecisionFromFileName('53NF4ZXWSGYEHXWCGH8B60.safetensors', precisions)).toBe(
+      'nf4'
+    );
+  });
+
   it('does not read int4 out of an ordinary word', () => {
     expect(
       inferPrecisionFromFileName(

--- a/src/utils/__tests__/file-helpers.precision-filename-fallback.test.ts
+++ b/src/utils/__tests__/file-helpers.precision-filename-fallback.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import { constants } from '~/server/common/constants';
+import {
+  inferPrecisionFromFileName,
+  inferSafetensorsPrecision,
+  resolveUploadPrecision,
+} from '~/utils/file-helpers';
+
+const precisions = [...constants.modelFileFp];
+
+/** Build a safetensors file whose header carries the given dtypes and byte shares. */
+function safetensorsFile(
+  name: string,
+  dtypes: Array<[dtype: string, count: number, bytes: number]>
+) {
+  const header: Record<string, { dtype: string; data_offsets: [number, number] }> = {};
+  let offset = 0;
+  for (const [dtype, count, bytes] of dtypes) {
+    const per = Math.floor(bytes / count);
+    for (let i = 0; i < count; i++) {
+      header[`${dtype}.${i}`] = { dtype, data_offsets: [offset, offset + per] };
+      offset += per;
+    }
+  }
+  const json = new TextEncoder().encode(JSON.stringify(header));
+  const len = new Uint8Array(8);
+  new DataView(len.buffer).setBigUint64(0, BigInt(json.byteLength), true);
+  return new File([len, json], name);
+}
+
+/**
+ * The two headers below are not invented. They were read from production on 2026-09-10 through
+ * `/api/v1/model-files/<id>/tensor-metadata`, which is why the byte shares are lopsided: the
+ * quantized bulk sits in U8, which the dtype mapper deliberately leaves unmapped, so the vote is
+ * decided by the housekeeping tensors that are left.
+ */
+const MXFP8_HEADER: Array<[string, number, number]> = [
+  ['F8_E4M3', 256, 12_498_501_632],
+  ['BF16', 174, 643_142_808],
+  ['U8', 256, 390_578_176],
+];
+const NVFP4_HEADER: Array<[string, number, number]> = [
+  ['U8', 448, 6_077_550_752],
+  ['F32', 239, 1_280_582_832],
+  ['F8_E4M3', 224, 759_693_312],
+  ['BF16', 191, 689_669_120],
+];
+
+describe('upload precision: filename fallback under the header', () => {
+  // 🔴 These two cases are the bug. Reverting resolveUploadPrecision to return the header answer
+  // makes them read 'fp8' and 'fp32' — the values production actually stored. Do not relax them
+  // into `toBeTruthy`; the wrong answer is a real precision, so only the exact value fails.
+  it('reads MXFP8 from the name when the scales were written as U8', async () => {
+    const file = safetensorsFile('krea2_finalcut_pro_mxfp8.safetensors', MXFP8_HEADER);
+    const headerFp = await inferSafetensorsPrecision(file);
+
+    expect(headerFp).toBe('fp8');
+    expect(resolveUploadPrecision({ fileName: file.name, headerFp, precisions })).toBe('mxfp8');
+  });
+
+  it('reads NVFP4 from the name when the weights were packed into U8', async () => {
+    const file = safetensorsFile('KREAtivity_5.0_NVFP4.safetensors', NVFP4_HEADER);
+    const headerFp = await inferSafetensorsPrecision(file);
+
+    expect(headerFp).toBe('fp32');
+    expect(resolveUploadPrecision({ fileName: file.name, headerFp, precisions })).toBe('nvfp4');
+  });
+
+  it('keeps the header when the name claims a precision a dtype can state', async () => {
+    const file = safetensorsFile('some_model_fp8.safetensors', [['BF16', 4, 4_000_000]]);
+    const headerFp = await inferSafetensorsPrecision(file);
+
+    expect(headerFp).toBe('bf16');
+    expect(resolveUploadPrecision({ fileName: file.name, headerFp, precisions })).toBe('bf16');
+  });
+
+  it('keeps a scheme the header observed directly over a contradicting name', async () => {
+    const file = safetensorsFile('something_nf4.safetensors', [
+      ['F8_E4M3', 8, 8_000_000],
+      ['F8_E8M0', 8, 250_000],
+    ]);
+    const headerFp = await inferSafetensorsPrecision(file);
+
+    expect(headerFp).toBe('mxfp8');
+    expect(resolveUploadPrecision({ fileName: file.name, headerFp, precisions })).toBe('mxfp8');
+  });
+});
+
+describe('inferPrecisionFromFileName', () => {
+  it('prefers the longest option, so fp8_scaled is not read as fp8', () => {
+    expect(inferPrecisionFromFileName('mymodel_fp8_scaled.safetensors', precisions)).toBe(
+      'fp8_scaled'
+    );
+    expect(inferPrecisionFromFileName('mymodel-fp8-scaled.safetensors', precisions)).toBe(
+      'fp8_scaled'
+    );
+  });
+
+  it('accepts a camelCase hump as a word start', () => {
+    expect(inferPrecisionFromFileName('RawGirlKreaNVFP4.safetensors', precisions)).toBe('nvfp4');
+  });
+
+  it('offers a precision a mod added at runtime and the constants do not carry', () => {
+    expect(constants.modelFileFp).not.toContain('mxfp6');
+    expect(inferPrecisionFromFileName('mymodel_mxfp6.safetensors', [...precisions, 'mxfp6'])).toBe(
+      'mxfp6'
+    );
+  });
+
+  // The positive control for the two negatives below: the same list, the same token, one
+  // legal boundary — so a null there is the boundary rule firing, not a matcher that
+  // can only ever return null.
+  it('matches nf4 and int4 when they start a word', () => {
+    expect(inferPrecisionFromFileName('PW2MQD_NF4_ZXWSGYEHXWCGH8B60.safetensors', precisions)).toBe(
+      'nf4'
+    );
+    expect(inferPrecisionFromFileName('lora_int4.safetensors', precisions)).toBe('int4');
+  });
+
+  it('does not read a precision out of a trained-file job id', () => {
+    expect(inferPrecisionFromFileName('PW2MQDNF4ZXWSGYEHXWCGH8B60.safetensors', precisions)).toBe(
+      null
+    );
+    expect(inferPrecisionFromFileName('AGAGENF442Q05F8KABM73JT1C0.safetensors', precisions)).toBe(
+      null
+    );
+  });
+
+  it('does not read int4 out of an ordinary word', () => {
+    expect(
+      inferPrecisionFromFileName(
+        'Jamie Lee Curtis LoRA use 0point4 strength.safetensors',
+        precisions
+      )
+    ).toBe(null);
+    expect(inferPrecisionFromFileName('SM-FinetunePaint40Art-Remake.safetensors', precisions)).toBe(
+      null
+    );
+  });
+});

--- a/src/utils/file-helpers.ts
+++ b/src/utils/file-helpers.ts
@@ -101,9 +101,10 @@ const isAlphanumeric = (char: string) => /[A-Za-z0-9]/.test(char);
  * lowercase letter may sit behind a version number, as in `v20NF4` and `_51NVFP4`. An UPPERCASE
  * letter before the token does not count, digits between or not: trained-file job ids are 26-char
  * base32, uppercase letters AND digits, so `F2NF4J1W4CGCKYETAEQJT9B5A0` has to be refused by the
- * same rule that accepts `TzigoAnimeFlux_v2NF4`. Of the 16 prod names with a digit before an
- * uppercase token, 12 are job ids. Missing an all-lowercase glued name (`ltx23devnvfp4`) is the
- * side to fail on.
+ * same rule that accepts `TzigoAnimeFlux_v2NF4`. That refuses all 12 of the prod names where a
+ * digit precedes an uppercase token and keeps the 4 real ones. Index 0 is a word start by
+ * construction, so an id that BEGINS with a token is still accepted — 1 row in 40,351, left
+ * alone. Missing an all-lowercase glued name (`ltx23devnvfp4`) is the side to fail on.
  */
 function startsWord(name: string, index: number) {
   if (index === 0) return true;
@@ -138,9 +139,12 @@ function tokenPattern(precision: string) {
 }
 
 /**
- * Find a packaging scheme named in a file's name. Only values `precisions` offers and a dtype
- * cannot state are considered, so this can never contradict a header that was able to answer.
- * Longest option first, so `fp8_scaled` is not read as `fp8` and `nvfp4` not as `fp4`.
+ * Find a precision named in a file's name. Candidates are the values `precisions` offers minus
+ * `DTYPE_STATEABLE_FP` — which is narrower than "what a dtype can state", so `int8` and `mxfp8`
+ * are candidates here and a header answering one of the other four CAN be contradicted. That is
+ * the accepted tradeoff, not an oversight; `resolveUploadPrecision` carries the rest of the rule.
+ * Longest option first, which matters only when a mod adds a variant of an existing option —
+ * `fp4` inside `nvfp4` is refused by the word-start rule, not by the ordering.
  */
 export function inferPrecisionFromFileName(
   fileName: string,
@@ -166,9 +170,11 @@ export function inferPrecisionFromFileName(
 }
 
 /**
- * Combine the two signals for an upload. The header wins wherever it can speak: it only loses to
- * a name that claims a scheme no dtype can express, and it keeps a scheme it observed directly
- * (F8_E8M0 scales are MXFP8 whatever the name says).
+ * Combine the two signals for an upload. A header answer outside `DTYPE_STATEABLE_FP` was
+ * observed directly and wins outright (F8_E8M0 scales are MXFP8 whatever the name says). One
+ * inside it loses to any name that claims a candidate precision — deliberately, since that is
+ * how a U8-packed NVFP4 body stops being read as the fp32 of its leftover tensors, and the
+ * uploader can still edit the field.
  */
 export function resolveUploadPrecision({
   fileName,

--- a/src/utils/file-helpers.ts
+++ b/src/utils/file-helpers.ts
@@ -85,30 +85,35 @@ export async function inferSafetensorsPrecision(file: File): Promise<ModelFileFp
 }
 
 /**
- * The precisions a safetensors dtype can state on its own. Every other value a mod adds to
- * `modelFileOptions` is a packaging scheme layered over a dtype — NVFP4 and NF4 pack their
- * weights into U8, GPTQ int8 into I32, and MXFP8's shared-exponent scales are usually written
- * as U8 rather than F8_E8M0 — all of which the mapper deliberately leaves unmapped, so the
- * quantized bulk contributes no bytes and the vote is won by whatever housekeeping tensors
- * are left. Measured on two production files: an MXFP8 checkpoint reads as fp8, and an NVFP4
- * one as fp32.
+ * The precisions whose answer from the header is authoritative, so a file name may never
+ * contradict one. Deliberately NOT every precision `SAFETENSORS_DTYPE_TO_FP` can emit: that map
+ * also emits `int8` and `mxfp8`, which a dtype states only sometimes — MXFP8 scales are usually
+ * written as U8 rather than F8_E8M0, and GPTQ int8 packs into the unmapped I32 — so a name may
+ * supply those, and `resolveUploadPrecision` still keeps either when the header did observe it.
+ * Adding a row to that map does not update this set; keep the two in step by hand.
  */
 const DTYPE_STATEABLE_FP = new Set(['fp32', 'fp16', 'bf16', 'fp8']);
 
 const isAlphanumeric = (char: string) => /[A-Za-z0-9]/.test(char);
 
 /**
- * Whether `name[index]` starts a word. A separator counts, and so does a camelCase hump
- * (`RawGirlKreaNVFP4`), but a letter running straight into the token does not — the trained-file
- * job ids are 26-char base32 (`PW2MQDNF4ZXWSGYEHXWCGH8B60`) and 50 of them contain `nf4` by
- * chance. Inventing a precision for those is the failure worth avoiding; missing an all-lowercase
- * glued name like `ltx23devnvfp4` is not.
+ * Whether `name[index]` starts a word. A separator counts, and so does a camelCase hump — whose
+ * lowercase letter may sit behind a version number, as in `v20NF4` and `_51NVFP4`. An UPPERCASE
+ * letter before the token does not count, digits between or not: trained-file job ids are 26-char
+ * base32, uppercase letters AND digits, so `F2NF4J1W4CGCKYETAEQJT9B5A0` has to be refused by the
+ * same rule that accepts `TzigoAnimeFlux_v2NF4`. Of the 16 prod names with a digit before an
+ * uppercase token, 12 are job ids. Missing an all-lowercase glued name (`ltx23devnvfp4`) is the
+ * side to fail on.
  */
 function startsWord(name: string, index: number) {
   if (index === 0) return true;
-  const prev = name[index - 1];
-  if (!isAlphanumeric(prev)) return true;
-  return /[a-z0-9]/.test(prev) && /[A-Z]/.test(name[index]);
+  if (!isAlphanumeric(name[index - 1])) return true;
+  if (!/[A-Z]/.test(name[index])) return false;
+
+  let before = index - 1;
+  while (before >= 0 && /[0-9]/.test(name[before])) before--;
+  if (before < 0 || !isAlphanumeric(name[before])) return true;
+  return /[a-z]/.test(name[before]);
 }
 
 /** A trailing digit means the token was part of a longer number (`_int40_`), not the token. */
@@ -142,7 +147,7 @@ export function inferPrecisionFromFileName(
   precisions: readonly string[]
 ): ModelFileFp | null {
   const candidates = precisions
-    .filter((precision) => precision && !DTYPE_STATEABLE_FP.has(precision))
+    .filter((precision) => precision && !DTYPE_STATEABLE_FP.has(precision.toLowerCase()))
     .sort((a, b) => b.length - a.length);
 
   for (const precision of candidates) {

--- a/src/utils/file-helpers.ts
+++ b/src/utils/file-helpers.ts
@@ -85,6 +85,100 @@ export async function inferSafetensorsPrecision(file: File): Promise<ModelFileFp
 }
 
 /**
+ * The precisions a safetensors dtype can state on its own. Every other value a mod adds to
+ * `modelFileOptions` is a packaging scheme layered over a dtype — NVFP4 and NF4 pack their
+ * weights into U8, GPTQ int8 into I32, and MXFP8's shared-exponent scales are usually written
+ * as U8 rather than F8_E8M0 — all of which the mapper deliberately leaves unmapped, so the
+ * quantized bulk contributes no bytes and the vote is won by whatever housekeeping tensors
+ * are left. Measured on two production files: an MXFP8 checkpoint reads as fp8, and an NVFP4
+ * one as fp32.
+ */
+const DTYPE_STATEABLE_FP = new Set(['fp32', 'fp16', 'bf16', 'fp8']);
+
+const isAlphanumeric = (char: string) => /[A-Za-z0-9]/.test(char);
+
+/**
+ * Whether `name[index]` starts a word. A separator counts, and so does a camelCase hump
+ * (`RawGirlKreaNVFP4`), but a letter running straight into the token does not — the trained-file
+ * job ids are 26-char base32 (`PW2MQDNF4ZXWSGYEHXWCGH8B60`) and 50 of them contain `nf4` by
+ * chance. Inventing a precision for those is the failure worth avoiding; missing an all-lowercase
+ * glued name like `ltx23devnvfp4` is not.
+ */
+function startsWord(name: string, index: number) {
+  if (index === 0) return true;
+  const prev = name[index - 1];
+  if (!isAlphanumeric(prev)) return true;
+  return /[a-z0-9]/.test(prev) && /[A-Z]/.test(name[index]);
+}
+
+/** A trailing digit means the token was part of a longer number (`_int40_`), not the token. */
+function endsWord(name: string, index: number) {
+  return index >= name.length || !/[0-9]/.test(name[index]);
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * `fp8_scaled` is written `fp8-scaled` or `fp8 scaled` about as often, so each run of
+ * separators in the option becomes an optional one.
+ */
+function tokenPattern(precision: string) {
+  return precision
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map(escapeRegExp)
+    .join('[-_. ]?');
+}
+
+/**
+ * Find a packaging scheme named in a file's name. Only values `precisions` offers and a dtype
+ * cannot state are considered, so this can never contradict a header that was able to answer.
+ * Longest option first, so `fp8_scaled` is not read as `fp8` and `nvfp4` not as `fp4`.
+ */
+export function inferPrecisionFromFileName(
+  fileName: string,
+  precisions: readonly string[]
+): ModelFileFp | null {
+  const candidates = precisions
+    .filter((precision) => precision && !DTYPE_STATEABLE_FP.has(precision))
+    .sort((a, b) => b.length - a.length);
+
+  for (const precision of candidates) {
+    const pattern = tokenPattern(precision);
+    if (!pattern) continue;
+    const matcher = new RegExp(pattern, 'gi');
+    let match: RegExpExecArray | null;
+    while ((match = matcher.exec(fileName)) !== null) {
+      if (startsWord(fileName, match.index) && endsWord(fileName, match.index + match[0].length))
+        return precision as ModelFileFp;
+      matcher.lastIndex = match.index + 1;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Combine the two signals for an upload. The header wins wherever it can speak: it only loses to
+ * a name that claims a scheme no dtype can express, and it keeps a scheme it observed directly
+ * (F8_E8M0 scales are MXFP8 whatever the name says).
+ */
+export function resolveUploadPrecision({
+  fileName,
+  headerFp,
+  precisions,
+}: {
+  fileName: string;
+  headerFp: ModelFileFp | null;
+  precisions: readonly string[];
+}): ModelFileFp | null {
+  if (headerFp && !DTYPE_STATEABLE_FP.has(headerFp)) return headerFp;
+  return inferPrecisionFromFileName(fileName, precisions) ?? headerFp;
+}
+
+/**
  * Maps llama.cpp's LLAMA_FTYPE enum (stored in GGUF `general.file_type`) to the
  * quant-type strings the upload form offers. Unquantized ftypes (F32/F16/BF16)
  * and quant schemes not in the form are intentionally omitted -> no auto-fill.


### PR DESCRIPTION
Reported by MNeMiC in Justin's Discord DM group (2026-09-10), a repeat of ClickUp [868km6k62](https://app.clickup.com/t/868km6k62), open since Aug 4.

## What was wrong

Precision auto-detection reads the safetensors header and picks the dtype owning the most tensor bytes (`inferSafetensorsPrecision`, called from `FilesProvider`). There is no filename layer — there never was one.

NVFP4 and NF4 pack their weights into `U8`, GPTQ int8 into `I32`, and MXFP8's shared-exponent scales are usually written as `U8` rather than `F8_E8M0`. The mapper deliberately leaves all of those unmapped, so the quantized bulk contributes no bytes and the vote is decided by whatever housekeeping tensors are left.

Measured against the shipped detector on two real production headers, read through `/api/v1/model-files/<id>/tensor-metadata`:

| file | header dtypes (bytes) | detector returns | should be |
|---|---|---|---|
| `krea2_finalcut_pro_mxfp8.safetensors` (3152071) | F8_E4M3 12.5G, BF16 643M, **U8 391M** | `fp8` | `mxfp8` |
| `KREAtivity_5.0_NVFP4.safetensors` (3157252, MNeMiC's) | **U8 6.08G**, F32 1.28G, F8_E4M3 760M, BF16 690M | `fp32` | `nvfp4` |

The NVFP4 case is not a miss — it auto-fills a *wrong* value the uploader then corrects by hand.

## Volume

Prod, 2026-09-10. 1,520,525 `ModelFile` rows; **13,174** have a filename stating a precision, and **3,078 of those (23%)** disagree with the stored `metadata.fp` — 2,278 null, 800 a different value. For the two reported schemes: **163 of 282 (58%)**. Worst relative offender is `fp8_scaled` at 148 of 158.

## What this does

A filename layer *underneath* the header. The name fills in only what a dtype cannot state; the eligible set is the **live** mod-managed `modelFileOptions` list minus a hardcoded four (`fp32`, `fp16`, `bf16`, `fp8`), so a precision a mod adds later is covered with no code change. A scheme the header observed *directly* — `F8_E8M0` scales are MXFP8 — still beats a name that disagrees. A header answer that is one of the four **can** be contradicted by a name; that is the point of the change and the accepted tradeoff below, not an oversight.

That four-value subtraction is **not** the same as "every precision a dtype can emit": `SAFETENSORS_DTYPE_TO_FP` also emits `int8` and `mxfp8`, and both are deliberately left eligible for the name because a dtype states them only sometimes. `resolveUploadPrecision` still keeps either when the header did observe it.

Matching requires a word start: a separator, or a camelCase hump whose lowercase letter may sit behind a version number (`v20NF4`, `_51NVFP4`). **An uppercase letter before the token never counts, digits between or not** — trained-file job ids are 26-char base32, uppercase letters *and* digits, so `F2NF4J1W4CGCKYETAEQJT9B5A0` is refused by the same rule that accepts `TzigoAnimeFlux_v2NF4`. Of the 16 prod names carrying a digit before an uppercase token, 12 are job ids and 4 are real; this shape refuses all 12 and keeps all 4. It costs an all-lowercase glued name like `ltx23devnvfp4`, which is the right side to fail on.

Two shapes reach a word start with nothing in front to judge and are **accepted by construction**: a token at index 0, and a token behind a digit run that reaches the start of the name — `NF4J1W4CGCKYETAEQJT9B5A0XY` and `53NF4ZXWSGYEHXWCGH8B60` both resolve to `nf4`. That is 1 row in 40,351 job-id names, so no special case; it is pinned as an assertion rather than claimed away, because a claim wider than the code is the mistake this PR made three times.

**Upload-time only.** The 3,078 existing rows are deliberately untouched — retroactive repair on a read path is what #4344 was reverted for (#4359). Two rules from that revert are honoured: `U8` stays unmapped, and the eligible set is derived from the live options rather than being a frozen list of scheme names.

### Known, accepted, quantified

A name token beats a *correct* header when the header's answer is one of the four. `flux-nf4-compatible-lora.safetensors` with a bf16 header reads `bf16` before this change and `nf4` after — a file named for the base quant it targets rather than its own packaging. Prod, last 180 days, files whose name carries `nf4|nvfp4|int8|int4` at a word start: LORA 3 files (2 stored full-precision), Checkpoint 795 (33 stored full-precision), everything else ≤22. So at most ~35 rows/180 days could flip from a correct full-precision value to a wrong scheme, against the 282 rows of the two reported schemes this is for. It is a pre-fill in a form the uploader can still edit before submit.

## Verification

```
pnpm run typecheck                    typecheck: OK — 0 type errors in 125s
pnpm exec eslint <the 3 files>        exit 0, no errors, no warnings
prettier --write <the 3 files>        clean
FULL_SUITE=1 pnpm run test:unit:run   Test Files  1 failed | 1752 passed | 3 skipped (1756)
                                      Tests  1 failed | 39975 passed | 35 skipped (40011)
blocks.router.workflow.test.ts        Test Files  1 passed (1) / Tests  380 passed (380)
```

**Nine mutation controls, each red with a legible assertion naming the wrong value:**

| mutation | result |
|---|---|
| `resolveUploadPrecision` body → `return headerFp` | `expected 'fp8' to be 'mxfp8'`, `expected 'fp32' to be 'nvfp4'` — 2 failed |
| `startsWord` → `true` | `expected 'nf4' to be null`, `expected 'int4' to be null` — 2 failed |
| `endsWord` → `true` | `expected 'int4' to be null` — 1 failed |
| revert to the old `[a-z0-9]` hump rule | `expected 'nf4' to be null` — 1 failed |
| drop the case fold on the option filter | `expected 'FP8' to be null` — 1 failed |
| drop the `data_offsets` byte weighting | `expected 'fp32' to be 'bf16'` — 1 failed |
| drop the longest-first sort | `expected 'fp8_scaled' to be 'fp8_scaled_v2'` — 1 failed |
| `startsWord` index-0 short-circuit → `false` | `expected null to be 'nf4'` — 1 failed |
| split the `before < 0` arm → `false` | `expected null to be 'nf4'` — 1 failed |

**The wiring is covered too, in a browser** — `src/components/Resource/FilesProvider.precision-autofill.browser.test.tsx`. It mounts `FilesProvider` with no `version`, which makes the auto-start upload effect return early, so it transfers no bytes and touches no S3; drops a file carrying the production header of ModelFile 3157252; and reads the precision the form lands on. `nvfp4`, where the header alone votes `fp32`.

Its second case is why it is a browser test rather than a fourth unit test: the extension check above the call lowercases the name into a local, and passing that local instead of `item.name` — which reads like an obvious tidy — silently kills every camelCase match, because the word-start rule needs the hump. A unit test calling the helper directly cannot see it. Controls: resolver → header-only fails 2 of 3 with `expected 'fp32' to be 'nvfp4'`; the lowercase substitution fails 1 of 3, the camelCase case alone, with the same message, both in ~200 ms.

```
pnpm run test:component               Test Files  1 failed | 229 passed (230)
                                      Tests  1 failed | 2560 passed (2561)
```

⚠️ **That component failure is not from this diff either.** `AppsPageLayout.geometry.browser.test.tsx` — `expected 133.13 to be close to 133.27, difference 0.14, expected 0.05`, a hardcoded tab-width constant. It fails **identically, to the decimal, with this branch's three files checked out from `origin/main`**, and none of them is in its import graph. Box font metrics, not this change. The `component` project is report-only in the preview pipeline rather than a merge gate.

⚠️ **The one unit-suite failure is not from this diff.** `src/server/integrations/__tests__/moderation-cache-probe.test.ts` — `expected +0 to be 2` at a `vi.waitFor` (1s default) on a fire-and-forget prom counter. It passes in isolation **both with and without** this change (`Tests 22 passed (22)`, exit 0, twice), nothing in its import graph touches either file here, and another agent reproduced it on detached `origin/main` today. A 1-second `waitFor` against an uninstrumented async probe under a 31-worker run is the mechanism. Left alone rather than widened.

`pnpm run lint` exits 1 repo-wide (358 pre-existing errors); the three files in this diff lint clean on their own.

## Review

Five main-app lanes read `1c214f3604`, all five confirming the SHA matched. Correctness and intent independently found the same defect — the first commit's claim that job ids "cannot mint a precision" was false, because base32 carries digits and both negative fixtures happened to be letter-preceded.

`8677641260` is the fix round; correctness and tests both re-read it and confirmed the SHA. The correctness re-read compared old and new `startsWord` exhaustively over 2,343 positions and found the new rule a strict tightening — more restrictive in 38, more permissive in none — and found one CONFIRMED comment-only defect: two further doc comments still asserted the guarantee the first round had just removed from a third. The test re-read ran a 19-mutation matrix and confirms every test is killed by at least one, with unique killers for the byte weighting, the sort, the case fold, `endsWord` and the index-0 pin.

`75a95a70d8` corrects those two comments and pins the two accepted gaps. No behaviour change in that commit.

Deferred rather than widened into this PR: `escapeRegExp` duplicates `lodash-es`; the unmemoized `FilesContext` value and the synchronous `JSON.parse` over a 64 MB-capped header are both pre-existing on this path; and a U8-packed file whose name carries **no** token still gets a confident wrong value — 1,507,351 of 1,520,525 rows have no precision in the name, so tracking the unmapped byte share and returning `null` when it dominates would close the class rather than the symptom. That one is a separate decision for Justin, not a tidy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV3wdDHLGXrv1pLJ2iUEaa
