### PR TITLE
ci(api): fail the build when a route declares a body limit Next will not deliver

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -646,6 +646,20 @@ jobs:
       - name: Next SVG loader patch applied
         run: node scripts/ci/assert-next-svg-patch-applied.mjs
 
+      # Parked here for the same reason as the step above: it must run in a job that FAILS
+      # the build, and it needs nothing but a checkout (~50ms, no test runner, no install —
+      # it reads next.config.mjs and the route files as text).
+      #
+      # What it guards: Next truncates a request body at
+      # `experimental.proxyClientMaxBodySize` (default 10MB) and then ENDS THE STREAM
+      # without telling the route, so a route declaring a larger `sizeLimit` silently
+      # receives a short body and reads it as a complete one. That shipped once already —
+      # the image-upload relay's 50MB cap was unreachable, and a valid 14.5MB PNG was stored
+      # truncated and undecodable while the route answered 200. Four routes still declare
+      # more than the framework delivers; those are baselined and warn. A NEW one fails.
+      - name: API body size limits are deliverable
+        run: node scripts/ci/body-size-limit-gate.mjs
+
       # Parked here for the same two reasons as the step above: it needs a completed
       # `pnpm install` and a job that FAILS the build, and this is the cheapest one that is
       # both. `postinstall` has already run `db:generate`, so the re-run inside the script is

