### PR TITLE
feat(announcements): report action + "leaving Civitai" warning for external links

### DIFF
--- a/apps/moderator/src/lib/__tests__/report-detail-entries.test.ts
+++ b/apps/moderator/src/lib/__tests__/report-detail-entries.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { reportDetailEntries } from '$lib/reports';
+
+describe('reportDetailEntries', () => {
+  it('lists primitive values as strings', () => {
+    expect(reportDetailEntries({ comment: 'spam', count: 3, flagged: true })).toEqual([
+      ['comment', 'spam'],
+      ['count', '3'],
+      ['flagged', 'true'],
+    ]);
+  });
+
+  it('drops null, undefined and blank values', () => {
+    expect(reportDetailEntries({ a: null, b: undefined, c: '', d: '   ', e: 'kept' })).toEqual([
+      ['e', 'kept'],
+    ]);
+  });
+
+  it('returns nothing for a non-object', () => {
+    expect(reportDetailEntries(null)).toEqual([]);
+    expect(reportDetailEntries('spam')).toEqual([]);
+  });
+
+  // 🔴 The row this helper renders is the `entity === 'other'` one — a report whose target is
+  // gone. A snapshot written so that report can still be ruled on is a nested object, so
+  // filtering objects out hid it on the one surface it exists for.
+  it('renders a nested object rather than dropping it', () => {
+    expect(
+      reportDetailEntries({
+        announcement: { title: 'Free stuff', content: 'grab it at [here](https://t.me/x)' },
+      })
+    ).toEqual([
+      ['announcement', '{"title":"Free stuff","content":"grab it at [here](https://t.me/x)"}'],
+    ]);
+  });
+
+  it('renders an array value', () => {
+    expect(reportDetailEntries({ links: ['https://t.me/x', 'https://t.me/y'] })).toEqual([
+      ['links', '["https://t.me/x","https://t.me/y"]'],
+    ]);
+  });
+});