--- a/scripts/__tests__/body-size-limit-gate.test.ts
+++ b/scripts/__tests__/body-size-limit-gate.test.ts
@@ -82,17 +82,39 @@ describe('body-size-limit-gate', () => {
 
   // Keeps the recorded baseline honest: a route added over the limit without regenerating
   // makes this fail even if someone only ran the unit tier and never the gate script.
-  it('baseline lists exactly the routes currently over the limit', () => {
+  //
+  // 🔴 DELIBERATELY ONE-DIRECTIONAL, and an earlier draft got this wrong in a way that
+  // punished the fix. It asserted the baseline EQUALLED the current over-limit set, so
+  // lowering a baselined route's sizeLimit — the exact change this gate exists to
+  // encourage — left the gate passing (fewer violations is fine) and turned this test RED.
+  // It also contradicted the gate's own docstring, which promises entries may shrink or
+  // disappear freely. Measured: dropping `clavata-image-process` from 17mb to 5mb gave
+  // gate rc=0 and this test failing.
+  //
+  // The invariant that actually matters is that no CURRENT violation is UNRECORDED. A
+  // baseline listing a route that no longer violates is merely stale, costs nothing, and
+  // is cleaned up by --write-baseline.
+  it('records every route currently over the limit (shrinking is allowed)', () => {
     const baseline = JSON.parse(
       readFileSync(join(REPO_ROOT, 'scripts', 'ci', 'body-size-limit-baseline.json'), 'utf8')
     );
     const limit = effectiveBodyLimit(readFileSync(join(REPO_ROOT, 'next.config.mjs'), 'utf8'));
-    const over = collectDeclaredLimits(join(REPO_ROOT, 'src', 'pages', 'api'), REPO_ROOT)
-      .filter((d: { bytes: number }) => d.bytes > limit.bytes)
-      .map((d: { file: string }) => d.file)
-      .sort();
+    const over = collectDeclaredLimits(join(REPO_ROOT, 'src', 'pages', 'api'), REPO_ROOT).filter(
+      (d: { bytes: number }) => d.bytes > limit.bytes
+    );
 
-    expect(Object.keys(baseline.routes).sort()).toEqual(over);
-    expect(baseline.effectiveLimitBytes).toBe(limit.bytes);
+    const unrecorded = over
+      .filter((d: { file: string }) => !(d.file in baseline.routes))
+      .map((d: { file: string }) => d.file);
+    expect(unrecorded, 'over-limit route(s) missing from the baseline').toEqual([]);
+
+    // A route may not quietly grow past what the baseline recorded for it either.
+    const worsened = over
+      .filter(
+        (d: { file: string; bytes: number }) =>
+          d.file in baseline.routes && d.bytes > baseline.routes[d.file]
+      )
+      .map((d: { file: string }) => d.file);
+    expect(worsened, 'baselined route(s) declaring MORE than recorded').toEqual([]);
   });
 });

--- a/scripts/__tests__/body-size-limit-gate.test.ts
+++ b/scripts/__tests__/body-size-limit-gate.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  NEXT_DEFAULT_PROXY_CLIENT_MAX_BODY_SIZE,
+  parseSizeLimit,
+  effectiveBodyLimit,
+  collectDeclaredLimits,
+} from '../ci/body-size-limit-gate.mjs';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+
+describe('body-size-limit-gate', () => {
+  // 🔴 THE LOAD-BEARING CASE. The gate hardcodes Next's default because reading a private
+  // build artifact at runtime would make it depend on that artifact's shape. The cost of
+  // hardcoding is that a Next upgrade could change the default and silently widen what the
+  // gate permits — nothing would fail, the number would just be wrong. This is what makes
+  // that impossible: it reads the default out of the INSTALLED Next and requires the
+  // constant to match. A Next bump that moves it fails here, in one named place.
+  it('pins the hardcoded default against the INSTALLED Next', () => {
+    const src = readFileSync(
+      join(REPO_ROOT, 'node_modules', 'next', 'dist', 'server', 'config-shared.js'),
+      'utf8'
+    );
+    const m = /proxyClientMaxBodySize:\s*(\d+)/.exec(src);
+
+    // Positive control on the extraction itself: if Next ever renames or restructures
+    // this, "no match" must fail loudly rather than skip the comparison and read green.
+    expect(m, 'could not find proxyClientMaxBodySize in the installed Next').not.toBeNull();
+    expect(Number(m![1])).toBe(NEXT_DEFAULT_PROXY_CLIENT_MAX_BODY_SIZE);
+  });
+
+  it('parses every SizeLimit spelling Next accepts', () => {
+    expect(parseSizeLimit('10mb')).toBe(10 * 1024 * 1024);
+    expect(parseSizeLimit('500kb')).toBe(500 * 1024);
+    expect(parseSizeLimit('1gb')).toBe(1024 ** 3);
+    expect(parseSizeLimit('2048')).toBe(2048); // bare number = bytes
+    expect(parseSizeLimit(4096)).toBe(4096);
+    expect(parseSizeLimit('1.5mb')).toBe(Math.round(1.5 * 1024 * 1024));
+    expect(parseSizeLimit('not-a-size')).toBeNull();
+  });
+
+  describe('effectiveBodyLimit', () => {
+    it('falls back to the framework default when the config sets neither key', () => {
+      const r = effectiveBodyLimit('export default { experimental: { ppr: true } };');
+      expect(r.bytes).toBe(NEXT_DEFAULT_PROXY_CLIENT_MAX_BODY_SIZE);
+      expect(r.source).toBe('next default');
+    });
+
+    it('reads proxyClientMaxBodySize when set', () => {
+      const r = effectiveBodyLimit("experimental: { proxyClientMaxBodySize: '72mb' }");
+      expect(r.bytes).toBe(72 * 1024 * 1024);
+      expect(r.source).toBe('proxyClientMaxBodySize');
+    });
+
+    it('still honours the DEPRECATED middlewareClientMaxBodySize alone', () => {
+      // Next maps the deprecated key onto the new one rather than ignoring it, so a repo
+      // that only sets the old name really does get a raised limit. Treating it as unset
+      // would make the gate fail routes that are in fact fine.
+      const r = effectiveBodyLimit("experimental: { middlewareClientMaxBodySize: '30mb' }");
+      expect(r.bytes).toBe(30 * 1024 * 1024);
+      expect(r.source).toBe('middlewareClientMaxBodySize');
+    });
+
+    it('prefers proxyClientMaxBodySize when BOTH are present, mirroring Next', () => {
+      const r = effectiveBodyLimit(
+        "experimental: { middlewareClientMaxBodySize: '30mb', proxyClientMaxBodySize: '60mb' }"
+      );
+      expect(r.bytes).toBe(60 * 1024 * 1024);
+      expect(r.source).toBe('proxyClientMaxBodySize');
+    });
+  });
+
+  // Guards the SCANNER, not the routes. A zero here would make the gate vacuous — it would
+  // report "0 over" forever and read as a clean repo. This is the reassuring-zero trap:
+  // an empty match set is indistinguishable from a probe wired to nothing.
+  it('actually finds the sizeLimit declarations in the tree', () => {
+    const found = collectDeclaredLimits(join(REPO_ROOT, 'src', 'pages', 'api'), REPO_ROOT);
+    expect(found.length).toBeGreaterThan(5);
+    expect(found.every((f) => typeof f.bytes === 'number' && f.bytes > 0)).toBe(true);
+  });
+
+  // Keeps the recorded baseline honest: a route added over the limit without regenerating
+  // makes this fail even if someone only ran the unit tier and never the gate script.
+  it('baseline lists exactly the routes currently over the limit', () => {
+    const baseline = JSON.parse(
+      readFileSync(join(REPO_ROOT, 'scripts', 'ci', 'body-size-limit-baseline.json'), 'utf8')
+    );
+    const limit = effectiveBodyLimit(readFileSync(join(REPO_ROOT, 'next.config.mjs'), 'utf8'));
+    const over = collectDeclaredLimits(join(REPO_ROOT, 'src', 'pages', 'api'), REPO_ROOT)
+      .filter((d: { bytes: number }) => d.bytes > limit.bytes)
+      .map((d: { file: string }) => d.file)
+      .sort();
+
+    expect(Object.keys(baseline.routes).sort()).toEqual(over);
+    expect(baseline.effectiveLimitBytes).toBe(limit.bytes);
+  });
+});

--- a/scripts/ci/body-size-limit-baseline.json
+++ b/scripts/ci/body-size-limit-baseline.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Routes declaring a bodyParser sizeLimit LARGER than Next will deliver, so the declared value is not what the route receives — Next truncates and the route is not told. Entries may shrink or disappear freely; adding one, or raising a byte count, fails the gate and is a deliberate act visible in review. Regenerate with: node scripts/ci/body-size-limit-gate.mjs --write-baseline",
+  "effectiveLimitBytes": 10485760,
+  "effectiveLimitSource": "next default",
+  "routes": {
+    "src/pages/api/blocks/submit-version.ts": 75497472,
+    "src/pages/api/mod/clavata-image-process.ts": 17825792,
+    "src/pages/api/trpc/[trpc].ts": 17825792,
+    "src/pages/api/v1/blocks/submit-version.ts": 75497472
+  }
+}