--- a/apps/moderator/src/lib/reports.ts
+++ b/apps/moderator/src/lib/reports.ts
@@ -206,11 +206,15 @@ export const getReportItemUrl = (
     ? `${base}${contextUrl}`
     : entityUrl(base, type, entityId);
 
-/** `Report.details` is free-form JSON; list its primitive key/value pairs for the moderator. Shared
- *  because it is the only view of a report whose target is gone — see the dashboard's unlinked rows. */
+/** `Report.details` is free-form JSON; list its key/value pairs for the moderator. Shared
+ *  because it is the only view of a report whose target is gone — see the dashboard's unlinked rows.
+ *
+ *  🔴 Nested objects are stringified, not skipped: a snapshot written so a deleted target can
+ *  still be ruled on IS a nested object, and this is the only place it reaches a moderator. */
 export const reportDetailEntries = (details: unknown): [string, string][] => {
   if (!details || typeof details !== 'object') return [];
   return Object.entries(details as Record<string, unknown>)
-    .filter(([, v]) => v != null && typeof v !== 'object' && String(v).trim() !== '')
-    .map(([k, v]) => [k, String(v)]);
+    .filter(([, v]) => v != null)
+    .map(([k, v]): [string, string] => [k, typeof v === 'object' ? JSON.stringify(v) : String(v)])
+    .filter(([, v]) => v.trim() !== '');
 };

--- a/apps/moderator/src/lib/reports.ts
+++ b/apps/moderator/src/lib/reports.ts
@@ -19,6 +19,7 @@ export const ReportEntity = {
   ComicProject: 'comicProject',
   Model3D: 'model3d',
   Model3DReview: 'model3dReview',
+  Announcement: 'announcement',
 } as const;
 export type ReportEntity = (typeof ReportEntity)[keyof typeof ReportEntity];
 
@@ -89,6 +90,7 @@ export const reportEntityLabels: Record<ReportEntity, string> = {
   comicProject: 'Comic',
   model3d: '3D Model',
   model3dReview: '3D Review',
+  announcement: 'Announcement',
 };
 
 // URL segment for each entity's report page. Part of shareable URLs and of the nav paths that grants match
@@ -109,6 +111,7 @@ export const reportEntitySlugs: Record<ReportEntity, string> = {
   comicProject: 'comic',
   model3d: '3d-model',
   model3dReview: '3d-review',
+  announcement: 'announcement',
 };
 
 const entityBySlug = new Map(

--- a/apps/moderator/src/lib/server/__tests__/reports.queries.explain.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/reports.queries.explain.test.ts
@@ -78,7 +78,7 @@ describe.skipIf(!h.hasDb)('report queries plan against the real schema', () => {
     }
   );
 
-  it('getReportCounts — the materialized CTE and all sixteen union branches', async () => {
+  it('getReportCounts — the materialized CTE and every union branch', async () => {
     await service.getReportCounts();
 
     const [counts] = h.queries;
@@ -94,7 +94,7 @@ describe.skipIf(!h.hasDb)('report queries plan against the real schema', () => {
     await service.getMostReportedPage({ page: 4, limit: 25, days: 30 });
     await plans();
   });
-  it('getMostReported — the LIMIT-in-a-CTE shape with its seventeen subplans', async () => {
+  it('getMostReported — the LIMIT-in-a-CTE shape with its per-entity subplans', async () => {
     // Subplans resolve OUTSIDE the CTE: Postgres cannot project through a Sort, so flattening this
     // evaluates them for every pending report of the week.
     await service.getMostReported({ limit: 10 });

--- a/apps/moderator/src/lib/server/__tests__/reports.queries.explain.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/reports.queries.explain.test.ts
@@ -78,7 +78,7 @@ describe.skipIf(!h.hasDb)('report queries plan against the real schema', () => {
     }
   );
 
-  it('getReportCounts — the materialized CTE and all fifteen union branches', async () => {
+  it('getReportCounts — the materialized CTE and all sixteen union branches', async () => {
     await service.getReportCounts();
 
     const [counts] = h.queries;

--- a/apps/moderator/src/lib/server/__tests__/reports.sql.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/reports.sql.test.ts
@@ -55,6 +55,7 @@ const EXPECTED: [string, string, string][] = [
   ['comicProject', 'ComicProjectReport', 'comicProjectId'],
   ['model3d', 'Model3DReport', 'model3dId'],
   ['model3dReview', 'Model3DReviewReport', 'model3dReviewId'],
+  ['announcement', 'AnnouncementReport', 'announcementId'],
   ['chat', 'ChatReport', 'chatId'],
   ['reportedUser', 'UserReport', 'userId'],
 ];

--- a/apps/moderator/src/lib/server/__tests__/reports.sql.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/reports.sql.test.ts
@@ -121,7 +121,7 @@ describe('getReportHistory', () => {
 });
 
 describe('the queries that fan out over every entity at once', () => {
-  it('getReportCounts names all fifteen report tables', async () => {
+  it('getReportCounts names all sixteen report tables', async () => {
     await service.getReportCounts();
 
     const [sql] = emitted();
@@ -188,6 +188,7 @@ describe('report rows link to what was reported', () => {
       'context:bountyEntry',
       'context:model3dReview',
       'context:reportedUser',
+      'context:announcement',
     ])
       expect(statements.some((sql) => sql.includes('AS "' + column + '"'))).toBe(true);
   });

--- a/apps/moderator/src/lib/server/__tests__/reports.sql.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/reports.sql.test.ts
@@ -121,7 +121,7 @@ describe('getReportHistory', () => {
 });
 
 describe('the queries that fan out over every entity at once', () => {
-  it('getReportCounts names all sixteen report tables', async () => {
+  it('getReportCounts names every report table', async () => {
     await service.getReportCounts();
 
     const [sql] = emitted();
@@ -164,7 +164,7 @@ describe('getMostReportedPage', () => {
   it('pages inside the CTE, where the LIMIT already is', async () => {
     await service.getMostReportedPage({ page: 3, limit: 25, days: 7 });
 
-    // OFFSET applied outside it would walk the discarded rows through all seventeen subplans — the
+    // OFFSET applied outside it would walk the discarded rows through every subplan — the
     // reason the LIMIT is in there in the first place.
     const list = emitted()
       .map((sql) => sql.toLowerCase())

--- a/apps/moderator/src/lib/server/report-entities.ts
+++ b/apps/moderator/src/lib/server/report-entities.ts
@@ -84,6 +84,12 @@ const TABLES: Record<ReportEntity, Omit<ReportEntityMeta, 'type' | 'label'>> = {
     table: 'Model3DReview',
     ownerColumn: 'userId',
   },
+  announcement: {
+    reportTable: 'AnnouncementReport',
+    fk: 'announcementId',
+    table: 'Announcement',
+    ownerColumn: 'userId',
+  },
   // `ownerId` is who OPENED the conversation, which is not who was reported — see
   // `chatReportSubject`. Null keeps it out of the owner-column loop; both call sites add it back with
   // that predicate.

--- a/apps/moderator/src/lib/server/reports.service.ts
+++ b/apps/moderator/src/lib/server/reports.service.ts
@@ -109,6 +109,16 @@ const CONTEXT_RESOLVERS: Partial<Record<ReportEntity, ContextResolver>> = {
     sql<string | null>`(
       SELECT '/user/' || u.username FROM "User" u WHERE u.id = ${entityId} AND u.username IS NOT NULL
     )`,
+
+  // An announcement has no page of its own, so `entityUrl` returns null and the row would
+  // render as dead grey text. The author's profile is where their announcements are rendered.
+  // Null for a sitewide row (`userId IS NULL`), which is not reportable.
+  announcement: (entityId) =>
+    sql<string | null>`(
+      SELECT '/user/' || u.username
+      FROM "Announcement" a JOIN "User" u ON u.id = a."userId"
+      WHERE a.id = ${entityId} AND u.username IS NOT NULL
+    )`,
 };
 
 /** The types `entityUrl` cannot answer for. Derived from the resolvers so a new one cannot be written

--- a/apps/moderator/src/lib/server/reports.service.ts
+++ b/apps/moderator/src/lib/server/reports.service.ts
@@ -37,7 +37,7 @@ export type ModeratorReportRow = {
 /**
  * Where to send a moderator for a reported thing that has no page of its own.
  *
- * Six of the sixteen report types name something the site only reaches through a parent — a comment
+ * Several report types name something the site only reaches through a parent — a comment
  * through its thread, a bounty entry through its bounty — so `entityUrl` returns null for them and the
  * row rendered as dead grey text. That was most of a moderator's clicks on the reports surfaces: the
  * only way to the words being reported was to search for them.
@@ -111,7 +111,7 @@ const CONTEXT_RESOLVERS: Partial<Record<ReportEntity, ContextResolver>> = {
     )`,
 
   // The author's profile is where an announcement is rendered; null for a sitewide row
-  // (`userId IS NULL`), which is not reportable.
+  // (`userId IS NULL`), which has no profile to link to.
   announcement: (entityId) =>
     sql<string | null>`(
       SELECT '/user/' || u.username
@@ -396,7 +396,7 @@ export type MostReportedRow = {
   reportCount: number;
   /** The reporter's own free-form fields. The only thing left to judge an `other` row on. */
   details: unknown;
-  /** `other` only when the report has no row in ANY of the sixteen report tables. */
+  /** `other` only when the report has no row in ANY report table. */
   entity: ReportEntity | 'other';
   entityId: number | null;
   /** Site-relative deep link for entities with no page of their own — see `commentContextUrl`. */
@@ -459,7 +459,7 @@ async function syncResolvedMarker(id: number, status: ReportStatus): Promise<voi
 
 /**
  * The dashboard's twenty and the paginated page are the same query with a different window, so they
- * share it — two copies of a seventeen-subplan statement is how one of them comes to cover five entity
+ * share it — two copies of this statement is how one of them comes to cover five entity
  * types.
  *
  * `days` is the age of the REPORT. The dashboard's week is what makes it a signal about now; the page
@@ -530,7 +530,7 @@ async function fetchMostReported({
   offset = 0,
   days = 7,
 }: MostReportedParams): Promise<MostReportedRow[]> {
-  // Raw sql throughout: `alsoReportedBy` is a Postgres array and the ordering key, and the sixteen
+  // Raw sql throughout: `alsoReportedBy` is a Postgres array and the ordering key, and the
   // per-type id columns are generated from `reportEntityJoin` rather than written out.
   //
   // The +1 is the report's own filer: `alsoReportedBy` holds every reporter EXCEPT `Report.userId`,
@@ -538,7 +538,7 @@ async function fetchMostReported({
   // two-reporter item behind copy promising "more than one reporter", and the dashboard's
   // URGENT_REPORT_COUNT fired a reporter late. `array_length` is NULL on an empty array, not 0.
   //
-  // The LIMIT is taken in a CTE and the seventeen subplans resolved OUTSIDE it. Postgres cannot project
+  // The LIMIT is taken in a CTE and the per-entity subplans resolved OUTSIDE it. Postgres cannot project
   // through a Sort, so in one flat query the target list is evaluated below the ORDER BY — for every
   // pending report of the week, not the twenty kept.
   const reportCount = sql<number>`coalesce(array_length(t."alsoReportedBy", 1), 0) + 1`;

--- a/apps/moderator/src/lib/server/reports.service.ts
+++ b/apps/moderator/src/lib/server/reports.service.ts
@@ -37,7 +37,7 @@ export type ModeratorReportRow = {
 /**
  * Where to send a moderator for a reported thing that has no page of its own.
  *
- * Six of the fifteen report types name something the site only reaches through a parent — a comment
+ * Six of the sixteen report types name something the site only reaches through a parent — a comment
  * through its thread, a bounty entry through its bounty — so `entityUrl` returns null for them and the
  * row rendered as dead grey text. That was most of a moderator's clicks on the reports surfaces: the
  * only way to the words being reported was to search for them.
@@ -110,9 +110,8 @@ const CONTEXT_RESOLVERS: Partial<Record<ReportEntity, ContextResolver>> = {
       SELECT '/user/' || u.username FROM "User" u WHERE u.id = ${entityId} AND u.username IS NOT NULL
     )`,
 
-  // An announcement has no page of its own, so `entityUrl` returns null and the row would
-  // render as dead grey text. The author's profile is where their announcements are rendered.
-  // Null for a sitewide row (`userId IS NULL`), which is not reportable.
+  // The author's profile is where an announcement is rendered; null for a sitewide row
+  // (`userId IS NULL`), which is not reportable.
   announcement: (entityId) =>
     sql<string | null>`(
       SELECT '/user/' || u.username
@@ -397,7 +396,7 @@ export type MostReportedRow = {
   reportCount: number;
   /** The reporter's own free-form fields. The only thing left to judge an `other` row on. */
   details: unknown;
-  /** `other` only when the report has no row in ANY of the fifteen report tables. */
+  /** `other` only when the report has no row in ANY of the sixteen report tables. */
   entity: ReportEntity | 'other';
   entityId: number | null;
   /** Site-relative deep link for entities with no page of their own — see `commentContextUrl`. */
@@ -531,7 +530,7 @@ async function fetchMostReported({
   offset = 0,
   days = 7,
 }: MostReportedParams): Promise<MostReportedRow[]> {
-  // Raw sql throughout: `alsoReportedBy` is a Postgres array and the ordering key, and the fifteen
+  // Raw sql throughout: `alsoReportedBy` is a Postgres array and the ordering key, and the sixteen
   // per-type id columns are generated from `reportEntityJoin` rather than written out.
   //
   // The +1 is the report's own filer: `alsoReportedBy` holds every reporter EXCEPT `Report.userId`,

--- a/apps/moderator/src/lib/server/reports.service.ts
+++ b/apps/moderator/src/lib/server/reports.service.ts
@@ -111,7 +111,7 @@ const CONTEXT_RESOLVERS: Partial<Record<ReportEntity, ContextResolver>> = {
     )`,
 
   // The author's profile is where an announcement is rendered; null for a sitewide row
-  // (`userId IS NULL`), which has no profile to link to.
+  // (`userId IS NULL`), which `createReport` refuses to report in the first place.
   announcement: (entityId) =>
     sql<string | null>`(
       SELECT '/user/' || u.username

--- a/apps/moderator/src/routes/+page.svelte
+++ b/apps/moderator/src/routes/+page.svelte
@@ -122,7 +122,7 @@
 
   // `getReportItemUrl`, not `entityUrl`: a chat has no page on the site (its transcript is Chat Audit,
   // in this app) and a comment hangs off a parent, so neither is derivable from the entity id.
-  // 'other' is what `Report` looks like when it joins none of the fifteen report tables — the row it
+  // 'other' is what `Report` looks like when it joins none of the sixteen report tables — the row it
   // named is gone, or was never written. "unknown" read as a rendering bug rather than a fact about
   // the report, which is what the mod team asked about.
   const entityLabel = (row: Reported) =>

--- a/apps/moderator/src/routes/+page.svelte
+++ b/apps/moderator/src/routes/+page.svelte
@@ -122,7 +122,7 @@
 
   // `getReportItemUrl`, not `entityUrl`: a chat has no page on the site (its transcript is Chat Audit,
   // in this app) and a comment hangs off a parent, so neither is derivable from the entity id.
-  // 'other' is what `Report` looks like when it joins none of the sixteen report tables — the row it
+  // 'other' is what `Report` looks like when it joins none of the report tables — the row it
   // named is gone, or was never written. "unknown" read as a rendering bug rather than a fact about
   // the report, which is what the mod team asked about.
   const entityLabel = (row: Reported) =>

--- a/packages/civitai-db-schema/prisma/migrations/20260910120000_add_announcement_report/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260910120000_add_announcement_report/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "AnnouncementReport" (
+    "announcementId" INTEGER NOT NULL,
+    "reportId" INTEGER NOT NULL,
+
+    CONSTRAINT "AnnouncementReport_pkey" PRIMARY KEY ("reportId","announcementId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AnnouncementReport_reportId_key" ON "AnnouncementReport"("reportId");
+
+-- CreateIndex
+CREATE INDEX "AnnouncementReport_announcementId_idx" ON "AnnouncementReport" USING HASH ("announcementId");
+
+-- AddForeignKey
+ALTER TABLE "AnnouncementReport" ADD CONSTRAINT "AnnouncementReport_announcementId_fkey" FOREIGN KEY ("announcementId") REFERENCES "Announcement"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AnnouncementReport" ADD CONSTRAINT "AnnouncementReport_reportId_fkey" FOREIGN KEY ("reportId") REFERENCES "Report"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -1500,6 +1500,7 @@ model Report {
   automated      ReportAutomated?
   model3d        Model3DReport?
   model3dReview  Model3DReviewReport?
+  announcement   AnnouncementReport?
 }
 
 model ResourceReviewReport {
@@ -4143,6 +4144,7 @@ model Announcement {
   profileOnly Boolean            @default(false)
   targetUsers AnnouncementUser[]
   spends      AnnouncementSpend[]
+  reports     AnnouncementReport[]
 
   @@index([userId, startsAt])
 }
@@ -6167,6 +6169,16 @@ model ChallengeReport {
 
   @@id([reportId, challengeId])
   @@index([challengeId], type: Hash)
+}
+
+model AnnouncementReport {
+  announcementId Int
+  announcement   Announcement @relation(fields: [announcementId], references: [id], onDelete: Cascade)
+  reportId       Int          @unique
+  report         Report       @relation(fields: [reportId], references: [id], onDelete: Cascade)
+
+  @@id([reportId, announcementId])
+  @@index([announcementId], type: Hash)
 }
 
 model ChallengeJudge {

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -180,6 +180,10 @@ export type Announcement = {
    */
   profileOnly: Generated<boolean>;
 };
+export type AnnouncementReport = {
+  announcementId: number;
+  reportId: number;
+};
 export type AnnouncementSpend = {
   id: Generated<number>;
   userId: number;
@@ -4300,6 +4304,7 @@ export type DB = {
   Account: Account;
   AdToken: AdToken;
   Announcement: Announcement;
+  AnnouncementReport: AnnouncementReport;
   AnnouncementSpend: AnnouncementSpend;
   AnnouncementUser: AnnouncementUser;
   Answer: Answer;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -1228,6 +1228,7 @@ export interface Report {
   automated?: ReportAutomated | null;
   model3d?: Model3DReport | null;
   model3dReview?: Model3DReviewReport | null;
+  announcement?: AnnouncementReport | null;
 }
 
 export interface ResourceReviewReport {
@@ -2681,6 +2682,7 @@ export interface Announcement {
   profileOnly: boolean;
   targetUsers?: AnnouncementUser[];
   spends?: AnnouncementSpend[];
+  reports?: AnnouncementReport[];
 }
 
 export interface AnnouncementSpend {
@@ -4004,6 +4006,13 @@ export interface ChallengeEntryComparison {
 export interface ChallengeReport {
   challengeId: number;
   challenge?: Challenge;
+  reportId: number;
+  report?: Report;
+}
+
+export interface AnnouncementReport {
+  announcementId: number;
+  announcement?: Announcement;
   reportId: number;
   report?: Report;
 }

--- a/src/components/Announcements/AnnouncementActionsMenu.tsx
+++ b/src/components/Announcements/AnnouncementActionsMenu.tsx
@@ -13,8 +13,7 @@ import { ReportEntity } from '~/shared/utils/report-helpers';
 
 /**
  * The options menu on a creator announcement, shared by the notifications panel and the author's
- * profile carousel. One component because the two surfaces had no reason to offer different
- * controls, and a second copy is how they would come to.
+ * profile carousel.
  */
 export function AnnouncementActionsMenu({ announcement }: { announcement: CreatorAnnouncement }) {
   const currentUser = useCurrentUser();

--- a/src/components/Announcements/AnnouncementActionsMenu.tsx
+++ b/src/components/Announcements/AnnouncementActionsMenu.tsx
@@ -1,0 +1,61 @@
+import { Menu } from '@mantine/core';
+import { IconDotsVertical } from '@tabler/icons-react';
+import React from 'react';
+import { AnnouncementMuteMenuItem } from '~/components/Announcements/AnnouncementMuteToggle';
+import { DeleteCreatorAnnouncementButton } from '~/components/Announcements/DeleteCreatorAnnouncementButton';
+import type { CreatorAnnouncement } from '~/components/Announcements/creator-announcement.types';
+import { useMutedCreators } from '~/components/Announcements/creator-announcements.utils';
+import { openReportModal } from '~/components/Dialog/triggers/report';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { ReportMenuItem } from '~/components/MenuItems/ReportMenuItem';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { ReportEntity } from '~/shared/utils/report-helpers';
+
+/**
+ * The options menu on a creator announcement, shared by the notifications panel and the author's
+ * profile carousel. One component because the two surfaces had no reason to offer different
+ * controls, and a second copy is how they would come to.
+ */
+export function AnnouncementActionsMenu({ announcement }: { announcement: CreatorAnnouncement }) {
+  const currentUser = useCurrentUser();
+  const mutedCreatorIds = useMutedCreators();
+  const isOwnAnnouncement = currentUser?.id === announcement.userId;
+
+  return (
+    <Menu withinPortal position="bottom-end">
+      <Menu.Target>
+        <LegacyActionIcon
+          variant="subtle"
+          color="gray"
+          radius="xl"
+          aria-label="Announcement options"
+        >
+          <IconDotsVertical size={16} />
+        </LegacyActionIcon>
+      </Menu.Target>
+      <Menu.Dropdown>
+        {/* Muting needs an author to mute; deleting does not, and a moderator should not lose
+            the control on the row most likely to need it. */}
+        {!!announcement.user && (
+          <AnnouncementMuteMenuItem
+            creatorId={announcement.user.id}
+            creatorName={announcement.user.username}
+            muted={mutedCreatorIds.includes(announcement.user.id)}
+          />
+        )}
+        {!isOwnAnnouncement && (
+          <ReportMenuItem
+            label="Report announcement"
+            onReport={() =>
+              openReportModal({
+                entityType: ReportEntity.Announcement,
+                entityId: announcement.id,
+              })
+            }
+          />
+        )}
+        <DeleteCreatorAnnouncementButton announcement={announcement} as="menu-item" />
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/src/components/Announcements/AnnouncementCard.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementCard.browser.test.tsx
@@ -25,7 +25,7 @@ vi.mock('~/hooks/useCurrentUser', async (importOriginal) => ({
 }));
 
 // `useTrackImpression` calls `useFeatureFlags()` unconditionally, even with no
-// `impressions` passed — same reason it's mocked in the sibling Announcement suites.
+// `impressions` passed.
 vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
   ...(await importOriginal<typeof FeatureFlagsProvider>()),
   useFeatureFlags: () => ({}),
@@ -59,8 +59,8 @@ describe('AnnouncementCard actions', () => {
 
     const cta = page.getByRole('button', { name: 'Join the group' });
     await expect.element(cta).toBeVisible();
-    // 🔴 The absence of an href is the fix, not a detail. An anchor stays middle-clickable,
-    // cmd-clickable and copyable — all of which route around the interstitial.
+    // 🔴 An anchor stays middle-, cmd-clickable and copyable — all routes around the
+    // interstitial. The missing href IS the fix.
     await expect.element(cta).not.toHaveAttribute('href');
 
     await cta.click();

--- a/src/components/Announcements/AnnouncementCard.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementCard.browser.test.tsx
@@ -97,10 +97,7 @@ describe('AnnouncementCard actions', () => {
   test('an external link in the body opens the interstitial', async () => {
     const { AnnouncementCard } = await import('~/components/Announcements/AnnouncementCard');
     renderWithProviders(
-      <AnnouncementCard
-        {...base}
-        content="grab them at [my telegram](https://t.me/SomeGroup)"
-      />
+      <AnnouncementCard {...base} content="grab them at [my telegram](https://t.me/SomeGroup)" />
     );
 
     const link = page.getByRole('link', { name: 'my telegram' });
@@ -112,13 +109,46 @@ describe('AnnouncementCard actions', () => {
   test('an internal link in the body is left alone', async () => {
     const { AnnouncementCard } = await import('~/components/Announcements/AnnouncementCard');
     // Hash target — see the comment above on the internal-action test.
-    renderWithProviders(
-      <AnnouncementCard {...base} content="see [my model](#offer)" />
-    );
+    renderWithProviders(<AnnouncementCard {...base} content="see [my model](#offer)" />);
 
     const link = page.getByRole('link', { name: 'my model' });
     await expect.element(link).toHaveAttribute('href', '#offer');
     await link.click();
     expect(mocks.openExternalLinkWarning).not.toHaveBeenCalled();
+  });
+});
+
+// 🔴 `warnOnExternalLinks` is opt-in, and every other surface — articles, comments, bios —
+// depends on that. Dropping the `warnOnExternalLinks &&` conjunct in `CustomMarkdown` would
+// put the interstitial in front of every external link in the app and pass every test above,
+// because they all render the one caller that opts in. This is what pins the boundary.
+describe('CustomMarkdown without warnOnExternalLinks', () => {
+  beforeEach(() => {
+    mocks.openExternalLinkWarning.mockClear();
+  });
+
+  test('leaves an external link alone', async () => {
+    const { CustomMarkdown } = await import('~/components/Markdown/CustomMarkdown');
+    // Nothing calls `preventDefault` on this path — that is the property under test — so the
+    // click would really open `target="_blank"`. Swallowing the default keeps the run
+    // deterministic; React still dispatches the component's own handler, if it has one.
+    const swallowNavigation = (e: MouseEvent) => e.preventDefault();
+    document.addEventListener('click', swallowNavigation, true);
+    try {
+      renderWithProviders(
+        <CustomMarkdown allowedElements={['a']} unwrapDisallowed>
+          grab them at [my telegram](https://t.me/SomeGroup)
+        </CustomMarkdown>
+      );
+
+      const link = page.getByRole('link', { name: 'my telegram' });
+      // Asserted so a "not called" cannot come from the href being mangled into something
+      // `isExternalHref` would have called internal anyway.
+      await expect.element(link).toHaveAttribute('href', 'https://t.me/SomeGroup');
+      await link.click();
+      expect(mocks.openExternalLinkWarning).not.toHaveBeenCalled();
+    } finally {
+      document.removeEventListener('click', swallowNavigation, true);
+    }
   });
 });

--- a/src/components/Announcements/AnnouncementCard.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementCard.browser.test.tsx
@@ -78,4 +78,47 @@ describe('AnnouncementCard actions', () => {
     await page.getByRole('button', { name: 'Join the group' }).click();
     expect(onActionClick).toHaveBeenCalledWith(action, 0);
   });
+
+  test('an internal action also reports the click to analytics', async () => {
+    const { AnnouncementCard } = await import('~/components/Announcements/AnnouncementCard');
+    const onActionClick = vi.fn();
+    // A hash target, not a real path — see the comment on `action` in
+    // announcement-tracking.browser.test.tsx: clicking a real path navigates the test
+    // iframe and kills the run, silently, with the remaining tests left "skipped".
+    const action = { link: '#offer', linkText: 'See the model' };
+    renderWithProviders(
+      <AnnouncementCard {...base} actions={[action]} onActionClick={onActionClick} />
+    );
+
+    await page.getByRole('link', { name: 'See the model' }).click();
+    expect(onActionClick).toHaveBeenCalledWith(action, 0);
+  });
+
+  test('an external link in the body opens the interstitial', async () => {
+    const { AnnouncementCard } = await import('~/components/Announcements/AnnouncementCard');
+    renderWithProviders(
+      <AnnouncementCard
+        {...base}
+        content="grab them at [my telegram](https://t.me/SomeGroup)"
+      />
+    );
+
+    const link = page.getByRole('link', { name: 'my telegram' });
+    await expect.element(link).toBeVisible();
+    await link.click();
+    expect(mocks.openExternalLinkWarning).toHaveBeenCalledWith('https://t.me/SomeGroup');
+  });
+
+  test('an internal link in the body is left alone', async () => {
+    const { AnnouncementCard } = await import('~/components/Announcements/AnnouncementCard');
+    // Hash target — see the comment above on the internal-action test.
+    renderWithProviders(
+      <AnnouncementCard {...base} content="see [my model](#offer)" />
+    );
+
+    const link = page.getByRole('link', { name: 'my model' });
+    await expect.element(link).toHaveAttribute('href', '#offer');
+    await link.click();
+    expect(mocks.openExternalLinkWarning).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/Announcements/AnnouncementCard.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementCard.browser.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as IsClientProvider from '~/providers/IsClientProvider';
+import type * as CurrentUser from '~/hooks/useCurrentUser';
+import type * as FeatureFlagsProvider from '~/providers/FeatureFlagsProvider';
+
+const mocks = vi.hoisted(() => ({ openExternalLinkWarning: vi.fn() }));
+
+vi.mock('~/components/ExternalLinkWarning/openExternalLinkWarning', () => ({
+  openExternalLinkWarning: mocks.openExternalLinkWarning,
+}));
+
+// `CustomMarkdown` reads both of these, and the scaffold mounts neither provider.
+// `useCurrentUser` goes through `useCivitaiSessionContext`, which throws on a missing
+// context — a throw during render empties the tree and turns every assertion into a timeout.
+vi.mock('~/providers/IsClientProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof IsClientProvider>()),
+  useIsClient: () => true,
+}));
+
+vi.mock('~/hooks/useCurrentUser', async (importOriginal) => ({
+  ...(await importOriginal<typeof CurrentUser>()),
+  useCurrentUser: () => ({ id: 1, isModerator: false }),
+}));
+
+// `useTrackImpression` calls `useFeatureFlags()` unconditionally, even with no
+// `impressions` passed — same reason it's mocked in the sibling Announcement suites.
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsProvider>()),
+  useFeatureFlags: () => ({}),
+}));
+
+const base = { title: 'Hello', content: 'body text', color: 'blue' as const };
+
+describe('AnnouncementCard actions', () => {
+  beforeEach(() => {
+    mocks.openExternalLinkWarning.mockClear();
+  });
+
+  test('an internal action renders an anchor that navigates directly', async () => {
+    const { AnnouncementCard } = await import('~/components/Announcements/AnnouncementCard');
+    renderWithProviders(
+      <AnnouncementCard {...base} actions={[{ link: '/models/123', linkText: 'See the model' }]} />
+    );
+
+    const cta = page.getByRole('link', { name: 'See the model' });
+    await expect.element(cta).toHaveAttribute('href', '/models/123');
+  });
+
+  test('an external action opens the interstitial instead of navigating', async () => {
+    const { AnnouncementCard } = await import('~/components/Announcements/AnnouncementCard');
+    renderWithProviders(
+      <AnnouncementCard
+        {...base}
+        actions={[{ link: 'https://t.me/SomeGroup', linkText: 'Join the group' }]}
+      />
+    );
+
+    const cta = page.getByRole('button', { name: 'Join the group' });
+    await expect.element(cta).toBeVisible();
+    // 🔴 The absence of an href is the fix, not a detail. An anchor stays middle-clickable,
+    // cmd-clickable and copyable — all of which route around the interstitial.
+    await expect.element(cta).not.toHaveAttribute('href');
+
+    await cta.click();
+    expect(mocks.openExternalLinkWarning).toHaveBeenCalledWith('https://t.me/SomeGroup');
+  });
+
+  test('an external action still reports the click to analytics', async () => {
+    const { AnnouncementCard } = await import('~/components/Announcements/AnnouncementCard');
+    const onActionClick = vi.fn();
+    const action = { link: 'https://t.me/SomeGroup', linkText: 'Join the group' };
+    renderWithProviders(
+      <AnnouncementCard {...base} actions={[action]} onActionClick={onActionClick} />
+    );
+
+    await page.getByRole('button', { name: 'Join the group' }).click();
+    expect(onActionClick).toHaveBeenCalledWith(action, 0);
+  });
+});

--- a/src/components/Announcements/AnnouncementCard.tsx
+++ b/src/components/Announcements/AnnouncementCard.tsx
@@ -164,7 +164,7 @@ export function AnnouncementCard({
             {controls}
           </div>
         )}
-        <CustomMarkdown allowedElements={['a']} unwrapDisallowed>
+        <CustomMarkdown allowedElements={['a']} unwrapDisallowed warnOnExternalLinks>
           {content}
         </CustomMarkdown>
         {!!actions.length && (

--- a/src/components/Announcements/AnnouncementCard.tsx
+++ b/src/components/Announcements/AnnouncementCard.tsx
@@ -176,9 +176,11 @@ export function AnnouncementCard({
                 if (external) openExternalLinkWarning(action.link);
               };
 
+              const variant = (action.variant || 'outline') as ButtonVariant;
+
               const shared = {
                 onClick: handleClick,
-                variant: (action.variant ? (action.variant as ButtonVariant) : 'outline') as ButtonVariant,
+                variant,
                 color: action.color ?? color,
                 children: action.linkText,
               };
@@ -186,7 +188,17 @@ export function AnnouncementCard({
               // No `href` when the destination is off-site: an anchor is still middle- and
               // cmd-clickable, which is a path around the interstitial rather than through it.
               return external ? (
-                <Button key={index} {...shared} />
+                <Button
+                  key={index}
+                  {...shared}
+                  type="button"
+                  // A `<button>` fires `auxclick`, not `click`, so without this middle-click is
+                  // dead rather than gated. Narrowed to button 1 because `auxclick` also fires
+                  // on right-click, where the interstitial would fight the context menu.
+                  onAuxClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                    if (e.button === 1) handleClick();
+                  }}
+                />
               ) : (
                 <Button key={index} component={Link} href={action.link} {...shared} />
               );

--- a/src/components/Announcements/AnnouncementCard.tsx
+++ b/src/components/Announcements/AnnouncementCard.tsx
@@ -11,6 +11,9 @@ import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { TwCard } from '~/components/TwCard/TwCard';
 import { useTrackImpression } from '~/components/TrackView/useTrackImpression';
 import type { ImpressionTarget } from '~/components/TrackView/useTrackImpression';
+import { openExternalLinkWarning } from '~/components/ExternalLinkWarning/openExternalLinkWarning';
+import { useInternalHosts } from '~/hooks/useInternalHosts';
+import { isExternalHref } from '~/utils/external-link';
 
 export type AnnouncementCardAction = {
   link: string;
@@ -101,6 +104,7 @@ export function AnnouncementCard({
 }: AnnouncementCardProps) {
   const impressionRef = useTrackImpression<HTMLElement>(impressions);
   const theme = useMantineTheme();
+  const internalHosts = useInternalHosts();
   const borderColor = theme.colors[color]?.[4] ?? theme.colors.blue[4];
 
   const body = (
@@ -165,18 +169,28 @@ export function AnnouncementCard({
         </CustomMarkdown>
         {!!actions.length && (
           <div className="flex gap-2">
-            {actions.map((action, index) => (
-              <Button
-                key={index}
-                component={Link}
-                href={action.link}
-                onClick={() => onActionClick?.(action, index)}
-                variant={action.variant ? (action.variant as ButtonVariant) : 'outline'}
-                color={action.color ?? color}
-              >
-                {action.linkText}
-              </Button>
-            ))}
+            {actions.map((action, index) => {
+              const external = isExternalHref(action.link, internalHosts);
+              const handleClick = () => {
+                onActionClick?.(action, index);
+                if (external) openExternalLinkWarning(action.link);
+              };
+
+              const shared = {
+                onClick: handleClick,
+                variant: (action.variant ? (action.variant as ButtonVariant) : 'outline') as ButtonVariant,
+                color: action.color ?? color,
+                children: action.linkText,
+              };
+
+              // No `href` when the destination is off-site: an anchor is still middle- and
+              // cmd-clickable, which is a path around the interstitial rather than through it.
+              return external ? (
+                <Button key={index} {...shared} />
+              ) : (
+                <Button key={index} component={Link} href={action.link} {...shared} />
+              );
+            })}
           </div>
         )}
         {footer}

--- a/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
@@ -43,9 +43,7 @@ vi.mock('~/components/Announcements/creator-announcements.utils', async (importO
   }),
   useMutedCreators: () => [],
   useDeleteCreatorAnnouncement: () => ({ deleteAnnouncement: vi.fn(), isLoading: false }),
-  // `AnnouncementMuteMenuItem` only renders once the kebab is opened, so no earlier test in
-  // this file reached it. Left on the real implementation it calls `trpc.useUtils()`, which
-  // this scaffold's tRPC stub doesn't cover.
+  // `useToggleAnnouncementMute` calls `trpc.useUtils()`, which the stub below doesn't cover.
   useToggleAnnouncementMute: () => ({ toggle: vi.fn(), isLoading: false }),
 }));
 
@@ -312,7 +310,6 @@ describe('AnnouncementsPanel', () => {
   });
 
   test('the kebab does not offer Report on your own announcement', async () => {
-    // The scaffold's `useCurrentUser` returns id 1; the fixture's author is 99.
     mocks.creators = [
       { ...creatorAnnouncement, userId: 1, user: { ...creatorAnnouncement.user, id: 1 } },
     ];

--- a/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
@@ -10,6 +10,7 @@ import type * as FeatureFlagsProvider from '~/providers/FeatureFlagsProvider';
 import type * as BrowserSettingsProvider from '~/providers/BrowserSettingsProvider';
 import type * as BrowsingLevelProvider from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import type * as Trpc from '~/utils/trpc';
+import type * as ReportTrigger from '~/components/Dialog/triggers/report';
 import {
   clearDismissedCreatorAnnouncements,
   CREATOR_ANNOUNCEMENTS_DISMISSED_KEY,
@@ -25,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   civitai: [] as any[],
   creators: [] as any[],
   featureEnabled: true,
+  openReportModal: vi.fn(),
 }));
 
 vi.mock('~/components/Announcements/announcements.utils', async (importOriginal) => ({
@@ -41,6 +43,10 @@ vi.mock('~/components/Announcements/creator-announcements.utils', async (importO
   }),
   useMutedCreators: () => [],
   useDeleteCreatorAnnouncement: () => ({ deleteAnnouncement: vi.fn(), isLoading: false }),
+  // `AnnouncementMuteMenuItem` only renders once the kebab is opened, so no earlier test in
+  // this file reached it. Left on the real implementation it calls `trpc.useUtils()`, which
+  // this scaffold's tRPC stub doesn't cover.
+  useToggleAnnouncementMute: () => ({ toggle: vi.fn(), isLoading: false }),
 }));
 
 // The panel's leaves read providers `renderWithProviders` does not mount: `useCurrentUser`
@@ -99,6 +105,11 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
     }),
   };
 });
+
+vi.mock('~/components/Dialog/triggers/report', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReportTrigger>()),
+  openReportModal: mocks.openReportModal,
+}));
 
 const civitaiAnnouncement = {
   id: 1,
@@ -276,5 +287,43 @@ describe('AnnouncementsPanel', () => {
     mocks.creators = [creatorAnnouncement];
     await renderPanel(['civitai', 'creators']);
     await expect.element(page.getByText('Creator says hello')).toBeInTheDocument();
+  });
+
+  test("the kebab offers Report on someone else's announcement", async () => {
+    // `ReportMenuItem` wraps in `LoginRedirect`, which gates on `window.isAuthed` — set by
+    // `CivitaiSessionProvider` post-hydration in production — rather than on `useCurrentUser()`,
+    // so the mocked user above is not enough on its own to reach `onReport`.
+    window.isAuthed = true;
+    try {
+      await renderPanel(['creators']);
+
+      await page.getByRole('button', { name: 'Announcement options' }).click();
+      const report = page.getByRole('menuitem', { name: 'Report announcement' });
+      await expect.element(report).toBeVisible();
+
+      await report.click();
+      expect(mocks.openReportModal).toHaveBeenCalledWith({
+        entityType: 'announcement',
+        entityId: 2,
+      });
+    } finally {
+      window.isAuthed = undefined;
+    }
+  });
+
+  test('the kebab does not offer Report on your own announcement', async () => {
+    // The scaffold's `useCurrentUser` returns id 1; the fixture's author is 99.
+    mocks.creators = [
+      { ...creatorAnnouncement, userId: 1, user: { ...creatorAnnouncement.user, id: 1 } },
+    ];
+    await renderPanel(['creators']);
+
+    await page.getByRole('button', { name: 'Announcement options' }).click();
+    // The menu is open — assert on a sibling that IS there, so this cannot pass by the
+    // dropdown simply never having rendered.
+    await expect.element(page.getByRole('menuitem', { name: /Delete announcement/ })).toBeVisible();
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Report announcement' }))
+      .not.toBeInTheDocument();
   });
 });

--- a/src/components/Announcements/AnnouncementsPanel.tsx
+++ b/src/components/Announcements/AnnouncementsPanel.tsx
@@ -19,6 +19,10 @@ import {
 import { Menu } from '@mantine/core';
 import { IconDotsVertical, IconX } from '@tabler/icons-react';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { ReportMenuItem } from '~/components/MenuItems/ReportMenuItem';
+import { openReportModal } from '~/components/Dialog/triggers/report';
+import { ReportEntity } from '~/shared/utils/report-helpers';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 
 export type AnnouncementSource = 'civitai' | 'creators';
 
@@ -26,6 +30,7 @@ export type AnnouncementSource = 'civitai' | 'creators';
 const EMPTY_CREATOR_ITEMS: never[] = [];
 
 export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] }) {
+  const currentUser = useCurrentUser();
   const creatorAnnouncementsEnabled = useCreatorAnnouncementsFeature();
   const showCivitai = sources.includes('civitai');
   const showCreators = sources.includes('creators') && creatorAnnouncementsEnabled;
@@ -103,6 +108,17 @@ export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] 
                       creatorId={announcement.user.id}
                       creatorName={announcement.user.username}
                       muted={mutedCreatorIds.includes(announcement.user.id)}
+                    />
+                  )}
+                  {currentUser?.id !== announcement.userId && (
+                    <ReportMenuItem
+                      label="Report announcement"
+                      onReport={() =>
+                        openReportModal({
+                          entityType: ReportEntity.Announcement,
+                          entityId: announcement.id,
+                        })
+                      }
                     />
                   )}
                   <DeleteCreatorAnnouncementButton announcement={announcement} as="menu-item" />

--- a/src/components/Announcements/AnnouncementsPanel.tsx
+++ b/src/components/Announcements/AnnouncementsPanel.tsx
@@ -9,20 +9,13 @@ import {
   selectUndismissedAnnouncements,
   useDismissedCreatorAnnouncements,
 } from '~/components/Announcements/creator-announcement-dismissals';
-import { DeleteCreatorAnnouncementButton } from '~/components/Announcements/CreatorAnnouncementsCarousel';
-import { AnnouncementMuteMenuItem } from '~/components/Announcements/AnnouncementMuteToggle';
+import { AnnouncementActionsMenu } from '~/components/Announcements/AnnouncementActionsMenu';
 import {
   useCreatorAnnouncementsFeature,
-  useMutedCreators,
   useQueryFollowedAnnouncements,
 } from '~/components/Announcements/creator-announcements.utils';
-import { Menu } from '@mantine/core';
-import { IconDotsVertical, IconX } from '@tabler/icons-react';
+import { IconX } from '@tabler/icons-react';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
-import { ReportMenuItem } from '~/components/MenuItems/ReportMenuItem';
-import { openReportModal } from '~/components/Dialog/triggers/report';
-import { ReportEntity } from '~/shared/utils/report-helpers';
-import { useCurrentUser } from '~/hooks/useCurrentUser';
 
 export type AnnouncementSource = 'civitai' | 'creators';
 
@@ -30,7 +23,6 @@ export type AnnouncementSource = 'civitai' | 'creators';
 const EMPTY_CREATOR_ITEMS: never[] = [];
 
 export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] }) {
-  const currentUser = useCurrentUser();
   const creatorAnnouncementsEnabled = useCreatorAnnouncementsFeature();
   const showCivitai = sources.includes('civitai');
   const showCreators = sources.includes('creators') && creatorAnnouncementsEnabled;
@@ -38,7 +30,6 @@ export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] 
   const { data: civitai, isLoading: loadingCivitai } = useGetAnnouncements();
   const { announcements: creators, isLoading: loadingCreators } =
     useQueryFollowedAnnouncements(showCreators);
-  const mutedCreatorIds = useMutedCreators();
   const dismissedCreatorIds = useDismissedCreatorAnnouncements();
 
   const isLoading = (showCivitai && loadingCivitai) || (showCreators && loadingCreators);
@@ -89,41 +80,7 @@ export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] 
           withAuthor
           actions={
             <div className="flex items-center gap-1">
-              <Menu withinPortal position="bottom-end">
-                <Menu.Target>
-                  <LegacyActionIcon
-                    variant="subtle"
-                    color="gray"
-                    radius="xl"
-                    aria-label="Announcement options"
-                  >
-                    <IconDotsVertical size={16} />
-                  </LegacyActionIcon>
-                </Menu.Target>
-                <Menu.Dropdown>
-                  {/* Muting needs an author to mute; deleting does not, and a moderator
-                      should not lose the control on the row most likely to need it. */}
-                  {!!announcement.user && (
-                    <AnnouncementMuteMenuItem
-                      creatorId={announcement.user.id}
-                      creatorName={announcement.user.username}
-                      muted={mutedCreatorIds.includes(announcement.user.id)}
-                    />
-                  )}
-                  {currentUser?.id !== announcement.userId && (
-                    <ReportMenuItem
-                      label="Report announcement"
-                      onReport={() =>
-                        openReportModal({
-                          entityType: ReportEntity.Announcement,
-                          entityId: announcement.id,
-                        })
-                      }
-                    />
-                  )}
-                  <DeleteCreatorAnnouncementButton announcement={announcement} as="menu-item" />
-                </Menu.Dropdown>
-              </Menu>
+              <AnnouncementActionsMenu announcement={announcement} />
               <LegacyActionIcon
                 variant="subtle"
                 color="gray"

--- a/src/components/Announcements/CreatorAnnouncementsCarousel.browser.test.tsx
+++ b/src/components/Announcements/CreatorAnnouncementsCarousel.browser.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as CreatorUtils from '~/components/Announcements/creator-announcements.utils';
+import type * as ReportTrigger from '~/components/Dialog/triggers/report';
+import type * as CurrentUser from '~/hooks/useCurrentUser';
+import type * as IsClientProvider from '~/providers/IsClientProvider';
+import type * as FeatureFlagsProvider from '~/providers/FeatureFlagsProvider';
+import type * as BrowserSettingsProvider from '~/providers/BrowserSettingsProvider';
+import type * as BrowsingLevelProvider from '~/components/BrowsingLevel/BrowsingLevelProvider';
+import type * as Trpc from '~/utils/trpc';
+
+/**
+ * The author's profile carousel carries the same options menu as the notifications panel.
+ *
+ * It shipped with a bare delete icon and no menu, so a reader looking at a spam announcement on a
+ * creator's profile had no way to report it — the only Report action lived in the panel, which
+ * requires following that creator first.
+ */
+
+const mocks = vi.hoisted(() => ({
+  announcements: [] as any[],
+  openReportModal: vi.fn(),
+}));
+
+vi.mock('~/components/Announcements/creator-announcements.utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof CreatorUtils>()),
+  useCreatorAnnouncementsFeature: () => true,
+  useQueryCreatorAnnouncements: () => ({ announcements: mocks.announcements, isLoading: false }),
+  useMutedCreators: () => [],
+  useDeleteCreatorAnnouncement: () => ({ deleteAnnouncement: vi.fn(), isLoading: false }),
+  useToggleAnnouncementMute: () => ({ toggle: vi.fn(), isLoading: false }),
+}));
+
+vi.mock('~/components/Dialog/triggers/report', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReportTrigger>()),
+  openReportModal: mocks.openReportModal,
+}));
+
+vi.mock('~/hooks/useCurrentUser', async (importOriginal) => ({
+  ...(await importOriginal<typeof CurrentUser>()),
+  useCurrentUser: () => ({ id: 1, isModerator: false }),
+}));
+
+vi.mock('~/providers/IsClientProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof IsClientProvider>()),
+  useIsClient: () => true,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsProvider>()),
+  useFeatureFlags: () => ({ canViewNsfw: false, creatorAnnouncements: true }),
+}));
+
+vi.mock('~/providers/BrowserSettingsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof BrowserSettingsProvider>()),
+  useBrowsingSettings: () => false,
+}));
+
+vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof BrowsingLevelProvider>()),
+  useViewerBrowsingLevelDebounced: () => 1,
+}));
+
+// A STUB tRPC client, not a narrowed real one — `trpc` is a flat Proxy whose ownKeys is empty, so
+// spreading the real module yields `{}`. The Proxy turns anything unnamed into a named error
+// instead of `Cannot read properties of undefined` inside a render.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof Trpc>();
+  const stubbed: Record<string, unknown> = {
+    user: { getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) } },
+    track: { trackShare: { useMutation: () => ({ mutateAsync: async () => undefined }) } },
+  };
+  return {
+    ...actual,
+    trpc: new Proxy(stubbed, {
+      get(target, prop: string) {
+        if (Object.hasOwn(target, prop)) return target[prop];
+        throw new Error(`Unmocked tRPC router in a component test: trpc.${String(prop)}`);
+      },
+    }),
+  };
+});
+
+const announcement = {
+  id: 2,
+  title: 'Creator says hello',
+  content: 'new lora dropping',
+  color: 'blue',
+  emoji: null,
+  metadata: {},
+  startsAt: new Date(),
+  endsAt: null,
+  createdAt: new Date(),
+  userId: 99,
+  nsfwLevel: 1,
+  cover: null,
+  user: {
+    id: 99,
+    username: 'someone',
+    image: null,
+    deletedAt: null,
+    cosmetics: [],
+    profilePicture: null,
+  },
+};
+
+async function renderCarousel() {
+  const { CreatorAnnouncementsCarousel } = await import(
+    '~/components/Announcements/CreatorAnnouncementsCarousel'
+  );
+  renderWithProviders(<CreatorAnnouncementsCarousel userId={99} />);
+}
+
+describe('CreatorAnnouncementsCarousel options menu', () => {
+  beforeEach(() => {
+    mocks.announcements = [announcement];
+    mocks.openReportModal.mockClear();
+  });
+
+  test("offers Report on another creator's announcement", async () => {
+    await renderCarousel();
+
+    await page.getByRole('button', { name: 'Announcement options' }).click();
+    const report = page.getByRole('menuitem', { name: 'Report announcement' });
+    await expect.element(report).toBeVisible();
+
+    // `ReportMenuItem` wraps in `LoginRedirect`, which gates the callback on the global
+    // `window.isAuthed` rather than on the mocked `useCurrentUser()`.
+    try {
+      window.isAuthed = true;
+      await report.click();
+      expect(mocks.openReportModal).toHaveBeenCalledWith({
+        entityType: 'announcement',
+        entityId: 2,
+      });
+    } finally {
+      window.isAuthed = undefined;
+    }
+  });
+
+  test('does not offer Report on your own announcement', async () => {
+    mocks.announcements = [{ ...announcement, userId: 1, user: { ...announcement.user, id: 1 } }];
+    await renderCarousel();
+
+    await page.getByRole('button', { name: 'Announcement options' }).click();
+    // Assert on a sibling that IS expected, so this cannot pass by the menu never rendering.
+    await expect.element(page.getByRole('menuitem', { name: /Delete announcement/ })).toBeVisible();
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Report announcement' }))
+      .not.toBeInTheDocument();
+  });
+});

--- a/src/components/Announcements/CreatorAnnouncementsCarousel.browser.test.tsx
+++ b/src/components/Announcements/CreatorAnnouncementsCarousel.browser.test.tsx
@@ -11,11 +11,8 @@ import type * as BrowsingLevelProvider from '~/components/BrowsingLevel/Browsing
 import type * as Trpc from '~/utils/trpc';
 
 /**
- * The author's profile carousel carries the same options menu as the notifications panel.
- *
- * It shipped with a bare delete icon and no menu, so a reader looking at a spam announcement on a
- * creator's profile had no way to report it — the only Report action lived in the panel, which
- * requires following that creator first.
+ * Report must be reachable from the profile carousel, not only from the panel — which requires
+ * following the creator first.
  */
 
 const mocks = vi.hoisted(() => ({

--- a/src/components/Announcements/CreatorAnnouncementsCarousel.tsx
+++ b/src/components/Announcements/CreatorAnnouncementsCarousel.tsx
@@ -1,70 +1,12 @@
-import { Menu } from '@mantine/core';
-import { openConfirmModal } from '@mantine/modals';
-import { IconTrash } from '@tabler/icons-react';
 import React from 'react';
+import { AnnouncementActionsMenu } from '~/components/Announcements/AnnouncementActionsMenu';
 import { AnnouncementCarouselFrame } from '~/components/Announcements/AnnouncementCarouselFrame';
 import { CreatorAnnouncement } from '~/components/Announcements/CreatorAnnouncement';
-import type { CreatorAnnouncement as CreatorAnnouncementModel } from '~/components/Announcements/creator-announcement.types';
-import {
-  useDeleteCreatorAnnouncement,
-  useQueryCreatorAnnouncements,
-} from '~/components/Announcements/creator-announcements.utils';
-import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
-import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useQueryCreatorAnnouncements } from '~/components/Announcements/creator-announcements.utils';
 
-/**
- * Delete an announcement, as an icon button or as a menu entry. One component with `as`
- * rather than two, following `HideUserButton` and its siblings: the permission, the confirm
- * step and the in-flight state cannot then differ between the two chromes.
- *
- * In the panel this lives in the options menu — a destructive control does not belong loose
- * in the card's top bar, which is chrome the reader scans.
- */
-export function DeleteCreatorAnnouncementButton({
-  announcement,
-  as = 'button',
-}: {
-  announcement: CreatorAnnouncementModel;
-  as?: 'menu-item' | 'button';
-}) {
-  const currentUser = useCurrentUser();
-  const { deleteAnnouncement, isLoading } = useDeleteCreatorAnnouncement();
-
-  const canDelete =
-    !!currentUser && (currentUser.isModerator || currentUser.id === announcement.userId);
-  if (!canDelete) return null;
-
-  const handleDelete = () =>
-    openConfirmModal({
-      title: 'Delete announcement',
-      children: 'Are you sure you want to delete this announcement? This cannot be undone.',
-      labels: { cancel: "No, don't delete it", confirm: 'Delete announcement' },
-      confirmProps: { color: 'red' },
-      onConfirm: () => deleteAnnouncement(announcement.id),
-    });
-
-  return as === 'button' ? (
-    <LegacyActionIcon
-      variant="subtle"
-      color="red"
-      radius="xl"
-      loading={isLoading}
-      onClick={handleDelete}
-      aria-label="Delete announcement"
-    >
-      <IconTrash size={18} />
-    </LegacyActionIcon>
-  ) : (
-    <Menu.Item
-      color="red"
-      disabled={isLoading}
-      leftSection={<IconTrash size={16} />}
-      onClick={handleDelete}
-    >
-      Delete announcement
-    </Menu.Item>
-  );
-}
+// The delete button used to live in this file and now has its own; re-exported so the split is not
+// a rename for callers.
+export { DeleteCreatorAnnouncementButton } from '~/components/Announcements/DeleteCreatorAnnouncementButton';
 
 export function CreatorAnnouncementsCarousel({
   userId,
@@ -81,7 +23,7 @@ export function CreatorAnnouncementsCarousel({
         <CreatorAnnouncement
           announcement={announcement}
           className="h-full"
-          actions={<DeleteCreatorAnnouncementButton announcement={announcement} />}
+          actions={<AnnouncementActionsMenu announcement={announcement} />}
         />
       )}
     </AnnouncementCarouselFrame>

--- a/src/components/Announcements/CreatorAnnouncementsCarousel.tsx
+++ b/src/components/Announcements/CreatorAnnouncementsCarousel.tsx
@@ -4,10 +4,6 @@ import { AnnouncementCarouselFrame } from '~/components/Announcements/Announceme
 import { CreatorAnnouncement } from '~/components/Announcements/CreatorAnnouncement';
 import { useQueryCreatorAnnouncements } from '~/components/Announcements/creator-announcements.utils';
 
-// The delete button used to live in this file and now has its own; re-exported so the split is not
-// a rename for callers.
-export { DeleteCreatorAnnouncementButton } from '~/components/Announcements/DeleteCreatorAnnouncementButton';
-
 export function CreatorAnnouncementsCarousel({
   userId,
   className,

--- a/src/components/Announcements/DeleteCreatorAnnouncement.browser.test.tsx
+++ b/src/components/Announcements/DeleteCreatorAnnouncement.browser.test.tsx
@@ -34,7 +34,7 @@ const announcement = { id: 1, userId: AUTHOR } as any;
 
 async function renderDelete() {
   const { DeleteCreatorAnnouncementButton } = await import(
-    '~/components/Announcements/CreatorAnnouncementsCarousel'
+    '~/components/Announcements/DeleteCreatorAnnouncementButton'
   );
   // The marker is load-bearing. A negative read straight after render sees an empty body —
   // the commit is asynchronous — so `elements()` would return 0 for every case, including

--- a/src/components/Announcements/DeleteCreatorAnnouncementButton.tsx
+++ b/src/components/Announcements/DeleteCreatorAnnouncementButton.tsx
@@ -1,0 +1,62 @@
+import { Menu } from '@mantine/core';
+import { openConfirmModal } from '@mantine/modals';
+import { IconTrash } from '@tabler/icons-react';
+import React from 'react';
+import type { CreatorAnnouncement as CreatorAnnouncementModel } from '~/components/Announcements/creator-announcement.types';
+import { useDeleteCreatorAnnouncement } from '~/components/Announcements/creator-announcements.utils';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+
+/**
+ * Delete an announcement, as an icon button or as a menu entry. One component with `as`
+ * rather than two, following `HideUserButton` and its siblings: the permission, the confirm
+ * step and the in-flight state cannot then differ between the two chromes.
+ *
+ * In the panel this lives in the options menu — a destructive control does not belong loose
+ * in the card's top bar, which is chrome the reader scans.
+ */
+export function DeleteCreatorAnnouncementButton({
+  announcement,
+  as = 'button',
+}: {
+  announcement: CreatorAnnouncementModel;
+  as?: 'menu-item' | 'button';
+}) {
+  const currentUser = useCurrentUser();
+  const { deleteAnnouncement, isLoading } = useDeleteCreatorAnnouncement();
+
+  const canDelete =
+    !!currentUser && (currentUser.isModerator || currentUser.id === announcement.userId);
+  if (!canDelete) return null;
+
+  const handleDelete = () =>
+    openConfirmModal({
+      title: 'Delete announcement',
+      children: 'Are you sure you want to delete this announcement? This cannot be undone.',
+      labels: { cancel: "No, don't delete it", confirm: 'Delete announcement' },
+      confirmProps: { color: 'red' },
+      onConfirm: () => deleteAnnouncement(announcement.id),
+    });
+
+  return as === 'button' ? (
+    <LegacyActionIcon
+      variant="subtle"
+      color="red"
+      radius="xl"
+      loading={isLoading}
+      onClick={handleDelete}
+      aria-label="Delete announcement"
+    >
+      <IconTrash size={18} />
+    </LegacyActionIcon>
+  ) : (
+    <Menu.Item
+      color="red"
+      disabled={isLoading}
+      leftSection={<IconTrash size={16} />}
+      onClick={handleDelete}
+    >
+      Delete announcement
+    </Menu.Item>
+  );
+}

--- a/src/components/ExternalLinkWarning/openExternalLinkWarning.tsx
+++ b/src/components/ExternalLinkWarning/openExternalLinkWarning.tsx
@@ -35,14 +35,14 @@ function Destination({ href }: { href: string }) {
  */
 export function openExternalLinkWarning(href: string) {
   openConfirmModal({
+    // `md` rather than `lg` on both: the modal's own close button shares this line, and at 320px
+    // a larger title runs into it.
     title: (
-      <Group gap="sm" wrap="nowrap">
-        <ThemeIcon color="yellow" variant="light" radius="xl" size="lg">
-          <IconExternalLink size={18} />
+      <Group gap="xs" wrap="nowrap">
+        <ThemeIcon color="yellow" variant="light" radius="xl" size="md">
+          <IconExternalLink size={16} />
         </ThemeIcon>
-        <Text fw={600} size="lg">
-          You&apos;re leaving Civitai
-        </Text>
+        <Text fw={600}>You&apos;re leaving Civitai</Text>
       </Group>
     ),
     centered: true,

--- a/src/components/ExternalLinkWarning/openExternalLinkWarning.tsx
+++ b/src/components/ExternalLinkWarning/openExternalLinkWarning.tsx
@@ -27,9 +27,11 @@ export function openExternalLinkWarning(href: string) {
         <Text size="xs" c="dimmed" className="break-all">
           {href}
         </Text>
+        {/* Author-neutral on purpose: this also fires on Civitai's own sitewide announcements,
+            where a claim that Civitai has neither reviewed nor endorsed the destination is false. */}
         <Text size="sm">
-          Civitai has not reviewed this site and is not endorsing it. Do not enter your Civitai
-          password or payment details there.
+          Check the address before you continue, and never enter your Civitai password or payment
+          details on another site.
         </Text>
       </Stack>
     ),

--- a/src/components/ExternalLinkWarning/openExternalLinkWarning.tsx
+++ b/src/components/ExternalLinkWarning/openExternalLinkWarning.tsx
@@ -35,8 +35,7 @@ function Destination({ href }: { href: string }) {
  */
 export function openExternalLinkWarning(href: string) {
   openConfirmModal({
-    // `md` rather than `lg` on both: the modal's own close button shares this line, and at 320px
-    // a larger title runs into it.
+    // Sized down to clear the modal's own close button, which shares this line at 320px.
     title: (
       <Group gap="xs" wrap="nowrap">
         <ThemeIcon color="yellow" variant="light" radius="xl" size="md">

--- a/src/components/ExternalLinkWarning/openExternalLinkWarning.tsx
+++ b/src/components/ExternalLinkWarning/openExternalLinkWarning.tsx
@@ -1,0 +1,40 @@
+import { Anchor, Stack, Text } from '@mantine/core';
+import { openConfirmModal } from '@mantine/modals';
+
+const hostOf = (href: string) => {
+  try {
+    return new URL(href).host;
+  } catch {
+    return href;
+  }
+};
+
+/**
+ * 🔴 `noopener` is not cosmetic here: without it the destination gets a live `window.opener`
+ * handle back to the Civitai tab and can navigate it.
+ */
+export function openExternalLinkWarning(href: string) {
+  openConfirmModal({
+    title: "You're leaving Civitai",
+    centered: true,
+    labels: { cancel: 'Cancel', confirm: 'Continue' },
+    children: (
+      <Stack gap="xs">
+        <Text size="sm">This link takes you to a site Civitai does not control:</Text>
+        <Anchor component="span" fw={600} className="break-all">
+          {hostOf(href)}
+        </Anchor>
+        <Text size="xs" c="dimmed" className="break-all">
+          {href}
+        </Text>
+        <Text size="sm">
+          Civitai has not reviewed this site and is not endorsing it. Do not enter your Civitai
+          password or payment details there.
+        </Text>
+      </Stack>
+    ),
+    onConfirm: () => {
+      window.open(href, '_blank', 'noopener,noreferrer');
+    },
+  });
+}

--- a/src/components/ExternalLinkWarning/openExternalLinkWarning.tsx
+++ b/src/components/ExternalLinkWarning/openExternalLinkWarning.tsx
@@ -1,13 +1,33 @@
-import { Anchor, Stack, Text } from '@mantine/core';
+import { Group, Stack, Text, ThemeIcon } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
+import { IconExternalLink } from '@tabler/icons-react';
 
-const hostOf = (href: string) => {
-  try {
-    return new URL(href).host;
-  } catch {
-    return href;
-  }
-};
+/**
+ * The destination, split at the end of its origin so the part that decides whether a link is safe
+ * reads first and the path recedes behind it.
+ *
+ * 🔴 Never an `Anchor` and never link-coloured. This is the thing being warned about, not something
+ * to click — styling it as a link invites exactly the click the modal exists to interrupt.
+ */
+function Destination({ href }: { href: string }) {
+  const { origin, rest } = (() => {
+    try {
+      const url = new URL(href);
+      return { origin: url.origin, rest: `${url.pathname}${url.search}${url.hash}` };
+    } catch {
+      return { origin: href, rest: '' };
+    }
+  })();
+
+  return (
+    <div className="rounded-md border border-gray-3 bg-gray-0 px-3 py-2 dark:border-dark-4 dark:bg-dark-6">
+      <Text size="sm" className="break-all font-mono leading-snug">
+        <span className="font-semibold">{origin}</span>
+        {rest !== '/' && <span className="text-gray-6 dark:text-dark-2">{rest}</span>}
+      </Text>
+    </div>
+  );
+}
 
 /**
  * 🔴 `noopener` is not cosmetic here: without it the destination gets a live `window.opener`
@@ -15,21 +35,25 @@ const hostOf = (href: string) => {
  */
 export function openExternalLinkWarning(href: string) {
   openConfirmModal({
-    title: "You're leaving Civitai",
+    title: (
+      <Group gap="sm" wrap="nowrap">
+        <ThemeIcon color="yellow" variant="light" radius="xl" size="lg">
+          <IconExternalLink size={18} />
+        </ThemeIcon>
+        <Text fw={600} size="lg">
+          You&apos;re leaving Civitai
+        </Text>
+      </Group>
+    ),
     centered: true,
     labels: { cancel: 'Cancel', confirm: 'Continue' },
     children: (
-      <Stack gap="xs">
+      <Stack gap="sm">
         <Text size="sm">This link takes you to a site Civitai does not control:</Text>
-        <Anchor component="span" fw={600} className="break-all">
-          {hostOf(href)}
-        </Anchor>
-        <Text size="xs" c="dimmed" className="break-all">
-          {href}
-        </Text>
+        <Destination href={href} />
         {/* Author-neutral on purpose: this also fires on Civitai's own sitewide announcements,
             where a claim that Civitai has neither reviewed nor endorsed the destination is false. */}
-        <Text size="sm">
+        <Text size="xs" c="dimmed">
           Check the address before you continue, and never enter your Civitai password or payment
           details on another site.
         </Text>

--- a/src/components/Markdown/CustomMarkdown.tsx
+++ b/src/components/Markdown/CustomMarkdown.tsx
@@ -13,10 +13,6 @@ import { isExternalHref } from '~/utils/external-link';
 
 type CustomOptions = Options & {
   allowExternalVideo?: boolean;
-  /**
-   * 🔴 Opt-in rather than a caller-supplied `a` renderer: `mergedComponents` spreads
-   * `components` FIRST and then defines `a`, so a caller's own `a` is silently dropped.
-   */
   warnOnExternalLinks?: boolean;
 };
 
@@ -53,6 +49,8 @@ export function CustomMarkdown({
       ? Array.from(new Set([...allowedElements, 'time']))
       : undefined;
 
+  // 🔴 `a` and `time` are defined AFTER the spread, so a caller's own renderers for them are
+  // silently dropped — which is why `warnOnExternalLinks` is a prop rather than a component.
   const mergedComponents: Options['components'] = {
     ...components,
     time: ({ node, ...props }) => {

--- a/src/components/Markdown/CustomMarkdown.tsx
+++ b/src/components/Markdown/CustomMarkdown.tsx
@@ -89,6 +89,8 @@ export function CustomMarkdown({
 
       href = href.replace(encodeURI('{userId}'), user?.id?.toString() ?? '');
 
+      // Unlike the CTA button, this href is kept — prose text needs it for copy-link and
+      // screen-reader destination announcement — so middle-click and copy-link stay ungated.
       const warn = warnOnExternalLinks && isExternalHref(href, internalHosts);
 
       return (

--- a/src/components/Markdown/CustomMarkdown.tsx
+++ b/src/components/Markdown/CustomMarkdown.tsx
@@ -7,9 +7,17 @@ import ContentErrorBoundary from '~/components/ErrorBoundary/ContentErrorBoundar
 import { LocalTimestamp } from '~/components/LocalTimestamp/LocalTimestamp';
 import { remarkTimestamp } from '~/components/Markdown/remark-timestamp';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { openExternalLinkWarning } from '~/components/ExternalLinkWarning/openExternalLinkWarning';
+import { useInternalHosts } from '~/hooks/useInternalHosts';
+import { isExternalHref } from '~/utils/external-link';
 
 type CustomOptions = Options & {
   allowExternalVideo?: boolean;
+  /**
+   * 🔴 Opt-in rather than a caller-supplied `a` renderer: `mergedComponents` spreads
+   * `components` FIRST and then defines `a`, so a caller's own `a` is silently dropped.
+   */
+  warnOnExternalLinks?: boolean;
 };
 
 /**
@@ -19,6 +27,7 @@ type CustomOptions = Options & {
  */
 export function CustomMarkdown({
   allowExternalVideo,
+  warnOnExternalLinks,
   components,
   className,
   remarkPlugins,
@@ -26,6 +35,7 @@ export function CustomMarkdown({
   ...options
 }: CustomOptions) {
   const user = useCurrentUser();
+  const internalHosts = useInternalHosts();
 
   // Discord-style `<t:UNIX:STYLE>` timestamp support is available in every
   // markdown surface. Caller-provided remark plugins still run alongside it.
@@ -79,9 +89,22 @@ export function CustomMarkdown({
 
       href = href.replace(encodeURI('{userId}'), user?.id?.toString() ?? '');
 
+      const warn = warnOnExternalLinks && isExternalHref(href, internalHosts);
+
       return (
         <Link legacyBehavior href={href} passHref>
-          <a target={isExternalLink ? '_blank' : '_self'} rel="nofollow noreferrer">
+          <a
+            target={isExternalLink ? '_blank' : '_self'}
+            rel="nofollow noreferrer"
+            onClick={
+              warn
+                ? (e) => {
+                    e.preventDefault();
+                    openExternalLinkWarning(href);
+                  }
+                : undefined
+            }
+          >
             {props.children}
           </a>
         </Link>

--- a/src/components/Modals/ReportModal.tsx
+++ b/src/components/Modals/ReportModal.tsx
@@ -26,7 +26,7 @@ import { SpamForm } from '~/components/Report/SpamForm';
 import { TosViolationForm } from '~/components/Report/TosViolationForm';
 import { useVoteForTags } from '~/components/VotableTags/votableTag.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { ReportEntity } from '~/shared/utils/report-helpers';
+import { ReportEntity, reportEntityLabels } from '~/shared/utils/report-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -239,7 +239,7 @@ export default function ReportModal({
     },
     async onSuccess(_, variables) {
       showSuccessNotification({
-        title: 'Resource reported',
+        title: `${reportEntityLabels[entityType]} reported`,
         message: 'Your request has been received',
       });
       dialog.onClose();

--- a/src/components/Modals/ReportModal.tsx
+++ b/src/components/Modals/ReportModal.tsx
@@ -86,6 +86,7 @@ const reports = [
       ReportEntity.Model3D,
       ReportEntity.Model3DReview,
       ReportEntity.Challenge,
+      ReportEntity.Announcement,
     ],
   },
   {
@@ -110,6 +111,7 @@ const reports = [
       ReportEntity.Model3D,
       ReportEntity.Model3DReview,
       ReportEntity.Challenge,
+      ReportEntity.Announcement,
     ],
   },
   {
@@ -161,6 +163,7 @@ const reports = [
       ReportEntity.Model3D,
       ReportEntity.Model3DReview,
       ReportEntity.Challenge,
+      ReportEntity.Announcement,
     ],
   },
 ];

--- a/src/hooks/useInternalHosts.ts
+++ b/src/hooks/useInternalHosts.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import { useMaybeAppContext } from '~/providers/AppProvider';
+
+/**
+ * Every host that counts as "still on Civitai": the one being viewed, plus every color's
+ * canonical host and aliases.
+ *
+ * Without the provider this is the current host alone, which OVER-warns (a .com→.red link
+ * would be gated). That is the safe direction for a guard: a warning that should not have
+ * appeared is a click, a warning that did not appear is the thing this exists to prevent.
+ */
+export function useInternalHosts(): string[] {
+  const context = useMaybeAppContext();
+  const serverDomains = context?.serverDomains;
+
+  return useMemo(() => {
+    const hosts = new Set<string>();
+    if (typeof window !== 'undefined') hosts.add(window.location.host);
+    for (const config of Object.values(serverDomains ?? {})) {
+      if (!config) continue;
+      hosts.add(config.primary);
+      for (const alias of config.aliases) hosts.add(alias);
+    }
+    return [...hosts];
+  }, [serverDomains]);
+}

--- a/src/hooks/useInternalHosts.ts
+++ b/src/hooks/useInternalHosts.ts
@@ -2,9 +2,6 @@ import { useMemo } from 'react';
 import { useMaybeAppContext } from '~/providers/AppProvider';
 
 /**
- * Every host that counts as "still on Civitai": the one being viewed, plus every color's
- * canonical host and aliases.
- *
  * Without the provider this is the current host alone, which OVER-warns (a .com→.red link
  * would be gated). That is the safe direction for a guard: a warning that should not have
  * appeared is a click, a warning that did not appear is the thing this exists to prevent.

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -80,9 +80,9 @@ export function useAppContext() {
 }
 
 /**
- * 🔴 Non-throwing on purpose. Component tests mount no `AppProvider`, and a hook that throws
- * during render empties the tree — every assertion in the file then times out with nothing
- * pointing at the cause. Only for consumers that have a correct answer without the provider.
+ * 🔴 Non-throwing on purpose, and only for consumers with a correct answer without the
+ * provider: component tests mount no `AppProvider`, and a throw during render empties the tree
+ * into unexplained timeouts.
  */
 export function useMaybeAppContext() {
   return useContext(Context);

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -80,6 +80,15 @@ export function useAppContext() {
 }
 
 /**
+ * 🔴 Non-throwing on purpose. Component tests mount no `AppProvider`, and a hook that throws
+ * during render empties the tree — every assertion in the file then times out with nothing
+ * pointing at the cause. Only for consumers that have a correct answer without the provider.
+ */
+export function useMaybeAppContext() {
+  return useContext(Context);
+}
+
+/**
  * Returns the canonical (primary) host for each color. Use this for outbound
  * URL construction — never link to an alias host.
  */

--- a/src/server/clickhouse/migrations/2026-09-10-announcement-report-entity.sql
+++ b/src/server/clickhouse/migrations/2026-09-10-announcement-report-entity.sql
@@ -2,28 +2,20 @@
 --
 -- Apply this MANUALLY. We do not auto-run DDL (same policy as the Postgres migrations).
 --
--- ⏳ NOT YET APPLIED. Apply it BEFORE the branch that adds ReportEntity.Announcement is
--- deployed — and read the restart caveat below, because that ordering rule is necessary and
--- not sufficient.
+-- ✅ COLUMN APPLIED 2026-09-11: `default.reports.entityType` carries 'announcement' = 17.
+-- 🔴 The tracker-restart half is NOT recorded. Treat "is the tracker actually writing this
+-- value" as OPEN until the positive control below returns non-zero — the same status section 5
+-- of ./2026-09-07-reaction-report-enum-widening.sql carries.
 --
--- WHY. `ReportEntity` (src/shared/utils/report-helpers.ts) gains `Announcement = 'announcement'`,
--- and `createReportHandler` emits it as `entityType` on every report event. The column's newest
--- definition, in ./2026-09-07-reaction-report-enum-widening.sql section 5, stops at
--- 'model3dReview' = 16.
+-- WHY. `ReportEntity` (src/shared/utils/report-helpers.ts) gains 'announcement', which
+-- `createReportHandler` emits as `entityType`. The column's newest definition — section 5 of
+-- ./2026-09-07-reaction-report-enum-widening.sql — stops at 'model3dReview' = 16.
 --
--- 🔴 THE FAILURE IS SILENT AND CLIENT-SIDE. The app POSTs to the tracker service
--- fire-and-forget; a value the target column does not carry is rejected THERE, while it is
--- serializing the batch, before ClickHouse is ever asked. So the caller sees a successful
--- send, the app logs nothing, `SHOW CREATE TABLE` looks fine, and the rows simply never
--- exist. A dashboard over them reads a clean zero that is indistinguishable from
--- "nobody reported an announcement". The report itself still lands in Postgres — what is lost
--- is the moderation analytics row, not the moderation.
---
--- 🔴 THE DDL IS ONLY HALF THE OPERATION. `civitai-clickhouse-tracker` builds its column
--- serializers from the schema its pods read AT CONNECT TIME and never re-reads them, so a
--- value added after those pods booted is still rejected client-side. See ./README.md — this
--- has shipped broken twice, and section 5 of the 2026-09-07 file is a third case where the
--- restart half was never confirmed.
+-- 🔴 THE DDL IS HALF THE OPERATION AND THE OTHER HALF FAILS SILENTLY. See ./README.md: the
+-- tracker rejects an unknown value client-side, so the send succeeds, the DDL verifies, and the
+-- rows never exist — the report still lands in Postgres, so what is lost is moderation
+-- analytics, not moderation. Section 5 of the 2026-09-07 file is a third case where the
+-- restart was never confirmed.
 --
 -- `MODIFY COLUMN` REPLACES the whole enum definition, so the statement below restates every
 -- existing value at exactly the index it already has and appends at an unused index — a
@@ -37,12 +29,6 @@
 -- narrowing an enum that already carries a value makes those rows unreadable.
 --
 -- POST-APPLY: restart civitai-clickhouse-tracker by pod delete, then confirm with a real event.
-
-
--- =====================================================================================
--- reports.entityType — adds 'announcement' = 17. Indices 1..16 are unchanged from
--- ./2026-09-07-reaction-report-enum-widening.sql section 5.
--- =====================================================================================
 
 ALTER TABLE default.reports
   MODIFY COLUMN `entityType` Enum8(
@@ -65,25 +51,17 @@ ALTER TABLE default.reports
     'announcement' = 17
   );
 
-
--- =====================================================================================
--- POST-APPLY verification. Run both halves; the DDL check alone is what has shipped broken
--- before, and a bare zero from the positive control proves nothing on its own.
--- =====================================================================================
+-- POST-APPLY verification. The DDL check alone is what has shipped broken before.
 --
 --   SHOW CREATE TABLE default.reports;
 --     -- `entityType` must show 'announcement' = 17, with 1..16 unchanged.
 --
--- Positive control, AFTER the tracker pods have been deleted and come back Ready — file a
--- report against an announcement yourself, then:
+-- Positive control, AFTER the tracker pods have been restarted — file a report against an
+-- announcement yourself, then:
 --
 --   SELECT count() FROM default.reports WHERE entityType = 'announcement';
---     -- No time predicate is needed: the column could not REPRESENT this value before this
---     -- ALTER, so any row carrying it necessarily postdates it.
 --     -- 🔴 A zero is ambiguous and must not be read as "fixed" — it is equally consistent
 --     -- with "the tracker was never restarted" and with "nobody has reported an announcement
 --     -- yet". Filing one yourself is what turns an absence into a real positive control.
 --
---   kubectl logs -n civitai-clickhouse-tracker <pod> --since=5m | grep 'Flush reports'
---     -- must read poison=0 dlq=0 for a batch that actually contained the attempt. Immediately
---     -- after a restart it only says no rejectable row was in that batch.
+-- The tracker's own flush log is the third signal; ask an infra owner for the command.

--- a/src/server/clickhouse/migrations/2026-09-10-announcement-report-entity.sql
+++ b/src/server/clickhouse/migrations/2026-09-10-announcement-report-entity.sql
@@ -1,0 +1,89 @@
+-- reports.entityType — add 'announcement'. ClickHouse DDL.
+--
+-- Apply this MANUALLY. We do not auto-run DDL (same policy as the Postgres migrations).
+--
+-- ⏳ NOT YET APPLIED. Apply it BEFORE the branch that adds ReportEntity.Announcement is
+-- deployed — and read the restart caveat below, because that ordering rule is necessary and
+-- not sufficient.
+--
+-- WHY. `ReportEntity` (src/shared/utils/report-helpers.ts) gains `Announcement = 'announcement'`,
+-- and `createReportHandler` emits it as `entityType` on every report event. The column's newest
+-- definition, in ./2026-09-07-reaction-report-enum-widening.sql section 5, stops at
+-- 'model3dReview' = 16.
+--
+-- 🔴 THE FAILURE IS SILENT AND CLIENT-SIDE. The app POSTs to the tracker service
+-- fire-and-forget; a value the target column does not carry is rejected THERE, while it is
+-- serializing the batch, before ClickHouse is ever asked. So the caller sees a successful
+-- send, the app logs nothing, `SHOW CREATE TABLE` looks fine, and the rows simply never
+-- exist. A dashboard over them reads a clean zero that is indistinguishable from
+-- "nobody reported an announcement". The report itself still lands in Postgres — what is lost
+-- is the moderation analytics row, not the moderation.
+--
+-- 🔴 THE DDL IS ONLY HALF THE OPERATION. `civitai-clickhouse-tracker` builds its column
+-- serializers from the schema its pods read AT CONNECT TIME and never re-reads them, so a
+-- value added after those pods booted is still rejected client-side. See ./README.md — this
+-- has shipped broken twice, and section 5 of the 2026-09-07 file is a third case where the
+-- restart half was never confirmed.
+--
+-- `MODIFY COLUMN` REPLACES the whole enum definition, so the statement below restates every
+-- existing value at exactly the index it already has and appends at an unused index — a
+-- metadata-only ALTER: no data is rewritten and no mutation is scheduled. Do NOT renumber or
+-- rename an existing value; that WOULD rewrite the table and silently remap existing rows.
+--
+-- Independent of every other section in this directory: no materialized view reads `reports`.
+--
+-- TO ROLL BACK: re-run the statement below with 'announcement' = 17 removed, having first
+-- confirmed `SELECT count() FROM default.reports WHERE entityType = 'announcement'` is 0 —
+-- narrowing an enum that already carries a value makes those rows unreadable.
+--
+-- POST-APPLY: restart civitai-clickhouse-tracker by pod delete, then confirm with a real event.
+
+
+-- =====================================================================================
+-- reports.entityType — adds 'announcement' = 17. Indices 1..16 are unchanged from
+-- ./2026-09-07-reaction-report-enum-widening.sql section 5.
+-- =====================================================================================
+
+ALTER TABLE default.reports
+  MODIFY COLUMN `entityType` Enum8(
+    'model' = 1,
+    'comment' = 2,
+    'commentV2' = 3,
+    'image' = 4,
+    'resourceReview' = 5,
+    'article' = 6,
+    'post' = 7,
+    'reportedUser' = 8,
+    'collection' = 9,
+    'bounty' = 10,
+    'bountyEntry' = 11,
+    'chat' = 12,
+    'challenge' = 13,
+    'comicProject' = 14,
+    'model3d' = 15,
+    'model3dReview' = 16,
+    'announcement' = 17
+  );
+
+
+-- =====================================================================================
+-- POST-APPLY verification. Run both halves; the DDL check alone is what has shipped broken
+-- before, and a bare zero from the positive control proves nothing on its own.
+-- =====================================================================================
+--
+--   SHOW CREATE TABLE default.reports;
+--     -- `entityType` must show 'announcement' = 17, with 1..16 unchanged.
+--
+-- Positive control, AFTER the tracker pods have been deleted and come back Ready — file a
+-- report against an announcement yourself, then:
+--
+--   SELECT count() FROM default.reports WHERE entityType = 'announcement';
+--     -- No time predicate is needed: the column could not REPRESENT this value before this
+--     -- ALTER, so any row carrying it necessarily postdates it.
+--     -- 🔴 A zero is ambiguous and must not be read as "fixed" — it is equally consistent
+--     -- with "the tracker was never restarted" and with "nobody has reported an announcement
+--     -- yet". Filing one yourself is what turns an absence into a real positive control.
+--
+--   kubectl logs -n civitai-clickhouse-tracker <pod> --since=5m | grep 'Flush reports'
+--     -- must read poison=0 dlq=0 for a batch that actually contained the attempt. Immediately
+--     -- after a restart it only says no rejectable row was in that batch.

--- a/src/server/services/__tests__/announcement-report-snapshot.test.ts
+++ b/src/server/services/__tests__/announcement-report-snapshot.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { ReportEntity } from '~/shared/utils/report-helpers';
+import { ReportReason } from '~/shared/utils/prisma/enums';
+
+vi.mock('~/server/services/system-cache', () => ({ getModeratedTags: vi.fn(async () => []) }));
+
+const { createReport } = await import('~/server/services/report.service');
+
+const announcementFindUnique = dbMock.dbRead.announcement.findUnique;
+const reportFindFirst = dbMock.dbWrite.report.findFirst;
+const reportCreate = dbMock.dbWrite.report.create;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // `clearAllMocks` clears calls but not implementations, so these are re-declared per test
+  // rather than left to leak from one case into the next.
+  announcementFindUnique.mockResolvedValue(null);
+  reportFindFirst.mockResolvedValue(null);
+  reportCreate.mockImplementation(async ({ data }: any) => ({ id: 1, ...data }));
+});
+
+describe('createReport — announcement snapshot', () => {
+  it('copies the announcement into details, from the row rather than the client', async () => {
+    announcementFindUnique.mockResolvedValue({
+      title: 'Free LoRAs',
+      content: 'join my telegram',
+      userId: 99,
+      metadata: { actions: [{ link: 'https://t.me/SomeGroup', linkText: 'Join' }] },
+    });
+
+    await createReport({
+      userId: 7,
+      id: 42,
+      type: ReportEntity.Announcement,
+      reason: ReportReason.Spam,
+      // A forged snapshot from the client must not survive.
+      details: { announcement: { title: 'innocuous', id: 1234 }, comment: 'spam' } as any,
+    });
+
+    const details = reportCreate.mock.calls[0][0].data.details;
+    expect(details.announcement).toEqual({
+      title: 'Free LoRAs',
+      content: 'join my telegram',
+      link: 'https://t.me/SomeGroup',
+      userId: 99,
+    });
+    expect(details.comment).toBe('spam');
+    // `Record<ReportEntity, …>` guarantees the key exists, not that its value names the right
+    // column, so the relation field and the foreign key are pinned against the schema here.
+    expect(reportCreate.mock.calls[0][0].data.announcement).toEqual({
+      create: { announcementId: 42 },
+    });
+  });
+
+  it('does not snapshot for any other entity type', async () => {
+    await createReport({
+      userId: 7,
+      id: 42,
+      type: ReportEntity.Article,
+      reason: ReportReason.Spam,
+      details: { comment: 'spam' } as any,
+    });
+
+    expect(announcementFindUnique).not.toHaveBeenCalled();
+    expect(reportCreate.mock.calls[0][0].data.details.announcement).toBeUndefined();
+  });
+});

--- a/src/server/services/__tests__/announcement-report-snapshot.test.ts
+++ b/src/server/services/__tests__/announcement-report-snapshot.test.ts
@@ -18,8 +18,8 @@ const reportUpdate = dbMock.dbWrite.report.update;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  // `clearAllMocks` clears calls but not implementations, so these are re-declared per test
-  // rather than left to leak from one case into the next.
+  // `clearAllMocks` does not reset implementations, so a mockResolvedValue from one test
+  // leaks into the next without these.
   announcementFindUnique.mockResolvedValue(null);
   reportFindFirst.mockResolvedValue(null);
   reportCreate.mockImplementation(async ({ data }: any) => ({ id: 1, ...data }));

--- a/src/server/services/__tests__/announcement-report-snapshot.test.ts
+++ b/src/server/services/__tests__/announcement-report-snapshot.test.ts
@@ -67,10 +67,20 @@ describe('createReport — announcement snapshot', () => {
     });
   });
 
-  it('does not read the announcement for a report that dedupes into an existing one', async () => {
+  it('does not snapshot onto a report that dedupes into an existing one', async () => {
     // `withAdditionalReport` keeps every key but `reportType`, so a snapshot stamped before the
     // dedupe short-circuit appends a second copy of the unbounded HTML content to the existing
     // row — for a duplicate reporter who wrote nothing at all.
+    //
+    // The row IS read on this path, unlike the snapshot: the sitewide guard needs it, and a
+    // guard below the short-circuit would let a second report on a Civitai announcement fold
+    // into the first and return success.
+    announcementFindUnique.mockResolvedValue({
+      title: 'Free LoRAs',
+      content: 'join my telegram',
+      userId: 99,
+      metadata: {},
+    });
     reportFindFirst.mockResolvedValue({
       id: 5,
       details: {},
@@ -88,7 +98,46 @@ describe('createReport — announcement snapshot', () => {
     });
 
     expect(reportUpdate.mock.calls[0][0].data.details).toBeUndefined();
-    expect(announcementFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('refuses a sitewide Civitai announcement, which has no author', async () => {
+    announcementFindUnique.mockResolvedValue({
+      title: 'Maintenance window',
+      content: 'back shortly',
+      userId: null,
+      metadata: {},
+    });
+
+    await expect(
+      createReport({
+        userId: 7,
+        id: 42,
+        type: ReportEntity.Announcement,
+        reason: ReportReason.Spam,
+        details: { comment: 'spam' } as any,
+      })
+    ).rejects.toThrow(/cannot be reported/i);
+
+    // Refused before anything was written, and before the dedupe lookup that would otherwise
+    // fold a second attempt into an existing report.
+    expect(reportCreate).not.toHaveBeenCalled();
+    expect(reportFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('refuses an announcement that no longer exists', async () => {
+    announcementFindUnique.mockResolvedValue(null);
+
+    await expect(
+      createReport({
+        userId: 7,
+        id: 42,
+        type: ReportEntity.Announcement,
+        reason: ReportReason.Spam,
+        details: { comment: 'spam' } as any,
+      })
+    ).rejects.toThrow(/no longer exists/i);
+
+    expect(reportCreate).not.toHaveBeenCalled();
   });
 
   it('does not snapshot for any other entity type', async () => {

--- a/src/server/services/__tests__/announcement-report-snapshot.test.ts
+++ b/src/server/services/__tests__/announcement-report-snapshot.test.ts
@@ -2,14 +2,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { ReportEntity } from '~/shared/utils/report-helpers';
 import { ReportReason } from '~/shared/utils/prisma/enums';
+import type * as SystemCache from '~/server/services/system-cache';
 
-vi.mock('~/server/services/system-cache', () => ({ getModeratedTags: vi.fn(async () => []) }));
+vi.mock('~/server/services/system-cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof SystemCache>()),
+  getModeratedTags: vi.fn(async () => []),
+}));
 
 const { createReport } = await import('~/server/services/report.service');
 
 const announcementFindUnique = dbMock.dbRead.announcement.findUnique;
 const reportFindFirst = dbMock.dbWrite.report.findFirst;
 const reportCreate = dbMock.dbWrite.report.create;
+const reportUpdate = dbMock.dbWrite.report.update;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -35,7 +40,16 @@ describe('createReport — announcement snapshot', () => {
       type: ReportEntity.Announcement,
       reason: ReportReason.Spam,
       // A forged snapshot from the client must not survive.
-      details: { announcement: { title: 'innocuous', id: 1234 }, comment: 'spam' } as any,
+      details: {
+        announcement: {
+          title: 'innocuous',
+          content: 'nice',
+          link: 'https://safe.example',
+          userId: 1,
+          id: 1234,
+        },
+        comment: 'spam',
+      } as any,
     });
 
     const details = reportCreate.mock.calls[0][0].data.details;
@@ -51,6 +65,30 @@ describe('createReport — announcement snapshot', () => {
     expect(reportCreate.mock.calls[0][0].data.announcement).toEqual({
       create: { announcementId: 42 },
     });
+  });
+
+  it('does not read the announcement for a report that dedupes into an existing one', async () => {
+    // `withAdditionalReport` keeps every key but `reportType`, so a snapshot stamped before the
+    // dedupe short-circuit appends a second copy of the unbounded HTML content to the existing
+    // row — for a duplicate reporter who wrote nothing at all.
+    reportFindFirst.mockResolvedValue({
+      id: 5,
+      details: {},
+      alsoReportedBy: [],
+      previouslyReviewedCount: 0,
+    });
+    reportUpdate.mockResolvedValue({ id: 5 });
+
+    await createReport({
+      userId: 7,
+      id: 42,
+      type: ReportEntity.Announcement,
+      reason: ReportReason.Spam,
+      details: {} as any,
+    });
+
+    expect(reportUpdate.mock.calls[0][0].data.details).toBeUndefined();
+    expect(announcementFindUnique).not.toHaveBeenCalled();
   });
 
   it('does not snapshot for any other entity type', async () => {

--- a/src/server/services/report.service.ts
+++ b/src/server/services/report.service.ts
@@ -282,6 +282,26 @@ export const createReport = async ({
   if (!data.details) data.details = {};
   (data.details as MixedObject).reportType = reportTypeNameMap[type];
 
+  // 🔴 The join row cascades on announcement delete, and deleting an announcement is instant
+  // and self-serve — so without this, the fastest way to erase a spam report is to delete the
+  // announcement it was about. Read from the row, never from `details`: the reporter controls
+  // that object, and a snapshot a reporter can author is a snapshot a reporter can forge.
+  if (type === ReportEntity.Announcement) {
+    const announcement = await dbRead.announcement.findUnique({
+      where: { id },
+      select: { title: true, content: true, userId: true, metadata: true },
+    });
+    if (announcement) {
+      const actions = (announcement.metadata as { actions?: { link?: string }[] } | null)?.actions;
+      (data.details as MixedObject).announcement = {
+        title: announcement.title,
+        content: announcement.content,
+        link: actions?.[0]?.link ?? null,
+        userId: announcement.userId,
+      };
+    }
+  }
+
   // only mods can create csam reports
   if (data.reason === ReportReason.CSAM && !isModerator) throw throwAuthorizationError();
 

--- a/src/server/services/report.service.ts
+++ b/src/server/services/report.service.ts
@@ -282,26 +282,6 @@ export const createReport = async ({
   if (!data.details) data.details = {};
   (data.details as MixedObject).reportType = reportTypeNameMap[type];
 
-  // 🔴 The join row cascades on announcement delete, and deleting an announcement is instant
-  // and self-serve — so without this, the fastest way to erase a spam report is to delete the
-  // announcement it was about. Read from the row, never from `details`: the reporter controls
-  // that object, and a snapshot a reporter can author is a snapshot a reporter can forge.
-  if (type === ReportEntity.Announcement) {
-    const announcement = await dbRead.announcement.findUnique({
-      where: { id },
-      select: { title: true, content: true, userId: true, metadata: true },
-    });
-    if (announcement) {
-      const actions = (announcement.metadata as { actions?: { link?: string }[] } | null)?.actions;
-      (data.details as MixedObject).announcement = {
-        title: announcement.title,
-        content: announcement.content,
-        link: actions?.[0]?.link ?? null,
-        userId: announcement.userId,
-      };
-    }
-  }
-
   // only mods can create csam reports
   if (data.reason === ReportReason.CSAM && !isModerator) throw throwAuthorizationError();
 
@@ -325,6 +305,26 @@ export const createReport = async ({
         })
       : null;
   if (validReport) return validReport;
+
+  // 🔴 The join row cascades on announcement delete, and deleting an announcement is instant
+  // and self-serve — so without this, the fastest way to erase a spam report is to delete the
+  // announcement it was about. Read from the row, never from `details`: the reporter controls
+  // that object, and a snapshot a reporter can author is a snapshot a reporter can forge.
+  if (type === ReportEntity.Announcement) {
+    const announcement = await dbRead.announcement.findUnique({
+      where: { id },
+      select: { title: true, content: true, userId: true, metadata: true },
+    });
+    if (announcement) {
+      const actions = (announcement.metadata as { actions?: { link?: string }[] } | null)?.actions;
+      (data.details as MixedObject).announcement = {
+        title: announcement.title,
+        content: announcement.content,
+        link: actions?.[0]?.link ?? null,
+        userId: announcement.userId,
+      };
+    }
+  }
 
   let recomputeArticleNsfwLevelId: number | null = null;
 

--- a/src/server/services/report.service.ts
+++ b/src/server/services/report.service.ts
@@ -206,6 +206,7 @@ const reportTypeNameMap: Record<ReportEntity, string> = {
   [ReportEntity.ComicProject]: 'comicProject',
   [ReportEntity.Model3D]: 'model3d',
   [ReportEntity.Model3DReview]: 'model3dReview',
+  [ReportEntity.Announcement]: 'announcement',
 };
 
 const reportTypeConnectionMap = {
@@ -225,6 +226,7 @@ const reportTypeConnectionMap = {
   [ReportEntity.ComicProject]: 'comicProjectId',
   [ReportEntity.Model3D]: 'model3dId',
   [ReportEntity.Model3DReview]: 'model3dReviewId',
+  [ReportEntity.Announcement]: 'announcementId',
 } as const;
 
 const statusOverrides: Partial<Record<ReportReason, ReportStatus>> = {

--- a/src/server/services/report.service.ts
+++ b/src/server/services/report.service.ts
@@ -292,6 +292,29 @@ export const createReport = async ({
       'You cannot report your own profile. To reach a moderator about your own account, use the Support Portal at /support-portal.'
     );
 
+  // Read once, here, because the GUARD below needs it and a guard that runs after the dedupe
+  // short-circuit is not a guard — a second report on a sitewide announcement would fold into
+  // the first and return success. The snapshot it also feeds is stamped further down; see there.
+  const reportedAnnouncement =
+    type === ReportEntity.Announcement
+      ? await dbRead.announcement.findUnique({
+          where: { id },
+          select: { title: true, content: true, userId: true, metadata: true },
+        })
+      : null;
+
+  if (type === ReportEntity.Announcement) {
+    if (!reportedAnnouncement) throw throwBadRequestError('That announcement no longer exists.');
+    // A null author IS the definition of a sitewide, Civitai-written announcement (see the
+    // `Announcement.userId` docstring). Reporting Civitai's own announcement to Civitai's
+    // moderators has no destination, and the UI offers no kebab on those rows — this is what
+    // makes that a rule rather than an appearance.
+    if (reportedAnnouncement.userId === null)
+      throw throwBadRequestError(
+        'Civitai announcements cannot be reported. To reach a moderator about one, use the Support Portal at /support-portal.'
+      );
+  }
+
   await assertReportedPlacementIsOnEntity({ type, entityId: id, details: data.details });
 
   const validReport =
@@ -306,24 +329,23 @@ export const createReport = async ({
       : null;
   if (validReport) return validReport;
 
-  // 🔴 The join row cascades on announcement delete, and deleting an announcement is instant
-  // and self-serve — so without this, the fastest way to erase a spam report is to delete the
-  // announcement it was about. Read from the row, never from `details`: the reporter controls
-  // that object, and a snapshot a reporter can author is a snapshot a reporter can forge.
-  if (type === ReportEntity.Announcement) {
-    const announcement = await dbRead.announcement.findUnique({
-      where: { id },
-      select: { title: true, content: true, userId: true, metadata: true },
-    });
-    if (announcement) {
-      const actions = (announcement.metadata as { actions?: { link?: string }[] } | null)?.actions;
-      (data.details as MixedObject).announcement = {
-        title: announcement.title,
-        content: announcement.content,
-        link: actions?.[0]?.link ?? null,
-        userId: announcement.userId,
-      };
-    }
+  // 🔴 Stamped HERE, below the dedupe short-circuit, not at the read above: `withAdditionalReport`
+  // keeps every key but `reportType`, so a snapshot stamped earlier appends a second copy of the
+  // unbounded content to the existing row for a duplicate reporter who wrote nothing.
+  //
+  // 🔴 From the row, never from `details` — the reporter controls that object, and a snapshot a
+  // reporter can author is a snapshot a reporter can forge. The join row cascades on announcement
+  // delete, which is instant and self-serve, so without this the fastest way to erase a spam
+  // report is to delete the announcement it was about.
+  if (reportedAnnouncement) {
+    const actions = (reportedAnnouncement.metadata as { actions?: { link?: string }[] } | null)
+      ?.actions;
+    (data.details as MixedObject).announcement = {
+      title: reportedAnnouncement.title,
+      content: reportedAnnouncement.content,
+      link: actions?.[0]?.link ?? null,
+      userId: reportedAnnouncement.userId,
+    };
   }
 
   let recomputeArticleNsfwLevelId: number | null = null;

--- a/src/shared/utils/__tests__/report-entity-labels.test.ts
+++ b/src/shared/utils/__tests__/report-entity-labels.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { ReportEntity, reportEntityLabels } from '~/shared/utils/report-helpers';
+import { getDisplayName } from '~/utils/string-helpers';
+
+/**
+ * The report toast reads `${reportEntityLabels[type]} reported`, so these strings are shown to
+ * the person who filed the report.
+ */
+describe('reportEntityLabels', () => {
+  it('labels every reportable entity', () => {
+    const missing = Object.values(ReportEntity).filter((e) => !reportEntityLabels[e]?.trim());
+    expect(missing).toEqual([]);
+  });
+
+  it('reads as a sentence in the toast', () => {
+    expect(`${reportEntityLabels[ReportEntity.Announcement]} reported`).toBe(
+      'Announcement reported'
+    );
+    expect(`${reportEntityLabels[ReportEntity.Model3D]} reported`).toBe('3D model reported');
+    expect(`${reportEntityLabels[ReportEntity.User]} reported`).toBe('User reported');
+  });
+
+  it('starts every label with a capital, which is what the toast needs', () => {
+    const uncapitalised = Object.values(ReportEntity).filter(
+      (e) => reportEntityLabels[e][0] !== reportEntityLabels[e][0].toUpperCase()
+    );
+    expect(uncapitalised).toEqual([]);
+  });
+
+  /**
+   * 🔴 The reason this map is hand-written. `getDisplayName` returns the enum value with its
+   * authored capitalisation, so a "simplification" back to it ships "announcement reported" and
+   * "reported User reported". Its `nameOverrides` covers `commentV2` and `model3d`, which is why
+   * the breakage is partial and easy to miss when spot-checking one entity.
+   */
+  it('differs from getDisplayName on the entities it would mangle', () => {
+    expect(getDisplayName(ReportEntity.Announcement)).toBe('announcement');
+    expect(getDisplayName(ReportEntity.User)).toBe('reported User');
+    expect(getDisplayName(ReportEntity.BountyEntry)).toBe('bounty Entry');
+
+    for (const entity of [ReportEntity.Announcement, ReportEntity.User, ReportEntity.BountyEntry]) {
+      expect(reportEntityLabels[entity]).not.toBe(getDisplayName(entity));
+    }
+  });
+});

--- a/src/shared/utils/report-helpers.ts
+++ b/src/shared/utils/report-helpers.ts
@@ -17,3 +17,33 @@ export enum ReportEntity {
   Model3DReview = 'model3dReview',
   Announcement = 'announcement',
 }
+
+/**
+ * What to call each reportable thing when telling a user what they just reported.
+ *
+ * 🔴 Not `getDisplayName`. That returns the enum value with its capitalisation as authored, so
+ * most of these come back lowercase ("model", "announcement") and the camelCase ones come back
+ * half-split ("reported User", "bounty Entry") — a toast reading "announcement reported". Its
+ * `nameOverrides` does fix `commentV2` and `model3d`, which is why the breakage looks partial.
+ * Typed `Record`, not `Partial`, so a new entity without a label is a type error rather than a
+ * toast reading "undefined reported".
+ */
+export const reportEntityLabels: Record<ReportEntity, string> = {
+  [ReportEntity.Model]: 'Model',
+  [ReportEntity.Comment]: 'Comment',
+  [ReportEntity.CommentV2]: 'Comment',
+  [ReportEntity.Image]: 'Image',
+  [ReportEntity.ResourceReview]: 'Review',
+  [ReportEntity.Article]: 'Article',
+  [ReportEntity.Post]: 'Post',
+  [ReportEntity.User]: 'User',
+  [ReportEntity.Collection]: 'Collection',
+  [ReportEntity.Challenge]: 'Challenge',
+  [ReportEntity.Bounty]: 'Bounty',
+  [ReportEntity.BountyEntry]: 'Bounty entry',
+  [ReportEntity.Chat]: 'Chat',
+  [ReportEntity.ComicProject]: 'Comic',
+  [ReportEntity.Model3D]: '3D model',
+  [ReportEntity.Model3DReview]: '3D review',
+  [ReportEntity.Announcement]: 'Announcement',
+};

--- a/src/shared/utils/report-helpers.ts
+++ b/src/shared/utils/report-helpers.ts
@@ -15,4 +15,5 @@ export enum ReportEntity {
   ComicProject = 'comicProject',
   Model3D = 'model3d',
   Model3DReview = 'model3dReview',
+  Announcement = 'announcement',
 }

--- a/src/utils/__tests__/external-link.test.ts
+++ b/src/utils/__tests__/external-link.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { isExternalHref } from '~/utils/external-link';
+
+const hosts = ['civitai.com', 'www.civitai.com', 'civitai.red'];
+
+describe('isExternalHref', () => {
+  it('treats a site-relative path as internal', () => {
+    expect(isExternalHref('/models/123', hosts)).toBe(false);
+  });
+
+  it('treats a fragment or query-only href as internal', () => {
+    expect(isExternalHref('#section', hosts)).toBe(false);
+    expect(isExternalHref('?tab=posts', hosts)).toBe(false);
+  });
+
+  it('treats an empty or whitespace href as internal', () => {
+    expect(isExternalHref('', hosts)).toBe(false);
+    expect(isExternalHref('   ', hosts)).toBe(false);
+  });
+
+  it('treats a known host as internal regardless of case or trailing dot', () => {
+    expect(isExternalHref('https://civitai.com/models/1', hosts)).toBe(false);
+    expect(isExternalHref('https://CIVITAI.com/models/1', hosts)).toBe(false);
+    expect(isExternalHref('https://civitai.com./models/1', hosts)).toBe(false);
+  });
+
+  it('treats an alias host as internal', () => {
+    expect(isExternalHref('https://www.civitai.com/models/1', hosts)).toBe(false);
+  });
+
+  it('treats a host with a port as internal when the bare host matches', () => {
+    expect(isExternalHref('http://civitai.com:3000/models/1', hosts)).toBe(false);
+  });
+
+  it('treats an unknown host as external', () => {
+    expect(isExternalHref('https://t.me/SomeGroup', hosts)).toBe(true);
+  });
+
+  // A subdomain is a different origin and a different owner. `evil-civitai.com`
+  // and `civitai.com.evil.test` are the attacks a suffix match would let through.
+  it('does not treat a lookalike or subdomain host as internal', () => {
+    expect(isExternalHref('https://evil-civitai.com/x', hosts)).toBe(true);
+    expect(isExternalHref('https://civitai.com.evil.test/x', hosts)).toBe(true);
+    expect(isExternalHref('https://cdn.civitai.com/x', hosts)).toBe(true);
+  });
+
+  // The announcement schema already refuses to store one, but a helper that reads
+  // `//evil.com` as a relative path is a trap for the next caller.
+  it('treats a scheme-relative URL as external', () => {
+    expect(isExternalHref('//evil.com/x', hosts)).toBe(true);
+  });
+
+  it('treats a non-http scheme as internal, so it is never gated by this modal', () => {
+    expect(isExternalHref('mailto:a@b.test', hosts)).toBe(false);
+    expect(isExternalHref('javascript:alert(1)', hosts)).toBe(false);
+  });
+
+  it('is external when no internal hosts are known and the href is absolute', () => {
+    expect(isExternalHref('https://civitai.com/x', [])).toBe(true);
+  });
+});

--- a/src/utils/__tests__/external-link.test.ts
+++ b/src/utils/__tests__/external-link.test.ts
@@ -32,6 +32,19 @@ describe('isExternalHref', () => {
     expect(isExternalHref('http://civitai.com:3000/models/1', hosts)).toBe(false);
   });
 
+  // The other direction, and the one that was broken: `useInternalHosts` seeds itself from
+  // `window.location.host`, which carries the port, while an href is compared as `url.hostname`,
+  // which never does. In local dev on :3000 that made every absolute internal link external.
+  it('treats an internal host entry carrying a port as matching the bare host', () => {
+    expect(isExternalHref('http://localhost:3000/models/1', ['localhost:3000'])).toBe(false);
+    expect(isExternalHref('https://civitai.com/models/1', ['civitai.com:3000'])).toBe(false);
+  });
+
+  it('still rejects a lookalike when the internal host entry carries a port', () => {
+    expect(isExternalHref('https://evil-civitai.com/x', ['civitai.com:3000'])).toBe(true);
+    expect(isExternalHref('https://cdn.civitai.com/x', ['civitai.com:3000'])).toBe(true);
+  });
+
   it('treats an unknown host as external', () => {
     expect(isExternalHref('https://t.me/SomeGroup', hosts)).toBe(true);
   });

--- a/src/utils/__tests__/external-link.test.ts
+++ b/src/utils/__tests__/external-link.test.ts
@@ -49,16 +49,13 @@ describe('isExternalHref', () => {
     expect(isExternalHref('https://t.me/SomeGroup', hosts)).toBe(true);
   });
 
-  // A subdomain is a different origin and a different owner. `evil-civitai.com`
-  // and `civitai.com.evil.test` are the attacks a suffix match would let through.
   it('does not treat a lookalike or subdomain host as internal', () => {
     expect(isExternalHref('https://evil-civitai.com/x', hosts)).toBe(true);
     expect(isExternalHref('https://civitai.com.evil.test/x', hosts)).toBe(true);
     expect(isExternalHref('https://cdn.civitai.com/x', hosts)).toBe(true);
   });
 
-  // The announcement schema already refuses to store one, but a helper that reads
-  // `//evil.com` as a relative path is a trap for the next caller.
+  // Only the creator schema refuses to store one; announcementMetaSchema does not.
   it('treats a scheme-relative URL as external', () => {
     expect(isExternalHref('//evil.com/x', hosts)).toBe(true);
   });

--- a/src/utils/external-link.ts
+++ b/src/utils/external-link.ts
@@ -1,4 +1,8 @@
-const normalizeHost = (host: string) => host.trim().toLowerCase().replace(/\.$/, '');
+// The port is stripped because the two sides are asymmetric: an href is compared as
+// `url.hostname`, which never carries one, while `internalHosts` entries come from
+// `window.location.host`, which does. Left in, every absolute internal link warns on :3000.
+const normalizeHost = (host: string) =>
+  host.trim().toLowerCase().replace(/:\d+$/, '').replace(/\.$/, '');
 
 /**
  * Whether following `href` leaves Civitai.

--- a/src/utils/external-link.ts
+++ b/src/utils/external-link.ts
@@ -1,0 +1,33 @@
+const normalizeHost = (host: string) => host.trim().toLowerCase().replace(/\.$/, '');
+
+/**
+ * Whether following `href` leaves Civitai.
+ *
+ * 🔴 Not a suffix match. `evil-civitai.com` and `civitai.com.evil.test` both end in a string
+ * a suffix test would accept, and `cdn.civitai.com` is a different origin with a different
+ * owner. Hosts are compared whole.
+ *
+ * Anything this cannot resolve to an http(s) origin — a relative path, a fragment, a
+ * `mailto:` — is internal. Failing the other way would put an interstitial in front of every
+ * unparseable href on the site.
+ */
+export function isExternalHref(href: string, internalHosts: readonly string[]): boolean {
+  const value = href.trim();
+  if (!value) return false;
+
+  // `new URL` resolves a scheme-relative `//evil.com` against the base, so the base has to be
+  // a host that can never be in `internalHosts`, or the answer would depend on the base.
+  const url = (() => {
+    try {
+      return new URL(value, 'https://invalid.');
+    } catch {
+      return null;
+    }
+  })();
+
+  if (!url || !['http:', 'https:'].includes(url.protocol)) return false;
+  if (url.hostname === 'invalid.') return false;
+
+  const host = normalizeHost(url.hostname);
+  return !internalHosts.some((internal) => normalizeHost(internal) === host);
+}


### PR DESCRIPTION
Closes [868m34u0d](https://app.clickup.com/t/868m34u0d). Raised by Ellie, 2026-09-08 (product / safety).

Creator announcements accept absolute `http(s)` links, and creators are already using them to push traffic off-site — the report that prompted this was an announcement advertising a Telegram group selling LoRAs. Two guardrails were missing: there was no way to report an announcement, and nothing warned a reader that a link left Civitai.

## What's here

**1. Announcements are reportable.** A new `ReportEntity.Announcement` with its own `AnnouncementReport` join table, wired through the main app's report service **and** through `apps/moderator`'s separate copy of the report entity maps. Reasons offered: TOS Violation, Spam, Needs Moderator Review. The Report item sits in the notifications-panel kebab, hidden on your own announcement.

`NSFW` is deliberately not offered: every NSFW branch in `createReport` casts tag votes, opens an `ImageRatingRequest`, or flips an `nsfw` column — an announcement has none of those — and `statusOverrides[NSFW] = Actioned` would file auto-actioned reports nobody reviews. A cover image with the wrong rating is still reported through the image.

**The announcement's content is snapshotted onto `Report.details` server-side**, read from the row rather than from client-supplied `details`. `AnnouncementReport.announcementId` cascades on delete and deleting an announcement is instant and self-serve, so without this the fastest way to erase a spam report is to delete the announcement it was about.

**2. A "You're leaving Civitai" interstitial** on announcement links that go off-site — CTA action buttons and body markdown links. `isExternalHref` compares whole hosts, never suffixes (`evil-civitai.com`, `civitai.com.evil.test` and `cdn.civitai.com` are all external), and the internal-host list comes from `serverDomains`, falling back to the current host alone when the app context is absent — it fails toward warning.

The external CTA drops its `href` entirely: an anchor stays middle-clickable, ⌘-clickable and copyable, each of which routes around the gate. Body links **keep** their `href`, because prose links need it for copy-link and screen-reader destination announcement — so middle-click and copy-link remain ungated there. That asymmetry is deliberate and commented at the code site.

## 🔴 Two migrations need applying by hand — neither is applied

1. **`packages/civitai-db-schema/prisma/migrations/20260910120000_add_announcement_report/migration.sql`** — apply **before or with** the deploy. No read-side hazard (it's a new table), but the Report menu item ships in the same deploy, so until the table exists every Report click 500s. This also unblocks 5 currently-red cases in `apps/moderator/src/lib/server/__tests__/reports.queries.explain.test.ts`, which runs `EXPLAIN` against a real database.

2. **`src/server/clickhouse/migrations/2026-09-10-announcement-report-entity.sql`** — and **restart the tracker pod afterwards**. `createReportHandler` emits `entityType` to a ClickHouse `Enum8` that previously stopped at `'model3dReview' = 16`; the tracker rejects unknown values client-side while serializing a fire-and-forget batch, so every announcement-report analytics event would be silently discarded while the app saw success. The migration restates the whole enum with `'announcement' = 17`, indices 1-16 unchanged, and carries the POST-APPLY marker — the DDL alone is inert against pods that already read the schema.

⚠️ **This PR carries the `preview` label.** Preview envs use the dev database, so until migration (1) is applied to dev, the Report button in the preview will fail.

## Deliberately out of scope

- **Sitewide (Civitai-authored) announcements are not reportable.** They have no kebab, and reporting Civitai's announcement to Civitai's moderators is a path with no destination.
- **The profile carousel gets no kebab.** A spam announcement is equally reportable there; adding a menu is new chrome the ticket didn't raise.
- **`CustomMarkdown` is unchanged for every other caller** — the interstitial is an opt-in prop, and a negative control pins that it stays off by default.
- **Plain-text URLs in an announcement body stay plain text.** `CustomMarkdown` loads no `remark-gfm`, so there's no autolinking to intercept — which is what the reported Telegram spam actually was.

## One thing worth a second opinion

`AnnouncementCard` is shared with sitewide announcements, so the interstitial fires on those too. The original copy claimed Civitai "is not endorsing" the destination, which is false when Civitai wrote the announcement and linked to its own Discord or blog — so the copy is now author-neutral and keeps the safety advice instead. Gating the behaviour on authorship rather than rewording is a one-line change if that's preferred.

## Testing

- `isExternalHref` — 13 unit tests covering relative paths, fragments, `mailto:`/`javascript:`, scheme-relative `//evil.com`, alias hosts, ports, case and trailing dots, and three lookalike hosts a suffix match would let through.
- The snapshot suite pins that a forged client `details.announcement` does not survive, and that the write shape is `{ announcement: { create: { announcementId } } }` — which is the only thing checking that the connection map's *value* names the right column.
- Browser tests cover both link call sites plus a negative control proving other `CustomMarkdown` callers are unaffected.
- Covering suites on the final tree: unit 63, component 51, moderator 75, convention guards 36 files / 501 tests. Main-app typecheck and `svelte-check` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1PWgNaDwQ8HxfSKhRzZKJ