--- a/scripts/ci/body-size-limit-gate.mjs
+++ b/scripts/ci/body-size-limit-gate.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Blocking guard: no API route may declare a request-body `sizeLimit` LARGER than the
+ * body Next will actually hand it.
+ *
+ * WHY THIS EXISTS. Next caps an incoming request body at
+ * `experimental.proxyClientMaxBodySize` (default 10MB) and then simply ENDS the stream.
+ * The route is not told. A handler reading that stream sees a clean end-of-body, not an
+ * error — so a route declaring `sizeLimit: '72mb'` does not get 72MB and does not get a
+ * failure either. It gets a silent truncation at 10MB.
+ *
+ * That is not hypothetical. `src/pages/api/v1/image-upload/relay.ts` shipped with a 50MB
+ * cap that was UNREACHABLE for exactly this reason, and before the guards added there a
+ * valid 14,523,378-byte PNG was stored as a 10,485,209-byte object with no `IEND`
+ * terminator while the route answered `200 {"id": …}` — a corrupt image reported to the
+ * caller as a successful upload. Measured on a deployed preview (Next 16.3.1),
+ * reproduced both through the ingress and from inside the container against the app port,
+ * so it is the framework and not a proxy in front:
+ *
+ *     sent 10,485,760 -> delivered 10,485,760   intact
+ *     sent 12,000,000 -> delivered 10,438,916   TRUNCATED
+ *     sent 55,000,000 -> delivered 10,479,830   TRUNCATED
+ *
+ * WHAT IT ASSERTS, AND WHY THAT IS THE RIGHT INVARIANT. It pins a RELATIONSHIP —
+ * declared limit <= deliverable limit — not a value. Either side may move freely as long
+ * as they stay consistent: raise `proxyClientMaxBodySize` and the routes are fine; lower
+ * a route's `sizeLimit` and it is fine. Only the incoherent combination fails, which is
+ * the only combination that silently corrupts data. A guard on a fixed number would need
+ * re-pinning on every Next bump and would say nothing about the pairing.
+ *
+ * DELTA, NOT ABSOLUTE. Four routes already declare more than the framework delivers (see
+ * the baseline). Failing on those would make this permanently red, and a permanently-red
+ * gate is worse than no gate — it trains everyone to click through. So a baselined
+ * violation WARNS and a new-or-worsened one FAILS. Shrinking a declared limit, or
+ * removing the route, is always allowed and the baseline may be regenerated down.
+ *
+ *   node scripts/ci/body-size-limit-gate.mjs                  # check (CI)
+ *   node scripts/ci/body-size-limit-gate.mjs --write-baseline # re-record current state
+ */
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const API_DIR = join(REPO_ROOT, 'src', 'pages', 'api');
+const NEXT_CONFIG = join(REPO_ROOT, 'next.config.mjs');
+const BASELINE = join(import.meta.dirname, 'body-size-limit-baseline.json');
+
+/**
+ * Next's own default for `experimental.proxyClientMaxBodySize`, in bytes.
+ *
+ * 🔴 Hardcoded ON PURPOSE, and pinned against the installed Next by
+ * `scripts/__tests__/body-size-limit-gate.test.ts`. Reading it out of Next's internals at
+ * runtime would make this gate depend on the shape of a private build artifact; asserting
+ * it in a test instead means a Next upgrade that changes the default fails loudly in one
+ * named place rather than silently widening what this gate permits.
+ */
+export const NEXT_DEFAULT_PROXY_CLIENT_MAX_BODY_SIZE = 10 * 1024 * 1024;
+
+/** Parse a Next `SizeLimit` (`'72mb'`, `'500kb'`, `1048576`) into bytes. */
+export function parseSizeLimit(raw) {
+  if (typeof raw === 'number') return raw;
+  const m = /^\s*(\d+(?:\.\d+)?)\s*(b|kb|mb|gb)?\s*$/i.exec(String(raw));
+  if (!m) return null;
+  const n = Number(m[1]);
+  const unit = (m[2] || 'b').toLowerCase();
+  return Math.round(n * { b: 1, kb: 1024, mb: 1024 ** 2, gb: 1024 ** 3 }[unit]);
+}
+
+/**
+ * The largest body Next will deliver to a route.
+ *
+ * Read by regex rather than by importing `next.config.mjs`: that module pulls in plugins
+ * and has side effects, and this gate is meant to run in ~50ms in a blocking job with no
+ * module graph. `proxyClientMaxBodySize` wins when both are present, mirroring Next's own
+ * precedence (`middlewareClientMaxBodySize` is deprecated in favour of it).
+ */
+export function effectiveBodyLimit(configSource) {
+  for (const key of ['proxyClientMaxBodySize', 'middlewareClientMaxBodySize']) {
+    const m = new RegExp(`${key}\\s*:\\s*(?:'([^']+)'|"([^"]+)"|([\\d_]+))`).exec(configSource);
+    if (m) {
+      const v = m[1] ?? m[2] ?? m[3].replace(/_/g, '');
+      const bytes = parseSizeLimit(v);
+      if (bytes !== null) return { bytes, source: key };
+    }
+  }
+  return { bytes: NEXT_DEFAULT_PROXY_CLIENT_MAX_BODY_SIZE, source: 'next default' };
+}
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.[cm]?tsx?$/.test(entry)) out.push(p);
+  }
+  return out;
+}
+
+/** Every `sizeLimit: '<v>'` declared under the API routes, as { file, declared, bytes }. */
+export function collectDeclaredLimits(apiDir, repoRoot) {
+  const found = [];
+  for (const file of walk(apiDir)) {
+    const src = readFileSync(file, 'utf8');
+    for (const m of src.matchAll(/sizeLimit\s*:\s*(?:'([^']+)'|"([^"]+)"|([\d_]+))/g)) {
+      const declared = m[1] ?? m[2] ?? m[3].replace(/_/g, '');
+      const bytes = parseSizeLimit(declared);
+      if (bytes === null) continue;
+      found.push({ file: relative(repoRoot, file).split('\\').join('/'), declared, bytes });
+    }
+  }
+  return found.sort((a, b) => a.file.localeCompare(b.file) || a.bytes - b.bytes);
+}
+
+function main() {
+  const write = process.argv.includes('--write-baseline');
+  const limit = effectiveBodyLimit(readFileSync(NEXT_CONFIG, 'utf8'));
+  const declared = collectDeclaredLimits(API_DIR, REPO_ROOT);
+  const over = declared.filter((d) => d.bytes > limit.bytes);
+
+  if (write) {
+    writeFileSync(
+      BASELINE,
+      `${JSON.stringify(
+        {
+          _comment:
+            'Routes declaring a bodyParser sizeLimit LARGER than Next will deliver, so the declared value is not what the route receives — Next truncates and the route is not told. Entries may shrink or disappear freely; adding one, or raising a byte count, fails the gate and is a deliberate act visible in review. Regenerate with: node scripts/ci/body-size-limit-gate.mjs --write-baseline',
+          effectiveLimitBytes: limit.bytes,
+          effectiveLimitSource: limit.source,
+          routes: Object.fromEntries(over.map((d) => [d.file, d.bytes])),
+        },
+        null,
+        2
+      )}\n`
+    );
+    console.log(`wrote baseline: ${over.length} route(s) over the ${limit.bytes}-byte limit`);
+    return 0;
+  }
+
+  const baseline = JSON.parse(readFileSync(BASELINE, 'utf8'));
+  const known = baseline.routes ?? {};
+  const regressions = over.filter((d) => !(d.file in known) || d.bytes > known[d.file]);
+
+  console.log(
+    `body-size-limit-gate: effective request-body limit ${limit.bytes} bytes (${limit.source}); ` +
+      `${declared.length} declared sizeLimit(s) scanned, ${over.length} over, ${regressions.length} NEW`
+  );
+
+  // A positive control on the scanner itself: if it matched nothing at all, it is far
+  // more likely the pattern or the path is wrong than that the repo declares no limits.
+  if (declared.length === 0) {
+    console.error(
+      `FAIL: scanned ${API_DIR} and found NO sizeLimit declarations at all. That is a broken\n` +
+        `scan, not a clean repo — every known revision of this tree declares several.`
+    );
+    return 1;
+  }
+
+  for (const d of over.filter((x) => !regressions.includes(x))) {
+    console.warn(
+      `  warn (baselined): ${d.file} declares ${d.declared} — truncated at ${limit.bytes}`
+    );
+  }
+
+  if (regressions.length === 0) return 0;
+
+  console.error('\nFAIL: a route declares a body limit larger than Next will deliver.\n');
+  for (const d of regressions) {
+    console.error(
+      `  ${d.file}\n    declares ${d.declared} (${d.bytes} bytes) but Next delivers at most ${limit.bytes}.`
+    );
+  }
+  console.error(
+    `\nNext truncates the body at ${limit.bytes} bytes and ENDS THE STREAM — the route is not\n` +
+      `told, so it reads a short body as a complete one. Either:\n` +
+      `  - lower the route's sizeLimit to <= ${limit.bytes}, or\n` +
+      `  - raise \`experimental.proxyClientMaxBodySize\` in next.config.mjs (repo-wide: it\n` +
+      `    widens the body EVERY route may receive, so weigh the memory cost), or\n` +
+      `  - if the truncation is genuinely acceptable for this route, re-record it:\n` +
+      `      node scripts/ci/body-size-limit-gate.mjs --write-baseline\n`
+  );
+  return 1;
+}
+
+// Run only when invoked directly, so the test can import the pure helpers above without
+// the gate executing (and exiting the test process) on import. Compared as resolved file
+// URLs: a suffix match on the basename would also fire for any same-named script.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/src/pages/api/v1/image-upload/relay.ts
+++ b/src/pages/api/v1/image-upload/relay.ts
@@ -59,8 +59,18 @@ export const config = {
  * 🔴 This is a property of the framework, not a choice of ours, and it is the reason
  * this route cannot simply pick its own limit. Next 16 caps the body it will hand a
  * route at 10MB by default and then just ENDS the stream — the route sees a clean
- * end-of-body, not an error. `next.config.mjs` does not set
- * `middlewareClientMaxBodySize`, so the default applies.
+ * end-of-body, not an error. `next.config.mjs` sets neither of the keys that would
+ * raise it, so the default applies.
+ *
+ * ⚠ CORRECTED. An earlier version of this comment named `middlewareClientMaxBodySize`
+ * as a plain `next.config.mjs` option. Both halves were wrong in a way that would waste
+ * someone's afternoon: the key lives under **`experimental`**, and that spelling is
+ * **deprecated** in favour of `experimental.proxyClientMaxBodySize` (Next maps the old
+ * name onto the new one and warns). Set at the top level it is simply ignored, so the
+ * "fix" would change nothing and the truncation would persist.
+ * `config-shared.js` declares the default as `proxyClientMaxBodySize: 10485760` —
+ * exactly the boundary measured below, which is the cross-check that this number is the
+ * framework's and not a coincidence.
  *
  * Measured on a deployed preview (Next 16.3.1), sent vs what actually reached the
  * store, reproduced BOTH through the ingress and by POSTing from inside the container
@@ -89,9 +99,10 @@ export const NEXT_BODY_TRUNCATION_BYTES = 1024 * 1024 * 10;
  * and the 413 branch below was dead code.
  *
  * Raising this above the truncation point requires raising
- * `middlewareClientMaxBodySize` in `next.config.mjs` IN THE SAME CHANGE — that is a
- * repo-wide widening of how large a body every route may receive, so it was not done
- * here. It buys little: sampled 111,097 rows of `Image.metadata->>'size'`, **0.679%**
+ * `experimental.proxyClientMaxBodySize` in `next.config.mjs` IN THE SAME CHANGE — that
+ * is a repo-wide widening of how large a body every route may receive, so it was not
+ * done here. `scripts/ci/body-size-limit-gate.mjs` fails the build if the two ever
+ * disagree, so this pairing is enforced rather than merely described. It buys little: sampled 111,097 rows of `Image.metadata->>'size'`, **0.679%**
  * of images exceed 10MB (p99 = 7.63MB), and this is a fallback that only fires for
  * clients who cannot resolve the storage host at all. Those few now get an honest 413
  * instead of a silently corrupted file.


### PR DESCRIPTION
ci(api): fail the build when a route declares a body limit Next will not deliver

Next caps an incoming request body at `experimental.proxyClientMaxBodySize`
(default 10MB) and then ENDS THE STREAM without telling the route. A handler
reading that stream sees a clean end-of-body, not an error — so a route declaring
`sizeLimit: '72mb'` does not get 72MB, and does not get a failure either. It gets a
silent truncation at 10MB.

That already shipped once. `api/v1/image-upload/relay.ts` carried a 50MB cap that
was UNREACHABLE for exactly this reason, and before the guards added there a valid
14,523,378-byte PNG was stored as a 10,485,209-byte object with no IEND terminator
while the route answered 200 — a corrupt image reported as a successful upload.
Fixing that route left the same trap live in four others, which is what this closes.

Four routes currently declare more than the framework delivers:

    api/blocks/submit-version.ts        72mb
    api/v1/blocks/submit-version.ts     72mb
    api/trpc/[trpc].ts                  17mb
    api/mod/clavata-image-process.ts    17mb

Production has logged ZERO truncation warnings, so nothing is bleeding today —
confirmed a real zero, not a silent one: the same log stream carries ~492k lines/hour.
The exposure is latent. Fixing those four is a judgement call about what each route
genuinely needs, so this change does not make it: they are BASELINED and warn. A new
or worsened one fails.

Delta rather than absolute because a permanently-red gate is worse than no gate — it
trains everyone to click through. Same reason `typecheck-scripts-gate` carries a
baseline.

The assertion is a RELATIONSHIP — declared <= deliverable — not a value. Either side
may move freely as long as they stay consistent, so a Next bump or a config change
needs no re-pinning, and only the incoherent combination (the one that silently
corrupts data) fails.

Validated by watching it go red, not by watching it go green:
- a NEW route over the limit          -> FAIL
- a new route UNDER the limit         -> PASS   (so it is not failing on everything)
- WORSENING a baselined route         -> FAIL   (baseline is not blanket immunity)

Three mutants, each killed by the test whose name claims that guard: breaking the
hardcoded default kills the pin-against-installed-Next test; reversing the key
precedence kills the precedence test; making the scanner match nothing kills the
"actually finds the declarations" test. That last one is why that test exists — a
scanner matching nothing would report "0 over" forever and read as a clean repo.
M3's syntax was checked with `node --check` first so its failure is the guard and
not a parse error.

Also corrects a comment this repo already merged. It named
`middlewareClientMaxBodySize` as a plain next.config option; both halves were wrong
in a way that would waste someone's afternoon — the key lives under `experimental`,
and that spelling is deprecated in favour of `experimental.proxyClientMaxBodySize`.
Set at the top level it is silently ignored, so the "fix" would have changed nothing.
Next's own `config-shared.js` declares the default as 10485760, exactly the boundary
measured on a deployed preview, which is the cross-check that the number is the
framework's and not a coincidence.

43 tests pass, cold typecheck 0 errors, eslint and prettier clean.

---

**Scope, honestly.** This does not fix the four baselined routes — whether each genuinely needs its declared size is a product judgement I did not make. It stops the fifth one, and records the four so they can be fixed deliberately.

**Not measured:** whether the two `submit-version` routes are actually failing for real users today. Production logs show no truncation warnings at all, so if large App Block versions are being submitted they are failing somewhere else, or they are not being submitted. Worth a look, separately.
