### PR TITLE
feat(abuse-board): let a moderator record a verdict, once per cluster

### DIFF
--- a/apps/moderator/abuse-detection/schema.sql
+++ b/apps/moderator/abuse-detection/schema.sql
@@ -12,10 +12,26 @@
 --   psql "$MODERATOR_DATABASE_URL" -f apps/moderator/abuse-detection/schema.sql
 --
 -- 🔴 AS THE APPLICATION ROLE (`internal_tools`), which is what that URL connects as. Running this
--- as `postgres` — the natural `kubectl exec … psql -U postgres` shortcut — creates postgres-owned
--- tables the app cannot read, and the page then reports a permission error it cannot distinguish
--- from an outage without the 42501 branch it now carries. If you already did that, either re-run as
--- the app role or:
+-- as `postgres` — the natural `psql -U postgres` shortcut — creates postgres-owned tables the app
+-- cannot read, and the page then reports a permission error it cannot distinguish from an outage
+-- without the 42501 branch it now carries.
+--
+-- 🔴 IF YOU ALREADY RAN IT AS THE WRONG ROLE, THE FIX IS OWNERSHIP, NOT A GRANT. This used to say
+-- "either re-run as the app role or GRANT SELECT, INSERT, UPDATE, DELETE …", and that remedy was
+-- correct only while this file did nothing but `CREATE TABLE IF NOT EXISTS`. It now runs
+-- `ALTER TABLE`, which Postgres permits ONLY to a table's owner (or a member of its owning role) —
+-- no combination of table privileges grants it. Measured: as a granted-but-not-owner role the first
+-- `ALTER TABLE` fails `42501 must be owner of table abuse_detection_finding`, and the stop-on-error
+-- directive below then halts the file — so it fails closed, adding no verdict columns rather than a
+-- subset, but a re-run as that role can never succeed. Transfer ownership first, as a superuser or
+-- as the current owner. One statement per object — `OWNER TO` takes a single object name, and the
+-- comma-separated form is a SYNTAX ERROR, which halts the recovery the same way:
+--   ALTER TABLE    abuse_detection_run               OWNER TO internal_tools;
+--   ALTER TABLE    abuse_detection_finding           OWNER TO internal_tools;
+--   ALTER SEQUENCE abuse_detection_run_id_seq        OWNER TO internal_tools;
+--   ALTER SEQUENCE abuse_detection_finding_id_seq    OWNER TO internal_tools;
+-- …then re-run this file as `internal_tools`. The GRANTs below are still what a read-only or
+-- reporting role needs, and are NOT a substitute for the four statements above:
 --   GRANT SELECT, INSERT, UPDATE, DELETE ON abuse_detection_run, abuse_detection_finding TO internal_tools;
 --   GRANT USAGE, SELECT ON SEQUENCE abuse_detection_run_id_seq, abuse_detection_finding_id_seq TO internal_tools;
 --
@@ -117,6 +133,11 @@ CREATE INDEX IF NOT EXISTS abuse_detection_finding_user_idx
 ALTER TABLE abuse_detection_finding ADD COLUMN IF NOT EXISTS verdict text;
 -- Who ruled, and when. Overwritten on a re-ruling — a moderator correcting a mistake must leave the
 -- record showing the CURRENT ruling and who stands behind it, not the first one.
+--
+-- 🔴 `verdict_by` HOLDS THE MODERATOR'S ID, AS TEXT — not their username. A username is reassignable:
+-- months later the record would name a handle that belongs to somebody else, which is the one thing
+-- an audit field must not do. `text` rather than an integer because this column identifies whoever
+-- made the ruling and nothing joins on it, so a future non-user actor does not need a migration.
 ALTER TABLE abuse_detection_finding ADD COLUMN IF NOT EXISTS verdict_by text;
 ALTER TABLE abuse_detection_finding ADD COLUMN IF NOT EXISTS verdict_at timestamptz;
 -- 🔴 The producer's cluster key: findings the detector believes are ONE actor, ruled once instead of

--- a/apps/moderator/abuse-detection/schema.sql
+++ b/apps/moderator/abuse-detection/schema.sql
@@ -99,3 +99,64 @@ CREATE INDEX IF NOT EXISTS abuse_detection_finding_run_idx
 -- "What has any detector said about this account?" — the per-user lookup the moderator app joins on.
 CREATE INDEX IF NOT EXISTS abuse_detection_finding_user_idx
   ON abuse_detection_finding (user_id, created_at DESC);
+
+-- ---------------------------------------------------------------------------------------------
+-- THE MODERATOR'S RULING.
+--
+-- 🔴 `verdict` IS NOT `actioned`, AND CONFLATING THE TWO IS THE MOST LIKELY BUG THIS TABLE WILL EVER
+-- HAVE. `actioned`/`action` above are the PRODUCER's self-report: what the detector did, written by
+-- the detector, never cross-checked. The three columns below are a HUMAN's judgement of whether the
+-- detector was right, written by a moderator in the board's UI. They answer different questions and
+-- move independently — the common row is `actioned = false` (the detector left the account alone)
+-- carrying `verdict = 'tp'` (and it was right to flag it). Nothing reads one to infer the other, and
+-- recording a verdict must leave `actioned`/`action` untouched.
+--
+-- NULL `verdict` means UNRULED, which is the state every finding starts in and the state a run's
+-- "still to review" count is derived from. It is not a fourth verdict: `skip` is the moderator
+-- saying "I looked and I am not calling it", which is a decision, and an unruled row is not.
+ALTER TABLE abuse_detection_finding ADD COLUMN IF NOT EXISTS verdict text;
+-- Who ruled, and when. Overwritten on a re-ruling — a moderator correcting a mistake must leave the
+-- record showing the CURRENT ruling and who stands behind it, not the first one.
+ALTER TABLE abuse_detection_finding ADD COLUMN IF NOT EXISTS verdict_by text;
+ALTER TABLE abuse_detection_finding ADD COLUMN IF NOT EXISTS verdict_at timestamptz;
+-- 🔴 The producer's cluster key: findings the detector believes are ONE actor, ruled once instead of
+-- N times. NULL for an ungrouped finding, which is most of them. Scoped to the run — the same key in
+-- two runs is two separate decisions, because the cohort behind it is different — so every read and
+-- write of it pairs `group_key` with `run_id`.
+--
+-- 🔴 IT MUST NOT CARRY ANYTHING THE FINDING'S OWN `reason` DOES NOT ALREADY SAY. The board is a wider
+-- audience than the investigative tools, and a key is rendered; the producer therefore derives it
+-- only from an attribute it has already written into the reason text.
+ALTER TABLE abuse_detection_finding ADD COLUMN IF NOT EXISTS group_key text;
+
+-- 🔴 EXACTLY THREE VERDICTS, OR NULL. Without this the column is free text, and a typo (`TP`, `fp `,
+-- `false-positive`) becomes a fourth silent category that every count query drops on the floor — the
+-- reassuring-zero failure the rest of this surface is built to refuse. `ADD CONSTRAINT` has no
+-- `IF NOT EXISTS` in Postgres, so the existence test is explicit; the whole file must stay
+-- re-runnable.
+--
+-- ⚠️ `verdict IS NULL OR` IS EXPLICITNESS, NOT ENFORCEMENT — stated because a comment claiming more
+-- than the code delivers is worse than none. A CHECK passes whenever its expression evaluates to
+-- NULL, so `verdict IN (…)` alone already admits an unruled row; deleting this clause changes no
+-- behaviour, and a mutation test proves it (the whole suite stays green). It is kept because the
+-- reader of a constraint should not have to know that rule to see that NULL is legal here. What a
+-- test CAN catch is the opposite edit — `verdict IS NOT NULL AND verdict IN (…)`, which would make
+-- every finding unwritable — and that is what the "accepts NULL" case guards.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'abuse_detection_finding'::regclass
+       AND conname = 'abuse_detection_finding_verdict_valid'
+  ) THEN
+    ALTER TABLE abuse_detection_finding
+      ADD CONSTRAINT abuse_detection_finding_verdict_valid
+      CHECK (verdict IS NULL OR verdict IN ('tp', 'fp', 'skip'));
+  END IF;
+END
+$$;
+
+-- No index on `verdict` or `group_key`, deliberately. Both are only ever read WITHIN one run — the
+-- unruled count is `WHERE run_id = $1`, and a group ruling is `WHERE run_id = $1 AND group_key = $2`
+-- — so `abuse_detection_finding_run_idx` above already selects the rows, and a report carries at
+-- most MAX_FINDINGS_PER_REPORT of them. A second index here would be write cost for no read.

--- a/apps/moderator/package.json
+++ b/apps/moderator/package.json
@@ -39,6 +39,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.4.6",
     "@sveltejs/adapter-node": "^5.3.2",
     "@sveltejs/kit": "^2.43.2",
     "@sveltejs/vite-plugin-svelte": "^6.0.0",

--- a/apps/moderator/src/lib/__tests__/abuse-decisions.test.ts
+++ b/apps/moderator/src/lib/__tests__/abuse-decisions.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { groupFindings, storedVerdict, type GroupableFinding } from '../abuse-decisions';
+import { ABUSE_VERDICTS } from '../abuse-verdicts';
+
+/**
+ * The collapse rule the run page renders.
+ *
+ * 🔴 WHY THESE ARE HERE AND NOT IN A ROUTE TEST. This app has no component render harness, so a
+ * grouping written inside a `$derived` would be untestable — and the two failure modes are both
+ * invisible to a type checker AND to a source-level grep: a ring of eleven rendering as one row that
+ * rules one account, and eleven ungrouped findings collapsing into a single row that rules them all.
+ * Both render plausibly, with a count and a member list, so the bug reads as the feature working.
+ *
+ * Fixtures use PAIRWISE-DISTINCT confidences and ids so no assertion can pass by two values
+ * coinciding.
+ */
+
+const f = (over: Partial<GroupableFinding> & { id: number }): GroupableFinding => ({
+  actioned: false,
+  confidence: 0.5,
+  groupKey: null,
+  verdict: null,
+  ...over,
+});
+
+describe('groupFindings', () => {
+  it('collapses a cluster into ONE decision carrying every member', () => {
+    const rows = [
+      f({ id: 1, groupKey: 'domain:ring.test', confidence: 0.91 }),
+      f({ id: 2, groupKey: 'domain:ring.test', confidence: 0.62 }),
+      f({ id: 3, groupKey: 'domain:ring.test', confidence: 0.44 }),
+    ];
+    const out = groupFindings(rows);
+    expect(out).toHaveLength(1);
+    expect(out[0].members.map((m) => m.id)).toEqual([1, 2, 3]);
+    expect(out[0].groupKey).toBe('domain:ring.test');
+    expect(out[0].id).toBe('group:domain:ring.test');
+  });
+
+  it('🔴 does NOT collapse ungrouped findings into one another', () => {
+    // A NULL key is the ABSENCE of a group. Bucketing on the raw value gives one row claiming to
+    // cover four unrelated accounts — and it renders perfectly.
+    const rows = [f({ id: 1 }), f({ id: 2 }), f({ id: 3 }), f({ id: 4 })];
+    const out = groupFindings(rows);
+    expect(out).toHaveLength(4);
+    expect(out.every((d) => d.members.length === 1)).toBe(true);
+    expect(out.map((d) => d.id).sort()).toEqual([
+      'finding:1',
+      'finding:2',
+      'finding:3',
+      'finding:4',
+    ]);
+  });
+
+  it('keeps two different clusters apart', () => {
+    const rows = [
+      f({ id: 1, groupKey: 'domain:a.test', confidence: 0.9 }),
+      f({ id: 2, groupKey: 'domain:b.test', confidence: 0.8 }),
+      f({ id: 3, groupKey: 'domain:a.test', confidence: 0.7 }),
+    ];
+    const out = groupFindings(rows);
+    expect(out.map((d) => d.groupKey)).toEqual(['domain:a.test', 'domain:b.test']);
+    expect(out[0].members.map((m) => m.id)).toEqual([1, 3]);
+    expect(out[1].members.map((m) => m.id)).toEqual([2]);
+  });
+
+  it('🔴 a producer key that looks like a row key cannot collide with one', () => {
+    // The namespaces exist for this. A producer's key is an opaque string IT chose; `"7"` is a legal
+    // one, and bucketing an ungrouped finding on its bare id would merge finding 7 into it.
+    const rows = [f({ id: 7 }), f({ id: 8, groupKey: '7' })];
+    const out = groupFindings(rows);
+    expect(out).toHaveLength(2);
+    expect(out.map((d) => d.id).sort()).toEqual(['finding:7', 'group:7']);
+  });
+
+  it('mixes grouped and ungrouped findings in one run', () => {
+    const rows = [
+      f({ id: 1, groupKey: 'domain:ring.test', confidence: 0.9 }),
+      f({ id: 2, confidence: 0.8 }),
+      f({ id: 3, groupKey: 'domain:ring.test', confidence: 0.7 }),
+      f({ id: 4, confidence: 0.6 }),
+    ];
+    const out = groupFindings(rows);
+    expect(out.map((d) => d.members.length)).toEqual([2, 1, 1]);
+  });
+
+  it('leads with the acted-on row, then the most confident', () => {
+    // The page's existing order. The lead is the row whose reason a moderator actually reads, so
+    // picking it by input order would change what they see when the service's sort changed.
+    const rows = [
+      f({ id: 1, confidence: 0.3 }),
+      f({ id: 2, confidence: 0.95 }),
+      f({ id: 3, confidence: 0.4, actioned: true }),
+    ];
+    expect(groupFindings(rows).map((d) => d.lead.id)).toEqual([3, 2, 1]);
+  });
+
+  it('picks the cluster lead the same way, inside the cluster', () => {
+    const rows = [
+      f({ id: 1, groupKey: 'k', confidence: 0.2 }),
+      f({ id: 2, groupKey: 'k', confidence: 0.99 }),
+      f({ id: 3, groupKey: 'k', confidence: 0.4, actioned: true }),
+    ];
+    const out = groupFindings(rows);
+    expect(out[0].lead.id).toBe(3);
+    expect(out[0].members.map((m) => m.id)).toEqual([3, 2, 1]);
+  });
+
+  it('does not mutate the array it was given', () => {
+    const rows = [f({ id: 1, confidence: 0.1 }), f({ id: 2, confidence: 0.9 })];
+    groupFindings(rows);
+    expect(rows.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('returns nothing for a run with no findings', () => {
+    expect(groupFindings([])).toEqual([]);
+  });
+});
+
+describe('storedVerdict', () => {
+  it('reports the shared verdict of a cluster', () => {
+    const [d] = groupFindings([
+      f({ id: 1, groupKey: 'k', verdict: 'tp' }),
+      f({ id: 2, groupKey: 'k', verdict: 'tp' }),
+    ]);
+    expect(storedVerdict(d)).toBe('tp');
+  });
+
+  it('reports null when nobody has ruled', () => {
+    const [d] = groupFindings([f({ id: 1, groupKey: 'k' }), f({ id: 2, groupKey: 'k' })]);
+    expect(storedVerdict(d)).toBeNull();
+  });
+
+  it('🔴 reports `mixed` rather than presenting one member’s ruling as the cluster’s', () => {
+    const [d] = groupFindings([
+      f({ id: 1, groupKey: 'k', verdict: 'tp' }),
+      f({ id: 2, groupKey: 'k', verdict: 'fp' }),
+    ]);
+    expect(storedVerdict(d)).toBe('mixed');
+  });
+
+  it('a half-ruled cluster is mixed too — an unruled member is a disagreement', () => {
+    const [d] = groupFindings([
+      f({ id: 1, groupKey: 'k', verdict: 'tp' }),
+      f({ id: 2, groupKey: 'k', verdict: null }),
+    ]);
+    expect(storedVerdict(d)).toBe('mixed');
+  });
+
+  it.each(ABUSE_VERDICTS)('round-trips a lone finding ruled %s', (verdict) => {
+    const [d] = groupFindings([f({ id: 1, verdict })]);
+    expect(storedVerdict(d)).toBe(verdict);
+  });
+});

--- a/apps/moderator/src/lib/abuse-decisions.ts
+++ b/apps/moderator/src/lib/abuse-decisions.ts
@@ -1,0 +1,84 @@
+import type { AbuseVerdict } from './abuse-verdicts';
+
+/**
+ * Collapsing a run's findings into the DECISIONS a moderator actually makes.
+ *
+ * 🔴 IN `$lib` RATHER THAN INSIDE `+page.svelte`, AND THAT IS THE POINT. This app has no component
+ * render harness — `routes/abuse/__tests__/load-status.test.ts` says so in as many words — so logic
+ * written inside a `$derived` is logic nothing can assert. The grouping rule is the substance of the
+ * feature: get it wrong and a ring of eleven renders as one row that rules one account, or as eleven
+ * rows that each rule all eleven. Neither is visible to a type checker and neither would fail a
+ * source-level grep. A pure function is testable as one.
+ */
+
+/** The finding fields this module reads. Structural, so both the page's row type and a test fixture
+ *  satisfy it without either importing the other's shape. */
+export type GroupableFinding = {
+  id: number;
+  actioned: boolean;
+  confidence: number;
+  groupKey: string | null;
+  verdict: AbuseVerdict | null;
+};
+
+export type Decision<F extends GroupableFinding> = {
+  /**
+   * Stable `{#each}` key.
+   *
+   * 🔴 TWO NAMESPACES, NOT ONE. A producer's group key is an opaque string it chose; keying an
+   * ungrouped finding on its bare id would let a producer that emitted the key `"7"` collapse into
+   * the finding whose id is 7. The prefixes make that unrepresentable rather than unlikely.
+   */
+  id: string;
+  groupKey: string | null;
+  /** Every finding this one decision covers — one element for an ungrouped finding. */
+  members: F[];
+  /** The row rendered: the most-confident member, matching the order the run is sorted in. */
+  lead: F;
+};
+
+/**
+ * One decision per cluster, and one per ungrouped finding.
+ *
+ * 🔴 A NULL `groupKey` IS THE ABSENCE OF A GROUP, NEVER A GROUP OF ITS OWN. Bucketing on the raw
+ * value would sweep every ungrouped finding in the run into a single row — and because that row
+ * would render plausibly, with a count and a list of members, the failure would read as the feature
+ * working. Each such finding therefore gets a bucket keyed on its own id.
+ *
+ * Ordering is the page's existing rule, applied at both levels: acted-on first (the rows with
+ * consequences lead), then by the producer's confidence. Applied WITHIN a cluster too, because that
+ * is what picks the lead, and a lead chosen by input order would change which reason a moderator
+ * reads when the service's sort changed.
+ */
+export function groupFindings<F extends GroupableFinding>(findings: readonly F[]): Decision<F>[] {
+  const byKey = new Map<string, F[]>();
+  for (const f of findings) {
+    const id = f.groupKey === null ? `finding:${f.id}` : `group:${f.groupKey}`;
+    const bucket = byKey.get(id);
+    if (bucket) bucket.push(f);
+    else byKey.set(id, [f]);
+  }
+
+  return [...byKey.entries()]
+    .map(([id, members]) => {
+      const sorted = [...members].sort(byConsequenceThenConfidence);
+      return { id, groupKey: sorted[0].groupKey, members: sorted, lead: sorted[0] };
+    })
+    .sort((a, b) => byConsequenceThenConfidence(a.lead, b.lead));
+}
+
+const byConsequenceThenConfidence = (a: GroupableFinding, b: GroupableFinding) =>
+  Number(b.actioned) - Number(a.actioned) || b.confidence - a.confidence;
+
+/**
+ * The stored ruling for a decision, or `'mixed'`.
+ *
+ * 🔴 `mixed` IS A REAL STATE AND IS REPORTED AS ONE. A cluster whose members were ruled individually
+ * — before the producer started grouping them, or by a ruling that predates the key — can genuinely
+ * disagree. Collapsing that to the lead's verdict would present one member's ruling as the whole
+ * cluster's, which is the board asserting something no human said.
+ */
+export function storedVerdict(d: Decision<GroupableFinding>): AbuseVerdict | 'mixed' | null {
+  const distinct = new Set(d.members.map((m) => m.verdict));
+  return distinct.size > 1 ? 'mixed' : d.members[0].verdict;
+}

--- a/apps/moderator/src/lib/abuse-verdicts.ts
+++ b/apps/moderator/src/lib/abuse-verdicts.ts
@@ -1,0 +1,34 @@
+/**
+ * The verdicts a moderator can record on an abuse-detection finding.
+ *
+ * 🔴 IN `$lib`, NOT `$lib/server`, AND THAT IS A CONSTRAINT RATHER THAN A PREFERENCE. SvelteKit
+ * refuses to bundle anything under `$lib/server` into client code, and the verdict buttons are
+ * client code — so the tuple that renders them cannot live beside the table definition that
+ * constrains them. Declaring it once here and importing it from BOTH sides is what keeps the page,
+ * the form action and the database's CHECK constraint agreeing on one set. A second copy written
+ * for the UI is how a fourth button appears that the database then refuses.
+ *
+ * Order is the order the UI offers them, and it is deliberate: the two real judgements first, the
+ * abstention last.
+ *
+ * 🔴 THESE ARE NOT `actioned`/`action`. Those two record what the DETECTOR did, and are written by
+ * the detector. These record whether a HUMAN thinks it was right. They move independently — the
+ * commonest finding is one the detector left alone (`actioned: false`) and a moderator rules `tp` —
+ * and nothing may read one to infer the other.
+ *
+ * `skip` is a DECISION ("I looked and I am not calling it"), which is why it is a verdict and not
+ * simply left unruled. A NULL verdict means nobody has looked at all, and that is what a run's
+ * "still to review" count is derived from.
+ */
+export const ABUSE_VERDICTS = ['tp', 'fp', 'skip'] as const;
+
+export type AbuseVerdict = (typeof ABUSE_VERDICTS)[number];
+
+/**
+ * Narrowing guard — the one place an untrusted string becomes an `AbuseVerdict`.
+ *
+ * `includes` on the widened array rather than a hand-written `===` chain: a value added to the tuple
+ * is covered here without anyone remembering to extend a second list.
+ */
+export const isAbuseVerdict = (value: unknown): value is AbuseVerdict =>
+  typeof value === 'string' && (ABUSE_VERDICTS as readonly string[]).includes(value);

--- a/apps/moderator/src/lib/server/__tests__/abuse-detection-pglite.harness.ts
+++ b/apps/moderator/src/lib/server/__tests__/abuse-detection-pglite.harness.ts
@@ -1,0 +1,197 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PGlite } from '@electric-sql/pglite';
+import {
+  CompiledQuery,
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  type CompiledQuery as CompiledQueryType,
+  type DatabaseConnection,
+  type Dialect,
+  type Driver,
+  type QueryResult,
+} from 'kysely';
+import type { AbuseDetectionTables } from '../abuse-detection-tables';
+
+/**
+ * `apps/moderator/abuse-detection/schema.sql`, APPLIED to a real Postgres.
+ *
+ * 🔴 WHY THIS TIER EXISTS, AND WHY THE EXISTING TWO CANNOT COVER IT. `abuse-detection.test.ts` fakes
+ * the builder and asserts what was passed to it; `abuse-detection.sql.test.ts` compiles the queries
+ * and asserts their text. Neither has ever executed a statement, so NOTHING in this app had any
+ * claim on the DDL at all: a CHECK constraint that admits the wrong set, a column the code writes
+ * and the table does not have, and a file that is not re-runnable would all pass both tiers.
+ *
+ * PGlite is Postgres compiled to WASM, in-process — the same instrument
+ * `<civitai>/src/server/services/__tests__/listForModel.harness.ts` uses. It is NOT a stand-in that
+ * approximates Postgres: the CHECK violations these tests assert come back with the real `23514`,
+ * from the real constraint, parsed from the real file.
+ *
+ * 🔴 IT IS NOT SKIPPABLE, AND THAT IS THE POINT. The EXPLAIN tier in this directory is
+ * `describe.skipIf(!h.hasDb)` and therefore does not run in CI or on a machine without `.env` — a
+ * test that skips itself proves nothing. This one needs no server, so it runs everywhere.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** `src/lib/server/__tests__` → the app root, where `abuse-detection/schema.sql` lives. */
+export const SCHEMA_PATH = join(HERE, '../../../../abuse-detection/schema.sql');
+
+export const readSchemaSql = (): string => readFileSync(SCHEMA_PATH, 'utf8');
+
+/**
+ * psql meta-commands removed — `\set ON_ERROR_STOP on` is an instruction to psql, not SQL, and the
+ * server rejects it as a syntax error.
+ *
+ * 🔴 STRIPPING IT IS EXACTLY WHY A SEPARATE TEXTUAL ASSERTION ON THAT LINE IS REQUIRED. Applying the
+ * file here says nothing about whether the directive is still in it, and the directive is what stops
+ * psql sailing past a failed statement on the one deployment that needs it most (see the file's own
+ * comment). Execution and presence are two different claims; this harness can only make the first.
+ */
+export function executableSchemaSql(sql: string): string {
+  return sql
+    .split('\n')
+    .map((line) => (line.trimStart().startsWith('\\') ? '' : line))
+    .join('\n');
+}
+
+/** Apply the real DDL, verbatim apart from the psql meta-commands. */
+export async function applySchema(db: PGlite): Promise<void> {
+  await db.exec(executableSchemaSql(readSchemaSql()));
+}
+
+/**
+ * A Kysely dialect over PGlite, so the SERVICE's own query builders run against real Postgres.
+ *
+ * 🔴 THE SERVICE, UNMODIFIED — that is the whole value. A fake builder can only be asked what it was
+ * told; it cannot answer "did this UPDATE touch a row in another run", which is the question every
+ * group-scoping guard in `recordAbuseVerdict` turns on. Those guards are about WHICH ROWS MOVE, and
+ * only rows can answer.
+ */
+export function pgliteDialect(db: PGlite): Dialect {
+  const connection: DatabaseConnection = {
+    async executeQuery<R>(compiled: CompiledQueryType): Promise<QueryResult<R>> {
+      const result = await db.query(compiled.sql, compiled.parameters as unknown[]);
+      return {
+        rows: result.rows as R[],
+        // 🔴 Kysely's `UpdateResult.numUpdatedRows` is derived from this field and nothing else.
+        // Omitting it makes every update report 0 rows changed — which is the value
+        // `recordAbuseVerdict` returns and the route branches on, so a harness that dropped it
+        // would make the "zero rows is not success" refusal fire on every successful ruling.
+        numAffectedRows: BigInt(result.affectedRows ?? 0),
+      };
+    },
+    // Throws rather than answering nothing: a silent empty stream would look like a query that
+    // legitimately found no rows. Nothing in this service streams, and if something starts to, this
+    // is where it should stop rather than quietly return the wrong answer.
+    // eslint-disable-next-line require-yield
+    async *streamQuery() {
+      throw new Error('streaming is not used by the abuse-detection service');
+    },
+  };
+
+  /** The three lifecycle hooks PGlite has no analogue for — it is one in-process database. */
+  const noop = async () => undefined;
+
+  const driver: Driver = {
+    init: noop,
+    async acquireConnection() {
+      return connection;
+    },
+    // Real transactions: `recordAbuseRun` writes a run and its findings in one, and the harness must
+    // not quietly turn that into two independent writes.
+    async beginTransaction(conn) {
+      await conn.executeQuery(CompiledQuery.raw('begin'));
+    },
+    async commitTransaction(conn) {
+      await conn.executeQuery(CompiledQuery.raw('commit'));
+    },
+    async rollbackTransaction(conn) {
+      await conn.executeQuery(CompiledQuery.raw('rollback'));
+    },
+    releaseConnection: noop,
+    destroy: noop,
+  };
+
+  return {
+    createAdapter: () => new PostgresAdapter(),
+    createDriver: () => driver,
+    createIntrospector: (k) => new PostgresIntrospector(k),
+    createQueryCompiler: () => new PostgresQueryCompiler(),
+  };
+}
+
+/** A client typed exactly as the service's own, over the in-process database. */
+export function pgliteKysely(db: PGlite): Kysely<AbuseDetectionTables> {
+  return new Kysely<AbuseDetectionTables>({ dialect: pgliteDialect(db) });
+}
+
+/** A fresh in-process Postgres with the real schema applied. */
+export async function freshDb(): Promise<PGlite> {
+  const db = await PGlite.create();
+  await applySchema(db);
+  return db;
+}
+
+/** One run header, returning its id. Findings are inserted by the tests that need them. */
+export async function seedRun(db: PGlite, detector: string, startedAt: string): Promise<number> {
+  const res = await db.query<{ id: number }>(
+    `INSERT INTO abuse_detection_run (detector, started_at, finished_at)
+     VALUES ($1, $2::timestamptz, $2::timestamptz) RETURNING id`,
+    [detector, startedAt]
+  );
+  return Number(res.rows[0].id);
+}
+
+/** One finding, returning its id. `actioned`/`action` default to the producer's common case. */
+export async function seedFinding(
+  db: PGlite,
+  row: {
+    runId: number;
+    userId: number;
+    confidence?: number;
+    reason?: string;
+    actioned?: boolean;
+    action?: string | null;
+    groupKey?: string | null;
+  }
+): Promise<number> {
+  const res = await db.query<{ id: number }>(
+    `INSERT INTO abuse_detection_finding
+       (run_id, user_id, confidence, reason, actioned, action, group_key)
+     VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
+    [
+      row.runId,
+      row.userId,
+      row.confidence ?? 0.5,
+      row.reason ?? 'seeded',
+      row.actioned ?? false,
+      row.action ?? null,
+      row.groupKey ?? null,
+    ]
+  );
+  return Number(res.rows[0].id);
+}
+
+export type FindingRow = {
+  id: number;
+  run_id: number;
+  user_id: number;
+  actioned: boolean;
+  action: string | null;
+  verdict: string | null;
+  verdict_by: string | null;
+  verdict_at: Date | null;
+  group_key: string | null;
+};
+
+/** Every finding in the database, id order — the ledger the group-scoping assertions read. */
+export async function allFindings(db: PGlite): Promise<FindingRow[]> {
+  const res = await db.query<FindingRow>(
+    `SELECT id, run_id, user_id, actioned, action, verdict, verdict_by, verdict_at, group_key
+       FROM abuse_detection_finding ORDER BY id`
+  );
+  return res.rows;
+}

--- a/apps/moderator/src/lib/server/__tests__/abuse-detection.schema.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/abuse-detection.schema.test.ts
@@ -204,3 +204,109 @@ describe('🔴 a verdict is not an action — the conflation regression', () => 
     ).rejects.toMatchObject({ code: '23514' });
   });
 });
+
+/**
+ * 🔴 THE HEADER'S RECOVERY, EXECUTED — because it is an instruction to a human holding a psql
+ * prompt against a live table, and a wrong one costs them a session they cannot undo by re-reading
+ * the file.
+ *
+ * The recovery it used to give was `GRANT SELECT, INSERT, UPDATE, DELETE … TO internal_tools`, and
+ * that was correct only while this file did nothing but `CREATE TABLE IF NOT EXISTS`. It now runs
+ * `ALTER TABLE`, which Postgres permits ONLY to a table's owner — no table privilege grants it. The
+ * cases below are the two arms: the grant arm must fail, the ownership arm must succeed, and the
+ * statements the header prints must be the ones that are run.
+ */
+describe('the header’s recovery for "you ran it as the wrong role"', () => {
+  /**
+   * The recovery statements the header actually prints, lifted out of it rather than retyped.
+   *
+   * 🔴 THIS IS WHAT MAKES THE TEST A CLAIM ABOUT THE FILE. Retyping them here would assert that a
+   * correct recipe works, which nobody doubted; reading them means a header that prints something
+   * unrunnable — `ALTER TABLE a, b OWNER TO x`, which is a SYNTAX ERROR in Postgres and was in this
+   * file's first draft of the fix — turns this suite red instead of shipping.
+   */
+  const headerRecoveryStatements = (): string[] =>
+    readSchemaSql()
+      .split('\n')
+      // The header only: stop at the first line that is not a comment.
+      .slice(
+        0,
+        readSchemaSql()
+          .split('\n')
+          .findIndex((l) => l.trim() !== '' && !l.trimStart().startsWith('--'))
+      )
+      .map((l) => l.replace(/^\s*--\s?/, '').trim())
+      .filter((l) => /^ALTER (TABLE|SEQUENCE)\b/i.test(l));
+
+  const asRole = async (d: PGlite, role: string, fn: () => Promise<void>) => {
+    await d.exec(`SET ROLE ${role};`);
+    try {
+      await fn();
+    } finally {
+      await d.exec(`RESET ROLE;`);
+    }
+  };
+
+  it('prints four single-object statements, and they PARSE — negative control on the extractor', () => {
+    const stmts = headerRecoveryStatements();
+    // If the extractor returned nothing, every executable assertion below would be vacuously true.
+    expect(stmts.length, 'the header prints no ALTER recovery at all').toBe(4);
+    // One object per statement. `OWNER TO` takes a single name; the comma form parses as nothing.
+    for (const s of stmts) expect(s, `${s} names more than one object`).not.toMatch(/,/);
+    expect(stmts.filter((s) => /^ALTER TABLE/i.test(s))).toHaveLength(2);
+    expect(stmts.filter((s) => /^ALTER SEQUENCE/i.test(s))).toHaveLength(2);
+  });
+
+  /**
+   * A role holding everything the header's GRANT lines give, plus the schema privileges the file's
+   * FIRST instruction already assumes — it says to run this file as this role, and `CREATE TABLE IF
+   * NOT EXISTS` needs `CREATE` on the schema regardless of whether the table is there. Arranging it
+   * identically in BOTH arms is what makes them a control pair: the only thing that differs between
+   * the arm that fails and the arm that succeeds is OWNERSHIP.
+   */
+  const createGrantedRole = async (d: PGlite) => {
+    await d.exec(`CREATE ROLE internal_tools LOGIN;`);
+    await d.exec(`GRANT USAGE, CREATE ON SCHEMA public TO internal_tools;`);
+    await d.exec(`GRANT SELECT, INSERT, UPDATE, DELETE
+                    ON abuse_detection_run, abuse_detection_finding TO internal_tools;`);
+    await d.exec(`GRANT USAGE, SELECT
+                    ON SEQUENCE abuse_detection_run_id_seq, abuse_detection_finding_id_seq
+                    TO internal_tools;`);
+  };
+
+  it('🔴 the OLD recovery cannot work — a granted, non-owning role may not ALTER', async () => {
+    const d = await db();
+    await createGrantedRole(d);
+
+    await asRole(d, 'internal_tools', async () => {
+      // The grants DO cover the reads and writes — so this arm is not failing for want of any
+      // privilege at all, which is the control that makes the rejection below attributable.
+      await expect(d.query(`SELECT count(*) FROM abuse_detection_finding`)).resolves.toBeDefined();
+      // …and do NOT cover the statement this file now runs.
+      await expect(
+        d.exec(`ALTER TABLE abuse_detection_finding ADD COLUMN IF NOT EXISTS probe text;`)
+      ).rejects.toMatchObject({
+        code: '42501',
+        message: expect.stringContaining('must be owner of table abuse_detection_finding'),
+      });
+    });
+  });
+
+  it('🔴 the NEW recovery does work — after it, the whole file re-applies as that role', async () => {
+    const d = await db();
+    await createGrantedRole(d);
+    // The ONLY difference from the arm above: the header's ownership transfer, run verbatim.
+    for (const stmt of headerRecoveryStatements()) await d.exec(`${stmt};`);
+
+    await asRole(d, 'internal_tools', async () => {
+      // The real file, verbatim, as the application role — the state the header is walking someone
+      // back to. Re-runnability is asserted elsewhere; what this adds is "by THIS role".
+      await applySchema(d);
+    });
+
+    // And the columns the ALTERs add are actually there afterwards, so the apply was not a no-op.
+    const columns = await columnNames(d, 'abuse_detection_finding');
+    for (const c of ['verdict', 'verdict_by', 'verdict_at', 'group_key'])
+      expect(columns, `${c} is missing after the recovery`).toContain(c);
+  });
+});

--- a/apps/moderator/src/lib/server/__tests__/abuse-detection.schema.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/abuse-detection.schema.test.ts
@@ -1,0 +1,206 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ABUSE_VERDICTS } from '../../abuse-verdicts';
+import {
+  allFindings,
+  applySchema,
+  executableSchemaSql,
+  freshDb,
+  readSchemaSql,
+  seedFinding,
+  seedRun,
+} from './abuse-detection-pglite.harness';
+
+/**
+ * `apps/moderator/abuse-detection/schema.sql` — EXECUTED, not read.
+ *
+ * See the harness for why this tier exists. In short: the two older tiers fake or compile, so before
+ * this file nothing in the app had any claim on the DDL, and a CHECK admitting the wrong set or a
+ * file that could not be re-run would pass both of them.
+ */
+
+let open: PGlite[] = [];
+const db = async () => {
+  const next = await freshDb();
+  open.push(next);
+  return next;
+};
+afterEach(async () => {
+  for (const d of open) await d.close();
+  open = [];
+});
+
+/** The constraint definition Postgres itself reports, which is the only authority on what it admits. */
+async function verdictConstraintDef(d: PGlite): Promise<string | null> {
+  const res = await d.query<{ def: string }>(
+    `SELECT pg_get_constraintdef(oid) AS def FROM pg_constraint
+      WHERE conrelid = 'abuse_detection_finding'::regclass
+        AND conname = 'abuse_detection_finding_verdict_valid'`
+  );
+  return res.rows[0]?.def ?? null;
+}
+
+const columnNames = async (d: PGlite, table: string) => {
+  const res = await d.query<{ column_name: string }>(
+    `SELECT column_name FROM information_schema.columns
+      WHERE table_name = $1 ORDER BY column_name`,
+    [table]
+  );
+  return res.rows.map((r) => r.column_name);
+};
+
+describe('the DDL applies', () => {
+  it('creates the four verdict columns on the findings table', async () => {
+    const d = await db();
+    const columns = await columnNames(d, 'abuse_detection_finding');
+    // Named individually rather than as a set diff, so a failure says WHICH column is missing.
+    for (const column of ['verdict', 'verdict_by', 'verdict_at', 'group_key'])
+      expect(columns, `${column} is missing from the applied schema`).toContain(column);
+  });
+
+  it('leaves the producer columns exactly as they were', async () => {
+    // 🔴 The regression that would be easiest to introduce and hardest to notice: a migration that
+    // "tidied" `actioned`/`action` away, or renamed one into the verdict family. They are a
+    // DIFFERENT record — what the detector did — and the whole board's purpose is comparing them.
+    const d = await db();
+    const columns = await columnNames(d, 'abuse_detection_finding');
+    expect(columns).toContain('actioned');
+    expect(columns).toContain('action');
+  });
+
+  it('is RE-RUNNABLE — applying it twice is clean and changes nothing', async () => {
+    // The file is applied by hand, in two environments, by whoever is standing there. It WILL be run
+    // twice. A second run that errors leaves the operator unable to tell a partial apply from a
+    // complete one, and `ON_ERROR_STOP` then aborts whatever came after.
+    const d = await db();
+    const before = await columnNames(d, 'abuse_detection_finding');
+    await expect(applySchema(d)).resolves.not.toThrow();
+    expect(await columnNames(d, 'abuse_detection_finding')).toEqual(before);
+
+    // And still exactly ONE verdict constraint — a `DO $$ … $$` guard that tested the wrong thing
+    // would add a second identical one per run rather than erroring, which no column check sees.
+    const constraints = await d.query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM pg_constraint
+        WHERE conrelid = 'abuse_detection_finding'::regclass
+          AND conname = 'abuse_detection_finding_verdict_valid'`
+    );
+    expect(constraints.rows[0].n).toBe(1);
+  });
+
+  it('a THIRD apply is still clean — idempotence is not a one-shot property', async () => {
+    const d = await db();
+    await applySchema(d);
+    await expect(applySchema(d)).resolves.not.toThrow();
+  });
+
+  it('keeps `\\set ON_ERROR_STOP on` — the harness strips it, so presence is its own claim', () => {
+    // 🔴 THIS CANNOT BE PROVEN BY APPLYING THE FILE. `\set` is a psql instruction and the server
+    // rejects it, so the harness blanks it before executing — which means execution says nothing
+    // about whether it is still there. Without it psql continues past a failed statement, and the
+    // file's own comment names the deployment where that leaves NO unique index at all.
+    const sql = readSchemaSql();
+    expect(sql).toContain('\\set ON_ERROR_STOP on');
+    // Before the first statement, or it does not protect the statements that precede it.
+    const directive = sql.indexOf('\\set ON_ERROR_STOP on');
+    const firstStatement = sql.search(/^\s*(CREATE|ALTER|DROP|DO)\b/im);
+    expect(firstStatement).toBeGreaterThan(-1);
+    expect(directive).toBeLessThan(firstStatement);
+    // And the stripper removed it rather than leaving a line the server would refuse.
+    expect(executableSchemaSql(sql)).not.toContain('ON_ERROR_STOP');
+  });
+});
+
+describe('the verdict CHECK constraint', () => {
+  it('accepts each of the three verdicts', async () => {
+    const d = await db();
+    const runId = await seedRun(d, 'bot-account-detection', '2026-09-03T03:20:00Z');
+    // Driven off the shared tuple so a verdict added in code without a DDL change fails HERE, at the
+    // seam, rather than in production on the first click.
+    for (const verdict of ABUSE_VERDICTS) {
+      const id = await seedFinding(d, { runId, userId: 1 });
+      await expect(
+        d.query(`UPDATE abuse_detection_finding SET verdict = $1 WHERE id = $2`, [verdict, id])
+      ).resolves.toBeTruthy();
+    }
+  });
+
+  it('accepts NULL — unruled is the state every finding starts in', async () => {
+    const d = await db();
+    const runId = await seedRun(d, 'bot-account-detection', '2026-09-03T03:20:00Z');
+    const id = await seedFinding(d, { runId, userId: 1 });
+    const rows = await allFindings(d);
+    expect(rows.find((r) => r.id === id)?.verdict).toBeNull();
+  });
+
+  it.each([
+    ['a capitalised verdict', 'TP'],
+    ['a trailing space', 'fp '],
+    ['a spelled-out verdict', 'false-positive'],
+    ['the empty string', ''],
+    ['an invented fourth verdict', 'maybe'],
+  ])('rejects %s with a CHECK violation', async (_label, verdict) => {
+    // 🔴 THE FAILURE'S OWN CODE, not merely "it threw". `23514` is check_violation; a NOT NULL
+    // failure, a type error or a missing column would all also throw, and any of them passing here
+    // would report this constraint as working while it does not exist.
+    const d = await db();
+    const runId = await seedRun(d, 'bot-account-detection', '2026-09-03T03:20:00Z');
+    const id = await seedFinding(d, { runId, userId: 1 });
+    await expect(
+      d.query(`UPDATE abuse_detection_finding SET verdict = $1 WHERE id = $2`, [verdict, id])
+    ).rejects.toMatchObject({ code: '23514' });
+  });
+
+  it('admits EXACTLY the set the application code offers — both directions', async () => {
+    // 🔴 THE SEAM, AND IT IS TWO-SIDED. A value in the DDL that the UI never offers is a state
+    // nothing can produce and every count query silently drops; a value in the UI that the DDL
+    // refuses is a button that 500s. Parsing the constraint Postgres reports — rather than the file
+    // text — means a hand-edit to a live database is what is being compared.
+    const d = await db();
+    const def = await verdictConstraintDef(d);
+    expect(def, 'the verdict constraint is not on the table').toBeTruthy();
+    const literals = [...(def as string).matchAll(/'([^']*)'/g)].map((m) => m[1]);
+    expect([...literals].sort()).toEqual([...ABUSE_VERDICTS].sort());
+  });
+
+  it('the code-side tuple is the three verdicts, spelled out', () => {
+    // Pinned as LITERALS, never derived from the constraint this file just read: two assertions that
+    // both read the database can only prove it agrees with itself.
+    expect([...ABUSE_VERDICTS]).toEqual(['tp', 'fp', 'skip']);
+  });
+});
+
+describe('🔴 a verdict is not an action — the conflation regression', () => {
+  it('recording a verdict leaves `actioned` and `action` untouched', async () => {
+    // The single most likely future bug on this table, named in the schema's own comment: the two
+    // pairs of columns look alike and mean opposite things. `actioned` is what the DETECTOR did;
+    // `verdict` is whether a human thinks it was right. A finding the detector acted on, later ruled
+    // a false positive, must still record that the action happened.
+    const d = await db();
+    const runId = await seedRun(d, 'bot-account-detection', '2026-09-03T03:20:00Z');
+    const acted = await seedFinding(d, { runId, userId: 1, actioned: true, action: 'exclude' });
+    const untouched = await seedFinding(d, { runId, userId: 2, actioned: false, action: null });
+
+    await d.query(
+      `UPDATE abuse_detection_finding SET verdict = 'fp', verdict_by = 'mod', verdict_at = now()
+        WHERE run_id = $1`,
+      [runId]
+    );
+
+    const rows = await allFindings(d);
+    const a = rows.find((r) => r.id === acted);
+    const b = rows.find((r) => r.id === untouched);
+    // Literal expectations, not re-reads of what was seeded.
+    expect(a).toMatchObject({ actioned: true, action: 'exclude', verdict: 'fp' });
+    expect(b).toMatchObject({ actioned: false, action: null, verdict: 'fp' });
+  });
+
+  it('the CHECK pairing `actioned` with `action` still holds alongside the verdict columns', async () => {
+    // The older constraint, re-asserted here because the new `DO $$ … $$` block runs an ALTER on the
+    // same table and a botched one could drop it. `23514` again: the same class, a different rule.
+    const d = await db();
+    const runId = await seedRun(d, 'bot-account-detection', '2026-09-03T03:20:00Z');
+    await expect(
+      seedFinding(d, { runId, userId: 1, actioned: true, action: null })
+    ).rejects.toMatchObject({ code: '23514' });
+  });
+});

--- a/apps/moderator/src/lib/server/__tests__/abuse-detection.sql.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/abuse-detection.sql.test.ts
@@ -48,12 +48,41 @@ const params: readonly unknown[][] = [];
 const CANNED_RUN_ID = 4242;
 let cannedRows: unknown[] = [{ id: CANNED_RUN_ID }];
 
+/**
+ * The ONE query this driver does read the SQL of: the service's capability probe, which asks
+ * `pg_attribute` which columns `abuse_detection_finding` actually has and shapes the INSERT from the
+ * answer. Everything else is still answered with `cannedRows` regardless of what it asked.
+ *
+ * 🔴 It has to be answered specifically, because it is the only query here whose RESULT changes the
+ * SQL of a later statement. Fed the generic canned row it sees no `attname`, concludes the verdict
+ * columns are absent, and compiles the pre-DDL INSERT — so the assertion that the findings insert
+ * names `group_key` failed against a service that was working correctly. Defaults to the applied
+ * schema; `pgAttributeRows` is what a case shrinks to compile the degraded shape.
+ */
+const APPLIED_COLUMNS = [
+  'id',
+  'run_id',
+  'user_id',
+  'confidence',
+  'reason',
+  'actioned',
+  'action',
+  'created_at',
+  'verdict',
+  'verdict_by',
+  'verdict_at',
+  'group_key',
+];
+let pgAttributeRows: unknown[] = APPLIED_COLUMNS.map((attname) => ({ attname }));
+
 class CannedRowDriver extends DummyDriver {
   async acquireConnection(): Promise<DatabaseConnection> {
     return {
       // Generic in `R`, matching `DatabaseConnection` — a concrete row type here does not satisfy it
       // and svelte-check rejects the whole dialect.
-      executeQuery: async <R>() => ({ rows: cannedRows as R[] }),
+      executeQuery: async <R>(compiled: { sql: string }) => ({
+        rows: (compiled.sql.includes('pg_attribute') ? pgAttributeRows : cannedRows) as R[],
+      }),
       streamQuery: async function* () {
         yield { rows: [] };
       },
@@ -93,6 +122,7 @@ beforeEach(() => {
   sql.length = 0;
   (params as unknown[][]).length = 0;
   cannedRows = [{ id: CANNED_RUN_ID }];
+  pgAttributeRows = APPLIED_COLUMNS.map((attname) => ({ attname }));
 });
 
 /** Whitespace-normalised, so a prettier reflow of the builder chain cannot fail these. */

--- a/apps/moderator/src/lib/server/__tests__/abuse-detection.sql.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/abuse-detection.sql.test.ts
@@ -272,6 +272,118 @@ describe('compiled SQL — column names and shape', () => {
     expect(insAt).toBeGreaterThan(delAt);
   });
 
+  it('getAbuseVerdictSummary counts ruled and unruled, scoped to the run', async () => {
+    await service.getAbuseVerdictSummary(42);
+    const q = lastSql();
+    expect(q).toContain('from "abuse_detection_finding"');
+    // 🔴 SCOPED. Without the predicate every run's page reports the WHOLE table's review backlog —
+    // a number that looks plausible, moves when work is done, and is about the wrong population.
+    expect(q).toContain('where "run_id" = $');
+    expect(params[params.length - 1]).toContain(42);
+    // Two conditional COUNTs, not `count(verdict)` and a subtraction: the pair has to be
+    // symmetrical, or one of them silently stops meaning what its alias says.
+    expect(q).toMatch(/count\(case when "verdict" is not null then "id" end\) as "ruled"/);
+    expect(q).toMatch(/count\(case when "verdict" is null then "id" end\) as "unruled"/);
+  });
+
+  it('recordAbuseVerdict reads the target scoped to BOTH the finding and the run', async () => {
+    cannedRows = [{ id: 91, group_key: null }];
+    await service.recordAbuseVerdict({
+      runId: 4,
+      findingId: 91,
+      verdict: 'tp',
+      verdictBy: 'mod-a',
+    });
+
+    const read = sql.map((s2) => s2.replace(/\s+/g, ' ')).find((s2) => s2.startsWith('select'));
+    expect(read).toBeDefined();
+    // 🔴 The run predicate is the write's authorisation boundary — the finding id arrives in a form
+    // post. A read scoped to the id alone lets a page for run 4 rule a finding on run 9.
+    expect(read).toContain('where "id" = $1 and "run_id" = $2');
+    expect(params[0]).toEqual([91, 4]);
+  });
+
+  it('an UNGROUPED ruling updates exactly the one row, still bounded by the run', async () => {
+    cannedRows = [{ id: 91, group_key: null }];
+    await service.recordAbuseVerdict({ runId: 4, findingId: 91, verdict: 'fp', verdictBy: 'm' });
+
+    const update = sql.map((s2) => s2.replace(/\s+/g, ' ')).find((s2) => s2.startsWith('update'));
+    expect(update).toContain('update "abuse_detection_finding" set');
+    // 🔴 THE PREDICATE, NOT THE PARAMETER NUMBERS. `$4`/`$5` were pinned here once, and a mutation
+    // that added ONE column to the SET clause shifted every index — so both of these cases went red
+    // for a reason that had nothing to do with the predicate they exist to guard. The bound VALUES
+    // are asserted below, which is the claim that actually matters.
+    expect(update).toMatch(/where "run_id" = \$\d+ and "id" = \$\d+/);
+    const oneParams = params[sql.findIndex((s2) => s2.replace(/\s+/g, ' ').startsWith('update'))];
+    expect(oneParams).toContain(4);
+    expect(oneParams).toContain(91);
+    // 🔴 NULL IS NEVER A MATCH VALUE. `where group_key = NULL` matches nothing in Postgres, but
+    // `where group_key is null` would rule every ungrouped finding in the run at once.
+    expect(update).not.toContain('"group_key"');
+  });
+
+  it('a GROUPED ruling updates by key AND run — never by key alone', async () => {
+    cannedRows = [{ id: 91, group_key: 'domain:ring.test' }];
+    await service.recordAbuseVerdict({ runId: 4, findingId: 91, verdict: 'tp', verdictBy: 'm' });
+
+    const update = sql.map((s2) => s2.replace(/\s+/g, ' ')).find((s2) => s2.startsWith('update'));
+    expect(update).toMatch(/where "run_id" = \$\d+ and "group_key" = \$\d+/);
+    // The id is NOT in the predicate — that is what makes it cover the cluster — and the run is,
+    // which is what stops it covering yesterday's copy of the same ring.
+    expect(update).not.toContain('"id" =');
+    const updateParams =
+      params[sql.findIndex((s2) => s2.replace(/\s+/g, ' ').startsWith('update'))];
+    expect(updateParams).toContain('domain:ring.test');
+    expect(updateParams).toContain(4);
+  });
+
+  it('🔴 a ruling writes ONLY the verdict columns — never the producer’s own record', async () => {
+    // The conflation regression in the compiled text: `actioned`/`action` are what the DETECTOR did,
+    // and overwriting them destroys the only evidence of it. Asserted on the SET clause alone, so an
+    // `actioned` appearing anywhere else in the statement cannot mask it.
+    cannedRows = [{ id: 91, group_key: null }];
+    await service.recordAbuseVerdict({ runId: 4, findingId: 91, verdict: 'tp', verdictBy: 'm' });
+
+    const update = sql
+      .map((s2) => s2.replace(/\s+/g, ' '))
+      .find((s2) => s2.startsWith('update')) as string;
+    const setClause = update.slice(update.indexOf('set'), update.indexOf('where'));
+    for (const col of ['"verdict"', '"verdict_by"', '"verdict_at"'])
+      expect(setClause).toContain(col);
+    for (const col of ['"actioned"', '"action"', '"confidence"', '"reason"', '"user_id"'])
+      expect(setClause, `a ruling must not write ${col}`).not.toContain(col);
+  });
+
+  it('does not update at all when the finding is not on this run', async () => {
+    // The read comes back empty, and nothing may be written on the strength of an absent row.
+    cannedRows = [];
+    await expect(
+      service.recordAbuseVerdict({ runId: 4, findingId: 91, verdict: 'tp', verdictBy: 'm' })
+    ).resolves.toEqual({ updated: 0, groupKey: null });
+    expect(sql).toHaveLength(1);
+  });
+
+  it('recordAbuseRun writes group_key on the findings insert', async () => {
+    await service.recordAbuseRun({
+      detector: 'bot-account-detection',
+      startedAt: '2026-08-21T11:00:00.000Z',
+      finishedAt: '2026-08-21T11:04:00.000Z',
+      findings: [
+        {
+          userId: 7,
+          confidence: 0.9,
+          reason: 'r',
+          actioned: false,
+          groupKey: 'domain:ring.test',
+        },
+      ],
+    });
+    const insert = sql
+      .map((s2) => s2.replace(/\s+/g, ' '))
+      .find((s2) => s2.startsWith('insert into "abuse_detection_finding"'));
+    expect(insert).toContain('"group_key"');
+  });
+
   // The header read short-circuits on a missing row, so without a row-returning driver this second
   // statement never compiled — three wrong versions of it shipped green.
   it('getAbuseRun scopes its counts to the run, and counts actioned separately', async () => {

--- a/apps/moderator/src/lib/server/__tests__/abuse-detection.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/abuse-detection.test.ts
@@ -262,6 +262,58 @@ describe('abuseReportInput — the wire contract', () => {
     expect(parsed.success).toBe(false);
   });
 
+  // 🔴 THE THREE DETECTORS ALREADY ON THIS BOARD SEND NO `groupKey`. A required key would 400 every
+  // one of their reports and take the surface down to add a feature none of them uses — so the
+  // absence of the field has to stay a first-class, accepted payload rather than merely working
+  // today. The three shapes a serialiser can produce are all pinned, in both directions.
+  it('accepts a report whose findings carry NO group key — the existing producers', () => {
+    const parsed = abuseReportInput.safeParse({
+      ...baseRun,
+      findings: [{ userId: 5, confidence: 0.5, reason: 'r', actioned: false }],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts a group key', () => {
+    const parsed = abuseReportInput.safeParse({
+      ...baseRun,
+      findings: [
+        { userId: 5, confidence: 0.5, reason: 'r', actioned: false, groupKey: 'domain:ring.test' },
+      ],
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.findings[0].groupKey).toBe('domain:ring.test');
+  });
+
+  it('accepts an explicit null group key, like every other nullable field here', () => {
+    const parsed = abuseReportInput.safeParse({
+      ...baseRun,
+      findings: [{ userId: 5, confidence: 0.5, reason: 'r', actioned: false, groupKey: null }],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects an EMPTY group key', () => {
+    // An empty string is not "no cluster" — it is a cluster every ungrouped finding would join, so
+    // one click would rule them all. `null`/absent is how "no cluster" is spelled.
+    const parsed = abuseReportInput.safeParse({
+      ...baseRun,
+      findings: [{ userId: 5, confidence: 0.5, reason: 'r', actioned: false, groupKey: '' }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects an absurdly long group key', () => {
+    // `group_key` is `text`, so nothing downstream bounds it; the column is rendered on a page.
+    const parsed = abuseReportInput.safeParse({
+      ...baseRun,
+      findings: [
+        { userId: 5, confidence: 0.5, reason: 'r', actioned: false, groupKey: 'x'.repeat(201) },
+      ],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
   it.each([
     ['reason', { userId: 5, confidence: 0.5, reason: '', actioned: false }],
     ['action', { userId: 5, confidence: 0.5, reason: 'r', actioned: true, action: '' }],
@@ -407,6 +459,36 @@ describe('recordAbuseRun', () => {
     transactionExecute.mockRejectedValueOnce(original);
 
     await expect(recordAbuseRun({ ...baseRun, findings: [] })).rejects.toBe(original);
+  });
+
+  it('writes the reported group key on the finding row', async () => {
+    await recordAbuseRun({
+      ...baseRun,
+      findings: [
+        {
+          userId: 7,
+          confidence: 0.5,
+          reason: 'r',
+          actioned: false,
+          groupKey: 'domain:ring.test',
+        },
+      ],
+    });
+    const values = valuesFor('abuse_detection_finding') as { group_key: string | null };
+    expect(values.group_key).toBe('domain:ring.test');
+  });
+
+  it('stores an ABSENT group key as NULL, not as undefined', async () => {
+    // 🔴 `undefined` in a Kysely `values()` row OMITS the column, and a replayed run mixing rows that
+    // have the key with rows that do not is an insert whose rows disagree about their columns — a
+    // runtime error rather than a missing value. NULL is also what "in no cluster" means here.
+    await recordAbuseRun({
+      ...baseRun,
+      findings: [{ userId: 7, confidence: 0.5, reason: 'r', actioned: false }],
+    });
+    const values = valuesFor('abuse_detection_finding') as Record<string, unknown>;
+    expect(values).toHaveProperty('group_key');
+    expect(values.group_key).toBeNull();
   });
 
   it('defaults absent counters to an empty object rather than null', async () => {

--- a/apps/moderator/src/lib/server/__tests__/abuse-detection.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/abuse-detection.test.ts
@@ -29,12 +29,38 @@ function insertChain(calls: Call[], resolveWith: unknown) {
   return builder;
 }
 
-const { calls, insertInto, transactionExecute } = vi.hoisted(() => {
+const { calls, insertInto, transactionExecute, catalog } = vi.hoisted(() => {
   const calls: [string, unknown[]][] = [];
   return {
     calls,
     insertInto: vi.fn(),
     transactionExecute: vi.fn(),
+    /**
+     * What the service's capability probe sees on `abuse_detection_finding`.
+     *
+     * 🔴 The probe is a RAW `sql` query, so it does not go through `insertInto`/`deleteFrom` — it
+     * asks the transaction for a Kysely executor. A fake that omitted one made every
+     * `recordAbuseRun` case throw `executorProvider.getExecutor is not a function`, which is a fact
+     * about the fake and not about the service. Defaulting to the post-DDL column set keeps every
+     * existing case asserting the shape it was written for; a case can shrink it to reproduce the
+     * pre-DDL table.
+     */
+    catalog: {
+      columns: [
+        'id',
+        'run_id',
+        'user_id',
+        'confidence',
+        'reason',
+        'actioned',
+        'action',
+        'created_at',
+        'verdict',
+        'verdict_by',
+        'verdict_at',
+        'group_key',
+      ] as string[],
+    },
   };
 });
 
@@ -52,6 +78,21 @@ beforeEach(() => {
   insertInto.mockReset();
   transactionExecute.mockReset();
 
+  catalog.columns = [
+    'id',
+    'run_id',
+    'user_id',
+    'confidence',
+    'reason',
+    'actioned',
+    'action',
+    'created_at',
+    'verdict',
+    'verdict_by',
+    'verdict_at',
+    'group_key',
+  ];
+
   // The trx handed to the callback. `insertInto` records the table so a test can assert BOTH inserts
   // happened (or that the second did not).
   const trx = {
@@ -63,6 +104,28 @@ beforeEach(() => {
       calls.push(['deleteFrom', [table]]);
       return insertChain(calls, undefined);
     },
+    // The surviving-ruled-rows read. Resolves empty by default: this tier answers "what query was
+    // built", and "which rows came back" is what the PGlite tier is for.
+    selectFrom: (table: string) => {
+      calls.push(['selectFrom', [table]]);
+      const builder: Record<string, unknown> = {};
+      for (const method of ['select', 'where', 'orderBy']) {
+        builder[method] = (...args: unknown[]) => {
+          calls.push([method, args]);
+          return builder;
+        };
+      }
+      builder.execute = async () => [];
+      builder.executeTakeFirst = async () => undefined;
+      return builder;
+    },
+    // The three methods Kysely's `RawBuilderImpl.execute` reaches for, and nothing more: it
+    // transforms the node, compiles it, then executes the compiled query.
+    getExecutor: () => ({
+      transformQuery: (node: unknown) => node,
+      compileQuery: () => ({ sql: '', parameters: [] }),
+      executeQuery: async () => ({ rows: catalog.columns.map((attname) => ({ attname })) }),
+    }),
   };
   transactionExecute.mockImplementation(async (cb: (t: unknown) => unknown) => cb(trx));
 });

--- a/apps/moderator/src/lib/server/__tests__/abuse-detection.verdict.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/abuse-detection.verdict.test.ts
@@ -1,0 +1,428 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  allFindings,
+  freshDb,
+  pgliteKysely,
+  seedFinding,
+  seedRun,
+} from './abuse-detection-pglite.harness';
+
+/**
+ * `recordAbuseVerdict` and `getAbuseVerdictSummary`, EXECUTED against a real Postgres.
+ *
+ * 🔴 WHY NOT THE FAKE-BUILDER TIER. Every guard in `recordAbuseVerdict` is a statement about WHICH
+ * ROWS MOVE: a group ruling must reach every member of the cluster in this run, and must not reach
+ * the identical cluster key in yesterday's run, or an ungrouped sibling, or the producer's own
+ * `actioned` column. A fake builder can only be asked what it was told — it has no rows, so it
+ * cannot distinguish a correctly scoped UPDATE from one scoped to the whole table. That is exactly
+ * the weakness `abuse-detection.test.ts` documents about the read chains, and it applies with more
+ * force to a write.
+ *
+ * The `sql.test.ts` tier still pins the compiled statement text; this one pins the effect.
+ */
+
+const { dbHandle } = vi.hoisted(() => ({ dbHandle: { current: null as unknown } }));
+
+vi.mock('../moderator-db', () => ({
+  getModeratorDb: () => {
+    if (!dbHandle.current) throw new Error('the pglite client was not installed for this test');
+    // `withTables` is a TYPE-level operation that returns the same client.
+    return Object.assign(dbHandle.current as object, { withTables: () => dbHandle.current });
+  },
+}));
+
+const service = await import('../abuse-detection.service');
+
+let db: PGlite;
+
+/** Two runs of the same detector, so "the same group key in another run" is a real row, not a hypothesis. */
+const STARTED_TODAY = '2026-09-03T03:20:00Z';
+const STARTED_YESTERDAY = '2026-09-02T03:20:00Z';
+const RING = 'domain:ring.test';
+
+beforeEach(async () => {
+  db = await freshDb();
+  dbHandle.current = pgliteKysely(db);
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  dbHandle.current = null;
+  await db.close();
+});
+
+/** The shape almost every case needs: a ring of three today, the same ring yesterday, and strays. */
+async function seedTwoRuns() {
+  const today = await seedRun(db, 'bot-account-detection', STARTED_TODAY);
+  const yesterday = await seedRun(db, 'bot-account-detection', STARTED_YESTERDAY);
+  const ids = {
+    today,
+    yesterday,
+    ringToday: [
+      await seedFinding(db, { runId: today, userId: 11, groupKey: RING }),
+      await seedFinding(db, { runId: today, userId: 12, groupKey: RING }),
+      await seedFinding(db, { runId: today, userId: 13, groupKey: RING }),
+    ],
+    // Same run, a DIFFERENT cluster — must not move with the ring above.
+    otherGroupToday: await seedFinding(db, {
+      runId: today,
+      userId: 14,
+      groupKey: 'domain:other.test',
+    }),
+    // Same run, NO cluster. Two of them, because "NULL is not a group" is only observable when
+    // there is a second NULL row that could wrongly be swept up with the first.
+    loneToday: await seedFinding(db, { runId: today, userId: 15 }),
+    otherLoneToday: await seedFinding(db, { runId: today, userId: 16 }),
+    // 🔴 THE SAME CLUSTER KEY IN ANOTHER RUN. A ring reappears in the next day's cohort under the
+    // identical key; ruling today must not rule yesterday.
+    ringYesterday: await seedFinding(db, { runId: yesterday, userId: 11, groupKey: RING }),
+  };
+  return ids;
+}
+
+const ruledIds = async () =>
+  (await allFindings(db)).filter((r) => r.verdict !== null).map((r) => r.id);
+
+describe('recordAbuseVerdict — which rows move', () => {
+  it('rules exactly ONE finding when it carries no group key', async () => {
+    const ids = await seedTwoRuns();
+    const out = await service.recordAbuseVerdict({
+      runId: ids.today,
+      findingId: ids.loneToday,
+      verdict: 'fp',
+      verdictBy: 'mod-a',
+    });
+
+    expect(out).toEqual({ updated: 1, groupKey: null });
+    // 🔴 The OTHER null-group finding in the same run is untouched. A NULL group key used as a match
+    // value would rule both, and the count above would still read as a plausible number.
+    expect(await ruledIds()).toEqual([ids.loneToday]);
+  });
+
+  it('rules every member of a cluster, in this run, with one click', async () => {
+    const ids = await seedTwoRuns();
+    const out = await service.recordAbuseVerdict({
+      runId: ids.today,
+      findingId: ids.ringToday[0],
+      verdict: 'tp',
+      verdictBy: 'mod-a',
+    });
+
+    expect(out).toEqual({ updated: 3, groupKey: RING });
+    expect(await ruledIds()).toEqual([...ids.ringToday].sort((a, b) => a - b));
+  });
+
+  it('🔴 does NOT reach the same cluster key in a DIFFERENT run', async () => {
+    // The expensive mistake this guard exists for. The same ring reappears in tomorrow's cohort
+    // under the identical key, so an UPDATE matching only `group_key` rules every day that ring has
+    // ever been seen — from one page, on one day's evidence, with nothing on screen saying so.
+    const ids = await seedTwoRuns();
+    await service.recordAbuseVerdict({
+      runId: ids.today,
+      findingId: ids.ringToday[0],
+      verdict: 'tp',
+      verdictBy: 'mod-a',
+    });
+
+    const rows = await allFindings(db);
+    const yesterdayRow = rows.find((r) => r.id === ids.ringYesterday);
+    expect(yesterdayRow?.group_key, 'the fixture must actually share the key').toBe(RING);
+    expect(yesterdayRow?.run_id).toBe(ids.yesterday);
+    expect(yesterdayRow?.verdict, 'yesterday’s run was ruled by a click on today’s').toBeNull();
+    expect(yesterdayRow?.verdict_by).toBeNull();
+  });
+
+  it('does not reach a different cluster, or an ungrouped finding, in the same run', async () => {
+    const ids = await seedTwoRuns();
+    await service.recordAbuseVerdict({
+      runId: ids.today,
+      findingId: ids.ringToday[0],
+      verdict: 'tp',
+      verdictBy: 'mod-a',
+    });
+
+    const rows = await allFindings(db);
+    for (const id of [ids.otherGroupToday, ids.loneToday, ids.otherLoneToday])
+      expect(rows.find((r) => r.id === id)?.verdict).toBeNull();
+  });
+
+  it('refuses a finding that belongs to another run, and writes nothing', async () => {
+    // The finding id arrives in a form post and is therefore attacker-chosen. Without the run bound,
+    // a post from today's page rules a row on yesterday's.
+    const ids = await seedTwoRuns();
+    const out = await service.recordAbuseVerdict({
+      runId: ids.today,
+      findingId: ids.ringYesterday,
+      verdict: 'tp',
+      verdictBy: 'mod-a',
+    });
+
+    expect(out).toEqual({ updated: 0, groupKey: null });
+    expect(await ruledIds()).toEqual([]);
+  });
+
+  it('refuses a finding id that does not exist at all', async () => {
+    const ids = await seedTwoRuns();
+    await expect(
+      service.recordAbuseVerdict({
+        runId: ids.today,
+        findingId: 999_999,
+        verdict: 'tp',
+        verdictBy: 'mod-a',
+      })
+    ).resolves.toEqual({ updated: 0, groupKey: null });
+  });
+});
+
+describe('recordAbuseVerdict — what it writes', () => {
+  it('stores the verdict, the moderator and the time', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-09-04T10:00:00.000Z'));
+    const ids = await seedTwoRuns();
+
+    await service.recordAbuseVerdict({
+      runId: ids.today,
+      findingId: ids.loneToday,
+      verdict: 'skip',
+      verdictBy: 'mod-a',
+    });
+
+    const row = (await allFindings(db)).find((r) => r.id === ids.loneToday);
+    // Literal expectations throughout — none of them read back from the implementation.
+    expect(row?.verdict).toBe('skip');
+    expect(row?.verdict_by).toBe('mod-a');
+    expect(new Date(row?.verdict_at as Date).toISOString()).toBe('2026-09-04T10:00:00.000Z');
+  });
+
+  it('a re-ruling OVERWRITES, and the record names the current ruler', async () => {
+    // A moderator correcting a mistake must stand behind the correction, not the mistake. A write
+    // that only filled NULLs — or an INSERT-shaped one — would leave the first ruler's name on a
+    // verdict they did not give.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-09-04T10:00:00.000Z'));
+    const ids = await seedTwoRuns();
+
+    await service.recordAbuseVerdict({
+      runId: ids.today,
+      findingId: ids.loneToday,
+      verdict: 'tp',
+      verdictBy: 'mod-a',
+    });
+
+    vi.setSystemTime(new Date('2026-09-04T11:30:00.000Z'));
+    const out = await service.recordAbuseVerdict({
+      runId: ids.today,
+      findingId: ids.loneToday,
+      verdict: 'fp',
+      verdictBy: 'mod-b',
+    });
+
+    expect(out.updated).toBe(1);
+    const row = (await allFindings(db)).find((r) => r.id === ids.loneToday);
+    expect(row?.verdict).toBe('fp');
+    expect(row?.verdict_by).toBe('mod-b');
+    expect(new Date(row?.verdict_at as Date).toISOString()).toBe('2026-09-04T11:30:00.000Z');
+    // Still one row, not a second one appended.
+    expect(await ruledIds()).toEqual([ids.loneToday]);
+  });
+
+  it('🔴 leaves the producer’s `actioned` and `action` exactly as they were', async () => {
+    // The conflation regression, through the SERVICE rather than raw SQL — the schema test asserts
+    // the database permits it, this asserts the code does it. `actioned: true, action: 'exclude'`
+    // ruled `fp` is the interesting row: the detector acted, and a human says it should not have.
+    // Losing the record of the action loses the only evidence of what actually happened.
+    const runId = await seedRun(db, 'bot-account-detection', STARTED_TODAY);
+    const id = await seedFinding(db, {
+      runId,
+      userId: 21,
+      actioned: true,
+      action: 'exclude',
+      groupKey: RING,
+    });
+    const sibling = await seedFinding(db, { runId, userId: 22, groupKey: RING });
+
+    await service.recordAbuseVerdict({ runId, findingId: id, verdict: 'fp', verdictBy: 'mod-a' });
+
+    const rows = await allFindings(db);
+    expect(rows.find((r) => r.id === id)).toMatchObject({
+      actioned: true,
+      action: 'exclude',
+      verdict: 'fp',
+    });
+    // And the group member the ruling reached keeps ITS producer record too.
+    expect(rows.find((r) => r.id === sibling)).toMatchObject({
+      actioned: false,
+      action: null,
+      verdict: 'fp',
+    });
+  });
+});
+
+describe('getAbuseVerdictSummary', () => {
+  it('counts the whole run, ruled and unruled', async () => {
+    const ids = await seedTwoRuns();
+    // Six findings today; rule the three-member ring.
+    await service.recordAbuseVerdict({
+      runId: ids.today,
+      findingId: ids.ringToday[0],
+      verdict: 'tp',
+      verdictBy: 'mod-a',
+    });
+
+    // Literal numbers, from the fixture's own shape: 6 findings today, 3 of them ruled.
+    await expect(service.getAbuseVerdictSummary(ids.today)).resolves.toEqual({
+      ruled: 3,
+      unruled: 3,
+    });
+    // The other run is unaffected, which is what makes the scoping above visible in the count too.
+    await expect(service.getAbuseVerdictSummary(ids.yesterday)).resolves.toEqual({
+      ruled: 0,
+      unruled: 1,
+    });
+  });
+
+  it('reports zeroes for a run with no findings, not null', async () => {
+    // `null` means "this deployment cannot record a ruling". A clean run must not borrow that state.
+    const runId = await seedRun(db, 'review-bomb', STARTED_TODAY);
+    await expect(service.getAbuseVerdictSummary(runId)).resolves.toEqual({ ruled: 0, unruled: 0 });
+  });
+});
+
+describe('the findings read carries the ruling', () => {
+  it('returns the verdict, the ruler and the group key', async () => {
+    const ids = await seedTwoRuns();
+    await service.recordAbuseVerdict({
+      runId: ids.today,
+      findingId: ids.ringToday[0],
+      verdict: 'tp',
+      verdictBy: 'mod-a',
+    });
+
+    const { findings } = await service.getAbuseFindings(ids.today);
+    const ruled = findings.find((f) => f.id === ids.ringToday[0]);
+    expect(ruled).toMatchObject({ verdict: 'tp', verdictBy: 'mod-a', groupKey: RING });
+    expect(ruled?.verdictAt).toBeInstanceOf(Date);
+    // An unruled row reports nulls rather than being omitted — the board renders it with buttons.
+    expect(findings.find((f) => f.id === ids.loneToday)).toMatchObject({
+      verdict: null,
+      verdictBy: null,
+      verdictAt: null,
+      groupKey: null,
+    });
+  });
+});
+
+describe('recordAbuseRun stores the producer’s group key', () => {
+  const report = (groupKey?: string | null) => ({
+    detector: 'bot-account-detection',
+    startedAt: '2026-09-05T03:20:00.000Z',
+    finishedAt: '2026-09-05T03:20:41.000Z',
+    findings: [
+      { userId: 31, confidence: 0.4, reason: 'in a ring', actioned: false, groupKey },
+      { userId: 32, confidence: 0.4, reason: 'alone', actioned: false },
+    ],
+  });
+
+  it('writes the key it was given, and NULL where it was given none', async () => {
+    await service.recordAbuseRun(report(RING));
+    const rows = await allFindings(db);
+    expect(rows.map((r) => [r.user_id, r.group_key])).toEqual([
+      [31, RING],
+      [32, null],
+    ]);
+  });
+
+  it('accepts a report from a producer that sends no group key at all', async () => {
+    // Three detectors already post to this board and none of them sends the field. A required key
+    // would 400 every one of their reports.
+    await service.recordAbuseRun(report());
+    expect((await allFindings(db)).map((r) => r.group_key)).toEqual([null, null]);
+  });
+
+  it('treats an explicit null the same as an absent key', async () => {
+    await service.recordAbuseRun(report(null));
+    expect((await allFindings(db)).map((r) => r.group_key)).toEqual([null, null]);
+  });
+});
+
+/**
+ * 🔴 THE PRE-DDL WINDOW, BUILT BY DROPPING THE COLUMNS.
+ *
+ * The DDL is applied by hand, so between this merging and someone running it the tables exist and
+ * these four columns do not. Dropping them reproduces that table EXACTLY — same rows, same producer
+ * columns, same indexes — and the errors that come back are the real `42703` from a real server, not
+ * a hand-thrown stand-in that could have the wrong code on it.
+ */
+describe('a deployment whose DDL has not been applied', () => {
+  beforeEach(async () => {
+    await db.exec(`ALTER TABLE abuse_detection_finding
+      DROP COLUMN verdict, DROP COLUMN verdict_by, DROP COLUMN verdict_at, DROP COLUMN group_key;`);
+  });
+
+  it('the board still reads its findings', async () => {
+    const runId = await seedRun(db, 'review-bomb', STARTED_TODAY);
+    await seedFindingLegacy(runId, 41);
+
+    const { findings } = await service.getAbuseFindings(runId);
+    expect(findings).toHaveLength(1);
+    // Reported as unruled, which is the truthful reading: nothing has been ruled here, and nothing
+    // can be. A thrown error would take the page down for a database serving every row it holds.
+    expect(findings[0]).toMatchObject({ verdict: null, verdictBy: null, groupKey: null });
+  });
+
+  it('the run header still reads', async () => {
+    const runId = await seedRun(db, 'review-bomb', STARTED_TODAY);
+    await seedFindingLegacy(runId, 41);
+    await expect(service.getAbuseRun(runId)).resolves.toMatchObject({ findingCount: 1 });
+  });
+
+  it('the verdict summary answers null rather than throwing', async () => {
+    const runId = await seedRun(db, 'review-bomb', STARTED_TODAY);
+    await expect(service.getAbuseVerdictSummary(runId)).resolves.toBeNull();
+  });
+
+  it('🔴 a WRITE is refused, with a message naming the file to run', async () => {
+    // A write must not degrade. Silently accepting a ruling that was never stored, and rendering it
+    // as recorded, is the one outcome worse than refusing it.
+    const runId = await seedRun(db, 'review-bomb', STARTED_TODAY);
+    const findingId = await seedFindingLegacy(runId, 41);
+    await expect(
+      service.recordAbuseVerdict({ runId, findingId, verdict: 'tp', verdictBy: 'mod-a' })
+    ).rejects.toThrow(/schema\.sql/);
+  });
+
+  it('🔴 the detectors keep reporting — a run lands, UNGROUPED', async () => {
+    // The ingest path must not be taken down by a column that was added for a feature. Three
+    // detectors post here; two of them do not use grouping at all.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await expect(
+      service.recordAbuseRun({
+        detector: 'bot-account-detection',
+        startedAt: '2026-09-05T03:20:00.000Z',
+        finishedAt: '2026-09-05T03:20:41.000Z',
+        findings: [
+          { userId: 31, confidence: 0.4, reason: 'in a ring', actioned: false, groupKey: RING },
+        ],
+      })
+    ).resolves.toMatchObject({ runId: expect.any(Number) });
+
+    const rows = await db.query<{ user_id: number }>(
+      `SELECT user_id FROM abuse_detection_finding ORDER BY id`
+    );
+    expect(rows.rows.map((r) => r.user_id)).toEqual([31]);
+    // Announced, not silent: "my ring did not collapse into one row" is otherwise an unexplainable
+    // UI bug, and the warning names the file that fixes it.
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('schema.sql'));
+  });
+});
+
+/** A findings row without the four columns — the only shape that table has before the DDL is run. */
+async function seedFindingLegacy(runId: number, userId: number): Promise<number> {
+  const res = await db.query<{ id: number }>(
+    `INSERT INTO abuse_detection_finding (run_id, user_id, confidence, reason, actioned)
+     VALUES ($1, $2, 0.5, 'seeded', false) RETURNING id`,
+    [runId, userId]
+  );
+  return Number(res.rows[0].id);
+}

--- a/apps/moderator/src/lib/server/__tests__/abuse-detection.verdict.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/abuse-detection.verdict.test.ts
@@ -23,10 +23,12 @@ import {
  *
  * 🔴 THE MUTATION LEDGER, RECORDED HERE BECAUSE A COUNT THAT LIVES ONLY IN A COMMIT MESSAGE GETS
  * CITED INSTEAD OF RE-DERIVED. Two different numbers were reported for the previous round's battery
- * and neither was written down anywhere a reader could check. **TWELVE** mutants, each applied to
+ * and neither was written down anywhere a reader could check. **THIRTEEN** mutants, each applied to
  * `abuse-detection.service.ts` (or `report.ts`), run, and confirmed to fail the named test — with
  * that test's own assertion, not merely "something went red". Re-derive rather than trusting the
- * list; it is a claim like any other.
+ * list; it is a claim like any other — 1–12 were run in the round that split the capability probe
+ * and have NOT been re-run since, and 13 in the round that stopped the refusal naming a column it
+ * had not read.
  *
  *  1 the capability probe back to all-four-or-none ....... 'keeps the ruling after `%s` is dropped'
  *  2 the pre-verdict branch refuses a storable key ....... 'still stores the cluster key when only…'
@@ -40,6 +42,11 @@ import {
  * 10 the scoped delete inverted to `is not null` ........ 'keeps the ruling, the ruler and the row…'
  * 11 the warning's "only when something was lost" gate .. 'writes ONCE and warns not at all…'
  * 12 the capability probe removed altogether ............ 'the detectors keep reporting — a run lands'
+ * 13 the refusal back to "has no verdict columns" ....... 'says `group_key` when only `group_key` is
+ *                                                         gone, and does not blame the verdict
+ *                                                         columns' — read as `AssertionError:
+ *                                                         expected '…has no verdict columns…' to
+ *                                                         contain 'has no group_key column'`
  */
 
 const { dbHandle } = vi.hoisted(() => ({ dbHandle: { current: null as unknown } }));
@@ -436,8 +443,11 @@ describe('🔴 a replay of a run does not destroy its verdicts', () => {
       verdict: 'tp',
       verdictBy: '77',
     });
-    // A ruled row is now on the run AND in the payload. Counting survivors per user is what stops
-    // it being inserted a second time beside the row it already has.
+    // A ruled row is now on the run AND in the payload. The two-pass consuming match over the
+    // survivor multiset is what stops it being inserted a second time beside the row it already
+    // has — here pass 1, on exact `(user_id, reason)`. Counting survivors per user also held this
+    // count, which is why it survived a round; it did not hold the row CONTENT (see the
+    // repeated-user describe below).
     await service.recordAbuseRun(replayReport());
     await service.recordAbuseRun(replayReport());
     expect(await allFindings(db)).toHaveLength(3);
@@ -934,9 +944,17 @@ describe('🔴 a ruling survives a replay whenever the `verdict` column is there
     }
   );
 
-  it('drops every row only when `verdict` ITSELF is gone — there is then nothing to preserve', async () => {
-    // The one state in which the unscoped delete is right, and the reason the comment above it may
-    // say so: with no `verdict` column no ruling can ever have been recorded on this deployment.
+  it('INVARIANT GUARD — drops every row only when `verdict` ITSELF is gone', async () => {
+    // 🔴 GREEN AT `c2f18a2f5` TOO: the all-four probe took this same branch in this same state, so
+    // this pins a direction the change did not alter rather than a regression the change fixed.
+    // Kept because the sibling cases above narrow the gate, and nothing else says the narrowing
+    // stopped at `verdict` instead of removing the branch.
+    //
+    // The one state in which the unscoped delete is right: with `verdict` gone there is no ruling
+    // left for it to destroy, because the column that carried one is already gone. NOT "the table
+    // never held one" — dropping the column on a board with rulings on it destroys them, and
+    // `verdict_by`/`verdict_at` go with the rows here too, which is what the id assertion below
+    // records.
     await service.recordAbuseRun(report());
     const before = await allFindings(db);
     await db.exec(`ALTER TABLE abuse_detection_finding DROP COLUMN verdict;`);
@@ -1140,6 +1158,82 @@ describe('a 42703 whose message cannot be parsed still degrades', () => {
     });
     return state;
   }
+});
+
+/**
+ * 🔴 A REFUSED RULING MUST NAME THE COLUMN THAT IS ACTUALLY MISSING.
+ *
+ * `recordAbuseVerdict` reads `group_key` as well as writing the three verdict columns, so `42703`
+ * there is not necessarily about a verdict column at all — and the state where it is not is one this
+ * board makes reachable and comfortable. Drop `group_key` alone: the page loads, the summary reads,
+ * every verdict already recorded is on screen, and the buttons render. The first click then answered
+ * "abuse_detection_finding has no verdict columns" about three columns that were all right there,
+ * while the page displayed their contents. Behaviourally that predates this change; it is fixed here
+ * because it is the same confident-wrong-column shape the ingest path was fixed for one branch away.
+ */
+describe('🔴 a refused ruling names the column that is actually missing', () => {
+  const seedRuleable = async () => {
+    const runId = await seedRun(db, 'bot-account-detection', STARTED_TODAY);
+    const findingId = await seedFinding(db, { runId, userId: 61, groupKey: RING });
+    return { runId, findingId };
+  };
+
+  it('says `group_key` when only `group_key` is gone, and does not blame the verdict columns', async () => {
+    const { runId, findingId } = await seedRuleable();
+    // The rollback this feature's own comments name: the grouping half reverted, the verdict half
+    // left in place. Nothing here stops a moderator reaching the button.
+    await db.exec(`ALTER TABLE abuse_detection_finding DROP COLUMN group_key;`);
+    await expect(service.getAbuseVerdictSummary(runId)).resolves.toEqual({ ruled: 0, unruled: 1 });
+
+    const err = await service
+      .recordAbuseVerdict({ runId, findingId, verdict: 'tp', verdictBy: 'mod-a' })
+      .then(
+        () => null,
+        (e: unknown) => e as Error
+      );
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err?.message).toContain('has no group_key column');
+    // The half that was wrong: it must not claim the verdict columns are the problem.
+    expect(err?.message).not.toContain('verdict');
+    // And the remedy, which was always right, is unchanged — the route gates the 503 on this.
+    expect(err?.message).toContain('schema.sql');
+  });
+
+  it('says `verdict` when the verdict half is the missing one', async () => {
+    // The other side of the same read: a name, not a category, whichever column it is.
+    const { runId, findingId } = await seedRuleable();
+    await db.exec(`ALTER TABLE abuse_detection_finding DROP COLUMN verdict;`);
+
+    await expect(
+      service.recordAbuseVerdict({ runId, findingId, verdict: 'tp', verdictBy: 'mod-a' })
+    ).rejects.toThrow(/has no verdict column — apply/);
+  });
+
+  it('names no column at all when the server did not name one in English', async () => {
+    // 🔴 The fallback is UNNAMED, never a guess. `missingColumnFromError` parses an ENGLISH message,
+    // so a non-English `lc_messages` yields null — and the wrong-column defect being fixed here is
+    // exactly what filling that gap with a plausible name would reintroduce.
+    const { runId, findingId } = await seedRuleable();
+    const real = db.query.bind(db);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(db, 'query' as any).mockImplementation(async (...args: unknown[]) => {
+      if (typeof args[0] === 'string' && /from "?abuse_detection_finding/i.test(args[0]))
+        throw Object.assign(new Error('Spalte »group_key« existiert nicht'), { code: '42703' });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return await (real as any)(...args);
+    });
+
+    const err = await service
+      .recordAbuseVerdict({ runId, findingId, verdict: 'tp', verdictBy: 'mod-a' })
+      .then(
+        () => null,
+        (e: unknown) => e as Error
+      );
+
+    expect(err?.message).toContain('is missing a column this write needs');
+    expect(err?.message).toContain('schema.sql');
+  });
 });
 
 /** A findings row without the four columns — the only shape that table has before the DDL is run. */

--- a/apps/moderator/src/lib/server/__tests__/abuse-detection.verdict.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/abuse-detection.verdict.test.ts
@@ -20,6 +20,26 @@ import {
  * force to a write.
  *
  * The `sql.test.ts` tier still pins the compiled statement text; this one pins the effect.
+ *
+ * 🔴 THE MUTATION LEDGER, RECORDED HERE BECAUSE A COUNT THAT LIVES ONLY IN A COMMIT MESSAGE GETS
+ * CITED INSTEAD OF RE-DERIVED. Two different numbers were reported for the previous round's battery
+ * and neither was written down anywhere a reader could check. **TWELVE** mutants, each applied to
+ * `abuse-detection.service.ts` (or `report.ts`), run, and confirmed to fail the named test — with
+ * that test's own assertion, not merely "something went red". Re-derive rather than trusting the
+ * list; it is a claim like any other.
+ *
+ *  1 the capability probe back to all-four-or-none ....... 'keeps the ruling after `%s` is dropped'
+ *  2 the pre-verdict branch refuses a storable key ....... 'still stores the cluster key when only…'
+ *  3 the ungrouped warning names the wrong column ........ 'a report that DOES carry a key…'
+ *  4 survivor pass 1 degraded to a per-user count ........ 'keeps the unruled sibling’s own evidence'
+ *  5 survivor pass 2's fallback removed .................. 'a ruled row keeps the evidence…'
+ *  6 the retry gate back on "a name came back" ........... 'the run still lands, ungrouped, when…'
+ *  7 the 42703 CODE gate dropped ........................ 'translates a missing-unique-index error…'
+ *  8 `report.ts`'s measured figure back to 251 .......... 'the figure `report.ts` reports as MEASURED'
+ *  9 the backstop retry removed entirely ................ 'INVARIANT GUARD — the backstop still fires'
+ * 10 the scoped delete inverted to `is not null` ........ 'keeps the ruling, the ruler and the row…'
+ * 11 the warning's "only when something was lost" gate .. 'writes ONCE and warns not at all…'
+ * 12 the capability probe removed altogether ............ 'the detectors keep reporting — a run lands'
  */
 
 const { dbHandle } = vi.hoisted(() => ({ dbHandle: { current: null as unknown } }));
@@ -694,6 +714,13 @@ describe('the pre-DDL window costs the untouched detectors nothing', () => {
     });
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('schema.sql'));
+    // 🔴 THE COLUMN IT NAMES, not merely that it named one. The message used to be handed a column
+    // by its caller, and the probe path had none to give — it passed the literal `group_key`
+    // whatever was actually absent. `group_key` is now the only absence that can reach this warning,
+    // so the name is checkable, and this is what checks it.
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('abuse_detection_finding has no group_key column')
+    );
   });
 
   it('🔴 an UNRELATED missing column is not reported as a group_key problem', async () => {
@@ -737,9 +764,10 @@ describe('the pre-DDL window costs the untouched detectors nothing', () => {
     expect(transactions(query)).toBe(1);
   });
 
-  it('a HALF-applied DDL is treated as not applied', async () => {
-    // Three of the four columns present is not "applied". The degraded shape is the one that cannot
-    // be wrong about a column it never names, so it is what a partial application gets.
+  it('a HALF-applied DDL stores ungrouped when only `group_key` is the missing half', async () => {
+    // `verdict` back, `group_key` still absent: the run lands, without its cluster key, and says so.
+    // The verdict half of the capability is irrelevant to this report — it carries no ruling — which
+    // is exactly why the two halves are asked separately.
     await db.exec(`ALTER TABLE abuse_detection_finding
       ADD COLUMN verdict text, ADD COLUMN verdict_by text, ADD COLUMN verdict_at timestamptz;`);
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -845,6 +873,273 @@ describe('missingColumnFromError', () => {
       service.missingColumnFromError(Object.assign(new Error('no idea'), { code: '42703' }))
     ).toBeNull();
   });
+});
+
+/**
+ * 🔴 THE TWO CAPABILITIES THE FOUR COLUMNS CARRY ARE INDEPENDENT, AND SO IS THE DEGRADATION.
+ *
+ * One boolean over all four columns conflated two unrelated questions — "can a ruling be preserved?"
+ * (which only `verdict` answers) and "can a cluster key be stored?" (which only `group_key` does) —
+ * so a table carrying rulings in a `verdict` column took the UNSCOPED delete the moment ANY of the
+ * other three went missing. Measured on this harness against that shape: rule one of two findings,
+ * `DROP COLUMN group_key`, replay, and `getAbuseVerdictSummary` went `{ ruled: 1, unruled: 1 }` →
+ * `{ ruled: 0, unruled: 2 }` — the same silent, irreversible loss the scoped delete was added to
+ * stop, reached through a narrower door.
+ *
+ * The live trigger is dropping one of the three non-`verdict` columns after rulings exist: rolling
+ * back the grouping half, or restoring a mid-rollout snapshot.
+ */
+describe('🔴 a ruling survives a replay whenever the `verdict` column is there', () => {
+  const STARTED = '2026-09-08T03:20:00.000Z';
+  const report = () => ({
+    detector: 'bot-account-detection',
+    startedAt: STARTED,
+    finishedAt: '2026-09-08T03:20:41.000Z',
+    findings: [
+      { userId: 81, confidence: 0.4, reason: 'ruled on this', actioned: false },
+      { userId: 82, confidence: 0.4, reason: 'left unruled', actioned: false },
+    ],
+  });
+
+  /** `verdict` deliberately absent from this list — its own absence is the case below. */
+  it.each(['verdict_by', 'verdict_at', 'group_key'])(
+    'keeps the ruling after `%s` is dropped underneath it',
+    async (column) => {
+      const { runId } = await service.recordAbuseRun(report());
+      const seeded = await allFindings(db);
+      const target = seeded.find((r) => r.user_id === 81);
+      await service.recordAbuseVerdict({
+        runId,
+        findingId: target?.id as number,
+        verdict: 'fp',
+        verdictBy: '77',
+      });
+      // The state the loss is measured FROM, pinned before the schema moves.
+      expect(await service.getAbuseVerdictSummary(runId)).toEqual({ ruled: 1, unruled: 1 });
+
+      await db.exec(`ALTER TABLE abuse_detection_finding DROP COLUMN ${column};`);
+      await service.recordAbuseRun(report());
+
+      // 🔴 The literal the all-four boolean produced here was `{ ruled: 0, unruled: 2 }`.
+      expect(await service.getAbuseVerdictSummary(runId)).toEqual({ ruled: 1, unruled: 1 });
+      const after = await db.query<{ id: number; user_id: number; verdict: string | null }>(
+        `SELECT id, user_id, verdict FROM abuse_detection_finding ORDER BY user_id`
+      );
+      expect(after.rows.map((r) => [r.user_id, r.verdict])).toEqual([
+        [81, 'fp'],
+        [82, null],
+      ]);
+      // The ROW survived rather than being re-created with a verdict copied onto a new one.
+      expect(after.rows[0].id).toBe(target?.id);
+    }
+  );
+
+  it('drops every row only when `verdict` ITSELF is gone — there is then nothing to preserve', async () => {
+    // The one state in which the unscoped delete is right, and the reason the comment above it may
+    // say so: with no `verdict` column no ruling can ever have been recorded on this deployment.
+    await service.recordAbuseRun(report());
+    const before = await allFindings(db);
+    await db.exec(`ALTER TABLE abuse_detection_finding DROP COLUMN verdict;`);
+
+    await service.recordAbuseRun(report());
+
+    const after = await db.query<{ id: number; user_id: number }>(
+      `SELECT id, user_id FROM abuse_detection_finding ORDER BY user_id`
+    );
+    expect(after.rows.map((r) => r.user_id)).toEqual([81, 82]);
+    // Re-inserted, not preserved: every id moved.
+    expect(after.rows.every((r) => !before.some((b) => b.id === r.id))).toBe(true);
+  });
+
+  it('🔴 still stores the cluster key when only `verdict` is missing, and warns about nothing', async () => {
+    // The F8 half: the probe path used to hardcode `group_key` in its warning, so this shape —
+    // `verdict` gone, `group_key` present, nothing lost — logged
+    // "abuse_detection_finding has no group_key column" about a column that was right there.
+    await db.exec(`ALTER TABLE abuse_detection_finding DROP COLUMN verdict;`);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await service.recordAbuseRun({
+      ...report(),
+      findings: [
+        { userId: 83, confidence: 0.4, reason: 'in a ring', actioned: false, groupKey: RING },
+      ],
+    });
+
+    const landed = await db.query<{ user_id: number; group_key: string | null }>(
+      `SELECT user_id, group_key FROM abuse_detection_finding ORDER BY id`
+    );
+    expect(landed.rows.map((r) => [r.user_id, r.group_key])).toEqual([[83, RING]]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * 🔴 THE SURVIVOR MATCH IS PER-USER, AND A PAYLOAD MAY NAME A USER TWICE.
+ *
+ * Counting survivors per user made the row COUNT a fixed point, and that is what was pinned — but
+ * not the row CONTENT. Measured on this harness against the count-only match: a payload of
+ * `[user 71 "first reason", user 71 "second reason"]` with the second row ruled replayed to
+ * `[{second, tp}, {second, null}]` — the first finding permanently gone and the board showing one
+ * account twice under identical text, on every subsequent replay.
+ *
+ * No first-party producer emits two findings for one user in one run, and the wire contract does not
+ * forbid it.
+ */
+describe('🔴 a replay of a payload that repeats a user keeps both findings', () => {
+  const STARTED = '2026-09-09T03:20:00.000Z';
+  const report = () => ({
+    detector: 'bot-account-detection',
+    startedAt: STARTED,
+    finishedAt: '2026-09-09T03:20:41.000Z',
+    findings: [
+      { userId: 71, confidence: 0.4, reason: 'first reason', actioned: false },
+      { userId: 71, confidence: 0.4, reason: 'second reason', actioned: false },
+    ],
+  });
+
+  const contents = async () =>
+    (
+      await db.query<{ reason: string; verdict: string | null }>(
+        `SELECT reason, verdict FROM abuse_detection_finding ORDER BY reason`
+      )
+    ).rows;
+
+  it('keeps the unruled sibling’s own evidence, not a second copy of the ruled one', async () => {
+    const { runId } = await service.recordAbuseRun(report());
+    const seeded = await db.query<{ id: number; reason: string }>(
+      `SELECT id, reason FROM abuse_detection_finding ORDER BY id`
+    );
+    const second = seeded.rows.find((r) => r.reason === 'second reason');
+    await service.recordAbuseVerdict({
+      runId,
+      findingId: second?.id as number,
+      verdict: 'tp',
+      verdictBy: '77',
+    });
+
+    await service.recordAbuseRun(report());
+
+    // 🔴 The literal the count-only match produced here was two `second reason` rows.
+    expect(await contents()).toEqual([
+      { reason: 'first reason', verdict: null },
+      { reason: 'second reason', verdict: 'tp' },
+    ]);
+
+    // And it is a fixed point, not a state that survives exactly one replay.
+    await service.recordAbuseRun(report());
+    await service.recordAbuseRun(report());
+    expect(await contents()).toEqual([
+      { reason: 'first reason', verdict: null },
+      { reason: 'second reason', verdict: 'tp' },
+    ]);
+  });
+});
+
+/**
+ * 🔴 THE DEGRADATION GATE IS THE ERROR CODE, WHICH IS LOCALE-INDEPENDENT; THE COLUMN NAME IS A
+ * REFINEMENT THAT CAN FAIL.
+ *
+ * `missingColumnFromError` reads the name out of the message, and Postgres localises messages: a
+ * server running a non-English `lc_messages` spells `column "verdict" does not exist` in its own
+ * language, the regex misses, and a gate written as "retry only when a name came back" turns the
+ * whole backstop OFF — reporting then fails where it previously degraded.
+ */
+describe('a 42703 whose message cannot be parsed still degrades', () => {
+  it('the run still lands, ungrouped, when the column name is unreadable', async () => {
+    await db.exec(`ALTER TABLE abuse_detection_finding
+      DROP COLUMN verdict, DROP COLUMN verdict_by, DROP COLUMN verdict_at, DROP COLUMN group_key;`);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // 🔴 The probe answers truthfully — the columns really are gone — so this case would not reach
+    // the backstop at all. The lying probe is what puts the write on it; `translate` then spells the
+    // server's refusal the way a non-English `lc_messages` would.
+    const probeLie = installLyingProbe({ translate: true });
+
+    await expect(
+      service.recordAbuseRun({
+        detector: 'review-bomb',
+        startedAt: '2026-09-10T03:20:00.000Z',
+        finishedAt: '2026-09-10T03:20:41.000Z',
+        findings: [
+          { userId: 91, confidence: 0.4, reason: 'in a ring', actioned: false, groupKey: RING },
+        ],
+      })
+    ).resolves.toMatchObject({ runId: expect.any(Number) });
+
+    expect(probeLie.used).toBe(true);
+    const landed = await db.query<{ user_id: number }>(
+      `SELECT user_id FROM abuse_detection_finding ORDER BY id`
+    );
+    expect(landed.rows.map((r) => r.user_id)).toEqual([91]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('schema.sql'));
+  });
+
+  it('INVARIANT GUARD — the backstop still fires when the name IS readable', async () => {
+    // Not a regression test: this passed before the gate moved to the code, and it pins that moving
+    // it did not cost the English-message path. It is also the only case that exercises the retry.
+    await db.exec(`ALTER TABLE abuse_detection_finding
+      DROP COLUMN verdict, DROP COLUMN verdict_by, DROP COLUMN verdict_at, DROP COLUMN group_key;`);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const probeLie = installLyingProbe();
+
+    await expect(
+      service.recordAbuseRun({
+        detector: 'review-bomb',
+        startedAt: '2026-09-10T03:20:00.000Z',
+        finishedAt: '2026-09-10T03:20:41.000Z',
+        findings: [
+          { userId: 92, confidence: 0.4, reason: 'in a ring', actioned: false, groupKey: RING },
+        ],
+      })
+    ).resolves.toMatchObject({ runId: expect.any(Number) });
+
+    expect(probeLie.used).toBe(true);
+    const landed = await db.query<{ user_id: number }>(
+      `SELECT user_id FROM abuse_detection_finding ORDER BY id`
+    );
+    expect(landed.rows.map((r) => r.user_id)).toEqual([92]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('schema.sql'));
+  });
+
+  /**
+   * The DDL vanishing between the capability probe and the write — the race the backstop exists for,
+   * and the only way to reach it deterministically. The table genuinely lacks the four columns; only
+   * the FIRST catalogue read claims otherwise, so the write is built in the full shape and the server
+   * refuses it.
+   *
+   * 🔴 ONE spy, both behaviours. `vi.spyOn` on an already-spied method returns the EXISTING spy, so a
+   * second `mockImplementation` would silently REPLACE this one rather than wrap it — and the `real`
+   * it captured would be the spy itself, i.e. unbounded recursion.
+   */
+  function installLyingProbe(opts: { translate?: boolean } = {}): { used: boolean } {
+    const state = { used: false };
+    const real = db.query.bind(db);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(db, 'query' as any).mockImplementation(async (...args: unknown[]) => {
+      if (!state.used && typeof args[0] === 'string' && args[0].includes('pg_attribute')) {
+        state.used = true;
+        return {
+          rows: [
+            { attname: 'verdict' },
+            { attname: 'verdict_by' },
+            { attname: 'verdict_at' },
+            { attname: 'group_key' },
+          ],
+          affectedRows: 0,
+          fields: [],
+        };
+      }
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return await (real as any)(...args);
+      } catch (e) {
+        if (!opts.translate || (e as { code?: string } | null)?.code !== '42703') throw e;
+        // The same error from a server whose `lc_messages` is not English: same code, no `column
+        // "…"` for the regex to find.
+        throw Object.assign(new Error('Spalte »verdict« existiert nicht'), { code: '42703' });
+      }
+    });
+    return state;
+  }
 });
 
 /** A findings row without the four columns — the only shape that table has before the DDL is run. */

--- a/apps/moderator/src/lib/server/__tests__/abuse-detection.verdict.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/abuse-detection.verdict.test.ts
@@ -48,6 +48,11 @@ beforeEach(async () => {
 
 afterEach(async () => {
   vi.useRealTimers();
+  // 🔴 `vi.spyOn` on an ALREADY-spied method returns the EXISTING spy rather than a fresh one, so
+  // without this a `console.warn` spy carries the previous test's calls into the next one. That is
+  // not a cosmetic leak: it made `expect(warn).not.toHaveBeenCalled()` fail against code that had
+  // warned nothing, and would equally have made it PASS for the wrong reason in the other order.
+  vi.restoreAllMocks();
   dbHandle.current = null;
   await db.close();
 });
@@ -313,6 +318,186 @@ describe('the findings read carries the ruling', () => {
   });
 });
 
+/**
+ * 🔴 A PRODUCER REPLAY MUST NOT DESTROY A MODERATOR'S RULING.
+ *
+ * The run upsert is idempotent on `(detector, started_at)`, so a re-POST keeps the SAME run row and
+ * the same id — which is the point, and is what makes the retry safe. What used to follow it was
+ * `DELETE FROM abuse_detection_finding WHERE run_id = …` and a re-insert from a payload that carries
+ * no verdict fields. That was lossless while these rows held only producer-generated data; it stopped
+ * being lossless the moment a human judgement went into the same row.
+ *
+ * Measured on this harness before the fix: rule three findings, re-POST the identical
+ * `(detector, startedAt)`, and `getAbuseVerdictSummary` went `{ ruled: 3, unruled: 0 }` →
+ * `{ ruled: 0, unruled: 3 }`, with new row ids and no warning of any kind. The replay that does it is
+ * the ordinary "committed, response lost to a timeout" retry the upsert's own comment describes.
+ *
+ * Every case below is asserted on ROWS, not on which function was called: the claim is about what
+ * survives a real second write, and only rows can answer that.
+ */
+describe('🔴 a replay of a run does not destroy its verdicts', () => {
+  const REPLAY_STARTED = '2026-09-06T03:20:00.000Z';
+  const REPLAY_RING = 'domain:replay-ring.test';
+
+  /** The producer's payload. `omit` drops a member, i.e. the detector stopped flagging that account. */
+  const replayReport = (opts: { omit?: number[]; reason?: string } = {}) => ({
+    detector: 'bot-account-detection',
+    startedAt: REPLAY_STARTED,
+    finishedAt: '2026-09-06T03:20:41.000Z',
+    findings: [
+      { userId: 51, groupKey: REPLAY_RING },
+      { userId: 52, groupKey: REPLAY_RING },
+      { userId: 53 },
+    ]
+      .filter((f) => !(opts.omit ?? []).includes(f.userId))
+      .map((f) => ({
+        confidence: 0.4,
+        reason: opts.reason ?? 'as first reported',
+        actioned: false,
+        ...f,
+      })),
+  });
+
+  const rowsByUser = async () =>
+    Object.fromEntries((await allFindings(db)).map((r) => [r.user_id, r]));
+
+  it('keeps the ruling, the ruler and the row itself across an identical re-POST', async () => {
+    const { runId } = await service.recordAbuseRun(replayReport());
+    const before = await rowsByUser();
+    // One ring member, so the group ruling covers 51 and 52, plus the lone finding.
+    await service.recordAbuseVerdict({
+      runId,
+      findingId: before[51].id,
+      verdict: 'tp',
+      verdictBy: '77',
+    });
+    await service.recordAbuseVerdict({
+      runId,
+      findingId: before[53].id,
+      verdict: 'fp',
+      verdictBy: '88',
+    });
+    expect(await service.getAbuseVerdictSummary(runId)).toEqual({ ruled: 3, unruled: 0 });
+
+    const { runId: replayedInto } = await service.recordAbuseRun(replayReport());
+
+    // Same run, by construction — the upsert's whole purpose.
+    expect(replayedInto).toBe(runId);
+    // 🔴 The literal the old code produced here was `{ ruled: 0, unruled: 3 }`.
+    expect(await service.getAbuseVerdictSummary(runId)).toEqual({ ruled: 3, unruled: 0 });
+
+    const after = await rowsByUser();
+    expect(after[51]).toMatchObject({ verdict: 'tp', verdict_by: '77' });
+    expect(after[52]).toMatchObject({ verdict: 'tp', verdict_by: '77' });
+    expect(after[53]).toMatchObject({ verdict: 'fp', verdict_by: '88' });
+    // The ROW survived, it was not deleted and re-created with the verdict copied onto a new one.
+    // A fresh id would mean the audit timestamp and the row's own history had been re-minted.
+    expect([after[51].id, after[52].id, after[53].id]).toEqual([
+      before[51].id,
+      before[52].id,
+      before[53].id,
+    ]);
+  });
+
+  it('still clears the UNRULED rows, so replaying does not double the findings', async () => {
+    // The bug the DELETE exists to prevent, and it must stay prevented: three replays, three rows.
+    await service.recordAbuseRun(replayReport());
+    await service.recordAbuseRun(replayReport());
+    await service.recordAbuseRun(replayReport());
+    expect(await allFindings(db)).toHaveLength(3);
+  });
+
+  it('does not double them once some of them are ruled, either', async () => {
+    const { runId } = await service.recordAbuseRun(replayReport());
+    const before = await rowsByUser();
+    await service.recordAbuseVerdict({
+      runId,
+      findingId: before[51].id,
+      verdict: 'tp',
+      verdictBy: '77',
+    });
+    // A ruled row is now on the run AND in the payload. Counting survivors per user is what stops
+    // it being inserted a second time beside the row it already has.
+    await service.recordAbuseRun(replayReport());
+    await service.recordAbuseRun(replayReport());
+    expect(await allFindings(db)).toHaveLength(3);
+    expect((await allFindings(db)).map((r) => r.user_id).sort()).toEqual([51, 52, 53]);
+  });
+
+  it('an UNRULED finding the replay no longer reports is dropped', async () => {
+    // The producer owns an unruled row outright: it stopped flagging the account, so the row goes.
+    await service.recordAbuseRun(replayReport());
+    await service.recordAbuseRun(replayReport({ omit: [53] }));
+    expect((await allFindings(db)).map((r) => r.user_id)).toEqual([51, 52]);
+  });
+
+  it('🔴 a RULED finding the replay no longer reports is KEPT — the decided direction', async () => {
+    // Both directions make a claim, and they are not symmetric. Keeping it leaves a row on the run
+    // that this payload did not assert — visible on the board, ruled, with its ruler and timestamp,
+    // and actionable by a human. Dropping it destroys a judgement silently and unrecoverably, and
+    // deflates the denominator of the false-positive rate this board exists to measure: a detector
+    // that stopped flagging an account it was told was a false positive would be erasing the
+    // evidence of its own error.
+    const { runId } = await service.recordAbuseRun(replayReport());
+    const before = await rowsByUser();
+    await service.recordAbuseVerdict({
+      runId,
+      findingId: before[53].id,
+      verdict: 'fp',
+      verdictBy: '88',
+    });
+
+    await service.recordAbuseRun(replayReport({ omit: [53] }));
+
+    const after = await rowsByUser();
+    expect(Object.keys(after).map(Number).sort()).toEqual([51, 52, 53]);
+    expect(after[53]).toMatchObject({ verdict: 'fp', verdict_by: '88' });
+    expect(after[53].id).toBe(before[53].id);
+    // And it stays kept across further replays rather than surviving exactly one.
+    await service.recordAbuseRun(replayReport({ omit: [53] }));
+    expect(await allFindings(db)).toHaveLength(3);
+  });
+
+  it('a ruled row keeps the evidence it was ruled on, not the replay’s copy', async () => {
+    // A moderator ruled on the `reason` that was on screen. Overwriting it with a later copy would
+    // leave a verdict attached to evidence nobody ruled on. For a genuine replay the two are the
+    // same text anyway — `(detector, started_at)` identifies one run.
+    const { runId } = await service.recordAbuseRun(replayReport({ reason: 'the text on screen' }));
+    const before = await rowsByUser();
+    await service.recordAbuseVerdict({
+      runId,
+      findingId: before[53].id,
+      verdict: 'skip',
+      verdictBy: '88',
+    });
+
+    await service.recordAbuseRun(replayReport({ reason: 'rewritten afterwards' }));
+
+    const reasons = await db.query<{ user_id: number; reason: string }>(
+      `SELECT user_id, reason FROM abuse_detection_finding ORDER BY user_id`
+    );
+    expect(reasons.rows).toEqual([
+      // Unruled: the producer's row, replaced by the producer's newer text.
+      { user_id: 51, reason: 'rewritten afterwards' },
+      { user_id: 52, reason: 'rewritten afterwards' },
+      // Ruled: untouched.
+      { user_id: 53, reason: 'the text on screen' },
+    ]);
+  });
+
+  it('a DIFFERENT run of the same detector is not touched by the replay', async () => {
+    // The delete is scoped to one run, and a replay of today must not reach into yesterday — the
+    // same scoping mistake the group-ruling guards above are about, on the other write.
+    const yesterday = await seedRun(db, 'bot-account-detection', STARTED_YESTERDAY);
+    const stray = await seedFinding(db, { runId: yesterday, userId: 51, groupKey: REPLAY_RING });
+    await service.recordAbuseRun(replayReport());
+    await service.recordAbuseRun(replayReport());
+    const rows = await allFindings(db);
+    expect(rows.filter((r) => r.run_id === yesterday).map((r) => r.id)).toEqual([stray]);
+    expect(rows).toHaveLength(4);
+  });
+});
+
 describe('recordAbuseRun stores the producer’s group key', () => {
   const report = (groupKey?: string | null) => ({
     detector: 'bot-account-detection',
@@ -414,6 +599,251 @@ describe('a deployment whose DDL has not been applied', () => {
     // Announced, not silent: "my ring did not collapse into one row" is otherwise an unexplainable
     // UI bug, and the warning names the file that fixes it.
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('schema.sql'));
+  });
+});
+
+/**
+ * 🔴 WHAT THE PRE-DDL WINDOW COSTS THE DETECTORS THAT ARE NOT USING THIS FEATURE.
+ *
+ * The window is real and open-ended — a human runs the file — and three detectors post through it
+ * every day, two of which send no `groupKey` at all. Before the capability probe, `group_key: null`
+ * was in the INSERT column list unconditionally, so EVERY report from EVERY detector raised 42703,
+ * rolled its whole transaction back, logged a warning naming a feature it was not using, and redid
+ * the write. Measured here by counting the statements that actually reach the server.
+ */
+describe('the pre-DDL window costs the untouched detectors nothing', () => {
+  const statements = (spy: ReturnType<typeof vi.spyOn>, pattern: RegExp) =>
+    spy.mock.calls.filter((call: unknown[]) => typeof call[0] === 'string' && pattern.test(call[0]))
+      .length;
+
+  /**
+   * 🔴 TRANSACTIONS, NOT INSERTS — and the difference is the whole measurement.
+   *
+   * A mutant that removes the capability probe still issues exactly ONE findings INSERT, because the
+   * statement that raises 42703 on a pre-DDL table is the DELETE that scopes itself by `verdict`,
+   * which runs BEFORE any insert. Counting inserts therefore reported 1 for both the fixed and the
+   * broken code, i.e. it measured nothing. What the cost actually is — a whole transaction rolled
+   * back and redone — is visible as a second `begin`, which is what this counts.
+   */
+  const transactions = (spy: ReturnType<typeof vi.spyOn>) => statements(spy, /^begin$/i);
+  const findingInserts = (spy: ReturnType<typeof vi.spyOn>) =>
+    statements(spy, /^insert into "abuse_detection_finding"/i);
+
+  const noKeyReport = {
+    detector: 'review-bomb',
+    startedAt: '2026-09-07T03:20:00.000Z',
+    finishedAt: '2026-09-07T03:20:41.000Z',
+    findings: [{ userId: 61, confidence: 0.4, reason: 'no cluster here', actioned: false }],
+  };
+
+  beforeEach(async () => {
+    await db.exec(`ALTER TABLE abuse_detection_finding
+      DROP COLUMN verdict, DROP COLUMN verdict_by, DROP COLUMN verdict_at, DROP COLUMN group_key;`);
+  });
+
+  it('writes ONCE and warns not at all for a report carrying no group key', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const query = vi.spyOn(db, 'query' as any);
+
+    await expect(service.recordAbuseRun(noKeyReport)).resolves.toMatchObject({
+      runId: expect.any(Number),
+    });
+
+    // 🔴 The literals. ONE transaction and ONE findings insert: the second of each is the redo the
+    // old 42703 round trip forced on every report from every detector, for a feature two of the
+    // three do not use. A positive control on both counters is the sibling case below.
+    expect(transactions(query)).toBe(1);
+    expect(findingInserts(query)).toBe(1);
+    // Nothing was lost, so there is nothing to announce. A warning here every time, forever, is a
+    // line whose reader learns to skip it — including on the report where it means something.
+    expect(warn).not.toHaveBeenCalled();
+    const landed = await db.query<{ user_id: number }>(
+      `SELECT user_id FROM abuse_detection_finding ORDER BY id`
+    );
+    expect(landed.rows.map((r) => r.user_id)).toEqual([61]);
+  });
+
+  it('positive control — the same counter reads 1 on a table that HAS the columns', async () => {
+    // Without this the `toBe(1)` above is indistinguishable from a counter wired to nothing: a
+    // regex that matched neither statement would report 0, and a `toBe(1)` that can never move is
+    // not a measurement. Re-applying the columns puts the write on the ordinary path.
+    await db.exec(`ALTER TABLE abuse_detection_finding
+      ADD COLUMN verdict text, ADD COLUMN verdict_by text,
+      ADD COLUMN verdict_at timestamptz, ADD COLUMN group_key text;`);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const query = vi.spyOn(db, 'query' as any);
+    await service.recordAbuseRun(noKeyReport);
+    expect(transactions(query)).toBe(1);
+    expect(findingInserts(query)).toBe(1);
+    // And both counters can move, so a `toBe(1)` is a measurement rather than a constant: a second
+    // report is a second transaction and a second insert on the same spy.
+    await service.recordAbuseRun({ ...noKeyReport, startedAt: '2026-09-07T04:20:00.000Z' });
+    expect(transactions(query)).toBe(2);
+    expect(findingInserts(query)).toBe(2);
+  });
+
+  it('a report that DOES carry a key still says so, once', async () => {
+    // The warning is not removed, it is narrowed to the case where something was actually lost.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await service.recordAbuseRun({
+      ...noKeyReport,
+      findings: [
+        { userId: 62, confidence: 0.4, reason: 'in a ring', actioned: false, groupKey: RING },
+      ],
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('schema.sql'));
+  });
+
+  it('🔴 an UNRELATED missing column is not reported as a group_key problem', async () => {
+    // Same error code, different fault, opposite remedy. The old branch caught EVERY 42703 and
+    // answered "abuse_detection_finding has no group_key column — apply schema.sql", pointing the
+    // operator at a file that would not fix this, and logging it just before the real error.
+    //
+    // 🔴 THE REPORT HERE CARRIES A GROUP KEY, DELIBERATELY. With a keyless report the misleading
+    // warning is suppressed by the OTHER guard, so the case passed against a mutant that caught
+    // every 42703 — green for the wrong reason, and measured: that mutant survived until this
+    // fixture carried a key.
+    await db.exec(`ALTER TABLE abuse_detection_finding
+      ADD COLUMN verdict text, ADD COLUMN verdict_by text,
+      ADD COLUMN verdict_at timestamptz, ADD COLUMN group_key text;`);
+    await db.exec(`ALTER TABLE abuse_detection_finding DROP COLUMN action;`);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const query = vi.spyOn(db, 'query' as any);
+
+    await expect(
+      service.recordAbuseRun({
+        ...noKeyReport,
+        findings: [
+          { userId: 64, confidence: 0.4, reason: 'in a ring', actioned: false, groupKey: RING },
+        ],
+      })
+    ).rejects.toMatchObject({
+      code: '42703',
+      // The REAL fault, unrewritten and unburied.
+      message: expect.stringContaining('"action"'),
+    });
+    // Not diagnosed as this feature's problem. 🔴 This line is NOT what kills the "catch every
+    // 42703" mutant — measured: under that mutant the warning is emitted only AFTER the retry
+    // succeeds, and the retry cannot succeed while `action` is still missing, so nothing is logged
+    // either way. It is a guard against the message MOVING back before the write, not the one
+    // holding this property.
+    expect(warn).not.toHaveBeenCalled();
+    // 🔴 THIS is the killing assertion, and it reads `expected 2 to be 1` under that mutant. A retry
+    // cannot help here — the column is still missing — so catching every 42703 buys a second
+    // rolled-back transaction and arrives at the identical error.
+    expect(transactions(query)).toBe(1);
+  });
+
+  it('a HALF-applied DDL is treated as not applied', async () => {
+    // Three of the four columns present is not "applied". The degraded shape is the one that cannot
+    // be wrong about a column it never names, so it is what a partial application gets.
+    await db.exec(`ALTER TABLE abuse_detection_finding
+      ADD COLUMN verdict text, ADD COLUMN verdict_by text, ADD COLUMN verdict_at timestamptz;`);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const query = vi.spyOn(db, 'query' as any);
+
+    await service.recordAbuseRun({
+      ...noKeyReport,
+      findings: [
+        { userId: 63, confidence: 0.4, reason: 'in a ring', actioned: false, groupKey: RING },
+      ],
+    });
+
+    expect(transactions(query)).toBe(1);
+    expect(findingInserts(query)).toBe(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('schema.sql'));
+    // Read without naming `group_key` — the whole premise of this case is that the column is absent,
+    // and the shared `allFindings` helper selects it.
+    const landed = await db.query<{ user_id: number }>(
+      `SELECT user_id FROM abuse_detection_finding ORDER BY id`
+    );
+    expect(landed.rows.map((r) => r.user_id)).toEqual([63]);
+  });
+});
+
+/**
+ * 🔴 THE OTHER "the DDL was applied by the wrong role" STATE, on the WRITE path.
+ *
+ * Both of this board's read paths already discriminate `42501` and say "re-run schema.sql as the
+ * application role". The write did not: it translated `42703` and let everything else fall through
+ * to the route's generic "the verdict was NOT recorded — the database refused the write", which
+ * reads as an outage on a database that is serving every row it holds. The file's own header exists
+ * because `psql -U postgres` is the natural shortcut, so this is a likely state, not a hypothetical.
+ */
+describe('a ruling refused for want of privilege', () => {
+  it('names the file and the role, not a generic refusal', async () => {
+    const runId = await seedRun(db, 'bot-account-detection', STARTED_TODAY);
+    const findingId = await seedFinding(db, { runId, userId: 21 });
+
+    await db.exec(`CREATE ROLE internal_tools LOGIN;`);
+    // SELECT but not UPDATE: the target lookup must SUCCEED, so the refusal is attributable to the
+    // UPDATE rather than to a role that cannot see the table at all — which would fail this test
+    // for a completely different reason and read as coverage.
+    await db.exec(`GRANT SELECT ON abuse_detection_finding TO internal_tools;`);
+    await db.exec(`SET ROLE internal_tools;`);
+    try {
+      await expect(
+        service.recordAbuseVerdict({ runId, findingId, verdict: 'tp', verdictBy: '77' })
+      ).rejects.toThrow(/schema\.sql/);
+      // And the cause is preserved, so the real code is still readable in a log.
+      await service
+        .recordAbuseVerdict({ runId, findingId, verdict: 'tp', verdictBy: '77' })
+        .catch((e: Error & { cause?: { code?: string } }) => {
+          expect(e.cause?.code).toBe('42501');
+          expect(e.message).toMatch(/application role/);
+        });
+    } finally {
+      await db.exec(`RESET ROLE;`);
+    }
+  });
+
+  it('positive control — the same ruling succeeds once the role may write', async () => {
+    // Without this, the rejection above is indistinguishable from a fixture that could never have
+    // recorded a verdict at all.
+    const runId = await seedRun(db, 'bot-account-detection', STARTED_TODAY);
+    const findingId = await seedFinding(db, { runId, userId: 21 });
+    await db.exec(`CREATE ROLE internal_tools LOGIN;`);
+    await db.exec(`GRANT SELECT, UPDATE ON abuse_detection_finding TO internal_tools;`);
+    await db.exec(`SET ROLE internal_tools;`);
+    try {
+      await expect(
+        service.recordAbuseVerdict({ runId, findingId, verdict: 'tp', verdictBy: '77' })
+      ).resolves.toEqual({ updated: 1, groupKey: null });
+    } finally {
+      await db.exec(`RESET ROLE;`);
+    }
+  });
+});
+
+describe('missingColumnFromError', () => {
+  // The two spellings a real server produces, captured from PGlite 0.4.6 rather than invented:
+  // `checkInsertTargets` names the relation, `errorMissingColumn` does not, and NEITHER populates an
+  // `error.column` field — which is why this reads the message at all.
+  it.each([
+    ['an INSERT target', 'column "group_key" of relation "abuse_detection_finding" does not exist'],
+    ['a WHERE clause', 'column "verdict" does not exist'],
+  ])('reads the column name out of %s', (_label, message) => {
+    expect(
+      service.missingColumnFromError(Object.assign(new Error(message), { code: '42703' }))
+    ).toBe(message.includes('group_key') ? 'group_key' : 'verdict');
+  });
+
+  it('answers null for any other error code, however similar the message', () => {
+    // The code is the discriminator, not the prose: a message mentioning a column on a connection
+    // failure must not be read as a schema problem.
+    const e = Object.assign(new Error('column "verdict" does not exist'), { code: '57P01' });
+    expect(service.missingColumnFromError(e)).toBeNull();
+  });
+
+  it('answers null for a 42703 whose message it does not recognise', () => {
+    // The safe direction: an unparsed failure propagates rather than being retried past.
+    expect(
+      service.missingColumnFromError(Object.assign(new Error('no idea'), { code: '42703' }))
+    ).toBeNull();
   });
 });
 

--- a/apps/moderator/src/lib/server/abuse-detection-tables.ts
+++ b/apps/moderator/src/lib/server/abuse-detection-tables.ts
@@ -1,4 +1,5 @@
 import type { Generated, Timestamp } from './moderator-db/types';
+import type { AbuseVerdict } from '../abuse-verdicts';
 
 /**
  * The abuse-detection tables, in the same database as the rest of this app's moderation data.
@@ -13,6 +14,14 @@ import type { Generated, Timestamp } from './moderator-db/types';
  *
  * snake_case, unlike the inherited Retool tables: these are new, written to Postgres convention.
  */
+/**
+ * 🔴 The verdict set lives in `$lib/abuse-verdicts` — client-safe, because the buttons that render
+ * it are client code and SvelteKit will not bundle `$lib/server` into those. It is the SAME tuple
+ * the table's CHECK constraint admits, and `abuse-detection.schema.test.ts` applies the real DDL to
+ * an in-process Postgres and asserts the two agree, in both directions.
+ */
+export type { AbuseVerdict } from '../abuse-verdicts';
+
 export type AbuseDetectionTables = {
   abuse_detection_run: {
     id: Generated<number>;
@@ -31,9 +40,29 @@ export type AbuseDetectionTables = {
     user_id: number;
     confidence: number;
     reason: string;
-    /** `false` is the common case: detected, scored, deliberately NOT acted on. */
+    /**
+     * 🔴 THE PRODUCER's self-report of what IT did — NOT a moderator's judgement. `verdict` below is
+     * the judgement, and the two are independent: `actioned: false` + `verdict: 'tp'` (left alone,
+     * and rightly flagged) is the commonest combination of them. Nothing may read one to infer the
+     * other, and recording a verdict must leave these two untouched.
+     */
     actioned: boolean;
     action: string | null;
     created_at: Generated<Timestamp>;
+    /**
+     * The MODERATOR's ruling — `tp` / `fp` / `skip`, or NULL for unruled. Constrained by a CHECK in
+     * `apps/moderator/abuse-detection/schema.sql`; typed as the union here so a call site cannot
+     * write a fourth value the database would then reject at runtime.
+     *
+     * 🔴 These four are added by the DDL and the DDL is applied BY HAND, so a deployment exists in
+     * which the tables are present and these columns are not. Every read of them goes through a
+     * branch that treats `42703` as "not applied yet" rather than as an outage.
+     */
+    verdict: AbuseVerdict | null;
+    verdict_by: string | null;
+    verdict_at: Timestamp | null;
+    /** The producer's cluster key — one ruling covers every finding sharing it WITHIN ONE RUN. NULL
+     *  for an ungrouped finding, which is most of them. */
+    group_key: string | null;
   };
 };

--- a/apps/moderator/src/lib/server/abuse-detection.service.ts
+++ b/apps/moderator/src/lib/server/abuse-detection.service.ts
@@ -1,9 +1,13 @@
 import { MAX_FINDINGS_PER_REPORT, type AbuseReportInput } from '@civitai/moderation';
+import { sql, type Kysely, type Transaction } from 'kysely';
 import { getModeratorDb } from './moderator-db';
 import type { AbuseDetectionTables, AbuseVerdict } from './abuse-detection-tables';
 
 /** The shared client, typed to include the two tables this module owns. */
 const abuseDb = () => getModeratorDb().withTables<AbuseDetectionTables>();
+
+type AbuseDb = ReturnType<typeof abuseDb>;
+type AbuseTrx = Transaction<AbuseDb extends Kysely<infer DB> ? DB : never>;
 
 /**
  * One client, shared with the rest of the app's moderation data — `withTables` adds these two tables
@@ -96,9 +100,86 @@ const PG_NO_MATCHING_CONFLICT_TARGET = '42P10';
  */
 const PG_UNDEFINED_COLUMN = '42703';
 
+/**
+ * Postgres `insufficient_privilege`.
+ *
+ * The read paths already discriminate it: `schema.sql` says to apply it AS THE APPLICATION ROLE, and
+ * running it as `postgres` instead — the natural `psql -U postgres` shortcut — leaves tables the app
+ * cannot touch. The write path has to say it too, for the same reason it translates 42703: a bare
+ * "the database refused the write" sends an operator hunting an outage on a database that is
+ * healthy, and the remedy (ownership, not a grant — `ALTER TABLE` needs to be run BY the owner) is
+ * not something the moderator on the other end of the click could guess.
+ */
+const PG_INSUFFICIENT_PRIVILEGE = '42501';
+
 /** True for the pg error raised when a column in the statement does not exist on the table. */
 export const isUndefinedColumnError = (e: unknown): boolean =>
   (e as { code?: unknown } | null)?.code === PG_UNDEFINED_COLUMN;
+
+/**
+ * The four columns THIS FEATURE added to a table that was already live and already receiving
+ * reports. Named once, because two different things branch on the set: the capability probe below,
+ * and the `42703` backstop, which has to separate two states that share one error code and have
+ * opposite remedies: a column THIS CHANGE added is missing, versus some unrelated column is.
+ */
+const VERDICT_DDL_COLUMNS = ['verdict', 'verdict_by', 'verdict_at', 'group_key'] as const;
+
+/**
+ * The column a `42703` names, or `null` for anything else.
+ *
+ * 🔴 PARSED FROM THE MESSAGE, BECAUSE THERE IS NO `error.column` TO READ. Measured against a real
+ * server (PGlite 0.4.6, the harness in `__tests__/abuse-detection-pglite.harness.ts`): Postgres
+ * populates the `column_name` error field for CONSTRAINT violations, not for a PARSE-time
+ * `undefined_column`. A dropped-column INSERT comes back `routine: 'checkInsertTargets'` and a
+ * dropped-column WHERE comes back `routine: 'errorMissingColumn'`, and NEITHER carries `column` —
+ * the name exists only in the message, in one of two spellings:
+ *
+ *   column "group_key" of relation "abuse_detection_finding" does not exist   (INSERT/UPDATE target)
+ *   column "verdict" does not exist                                           (everywhere else)
+ *
+ * The leading `column "…"` is common to both, which is what this reads. An unrecognised message
+ * yields `null` and the error propagates unchanged — the safe direction, because the alternative is
+ * retrying a write whose failure nobody understood.
+ */
+export function missingColumnFromError(e: unknown): string | null {
+  const err = e as { code?: unknown; message?: unknown } | null;
+  if (err?.code !== PG_UNDEFINED_COLUMN) return null;
+  if (typeof err.message !== 'string') return null;
+  const m = /column "([^"]+)"/.exec(err.message);
+  return m ? m[1] : null;
+}
+
+/**
+ * Does the live table carry the columns this feature added?
+ *
+ * 🔴 ASKED, NOT DISCOVERED BY FAILING — and that is the whole point of this function. The DDL is
+ * applied by hand, so there is a window in which the table exists and these columns do not. Learning
+ * that from a `42703` costs a ROLLED-BACK TRANSACTION plus a full redo on every report from every
+ * detector, including the two that never send a group key and therefore lose nothing; and it cannot
+ * separate a missing column of THIS change's from an unrelated missing column, so it reports the
+ * second as the first and points the operator at the wrong file. One catalogue read answers it
+ * outright, on a path that runs a handful of times a day.
+ *
+ * 🔴 NOT MEMOISED. A per-process cache would answer from a measurement taken before the operator ran
+ * the file, so the first pod to report in the pre-DDL window would keep storing runs ungrouped until
+ * it was restarted — and the same staleness in a test process, where each case builds its own
+ * database, would answer about the previous case's table. A round trip is cheaper than either.
+ *
+ * `to_regclass` resolves the name through the SAME `search_path` the statements below use, and
+ * answers NULL for a table that is not there at all — in which case no rows come back, the write is
+ * built in its pre-DDL shape, and the missing TABLE raises its own `42P01` exactly as before.
+ *
+ * ALL FOUR or none: a half-applied DDL is treated as not applied, because the degraded path is the
+ * one that cannot be wrong about a column it never names.
+ */
+async function verdictColumnsPresent(trx: AbuseTrx): Promise<boolean> {
+  const { rows } = await sql<{ attname: string }>`
+    SELECT attname FROM pg_attribute
+     WHERE attrelid = to_regclass('abuse_detection_finding')
+       AND attnum > 0 AND NOT attisdropped`.execute(trx);
+  const present = new Set(rows.map((r) => r.attname));
+  return VERDICT_DDL_COLUMNS.every((c) => present.has(c));
+}
 
 /**
  * Store one run and its findings.
@@ -110,24 +191,26 @@ export const isUndefinedColumnError = (e: unknown): boolean =>
 export async function recordAbuseRun(input: AbuseReportInput): Promise<{ runId: number }> {
   const db = abuseDb();
   try {
-    return await writeRun(db, input);
+    const { runId, storedUngrouped } = await writeRun(db, input);
+    if (storedUngrouped) warnStoringUngrouped('group_key', input);
+    return { runId };
   } catch (e) {
-    // 🔴 THE INGEST PATH DEGRADES RATHER THAN STOPPING. `group_key` is a column this change ADDED to
-    // a table that is already live and already receiving reports from three detectors — so between
-    // this deploying and someone running the DDL, an insert naming it raises 42703 and would take
-    // down reporting for every producer, including the two that do not use the feature at all. A
-    // new column must not be able to cost the surface its existing job.
+    // 🔴 THE INGEST PATH DEGRADES RATHER THAN STOPPING, AND THIS IS NOW ONLY THE BACKSTOP.
+    // `verdictColumnsPresent` asks the catalogue before building the statements, so an ordinary
+    // pre-DDL report never reaches here at all — no rolled-back transaction and no redo, which is
+    // what every report from every detector used to pay for a feature two of the three do not use.
+    // What is left for this branch is the race: the DDL applied, or reverted, between the probe and
+    // the write.
     //
-    // Retried WITHOUT the column, exactly once. What is lost is the grouping — every finding lands
-    // ungrouped and is ruled individually, which is precisely the behaviour before this change — and
-    // the loss is announced rather than silent, because "my ring did not collapse" is otherwise an
-    // unexplainable UI bug. A second 42703 from the retry is a different fault and propagates.
-    if (isUndefinedColumnError(e)) {
-      console.warn(
-        '[abuse-detection] abuse_detection_finding has no group_key column — storing this run ' +
-          'UNGROUPED. Apply apps/moderator/abuse-detection/schema.sql to MODERATOR_DATABASE_URL.'
-      );
-      return await writeRun(db, input, { withGroupKey: false });
+    // 🔴 GATED ON WHICH COLUMN IS MISSING. `42703` is equally what an UNRELATED dropped column
+    // raises, and the old unconditional branch answered that with `abuse_detection_finding has no
+    // group_key column - apply schema.sql`: a confident, wrong remedy for a different fault, logged
+    // just before the real error propagated. Only a column THIS change added is retried past.
+    const missing = missingColumnFromError(e);
+    if (missing !== null && (VERDICT_DDL_COLUMNS as readonly string[]).includes(missing)) {
+      const { runId } = await writeRun(db, input, { forceLegacyShape: true });
+      warnStoringUngrouped(missing, input);
+      return { runId };
     }
     if ((e as { code?: unknown }).code === PG_NO_MATCHING_CONFLICT_TARGET)
       throw new Error(
@@ -139,13 +222,34 @@ export async function recordAbuseRun(input: AbuseReportInput): Promise<{ runId: 
   }
 }
 
-function writeRun(
-  db: ReturnType<typeof abuseDb>,
+/**
+ * 🔴 WARNED ONLY WHEN SOMETHING WAS ACTUALLY LOST — i.e. when this report carried a key the table
+ * cannot hold. Three detectors post to this board and two of them send no key at all; warning on
+ * their reports too, on every report, until a human runs a file, is a log line that carries no
+ * information and trains its reader past the one that does. "My ring did not collapse into one row"
+ * is the otherwise-unexplainable UI bug this message exists to explain, and a report with no ring in
+ * it cannot have that bug.
+ *
+ * Emitted after the write, not before: a run that did not land has lost its grouping the way it lost
+ * everything else, and saying so separately would be a second explanation for one failure.
+ */
+function warnStoringUngrouped(column: string, input: AbuseReportInput): void {
+  if (!input.findings.some((f) => f.groupKey != null)) return;
+  console.warn(
+    `[abuse-detection] abuse_detection_finding has no ${column} column — storing this run ` +
+      'UNGROUPED. Apply apps/moderator/abuse-detection/schema.sql to MODERATOR_DATABASE_URL.'
+  );
+}
+
+async function writeRun(
+  db: AbuseDb,
   input: AbuseReportInput,
-  opts: { withGroupKey?: boolean } = {}
-): Promise<{ runId: number }> {
-  const withGroupKey = opts.withGroupKey ?? true;
+  opts: { forceLegacyShape?: boolean } = {}
+): Promise<{ runId: number; storedUngrouped: boolean }> {
   return db.transaction().execute(async (trx) => {
+    // Asked once per report, inside the transaction whose statements are shaped by the answer.
+    const withVerdictColumns = opts.forceLegacyShape ? false : await verdictColumnsPresent(trx);
+
     const run = await trx
       .insertInto('abuse_detection_run')
       .values({
@@ -159,7 +263,18 @@ function writeRun(
       // 🔴 IDEMPOTENT on (detector, started_at). The producers retry: a POST that commits but whose
       // response is lost to a timeout gets sent again, and without this the board grows a duplicate
       // run every time — two rows claiming to be the same run, which is worse than none because a
-      // reader cannot tell which is current. Re-reporting the same run REPLACES it.
+      // reader cannot tell which is current.
+      //
+      // 🔴 RE-REPORTING REPLACES THE PRODUCER'S DATA AND KEEPS THE MODERATOR'S. It used to replace
+      // everything: the run row survived the upsert with the same id, and the next statement deleted
+      // every finding on it and re-inserted them from a payload that carries no verdict fields. That
+      // was lossless while these rows held only producer-generated data; it stopped being lossless
+      // the moment a human judgement went into the same row. Measured against this file's own PGlite
+      // harness: rule three findings, re-POST the identical (detector, startedAt), and the run's
+      // "still to review" count went from `{ ruled: 3, unruled: 0 }` back to `{ ruled: 0, unruled: 3 }`
+      // — silently, with new row ids, reading exactly like a fresh run. The replay that does it is
+      // the ordinary "committed, response lost to a timeout" retry this upsert exists for. See
+      // `replaceFindings` below for what survives now.
       .onConflict((oc) =>
         oc.columns(['detector', 'started_at']).doUpdateSet({
           finished_at: new Date(input.finishedAt),
@@ -174,43 +289,126 @@ function writeRun(
       .returning('id')
       .executeTakeFirstOrThrow();
 
-    // Clear before re-inserting, so a replayed run does not accumulate its findings twice. A no-op on
-    // the first write; the ON DELETE CASCADE does not help here because the run row survives.
-    await trx.deleteFrom('abuse_detection_finding').where('run_id', '=', run.id).execute();
-
-    if (input.findings.length > 0) {
-      await trx
-        .insertInto('abuse_detection_finding')
-        .values(
-          input.findings.map((f) => ({
-            run_id: run.id,
-            user_id: f.userId,
-            confidence: f.confidence,
-            reason: f.reason,
-            actioned: f.actioned,
-            // Mirrors the table's CHECK for the `actioned: false` direction. It CANNOT repair the
-            // other one — an `actioned: true` carrying no action still normalises to NULL here, and
-            // the CHECK would reject it, aborting the transaction and losing the whole run. That
-            // shape is unreachable only because the CONTRACT now refuses it at the edge, which is
-            // where a missing value has to be caught: this line has nothing to substitute for it.
-            action: f.actioned ? f.action ?? null : null,
-            // 🔴 NORMALISED TO NULL, never left undefined. The contract accepts an ABSENT key from
-            // the three producers that do not send one, and `undefined` in a Kysely `values()` row
-            // omits the column from the INSERT — which is fine on its own, but a REPLAYED run mixes
-            // rows that have the key with rows that do not, and an insert whose rows disagree about
-            // their columns is a runtime error rather than a missing value. NULL is also exactly
-            // what "this finding is in no cluster" means in the table.
-            //
-            // Dropped entirely — not set to NULL — on the pre-DDL retry, because naming a column
-            // that does not exist is the error being retried past.
-            ...(withGroupKey ? { group_key: f.groupKey ?? null } : {}),
-          }))
-        )
-        .execute();
-    }
-
-    return { runId: run.id };
+    await replaceFindings(trx, run.id, input.findings, withVerdictColumns);
+    return { runId: run.id, storedUngrouped: !withVerdictColumns };
   });
+}
+
+/**
+ * Bring one run's findings in line with the payload, WITHOUT destroying a ruling.
+ *
+ * 🔴 THE DELETE IS SCOPED TO THE UNRULED ROWS, AND THAT IS THE WHOLE FIX. A clear-and-reinsert is the
+ * right shape for rows a producer owns outright — it is what stops a replayed run accumulating its
+ * findings twice, which is a real bug and is still prevented here. It is the wrong shape for a row a
+ * human has written to. A verdict is not the producer's to delete by re-POSTing, and it is the one
+ * thing in this table that cannot be recomputed: re-running the detector reproduces every producer
+ * column exactly and reproduces no verdict at all.
+ *
+ * 🔴 NO ACCUMULATION. After this runs, the findings on the run are: every ruled row that was already
+ * there, plus one row for each payload finding no ruled row already covers. Both halves are fixed
+ * points — a second replay of the same payload deletes the unruled half and re-inserts exactly it —
+ * so replaying N times leaves the same row count as replaying once. Growth is possible only through
+ * a moderator ruling something, which is the intended direction.
+ *
+ * 🔴 THE MATCH IS `(run_id, user_id)`, and it is a match, not a key. The table has no unique index on
+ * that pair and this does not add one — adding one would be a second hand-applied DDL step, and on a
+ * live table already holding whatever the detectors have written it could not be created at all
+ * without a de-duplication pass first. Counting survivors per user instead makes a payload that
+ * repeats a user behave sanely (its first N findings for that user are the ones already present)
+ * without claiming a uniqueness the database does not enforce.
+ *
+ * 🔴 A RULED ROW IS NOT REFRESHED FROM THE PAYLOAD, deliberately. The moderator ruled on the `reason`
+ * and `confidence` that were on screen; overwriting them with a replay's copy would leave a verdict
+ * attached to evidence nobody ruled on. For a genuine replay the two are identical anyway — the
+ * payload is keyed by `(detector, started_at)`, so a second POST under that pair is the same run.
+ *
+ * 🔴 THE AWKWARD CASE — A RULED FINDING THE REPLAY NO LONGER REPORTS — IS KEPT, NOT DROPPED, and this
+ * is a decision rather than a fallout. Either way makes a claim: keeping it leaves a row on the run
+ * that this payload did not assert, and dropping it destroys a judgement a human made. Kept, because
+ * the two failures are not symmetric. A retained row is visible — it is on the board, ruled, with its
+ * ruler and its timestamp — and a moderator or an operator can act on it. A dropped verdict is
+ * invisible, unrecoverable, and it silently deflates the denominator of the false-positive rate this
+ * whole board exists to measure; a detector that stopped flagging an account it was told was a false
+ * positive would be erasing precisely the evidence of its own error. `abuse-detection.verdict.test.ts`
+ * pins this direction.
+ */
+async function replaceFindings(
+  trx: AbuseTrx,
+  runId: number,
+  findings: AbuseReportInput['findings'],
+  withVerdictColumns: boolean
+): Promise<void> {
+  if (!withVerdictColumns) {
+    // Pre-DDL there is no `verdict` column to scope the delete by, and nothing to preserve either:
+    // no ruling can have been recorded on a deployment that cannot store one. The original
+    // clear-and-reinsert is exactly right there, and naming a column that does not exist is the
+    // error this whole branch exists to avoid.
+    await trx.deleteFrom('abuse_detection_finding').where('run_id', '=', runId).execute();
+    await insertFindings(trx, runId, findings, false);
+    return;
+  }
+
+  await trx
+    .deleteFrom('abuse_detection_finding')
+    .where('run_id', '=', runId)
+    .where('verdict', 'is', null)
+    .execute();
+
+  const survivors = await trx
+    .selectFrom('abuse_detection_finding')
+    .select(['id', 'user_id'])
+    .where('run_id', '=', runId)
+    .execute();
+
+  const survivorsPerUser = new Map<number, number>();
+  for (const s of survivors)
+    survivorsPerUser.set(s.user_id, (survivorsPerUser.get(s.user_id) ?? 0) + 1);
+
+  const fresh: AbuseReportInput['findings'] = [];
+  for (const f of findings) {
+    const remaining = survivorsPerUser.get(f.userId) ?? 0;
+    // Already on the run, carrying a ruling. Left exactly as it is.
+    if (remaining > 0) survivorsPerUser.set(f.userId, remaining - 1);
+    else fresh.push(f);
+  }
+  await insertFindings(trx, runId, fresh, true);
+}
+
+/** The producer's rows, in the shape the live table can hold. */
+async function insertFindings(
+  trx: AbuseTrx,
+  runId: number,
+  findings: AbuseReportInput['findings'],
+  withGroupKey: boolean
+): Promise<void> {
+  if (findings.length === 0) return;
+  await trx
+    .insertInto('abuse_detection_finding')
+    .values(
+      findings.map((f) => ({
+        run_id: runId,
+        user_id: f.userId,
+        confidence: f.confidence,
+        reason: f.reason,
+        actioned: f.actioned,
+        // Mirrors the table's CHECK for the `actioned: false` direction. It CANNOT repair the
+        // other one — an `actioned: true` carrying no action still normalises to NULL here, and
+        // the CHECK would reject it, aborting the transaction and losing the whole run. That
+        // shape is unreachable only because the CONTRACT now refuses it at the edge, which is
+        // where a missing value has to be caught: this line has nothing to substitute for it.
+        action: f.actioned ? f.action ?? null : null,
+        // 🔴 NORMALISED TO NULL, never left undefined. The contract accepts an ABSENT key from
+        // the three producers that do not send one, and `undefined` in a Kysely `values()` row
+        // omits the column from the INSERT — which is fine on its own, but one statement whose
+        // rows disagree about their columns is a runtime error rather than a missing value. NULL
+        // is also exactly what "this finding is in no cluster" means in the table.
+        //
+        // Dropped entirely — not set to NULL — in the pre-DDL shape, because naming a column that
+        // does not exist is the error that shape exists to avoid.
+        ...(withGroupKey ? { group_key: f.groupKey ?? null } : {}),
+      }))
+    )
+    .execute();
 }
 
 /**
@@ -512,6 +710,19 @@ export async function recordAbuseVerdict(input: {
       throw new Error(
         'abuse_detection_finding has no verdict columns — apply ' +
           'apps/moderator/abuse-detection/schema.sql to MODERATOR_DATABASE_URL as the application role',
+        { cause: e }
+      );
+    // 🔴 THE SAME DISCRIMINATION THE TWO READ PATHS ALREADY MAKE. Both `+page.server.ts` loads
+    // branch on 42501 and say "re-run schema.sql as the application role"; without this the write
+    // answered the identical cause with "the database refused the write", which reads as an outage.
+    // It is a LIKELY state, not a hypothetical: the file's own header exists because `psql -U
+    // postgres` is the natural shortcut, and it leaves tables the app can be granted rights on but
+    // still does not own — enough to SELECT, not enough for the `ALTER TABLE`s this file now runs.
+    if ((e as { code?: unknown }).code === PG_INSUFFICIENT_PRIVILEGE)
+      throw new Error(
+        'this role cannot write abuse_detection_finding — re-run ' +
+          'apps/moderator/abuse-detection/schema.sql as the application role, or transfer ownership ' +
+          'of the tables to it (see the file header)',
         { cause: e }
       );
     throw e;

--- a/apps/moderator/src/lib/server/abuse-detection.service.ts
+++ b/apps/moderator/src/lib/server/abuse-detection.service.ts
@@ -1,6 +1,6 @@
 import { MAX_FINDINGS_PER_REPORT, type AbuseReportInput } from '@civitai/moderation';
 import { getModeratorDb } from './moderator-db';
-import type { AbuseDetectionTables } from './abuse-detection-tables';
+import type { AbuseDetectionTables, AbuseVerdict } from './abuse-detection-tables';
 
 /** The shared client, typed to include the two tables this module owns. */
 const abuseDb = () => getModeratorDb().withTables<AbuseDetectionTables>();
@@ -50,9 +50,18 @@ export type AbuseFinding = {
   userId: number;
   confidence: number;
   reason: string;
+  /** 🔴 The PRODUCER's self-report. Not a verdict — see `verdict` below and the schema's comment. */
   actioned: boolean;
   action: string | null;
   createdAt: Date;
+  /** The MODERATOR's ruling, or `null` for unruled. `null` is also what a deployment that has not
+   *  applied the DDL yet reports for every row, which is the correct read-only degradation: nothing
+   *  has been ruled there, because nothing CAN be. */
+  verdict: AbuseVerdict | null;
+  verdictBy: string | null;
+  verdictAt: Date | null;
+  /** The producer's cluster key. Findings sharing one WITHIN A RUN are one decision. */
+  groupKey: string | null;
 };
 
 /**
@@ -71,6 +80,27 @@ export type AbuseFinding = {
 const PG_NO_MATCHING_CONFLICT_TARGET = '42P10';
 
 /**
+ * Postgres `undefined_column`.
+ *
+ * 🔴 THE SIBLING OF `42P01`, AND IT EXISTS BECAUSE THE DDL IS APPLIED BY HAND. `42P01` is "the
+ * tables were never created"; this is the state that only became reachable once columns were ADDED
+ * to a table that already exists — the board is live, the runs and findings are all there, and the
+ * four verdict columns are not, because nobody has re-run `schema.sql` since the deploy. Read as an
+ * outage it sends an operator hunting a database that is working perfectly.
+ *
+ * The two sides answer it differently, on purpose. A READ degrades: `getAbuseVerdictSummary` returns
+ * `null`, the page renders every finding read-only, and no moderator is shown an error about a
+ * feature they were not using a minute ago. A WRITE cannot degrade — silently accepting a ruling
+ * that was never stored is the one outcome worse than refusing it — so `recordAbuseVerdict`
+ * translates it into a message naming the file to run, exactly as the 42P10 branch above does.
+ */
+const PG_UNDEFINED_COLUMN = '42703';
+
+/** True for the pg error raised when a column in the statement does not exist on the table. */
+export const isUndefinedColumnError = (e: unknown): boolean =>
+  (e as { code?: unknown } | null)?.code === PG_UNDEFINED_COLUMN;
+
+/**
  * Store one run and its findings.
  *
  * One transaction: a run header whose findings failed to land would render as "0 findings", which is
@@ -82,6 +112,23 @@ export async function recordAbuseRun(input: AbuseReportInput): Promise<{ runId: 
   try {
     return await writeRun(db, input);
   } catch (e) {
+    // 🔴 THE INGEST PATH DEGRADES RATHER THAN STOPPING. `group_key` is a column this change ADDED to
+    // a table that is already live and already receiving reports from three detectors — so between
+    // this deploying and someone running the DDL, an insert naming it raises 42703 and would take
+    // down reporting for every producer, including the two that do not use the feature at all. A
+    // new column must not be able to cost the surface its existing job.
+    //
+    // Retried WITHOUT the column, exactly once. What is lost is the grouping — every finding lands
+    // ungrouped and is ruled individually, which is precisely the behaviour before this change — and
+    // the loss is announced rather than silent, because "my ring did not collapse" is otherwise an
+    // unexplainable UI bug. A second 42703 from the retry is a different fault and propagates.
+    if (isUndefinedColumnError(e)) {
+      console.warn(
+        '[abuse-detection] abuse_detection_finding has no group_key column — storing this run ' +
+          'UNGROUPED. Apply apps/moderator/abuse-detection/schema.sql to MODERATOR_DATABASE_URL.'
+      );
+      return await writeRun(db, input, { withGroupKey: false });
+    }
     if ((e as { code?: unknown }).code === PG_NO_MATCHING_CONFLICT_TARGET)
       throw new Error(
         'abuse_detection_run is missing its (detector, started_at) UNIQUE index — apply ' +
@@ -94,8 +141,10 @@ export async function recordAbuseRun(input: AbuseReportInput): Promise<{ runId: 
 
 function writeRun(
   db: ReturnType<typeof abuseDb>,
-  input: AbuseReportInput
+  input: AbuseReportInput,
+  opts: { withGroupKey?: boolean } = {}
 ): Promise<{ runId: number }> {
+  const withGroupKey = opts.withGroupKey ?? true;
   return db.transaction().execute(async (trx) => {
     const run = await trx
       .insertInto('abuse_detection_run')
@@ -145,6 +194,16 @@ function writeRun(
             // shape is unreachable only because the CONTRACT now refuses it at the edge, which is
             // where a missing value has to be caught: this line has nothing to substitute for it.
             action: f.actioned ? f.action ?? null : null,
+            // 🔴 NORMALISED TO NULL, never left undefined. The contract accepts an ABSENT key from
+            // the three producers that do not send one, and `undefined` in a Kysely `values()` row
+            // omits the column from the INSERT — which is fine on its own, but a REPLAYED run mixes
+            // rows that have the key with rows that do not, and an insert whose rows disagree about
+            // their columns is a runtime error rather than a missing value. NULL is also exactly
+            // what "this finding is in no cluster" means in the table.
+            //
+            // Dropped entirely — not set to NULL — on the pre-DDL retry, because naming a column
+            // that does not exist is the error being retried past.
+            ...(withGroupKey ? { group_key: f.groupKey ?? null } : {}),
           }))
         )
         .execute();
@@ -305,6 +364,17 @@ export async function getAbuseDetectors(): Promise<string[]> {
   return rows.map((r) => r.detector);
 }
 
+/**
+ * 🔴 THE FOUR VERDICT FIELDS ARE OPTIONAL ON THE INPUT, AND THAT IS THE READ-SIDE DEGRADATION.
+ *
+ * Both find queries are `selectAll()`, so against a database whose DDL has not been applied the
+ * driver simply hands back rows without these keys — no error, because nothing NAMED a column that
+ * is missing. `?? null` is what turns that into "unruled", which is the truthful reading: on a
+ * deployment with no verdict columns, nothing has been ruled and nothing can be.
+ *
+ * Widening `selectAll()` into an explicit column list would convert that silent, correct degradation
+ * into a 42703 on the board's main read. Do not.
+ */
 function toFinding(r: {
   id: number;
   run_id: number;
@@ -314,6 +384,10 @@ function toFinding(r: {
   actioned: boolean;
   action: string | null;
   created_at: Date;
+  verdict?: AbuseVerdict | null;
+  verdict_by?: string | null;
+  verdict_at?: Date | null;
+  group_key?: string | null;
 }): AbuseFinding {
   return {
     id: r.id,
@@ -324,7 +398,124 @@ function toFinding(r: {
     actioned: r.actioned,
     action: r.action,
     createdAt: r.created_at,
+    verdict: r.verdict ?? null,
+    verdictBy: r.verdict_by ?? null,
+    verdictAt: r.verdict_at ?? null,
+    groupKey: r.group_key ?? null,
   };
+}
+
+/**
+ * How much of a run has been ruled on, or `null` when the verdict columns are not applied here.
+ *
+ * 🔴 A SEPARATE QUERY RATHER THAN A COLUMN ON `getAbuseRun`, and the separation is the degradation.
+ * This is the one read that NAMES `verdict`, so it is the one read that can raise 42703 — folding it
+ * into the run header's counts would put that failure on the path the whole detail page depends on,
+ * and the page would 503 on a database that is serving every row it holds.
+ *
+ * 🔴 COUNTED OVER THE WHOLE RUN, not over the page. `getAbuseFindings` caps at
+ * MAX_FINDINGS_PER_REPORT and reports `truncated`; a "12 still to review" derived from the rendered
+ * rows would be a cap presented as a total — the exact lie the per-user read was fixed for.
+ *
+ * `null` is not zero and the caller must not render it as one: zero means "everything here has been
+ * ruled on", `null` means "this deployment cannot record a ruling at all".
+ */
+export async function getAbuseVerdictSummary(
+  runId: number
+): Promise<{ ruled: number; unruled: number } | null> {
+  try {
+    const row = await abuseDb()
+      .selectFrom('abuse_detection_finding')
+      .select(({ fn, eb }) => [
+        // COUNT of a filtered expression: `count(verdict)` alone would skip NULLs and give the ruled
+        // half, but there is no matching spelling for the unruled half, and two differently-shaped
+        // counters beside each other is how one of them silently stops meaning what it says.
+        fn
+          .count<string>(eb.case().when('verdict', 'is not', null).then(eb.ref('id')).end())
+          .as('ruled'),
+        fn
+          .count<string>(eb.case().when('verdict', 'is', null).then(eb.ref('id')).end())
+          .as('unruled'),
+      ])
+      .where('run_id', '=', runId)
+      .executeTakeFirst();
+    return { ruled: Number(row?.ruled ?? 0), unruled: Number(row?.unruled ?? 0) };
+  } catch (e) {
+    // The DDL has not been applied here. Read-only is the correct state, not an error.
+    if (isUndefinedColumnError(e)) return null;
+    throw e;
+  }
+}
+
+/**
+ * Record one moderator's ruling.
+ *
+ * 🔴 SCOPED TO THE RUN, ALWAYS — `runId` is not a convenience, it is the authorisation boundary of
+ * the write. A finding id arrives in a form post and is therefore attacker-chosen; without the run
+ * predicate, a post from run 7's page could rule a finding belonging to run 9, and — worse, because
+ * it is invisible — a group ruling would reach every run that ever carried the same `group_key`. The
+ * same email-domain ring reappears in tomorrow's cohort under the identical key, so "all findings
+ * with this key" without a run bound is "every day this ring has ever been seen", ruled in one click
+ * by someone who reviewed one day's evidence.
+ *
+ * 🔴 ONE RULING, N FINDINGS, only when the producer said so. A non-NULL `group_key` is the producer's
+ * claim that these rows are one actor; the ruling then covers all of them IN THIS RUN. A NULL key is
+ * not a group — it is the absence of one — so it must never be used as a match value, or every
+ * ungrouped finding in the run would be ruled together by the first one anybody clicked.
+ *
+ * 🔴 IT DOES NOT TOUCH `actioned` OR `action`. Those are the producer's record of what IT did; this
+ * is a human's record of whether that was right. Overwriting the first with the second would destroy
+ * the only evidence of what the detector actually chose to do, which is the measurement this whole
+ * board exists to make.
+ *
+ * Re-ruling is expected and overwrites: `verdict_by`/`verdict_at` always name the CURRENT ruling, so
+ * a moderator correcting a mistake stands behind the correction rather than the mistake.
+ */
+export async function recordAbuseVerdict(input: {
+  runId: number;
+  findingId: number;
+  verdict: AbuseVerdict;
+  verdictBy: string;
+}): Promise<{ updated: number; groupKey: string | null }> {
+  const db = abuseDb();
+  try {
+    // The clicked finding, read first — it is what supplies the group key, and reading it is also
+    // how a finding that does not belong to this run is refused rather than ruled.
+    const target = await db
+      .selectFrom('abuse_detection_finding')
+      .select(['id', 'group_key'])
+      .where('id', '=', input.findingId)
+      .where('run_id', '=', input.runId)
+      .executeTakeFirst();
+    if (!target) return { updated: 0, groupKey: null };
+
+    const groupKey = target.group_key ?? null;
+    let q = db
+      .updateTable('abuse_detection_finding')
+      .set({
+        verdict: input.verdict,
+        verdict_by: input.verdictBy,
+        // The server's clock, not the browser's: this is an audit field.
+        verdict_at: new Date(),
+      })
+      .where('run_id', '=', input.runId);
+    // Grouped: every member of the cluster in THIS run. Ungrouped: this row and nothing else.
+    q =
+      groupKey === null ? q.where('id', '=', input.findingId) : q.where('group_key', '=', groupKey);
+
+    const result = await q.executeTakeFirst();
+    return { updated: Number(result?.numUpdatedRows ?? 0), groupKey };
+  } catch (e) {
+    // 🔴 A WRITE MUST NOT DEGRADE. Accepting a ruling the database never stored, and rendering it as
+    // recorded, is worse than refusing it — the moderator moves on believing the row is graded.
+    if (isUndefinedColumnError(e))
+      throw new Error(
+        'abuse_detection_finding has no verdict columns — apply ' +
+          'apps/moderator/abuse-detection/schema.sql to MODERATOR_DATABASE_URL as the application role',
+        { cause: e }
+      );
+    throw e;
+  }
 }
 
 /**

--- a/apps/moderator/src/lib/server/abuse-detection.service.ts
+++ b/apps/moderator/src/lib/server/abuse-detection.service.ts
@@ -118,11 +118,28 @@ export const isUndefinedColumnError = (e: unknown): boolean =>
 
 /**
  * The four columns THIS FEATURE added to a table that was already live and already receiving
- * reports. Named once, because two different things branch on the set: the capability probe below,
- * and the `42703` backstop, which has to separate two states that share one error code and have
- * opposite remedies: a column THIS CHANGE added is missing, versus some unrelated column is.
+ * reports. The SET is what the `42703` backstop branches on, because it has to separate two states
+ * that share one error code and have opposite remedies: a column THIS CHANGE added is missing,
+ * versus some unrelated column is.
+ *
+ * 🔴 THE CAPABILITY PROBE DOES **NOT** USE THIS SET — it asks about `verdict` and `group_key`
+ * individually (see `VerdictColumnSupport`). An all-four-or-none probe is exactly the defect that
+ * sent a table holding rulings down the unscoped delete, so widening the probe back to this constant
+ * is the regression to watch for.
  */
 const VERDICT_DDL_COLUMNS = ['verdict', 'verdict_by', 'verdict_at', 'group_key'] as const;
+
+/**
+ * The one column that decides whether a ruling can EXIST, and therefore the only one the scoped
+ * delete names. Its absence, and nothing else's, means there is nothing to preserve.
+ */
+const VERDICT_COLUMN = 'verdict';
+
+/**
+ * The one column that decides whether a producer's cluster key can be STORED, and therefore the only
+ * one whose absence a report can actually lose something to.
+ */
+const GROUP_KEY_COLUMN = 'group_key';
 
 /**
  * The column a `42703` names, or `null` for anything else.
@@ -150,7 +167,30 @@ export function missingColumnFromError(e: unknown): string | null {
 }
 
 /**
- * Does the live table carry the columns this feature added?
+ * What the live table can actually do, as TWO independent capabilities.
+ *
+ * 🔴 ONE BOOLEAN OVER ALL FOUR COLUMNS CONFLATED TWO UNRELATED QUESTIONS, AND THAT COST VERDICTS.
+ * "Can a ruling be preserved?" is answered by `verdict` alone — it is the only column the scoped
+ * delete names. "Can a cluster key be stored?" is answered by `group_key` alone. An all-or-none
+ * probe sent a table that HAS `verdict`, and rulings recorded in it, down the unscoped
+ * `DELETE … WHERE run_id = …` the moment any ONE of the other three went missing — the same silent,
+ * irreversible loss the scoped delete exists to stop, reached through a narrower door. Measured on
+ * this file's PGlite harness: rule one of two findings, `DROP COLUMN group_key`, replay, and the
+ * run's ruled count went 1 → 0. The live trigger is dropping one of the three non-`verdict` columns
+ * after rulings exist — rolling back the grouping half, or restoring a mid-rollout snapshot.
+ *
+ * `verdict_by` and `verdict_at` appear in neither capability because this write path never names
+ * them; `recordAbuseVerdict` does, and it refuses rather than degrading.
+ */
+type VerdictColumnSupport = {
+  /** `verdict` exists, so the delete can be scoped to the rows no moderator has ruled on. */
+  canPreserveVerdicts: boolean;
+  /** `group_key` exists, so the producer's cluster key can be written. */
+  canStoreGroupKey: boolean;
+};
+
+/**
+ * Which of this feature's capabilities does the live table actually support?
  *
  * 🔴 ASKED, NOT DISCOVERED BY FAILING — and that is the whole point of this function. The DDL is
  * applied by hand, so there is a window in which the table exists and these columns do not. Learning
@@ -169,16 +209,19 @@ export function missingColumnFromError(e: unknown): string | null {
  * answers NULL for a table that is not there at all — in which case no rows come back, the write is
  * built in its pre-DDL shape, and the missing TABLE raises its own `42P01` exactly as before.
  *
- * ALL FOUR or none: a half-applied DDL is treated as not applied, because the degraded path is the
- * one that cannot be wrong about a column it never names.
+ * EACH COLUMN ANSWERS ONLY FOR ITSELF — see `VerdictColumnSupport` above for why an all-four-or-none
+ * answer destroyed rulings on a half-applied table.
  */
-async function verdictColumnsPresent(trx: AbuseTrx): Promise<boolean> {
+async function verdictColumnSupport(trx: AbuseTrx): Promise<VerdictColumnSupport> {
   const { rows } = await sql<{ attname: string }>`
     SELECT attname FROM pg_attribute
      WHERE attrelid = to_regclass('abuse_detection_finding')
        AND attnum > 0 AND NOT attisdropped`.execute(trx);
   const present = new Set(rows.map((r) => r.attname));
-  return VERDICT_DDL_COLUMNS.every((c) => present.has(c));
+  return {
+    canPreserveVerdicts: present.has(VERDICT_COLUMN),
+    canStoreGroupKey: present.has(GROUP_KEY_COLUMN),
+  };
 }
 
 /**
@@ -192,7 +235,7 @@ export async function recordAbuseRun(input: AbuseReportInput): Promise<{ runId: 
   const db = abuseDb();
   try {
     const { runId, storedUngrouped } = await writeRun(db, input);
-    if (storedUngrouped) warnStoringUngrouped('group_key', input);
+    if (storedUngrouped) warnStoringUngrouped(input);
     return { runId };
   } catch (e) {
     // 🔴 THE INGEST PATH DEGRADES RATHER THAN STOPPING, AND THIS IS NOW ONLY THE BACKSTOP.
@@ -202,15 +245,30 @@ export async function recordAbuseRun(input: AbuseReportInput): Promise<{ runId: 
     // What is left for this branch is the race: the DDL applied, or reverted, between the probe and
     // the write.
     //
-    // 🔴 GATED ON WHICH COLUMN IS MISSING. `42703` is equally what an UNRELATED dropped column
-    // raises, and the old unconditional branch answered that with `abuse_detection_finding has no
-    // group_key column - apply schema.sql`: a confident, wrong remedy for a different fault, logged
-    // just before the real error propagated. Only a column THIS change added is retried past.
-    const missing = missingColumnFromError(e);
-    if (missing !== null && (VERDICT_DDL_COLUMNS as readonly string[]).includes(missing)) {
-      const { runId } = await writeRun(db, input, { forceLegacyShape: true });
-      warnStoringUngrouped(missing, input);
-      return { runId };
+    // 🔴 THE CODE IS THE GATE; THE COLUMN NAME IS A REFINEMENT THAT MAY FAIL. `42703` is
+    // locale-independent, the message is not: `missingColumnFromError` reads the name out of an
+    // ENGLISH message, so a server running a non-English `lc_messages` yields `null` for a perfectly
+    // ordinary missing column. Gating the retry on "a name came back" therefore turned the whole
+    // backstop OFF on those servers — reporting would fail where it used to degrade. So an
+    // unreadable name degrades, and only a name we CAN read and recognise as someone else's problem
+    // stops the retry: `42703` is equally what an UNRELATED dropped column raises, and the old
+    // unconditional branch answered that with `abuse_detection_finding has no group_key column —
+    // apply schema.sql`, a confident wrong remedy for a different fault.
+    if (isUndefinedColumnError(e)) {
+      const missing = missingColumnFromError(e);
+      const ours = missing === null || (VERDICT_DDL_COLUMNS as readonly string[]).includes(missing);
+      if (ours) {
+        // 🔴 RE-PROBED, NOT FORCED INTO THE LEGACY SHAPE. This branch is the race — the DDL applied,
+        // or reverted, between the probe and the write — and the catalogue read at the top of the
+        // retry is the authoritative answer to what it is now. Forcing the pre-DDL shape instead
+        // assumed the reverted direction and, on a table that still had `verdict`, answered a
+        // missing `group_key` with the unscoped delete that erases rulings. If the shape is
+        // genuinely unchanged the retry reproduces the same failure and it propagates, which is the
+        // honest outcome for a fault nobody here can name.
+        const { runId, storedUngrouped } = await writeRun(db, input);
+        if (storedUngrouped) warnStoringUngrouped(input);
+        return { runId };
+      }
     }
     if ((e as { code?: unknown }).code === PG_NO_MATCHING_CONFLICT_TARGET)
       throw new Error(
@@ -232,23 +290,30 @@ export async function recordAbuseRun(input: AbuseReportInput): Promise<{ runId: 
  *
  * Emitted after the write, not before: a run that did not land has lost its grouping the way it lost
  * everything else, and saying so separately would be a second explanation for one failure.
+ *
+ * 🔴 IT NAMES `group_key` BECAUSE THAT IS THE ONLY COLUMN WHOSE ABSENCE CAN REACH HERE. It used to be
+ * handed a column name by two callers, one of which did not have one: the probe path passed the
+ * literal `'group_key'` whatever the all-four probe had actually found missing, so a table with
+ * `verdict` dropped and `group_key` right there logged "abuse_detection_finding has no group_key
+ * column" — the same confident-wrong-column shape the `42703` backstop was fixed for. Now the only
+ * thing that sets `storedUngrouped` is `group_key` itself being absent, so the name is a fact rather
+ * than a guess, and no caller supplies one.
  */
-function warnStoringUngrouped(column: string, input: AbuseReportInput): void {
+function warnStoringUngrouped(input: AbuseReportInput): void {
   if (!input.findings.some((f) => f.groupKey != null)) return;
   console.warn(
-    `[abuse-detection] abuse_detection_finding has no ${column} column — storing this run ` +
+    `[abuse-detection] abuse_detection_finding has no ${GROUP_KEY_COLUMN} column — storing this run ` +
       'UNGROUPED. Apply apps/moderator/abuse-detection/schema.sql to MODERATOR_DATABASE_URL.'
   );
 }
 
 async function writeRun(
   db: AbuseDb,
-  input: AbuseReportInput,
-  opts: { forceLegacyShape?: boolean } = {}
+  input: AbuseReportInput
 ): Promise<{ runId: number; storedUngrouped: boolean }> {
   return db.transaction().execute(async (trx) => {
     // Asked once per report, inside the transaction whose statements are shaped by the answer.
-    const withVerdictColumns = opts.forceLegacyShape ? false : await verdictColumnsPresent(trx);
+    const support = await verdictColumnSupport(trx);
 
     const run = await trx
       .insertInto('abuse_detection_run')
@@ -289,8 +354,8 @@ async function writeRun(
       .returning('id')
       .executeTakeFirstOrThrow();
 
-    await replaceFindings(trx, run.id, input.findings, withVerdictColumns);
-    return { runId: run.id, storedUngrouped: !withVerdictColumns };
+    await replaceFindings(trx, run.id, input.findings, support);
+    return { runId: run.id, storedUngrouped: !support.canStoreGroupKey };
   });
 }
 
@@ -310,12 +375,30 @@ async function writeRun(
  * so replaying N times leaves the same row count as replaying once. Growth is possible only through
  * a moderator ruling something, which is the intended direction.
  *
- * 🔴 THE MATCH IS `(run_id, user_id)`, and it is a match, not a key. The table has no unique index on
- * that pair and this does not add one — adding one would be a second hand-applied DDL step, and on a
- * live table already holding whatever the detectors have written it could not be created at all
- * without a de-duplication pass first. Counting survivors per user instead makes a payload that
- * repeats a user behave sanely (its first N findings for that user are the ones already present)
- * without claiming a uniqueness the database does not enforce.
+ * 🔴 THE MATCH IS `(user_id, reason)` FIRST AND `user_id` ONLY AS A FALLBACK, and it is a match, not
+ * a key. The table has no unique index on either pair and this does not add one — that would be a
+ * second hand-applied DDL step, and on a live table already holding whatever the detectors have
+ * written it could not be created at all without a de-duplication pass first.
+ *
+ * The two passes exist because the two things a survivor match has to get right pull in opposite
+ * directions, and a per-user COUNT alone got the second one wrong:
+ *
+ *   PASS 1, exact content. A payload finding whose `(user_id, reason)` is already on the run is the
+ *   row that is already there. Counting survivors per user instead made the row COUNT a fixed point
+ *   while losing row CONTENT on a payload that names one user twice: measured here, a payload of
+ *   `[user 71 "first reason", user 71 "second reason"]` with the second ruled replayed to
+ *   `[{second, tp}, {second, null}]` on every subsequent replay — "first reason" permanently gone and
+ *   the board showing one account twice under identical text. No first-party producer emits two
+ *   findings per user per run, and the wire contract does not forbid it.
+ *
+ *   PASS 2, the same user, whatever the text. A ruled row is deliberately NOT refreshed from the
+ *   payload (see below), so a producer that rewrote its `reason` between the ruling and the replay
+ *   leaves a survivor whose text no longer matches anything. Content matching alone would insert the
+ *   payload's copy beside it and render that account twice — so a leftover payload finding consumes
+ *   any remaining survivor for its user rather than becoming a new row.
+ *
+ * Neither pass claims a uniqueness the database does not enforce; both are consuming matches over a
+ * multiset, so N survivors for a user absorb at most N payload findings.
  *
  * 🔴 A RULED ROW IS NOT REFRESHED FROM THE PAYLOAD, deliberately. The moderator ruled on the `reason`
  * and `confidence` that were on screen; overwriting them with a replay's copy would leave a verdict
@@ -336,15 +419,17 @@ async function replaceFindings(
   trx: AbuseTrx,
   runId: number,
   findings: AbuseReportInput['findings'],
-  withVerdictColumns: boolean
+  support: VerdictColumnSupport
 ): Promise<void> {
-  if (!withVerdictColumns) {
-    // Pre-DDL there is no `verdict` column to scope the delete by, and nothing to preserve either:
-    // no ruling can have been recorded on a deployment that cannot store one. The original
-    // clear-and-reinsert is exactly right there, and naming a column that does not exist is the
-    // error this whole branch exists to avoid.
+  if (!support.canPreserveVerdicts) {
+    // 🔴 GATED ON `verdict` ALONE, AND THAT IS LOAD-BEARING. Without that column there is no
+    // predicate to scope the delete BY — and, equally, nothing this branch can destroy: a ruling is
+    // stored in `verdict` and nowhere else, so a table without it has never held one. Neither clause
+    // survives widening the gate to the other three columns, which is what an all-four probe did:
+    // a table carrying rulings in a `verdict` that was right there took this delete because
+    // `group_key` had been dropped.
     await trx.deleteFrom('abuse_detection_finding').where('run_id', '=', runId).execute();
-    await insertFindings(trx, runId, findings, false);
+    await insertFindings(trx, runId, findings, support.canStoreGroupKey);
     return;
   }
 
@@ -356,22 +441,40 @@ async function replaceFindings(
 
   const survivors = await trx
     .selectFrom('abuse_detection_finding')
-    .select(['id', 'user_id'])
+    .select(['id', 'user_id', 'reason'])
     .where('run_id', '=', runId)
     .execute();
 
-  const survivorsPerUser = new Map<number, number>();
-  for (const s of survivors)
-    survivorsPerUser.set(s.user_id, (survivorsPerUser.get(s.user_id) ?? 0) + 1);
-
-  const fresh: AbuseReportInput['findings'] = [];
-  for (const f of findings) {
-    const remaining = survivorsPerUser.get(f.userId) ?? 0;
-    // Already on the run, carrying a ruling. Left exactly as it is.
-    if (remaining > 0) survivorsPerUser.set(f.userId, remaining - 1);
-    else fresh.push(f);
+  // The survivors' evidence text, per user, as a multiset both passes consume from.
+  const survivorReasons = new Map<number, string[]>();
+  for (const s of survivors) {
+    const forUser = survivorReasons.get(s.user_id);
+    if (forUser) forUser.push(s.reason);
+    else survivorReasons.set(s.user_id, [s.reason]);
   }
-  await insertFindings(trx, runId, fresh, true);
+
+  // PASS 1 — a payload finding whose exact `(user_id, reason)` is already on the run IS that row.
+  const covered = findings.map(() => false);
+  findings.forEach((f, i) => {
+    const forUser = survivorReasons.get(f.userId);
+    if (!forUser) return;
+    const at = forUser.indexOf(f.reason);
+    if (at === -1) return;
+    forUser.splice(at, 1);
+    covered[i] = true;
+  });
+
+  // PASS 2 — anything left over takes a remaining survivor for its user, whatever that row's text.
+  const fresh: AbuseReportInput['findings'] = [];
+  findings.forEach((f, i) => {
+    if (covered[i]) return;
+    const forUser = survivorReasons.get(f.userId);
+    // Already on the run, carrying a ruling. Left exactly as it is.
+    if (forUser && forUser.length > 0) forUser.shift();
+    else fresh.push(f);
+  });
+
+  await insertFindings(trx, runId, fresh, support.canStoreGroupKey);
 }
 
 /** The producer's rows, in the shape the live table can hold. */

--- a/apps/moderator/src/lib/server/abuse-detection.service.ts
+++ b/apps/moderator/src/lib/server/abuse-detection.service.ts
@@ -180,7 +180,9 @@ export function missingColumnFromError(e: unknown): string | null {
  * after rulings exist — rolling back the grouping half, or restoring a mid-rollout snapshot.
  *
  * `verdict_by` and `verdict_at` appear in neither capability because this write path never names
- * them; `recordAbuseVerdict` does, and it refuses rather than degrading.
+ * them. `recordAbuseVerdict` names both — and `group_key` as well, which IS a probed capability
+ * here; it does not probe for either, because a write must not degrade. Any column missing under it
+ * refuses the ruling, naming the column the server named.
  */
 type VerdictColumnSupport = {
   /** `verdict` exists, so the delete can be scoped to the rows no moderator has ruled on. */
@@ -239,7 +241,7 @@ export async function recordAbuseRun(input: AbuseReportInput): Promise<{ runId: 
     return { runId };
   } catch (e) {
     // 🔴 THE INGEST PATH DEGRADES RATHER THAN STOPPING, AND THIS IS NOW ONLY THE BACKSTOP.
-    // `verdictColumnsPresent` asks the catalogue before building the statements, so an ordinary
+    // `verdictColumnSupport` asks the catalogue before building the statements, so an ordinary
     // pre-DDL report never reaches here at all — no rolled-back transaction and no redo, which is
     // what every report from every detector used to pay for a feature two of the three do not use.
     // What is left for this branch is the race: the DDL applied, or reverted, between the probe and
@@ -423,11 +425,19 @@ async function replaceFindings(
 ): Promise<void> {
   if (!support.canPreserveVerdicts) {
     // 🔴 GATED ON `verdict` ALONE, AND THAT IS LOAD-BEARING. Without that column there is no
-    // predicate to scope the delete BY — and, equally, nothing this branch can destroy: a ruling is
-    // stored in `verdict` and nowhere else, so a table without it has never held one. Neither clause
-    // survives widening the gate to the other three columns, which is what an all-four probe did:
-    // a table carrying rulings in a `verdict` that was right there took this delete because
-    // `group_key` had been dropped.
+    // predicate to scope the delete BY — and no ruling left for this branch to destroy, because the
+    // column that carried one is already gone. Neither clause survives widening the gate to the
+    // other three columns, which is what an all-four probe did: a table carrying rulings in a
+    // `verdict` that was right there took this delete because `group_key` had been dropped.
+    //
+    // 🔴 THAT IS NOT "THE TABLE HAS NEVER HELD A RULING", which is what this comment used to claim,
+    // and the difference matters to whoever reads it after an incident. `ALTER TABLE
+    // abuse_detection_finding DROP COLUMN verdict` on a board moderators had already ruled on
+    // destroys those rulings outright — the table DID hold them, and the DROP is what took them,
+    // not this delete. Nor is `verdict` the only column a ruling writes: `verdict_by` and
+    // `verdict_at` can still be present in this state, and the rows carrying them go with
+    // everything else here. Neither of those has a justification in this branch; the gate rests on
+    // the first paragraph alone.
     await trx.deleteFrom('abuse_detection_finding').where('run_id', '=', runId).execute();
     await insertFindings(trx, runId, findings, support.canStoreGroupKey);
     return;
@@ -809,12 +819,27 @@ export async function recordAbuseVerdict(input: {
   } catch (e) {
     // 🔴 A WRITE MUST NOT DEGRADE. Accepting a ruling the database never stored, and rendering it as
     // recorded, is worse than refusing it — the moderator moves on believing the row is graded.
-    if (isUndefinedColumnError(e))
+    //
+    // 🔴 IT NAMES THE COLUMN THE SERVER NAMED, NOT "the verdict columns". This path reads
+    // `group_key` as well as writing the three verdict columns, and a board that has lost ONLY
+    // `group_key` still loads, still renders the buttons, and still shows every verdict already
+    // recorded — `getAbuseVerdictSummary` needs none of it. So the first click produced "has no
+    // verdict columns" on a page displaying verdicts, about three columns that were all right
+    // there: the same confident-wrong-column shape the ingest path was fixed for, on the branch
+    // next door. Same refinement as that fix and the same limit — the name is read out of an
+    // ENGLISH message, so a non-English `lc_messages` yields `null`, which falls back to naming no
+    // column rather than to guessing one. The remedy is unchanged either way: it is the same file.
+    if (isUndefinedColumnError(e)) {
+      const missing = missingColumnFromError(e);
       throw new Error(
-        'abuse_detection_finding has no verdict columns — apply ' +
-          'apps/moderator/abuse-detection/schema.sql to MODERATOR_DATABASE_URL as the application role',
+        (missing === null
+          ? 'abuse_detection_finding is missing a column this write needs'
+          : `abuse_detection_finding has no ${missing} column`) +
+          ' — apply apps/moderator/abuse-detection/schema.sql to MODERATOR_DATABASE_URL as the ' +
+          'application role',
         { cause: e }
       );
+    }
     // 🔴 THE SAME DISCRIMINATION THE TWO READ PATHS ALREADY MAKE. Both `+page.server.ts` loads
     // branch on 42501 and say "re-run schema.sql as the application role"; without this the write
     // answered the identical cause with "the database refused the write", which reads as an outage.

--- a/apps/moderator/src/routes/abuse/[runId]/+page.server.ts
+++ b/apps/moderator/src/routes/abuse/[runId]/+page.server.ts
@@ -88,10 +88,18 @@ export const actions: Actions = {
     if (!Number.isSafeInteger(findingId) || findingId <= 0)
       return fail(400, { error: 'Missing finding id.' });
 
-    // The moderator's own name where there is one, their id where there is not. Never a display
-    // string assembled here: this is an audit field, and it has to still identify someone after a
-    // rename.
-    const verdictBy = locals.user.username ?? String(locals.user.id);
+    // 🔴 THE ID, NOT THE USERNAME — and the comment that used to sit here claimed the opposite of
+    // what the code did. It said the audit field "has to still identify someone after a rename" and
+    // then stored `locals.user.username`, which is precisely the value a rename changes: the record
+    // would go on naming a handle that now belongs to nobody, or to somebody else. `id` is the one
+    // identifier this app cannot reassign.
+    //
+    // The cost is that the board renders an id rather than a name; the page labels it as one. That
+    // is the right trade for a field whose entire job is to say, months later, who stands behind a
+    // ruling — a name that resolves to the wrong person is worse than a number that resolves to the
+    // right one. Resolving the id back to a display name at render time is a further improvement and
+    // is not made here: it needs a user lookup this board does not currently do.
+    const verdictBy = String(locals.user.id);
 
     try {
       const { updated, groupKey } = await recordAbuseVerdict({

--- a/apps/moderator/src/routes/abuse/[runId]/+page.server.ts
+++ b/apps/moderator/src/routes/abuse/[runId]/+page.server.ts
@@ -1,19 +1,40 @@
-import { error } from '@sveltejs/kit';
-import type { PageServerLoad } from './$types';
-import { getAbuseFindings, getAbuseRun } from '$lib/server/abuse-detection.service';
+import { error, fail } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import {
+  getAbuseFindings,
+  getAbuseRun,
+  getAbuseVerdictSummary,
+  recordAbuseVerdict,
+} from '$lib/server/abuse-detection.service';
+import { isAbuseVerdict } from '$lib/abuse-verdicts';
 
-export const load: PageServerLoad = async ({ params }) => {
-  const runId = Number(params.runId);
+/** Shared by the load's 404 and the action's refusal, so the two cannot drift apart. */
+const parseRunId = (raw: string): number | null => {
+  const runId = Number(raw);
   // `Number.isSafeInteger`, not just `!isNaN`: `Number('1e999')` is `Infinity`, which is neither NaN
   // nor a valid bigint id, and `id` is `bigserial` so an absurd value still costs a query.
-  if (!Number.isSafeInteger(runId) || runId <= 0) throw error(404, 'No such run.');
+  return Number.isSafeInteger(runId) && runId > 0 ? runId : null;
+};
+
+export const load: PageServerLoad = async ({ params }) => {
+  const runId = parseRunId(params.runId);
+  if (runId === null) throw error(404, 'No such run.');
 
   try {
     // A dedicated single-run read. Filtering a bounded list in memory made any run outside that
     // window 404 as "No such run" — false, and reachable long before the limit looks close.
-    const [run, findings] = await Promise.all([getAbuseRun(runId), getAbuseFindings(runId)]);
+    //
+    // 🔴 `getAbuseVerdictSummary` answers `null` — it does NOT throw — on a deployment whose DDL has
+    // not been applied, which is what keeps this page loading read-only in that window. It is in the
+    // same `Promise.all` as the two reads the page cannot render without, so it must not be able to
+    // fail them; that is a property of the service function, not of this call site.
+    const [run, findings, verdicts] = await Promise.all([
+      getAbuseRun(runId),
+      getAbuseFindings(runId),
+      getAbuseVerdictSummary(runId),
+    ]);
     if (!run) throw error(404, 'No such run.');
-    return { run, findings: findings.findings, truncated: findings.truncated };
+    return { run, findings: findings.findings, truncated: findings.truncated, verdicts };
   } catch (e) {
     // A SvelteKit `error()` carries a numeric status; rethrow it rather than reporting a missing run
     // as a database outage. Anything else genuinely is one.
@@ -35,4 +56,67 @@ export const load: PageServerLoad = async ({ params }) => {
       throw error(503, 'MODERATOR_DATABASE_URL is not configured for this environment.');
     throw error(503, 'Could not reach the abuse-detection database.');
   }
+};
+
+/**
+ * The board's FIRST write, and the only one.
+ *
+ * 🔴 IT GRANTS NOTHING NEW. Whoever can open `/abuse` can rule; the page grant is enforced in
+ * `hooks.server.ts` before any handler runs, so there is no permission check to add here and adding
+ * one would be a second, drifting copy of the routing authority. Widening who reaches this board is
+ * a separate, deliberate decision and is NOT made by this change.
+ *
+ * 🔴 CSRF IS THE FRAMEWORK'S, DELIBERATELY. SvelteKit refuses a cross-origin form POST at the
+ * `csrf.checkOrigin` gate in `handle`, which is ON by default and which `svelte.config.js` does not
+ * disable — the same protection every other form action in this app relies on. A hand-rolled token
+ * here would be a second mechanism guarding one route while the other thirty rely on the first.
+ */
+export const actions: Actions = {
+  verdict: async ({ request, params, locals }) => {
+    const runId = parseRunId(params.runId);
+    if (runId === null) return fail(400, { error: 'No such run.' });
+
+    const form = await request.formData();
+    const findingId = Number(form.get('findingId'));
+    const verdict = form.get('verdict');
+
+    // 🔴 VALIDATED AGAINST THE SAME TUPLE THE TABLE'S CHECK CONSTRAINT USES. Left unchecked, a
+    // hand-posted value reaches the UPDATE and Postgres refuses it — a 500 on a moderator's click,
+    // for an input this route could have named precisely.
+    if (!isAbuseVerdict(verdict))
+      return fail(400, { error: 'A verdict must be one of tp, fp or skip.' });
+    if (!Number.isSafeInteger(findingId) || findingId <= 0)
+      return fail(400, { error: 'Missing finding id.' });
+
+    // The moderator's own name where there is one, their id where there is not. Never a display
+    // string assembled here: this is an audit field, and it has to still identify someone after a
+    // rename.
+    const verdictBy = locals.user.username ?? String(locals.user.id);
+
+    try {
+      const { updated, groupKey } = await recordAbuseVerdict({
+        runId,
+        findingId,
+        verdict,
+        verdictBy,
+      });
+      // Zero rows is not success. It means the finding is not on this run — a stale page, or a post
+      // aimed at another run — and reporting it as recorded would leave the moderator believing a
+      // row was graded that was not.
+      if (updated === 0)
+        return fail(404, { error: 'That finding is not part of this run — reload the page.' });
+      return { success: true, findingId, verdict, verdictBy, updated, groupKey };
+    } catch (e) {
+      console.error('[abuse-detection] verdict failed', e);
+      // Refused, never swallowed — see `recordAbuseVerdict`. The message names the file to run,
+      // because "the DDL is not applied here" is the overwhelmingly likely cause on a fresh deploy
+      // and is otherwise indistinguishable from an outage.
+      return fail(503, {
+        error:
+          e instanceof Error && e.message.includes('schema.sql')
+            ? e.message
+            : 'The verdict was NOT recorded — the database refused the write.',
+      });
+    }
+  },
 };

--- a/apps/moderator/src/routes/abuse/[runId]/+page.svelte
+++ b/apps/moderator/src/routes/abuse/[runId]/+page.svelte
@@ -203,8 +203,11 @@
                      🔴 WITHHELD ON A MIXED CLUSTER. This reads the LEAD's ruler, and on a cluster
                      whose members disagree that is one person's name printed beside a verdict the
                      others did not give — the board attributing a ruling nobody made. -->
+                <!-- Labelled, because the stored value is the moderator's ID and not their name:
+                     `+page.server.ts` stores the one identifier a rename cannot move. An unlabelled
+                     bare number beside a verdict reads as a count of something. -->
                 <div class="text-dark-2 text-xs">
-                  {ruledBy(d)}{#if ruledAt(d)} · {dateTime(ruledAt(d) as Date)}{/if}
+                  moderator #{ruledBy(d)}{#if ruledAt(d)} · {dateTime(ruledAt(d) as Date)}{/if}
                 </div>
               {/if}
             {/if}

--- a/apps/moderator/src/routes/abuse/[runId]/+page.svelte
+++ b/apps/moderator/src/routes/abuse/[runId]/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { enhance } from '$app/forms';
+  import { SvelteMap } from 'svelte/reactivity';
   import {
     Table,
     TableBody,
@@ -7,10 +9,15 @@
     TableHeader,
     TableRow,
   } from '@civitai/ui/components/ui/table/index.js';
+  import { optimisticEnhancer } from '$lib/form-action';
   import { dateTime, num, LINK_CLASS } from '$lib/format';
-  import type { PageData } from './$types';
+  import { ABUSE_VERDICTS, type AbuseVerdict } from '$lib/abuse-verdicts';
+  import { groupFindings, storedVerdict } from '$lib/abuse-decisions';
+  import type { ActionData, PageData } from './$types';
 
-  let { data }: { data: PageData } = $props();
+  let { data, form }: { data: PageData; form: ActionData } = $props();
+
+  type Finding = PageData['findings'][number];
 
   const counters = $derived(Object.entries(data.run.counters).sort(([a], [b]) => a.localeCompare(b)));
 
@@ -19,11 +26,60 @@
   // meaningless, and a bare decimal reads as the raw number it is.
   const confidence = (v: number) => v.toFixed(2);
 
-  // Sorted actioned-first so the rows with consequences lead, then by the producer's confidence. The
-  // service already returns confidence-desc; this is a stable second pass over the same array.
-  const rows = $derived(
-    [...data.findings].sort((a, b) => Number(b.actioned) - Number(a.actioned) || b.confidence - a.confidence)
-  );
+  const VERDICT_LABEL: Record<AbuseVerdict, string> = {
+    tp: 'Correct',
+    fp: 'False positive',
+    skip: 'Skip',
+  };
+  // Spelled out beside the buttons, because "TP" is jargon for the person who wrote the detector and
+  // nothing at all for the moderator being asked to rule.
+  const VERDICT_HINT: Record<AbuseVerdict, string> = {
+    tp: 'The detector was right about this account.',
+    fp: 'The detector was wrong — this account is fine.',
+    skip: 'Looked at it; not calling it either way.',
+  };
+  const VERDICT_CLASS: Record<AbuseVerdict, string> = {
+    tp: 'border-rose-500/40 text-rose-400 hover:bg-rose-500/10',
+    fp: 'border-teal-600/40 text-teal-400 hover:bg-teal-500/10',
+    skip: 'border-muted-foreground/40 text-muted-foreground hover:bg-muted/40',
+  };
+
+  /**
+   * 🔴 ONE DECISION PER CLUSTER, NOT PER ROW. A coordinated ring arrives as N findings the producer
+   * has already said are one actor; rendering N rows asks a moderator to make the same judgement N
+   * times and — because they will stop partway — leaves the run half-ruled with no way to tell a
+   * deliberate partial ruling from an abandoned one.
+   *
+   * The rule itself lives in `$lib/abuse-decisions.ts` and is tested there: this app has no
+   * component render harness, so a `$derived` written here would be logic nothing can assert.
+   */
+  type Decision = ReturnType<typeof groupFindings<Finding>>[number];
+
+  const decisions = $derived(groupFindings(data.findings));
+
+  const ruledBy = (d: Decision) => d.lead.verdictBy;
+  const ruledAt = (d: Decision) => d.lead.verdictAt;
+
+  // decision id → the verdict this session just submitted, shown until the reload lands.
+  const pending = new SvelteMap<string, AbuseVerdict>();
+  $effect(() => {
+    data.findings;
+    pending.clear();
+  });
+
+  const submit = (d: Decision, verdict: AbuseVerdict) =>
+    optimisticEnhancer(
+      () => {
+        pending.set(d.id, verdict);
+        return () => pending.delete(d.id);
+      },
+      // Re-runs the load on success, so the rendered verdict and the run's "still to review" count
+      // come from the database rather than from what this page hoped would happen.
+      { reload: true }
+    );
+
+  /** A few members, named. Not all of them: the point of collapsing is that the list is long. */
+  const EXAMPLES = 4;
 </script>
 
 <header class="page-header">
@@ -51,15 +107,39 @@
   </dl>
 {/if}
 
+{#if data.verdicts === null}
+  <!-- 🔴 READ-ONLY, AND IT SAYS SO. `null` is not "nothing ruled yet" — it is "this deployment
+       cannot record a ruling", because the verdict columns have never been applied here. The
+       controls are withheld rather than shown-and-broken: a button that always errors teaches a
+       moderator the board is broken, when the board is fine and a one-line DDL has not been run. -->
+  <p class="text-dark-2 mb-4">
+    Verdicts cannot be recorded here yet — <code>abuse_detection_finding</code> has no verdict
+    columns. They are applied by hand: run
+    <code>apps/moderator/abuse-detection/schema.sql</code> against
+    <code>MODERATOR_DATABASE_URL</code> as the application role. Everything below still reads.
+  </p>
+{:else}
+  <p class="mb-4">
+    <!-- The run's WHOLE population, not the page's. `getAbuseFindings` caps and reports it
+         separately; a count derived from the rendered rows would present that cap as a total. -->
+    {num(data.verdicts.unruled)} of {num(data.verdicts.ruled + data.verdicts.unruled)} findings still
+    to review.
+  </p>
+{/if}
+
+{#if form?.error}
+  <p class="mb-4 text-rose-400">{form.error}</p>
+{/if}
+
 {#if data.truncated}
   <!-- Never truncate silently: the list page shows this run's true total, so a quiet cap makes the
        two screens disagree about the same run and hides exactly the rows the sort pushed down. -->
   <p class="text-dark-2 mb-2">
-    Showing the first {num(rows.length)} of {num(data.run.findingCount)} findings.
+    Showing the first {num(data.findings.length)} of {num(data.run.findingCount)} findings.
   </p>
 {/if}
 
-{#if rows.length === 0}
+{#if decisions.length === 0}
   <!-- A run with no findings is a real, healthy result and must not read as a broken page. -->
   <p class="text-dark-2">This run reported no findings.</p>
 {:else}
@@ -73,10 +153,15 @@
         <TableHead>Confidence (reported)</TableHead>
         <TableHead>Acted (reported)</TableHead>
         <TableHead>Reason</TableHead>
+        <!-- 🔴 A SEPARATE COLUMN FROM "Acted", and the heading says whose opinion it is. The two are
+             independent: the common row is not-acted-on and ruled correct. -->
+        <TableHead>Your verdict</TableHead>
       </TableRow>
     </TableHeader>
     <TableBody>
-      {#each rows as f (f.id)}
+      {#each decisions as d (d.id)}
+        {@const stored = storedVerdict(d)}
+        {@const shown = pending.get(d.id) ?? stored}
         <TableRow>
           <TableCell>
             <!-- `?q=`, not `?userId=` — an unknown param is dropped, landing the moderator on an
@@ -85,13 +170,66 @@
                  lands on Basic. Following this link used to arrive at a page with ~20 panels and
                  nothing about abuse detection; mod-activity is where AbuseFindingsPanel renders, so
                  the finding a moderator clicked is on the page they land on. -->
-            <a class={LINK_CLASS} href="/retool/user-lookup/mod-activity?q={f.userId}">{f.userId}</a>
+            <a class={LINK_CLASS} href="/retool/user-lookup/mod-activity?q={d.lead.userId}"
+              >{d.lead.userId}</a
+            >
+            {#if d.members.length > 1}
+              <!-- The SIZE first, because it is what changes the decision: ruling one account and
+                   ruling eleven are different acts. The examples follow so the sentence is
+                   checkable rather than a number to be taken on trust. -->
+              <div class="text-dark-2 mt-1 text-xs">
+                {num(d.members.length)} accounts, ruled together —
+                {#each d.members.slice(1, EXAMPLES + 1) as m, i (m.id)}{i > 0 ? ', ' : ''}<a
+                    class={LINK_CLASS}
+                    href="/retool/user-lookup/mod-activity?q={m.userId}">{m.userId}</a
+                  >{/each}{#if d.members.length > EXAMPLES + 1}
+                  and {num(d.members.length - EXAMPLES - 1)} more{/if}
+              </div>
+            {/if}
           </TableCell>
-          <TableCell>{confidence(f.confidence)}</TableCell>
+          <TableCell>{confidence(d.lead.confidence)}</TableCell>
           <!-- "No" is the common and important case: detected, scored, deliberately left alone. It is
                spelled out rather than shown as a blank, which would read as missing data. -->
-          <TableCell>{f.actioned ? f.action : 'No'}</TableCell>
-          <TableCell class="max-w-2xl">{f.reason}</TableCell>
+          <TableCell>{d.lead.actioned ? d.lead.action : 'No'}</TableCell>
+          <TableCell class="max-w-2xl">{d.lead.reason}</TableCell>
+          <TableCell>
+            {#if shown !== null}
+              <div class="text-xs font-semibold">
+                {shown === 'mixed' ? 'Mixed — members ruled separately' : VERDICT_LABEL[shown]}
+              </div>
+              {#if ruledBy(d) && stored !== null && stored !== 'mixed'}
+                <!-- The CURRENT ruling and who stands behind it. A re-ruling overwrites both, so
+                     this never shows the person who was later corrected.
+                     🔴 WITHHELD ON A MIXED CLUSTER. This reads the LEAD's ruler, and on a cluster
+                     whose members disagree that is one person's name printed beside a verdict the
+                     others did not give — the board attributing a ruling nobody made. -->
+                <div class="text-dark-2 text-xs">
+                  {ruledBy(d)}{#if ruledAt(d)} · {dateTime(ruledAt(d) as Date)}{/if}
+                </div>
+              {/if}
+            {/if}
+            {#if data.verdicts !== null}
+              <div class="mt-1 flex flex-wrap gap-1.5">
+                {#each ABUSE_VERDICTS as v (v)}
+                  <form method="POST" action="?/verdict" use:enhance={submit(d, v)}>
+                    <!-- The LEAD's id. The server reads the group key off this row and rules every
+                         member sharing it IN THIS RUN — the run bound lives there, not here, because
+                         everything in this form is attacker-supplied. -->
+                    <input type="hidden" name="findingId" value={d.lead.id} />
+                    <input type="hidden" name="verdict" value={v} />
+                    <button
+                      type="submit"
+                      title={VERDICT_HINT[v]}
+                      aria-pressed={shown === v}
+                      class="rounded border px-2 py-1 text-xs font-semibold transition {VERDICT_CLASS[
+                        v
+                      ]} {shown === v ? 'bg-muted/60' : ''}">{VERDICT_LABEL[v]}</button
+                    >
+                  </form>
+                {/each}
+              </div>
+            {/if}
+          </TableCell>
         </TableRow>
       {/each}
     </TableBody>

--- a/apps/moderator/src/routes/abuse/__tests__/verdict-action.test.ts
+++ b/apps/moderator/src/routes/abuse/__tests__/verdict-action.test.ts
@@ -178,10 +178,12 @@ describe('the verdict action never reports an unrecorded ruling as recorded', ()
 
   it('surfaces the missing-DDL message verbatim rather than as a generic outage', async () => {
     // The overwhelmingly likely cause on a fresh deploy, and otherwise indistinguishable from a
-    // database being down. The message names the file to run.
+    // database being down. The message names the file to run. It also names the missing COLUMN now,
+    // which is why this fixture is spelled the way the service spells it: the route's own gate is
+    // `message.includes('schema.sql')`, so the varying half must not be what it keys on.
     recordAbuseVerdict.mockRejectedValue(
       new Error(
-        'abuse_detection_finding has no verdict columns — apply ' +
+        'abuse_detection_finding has no verdict column — apply ' +
           'apps/moderator/abuse-detection/schema.sql to MODERATOR_DATABASE_URL as the application role'
       )
     );

--- a/apps/moderator/src/routes/abuse/__tests__/verdict-action.test.ts
+++ b/apps/moderator/src/routes/abuse/__tests__/verdict-action.test.ts
@@ -79,7 +79,10 @@ describe('the verdict action records a ruling', () => {
       runId: 4,
       findingId: 91,
       verdict: 'tp',
-      verdictBy: 'mod-a',
+      // 🔴 THE ID, NOT `mod-a`. The default fixture user is `{ id: 77, username: 'mod-a' }`, so
+      // this assertion is what separates the two: an audit field storing a renameable handle
+      // would read `mod-a` here.
+      verdictBy: '77',
     });
     expect(out).toMatchObject({ success: true, findingId: 91, verdict: 'tp' });
   });
@@ -102,8 +105,19 @@ describe('the verdict action records a ruling', () => {
     expect(recordAbuseVerdict).toHaveBeenCalledWith(expect.objectContaining({ verdict: expected }));
   });
 
-  it('records the moderator’s id when they have no username', async () => {
-    // An audit field has to identify someone even when the display name is absent.
+  it('🔴 records the moderator’s ID, never their username — a username is renameable', async () => {
+    // The comment at this line used to say the audit field "has to still identify someone after a
+    // rename" while the code stored `locals.user.username`, which is exactly the value a rename
+    // moves: the record would go on naming a handle that now belongs to nobody, or to someone else.
+    //
+    // 🔴 THE FIXTURE'S TWO VALUES ARE DELIBERATELY DISTINGUISHABLE, and pairwise distinct from the
+    // other ids in this file. A user whose username happened to equal their id could not see this
+    // regression at all.
+    await post({ findingId: '91', verdict: 'fp' }, { user: { id: 77, username: 'renamed-later' } });
+    expect(recordAbuseVerdict).toHaveBeenCalledWith(expect.objectContaining({ verdictBy: '77' }));
+  });
+
+  it('still identifies the moderator when they have no username at all', async () => {
     await post({ findingId: '91', verdict: 'fp' }, { user: { id: 77 } });
     expect(recordAbuseVerdict).toHaveBeenCalledWith(expect.objectContaining({ verdictBy: '77' }));
   });
@@ -320,6 +334,13 @@ describe('the board executes nothing', () => {
       './moderator-db',
       '@civitai/moderation',
       '@sveltejs/kit',
+      // The query builder itself, for the raw `pg_attribute` capability probe in
+      // `recordAbuseRun` and for the two transaction types it is written against. A SQL compiler
+      // reaches no account surface: it has no client, no session and no knowledge of this app's
+      // services — the connection it runs on is still the one `./moderator-db` hands out, which is
+      // already in this ledger and is scoped to the moderator database. Added deliberately, which is
+      // what a ledger that fails on GROWTH is for.
+      'kysely',
       'zod',
     ]);
   });

--- a/apps/moderator/src/routes/abuse/__tests__/verdict-action.test.ts
+++ b/apps/moderator/src/routes/abuse/__tests__/verdict-action.test.ts
@@ -1,0 +1,343 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The run page's form action — the board's FIRST write.
+ *
+ * 🔴 The service's own behaviour (which rows move) is asserted against a real Postgres in
+ * `lib/server/__tests__/abuse-detection.verdict.test.ts`. This file asserts the OTHER half: what the
+ * route hands the service, and what it refuses before reaching it. They are different claims — a
+ * perfectly scoped service called with the wrong run id is still the wrong write.
+ */
+
+const { getAbuseRun, getAbuseFindings, getAbuseVerdictSummary, recordAbuseVerdict } = vi.hoisted(
+  () => ({
+    getAbuseRun: vi.fn(),
+    getAbuseFindings: vi.fn(),
+    getAbuseVerdictSummary: vi.fn(),
+    recordAbuseVerdict: vi.fn(),
+  })
+);
+
+vi.mock('$lib/server/abuse-detection.service', () => ({
+  getAbuseRun,
+  getAbuseFindings,
+  getAbuseVerdictSummary,
+  recordAbuseVerdict,
+}));
+// Required for the same reason `load-status.test.ts` documents: the route's import graph reaches
+// `$lib/server/db`, which demands a connection string at module scope that the config withholds.
+vi.mock('$lib/server/db', () => ({ dbRead: {}, dbWrite: {} }));
+
+const mod = await import('../[runId]/+page.server');
+const { load, actions } = mod;
+
+type ActionResult = { status?: number; data?: { error?: string }; success?: boolean } & Record<
+  string,
+  unknown
+>;
+
+/** The action, driven with a form body and a signed-in moderator. */
+const post = (
+  fields: Record<string, string>,
+  opts: { runId?: string; user?: { id: number; username?: string } } = {}
+): Promise<ActionResult> => {
+  const body = new URLSearchParams(fields);
+  return (
+    actions as unknown as Record<
+      string,
+      (e: {
+        request: Request;
+        params: { runId: string };
+        locals: { user: { id: number; username?: string } };
+      }) => Promise<ActionResult>
+    >
+  ).verdict({
+    request: new Request('https://moderator.example/abuse/4', { method: 'POST', body }),
+    params: { runId: opts.runId ?? '4' },
+    locals: { user: opts.user ?? { id: 77, username: 'mod-a' } },
+  });
+};
+
+beforeEach(() => {
+  for (const m of [getAbuseRun, getAbuseFindings, getAbuseVerdictSummary, recordAbuseVerdict])
+    m.mockReset();
+  recordAbuseVerdict.mockResolvedValue({ updated: 1, groupKey: null });
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('the verdict action records a ruling', () => {
+  it('passes the run from the URL, the finding and verdict from the form, and the moderator', async () => {
+    const out = await post({ findingId: '91', verdict: 'tp' }, { runId: '4' });
+
+    // 🔴 The run id comes from the ROUTE, never from the form — it is the authorisation boundary of
+    // the write, and a form field is attacker-supplied. An assertion on the whole argument object,
+    // so a fifth key appearing (or `runId` quietly sourced from the body) fails here.
+    expect(recordAbuseVerdict).toHaveBeenCalledWith({
+      runId: 4,
+      findingId: 91,
+      verdict: 'tp',
+      verdictBy: 'mod-a',
+    });
+    expect(out).toMatchObject({ success: true, findingId: 91, verdict: 'tp' });
+  });
+
+  it('🔴 IGNORES a runId smuggled into the form body', async () => {
+    // Red before this case existed, and the mutant is one line: preferring `form.get('runId')` to
+    // the route param left the whole suite green, because no test had ever POSTED a runId. The route
+    // param is the authorisation boundary — a moderator reached run 4 by being allowed to open its
+    // page; a body field is chosen by whoever submits it.
+    await post({ findingId: '91', verdict: 'tp', runId: '9' }, { runId: '4' });
+    expect(recordAbuseVerdict).toHaveBeenCalledWith(expect.objectContaining({ runId: 4 }));
+  });
+
+  it.each([
+    ['tp', 'tp'],
+    ['fp', 'fp'],
+    ['skip', 'skip'],
+  ])('accepts %s', async (input, expected) => {
+    await post({ findingId: '91', verdict: input });
+    expect(recordAbuseVerdict).toHaveBeenCalledWith(expect.objectContaining({ verdict: expected }));
+  });
+
+  it('records the moderator’s id when they have no username', async () => {
+    // An audit field has to identify someone even when the display name is absent.
+    await post({ findingId: '91', verdict: 'fp' }, { user: { id: 77 } });
+    expect(recordAbuseVerdict).toHaveBeenCalledWith(expect.objectContaining({ verdictBy: '77' }));
+  });
+
+  it('reports the group a ruling covered, so the page can say how many rows moved', async () => {
+    recordAbuseVerdict.mockResolvedValue({ updated: 11, groupKey: 'domain:ring.test' });
+    await expect(post({ findingId: '91', verdict: 'tp' })).resolves.toMatchObject({
+      success: true,
+      updated: 11,
+      groupKey: 'domain:ring.test',
+    });
+  });
+});
+
+describe('the verdict action refuses bad input BEFORE it reaches the database', () => {
+  it.each([
+    ['an invented verdict', 'maybe'],
+    ['a capitalised one', 'TP'],
+    ['one with a trailing space', 'fp '],
+    ['an empty verdict', ''],
+  ])('refuses %s with a 400 and never calls the service', async (_label, verdict) => {
+    // Unchecked, Postgres refuses it at the CHECK constraint and the moderator's click becomes a
+    // 500 — for an input this route could name precisely.
+    const out = await post({ findingId: '91', verdict });
+    expect(out.status).toBe(400);
+    expect(out.data?.error).toMatch(/tp, fp or skip/);
+    expect(recordAbuseVerdict).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a missing finding id', {}],
+    ['a non-numeric finding id', { findingId: 'abc' }],
+    ['a zero finding id', { findingId: '0' }],
+    ['a negative finding id', { findingId: '-3' }],
+    ['an id beyond a safe integer', { findingId: '1e999' }],
+  ])('refuses %s', async (_label, fields) => {
+    const out = await post({ verdict: 'tp', ...(fields as Record<string, string>) });
+    expect(out.status).toBe(400);
+    expect(recordAbuseVerdict).not.toHaveBeenCalled();
+  });
+
+  it('refuses a run id the route could never have served', async () => {
+    const out = await post({ findingId: '91', verdict: 'tp' }, { runId: 'nonsense' });
+    expect(out.status).toBe(400);
+    expect(recordAbuseVerdict).not.toHaveBeenCalled();
+  });
+});
+
+describe('the verdict action never reports an unrecorded ruling as recorded', () => {
+  it('turns zero rows into a 404 telling the moderator to reload', async () => {
+    // Zero rows means the finding is not on this run — a stale page, or a post aimed elsewhere.
+    // Reporting it as success leaves a moderator believing a row was graded that was not.
+    recordAbuseVerdict.mockResolvedValue({ updated: 0, groupKey: null });
+    const out = await post({ findingId: '91', verdict: 'tp' });
+    expect(out.status).toBe(404);
+    expect(out.data?.error).toMatch(/not part of this run/);
+  });
+
+  it('surfaces the missing-DDL message verbatim rather than as a generic outage', async () => {
+    // The overwhelmingly likely cause on a fresh deploy, and otherwise indistinguishable from a
+    // database being down. The message names the file to run.
+    recordAbuseVerdict.mockRejectedValue(
+      new Error(
+        'abuse_detection_finding has no verdict columns — apply ' +
+          'apps/moderator/abuse-detection/schema.sql to MODERATOR_DATABASE_URL as the application role'
+      )
+    );
+    const out = await post({ findingId: '91', verdict: 'tp' });
+    expect(out.status).toBe(503);
+    expect(out.data?.error).toMatch(/schema\.sql/);
+  });
+
+  it('reports any other database failure as a refusal, not a success', async () => {
+    recordAbuseVerdict.mockRejectedValue(Object.assign(new Error('boom'), { code: '57P01' }));
+    const out = await post({ findingId: '91', verdict: 'tp' });
+    expect(out.status).toBe(503);
+    expect(out.data?.error).toMatch(/NOT recorded/);
+  });
+});
+
+describe('the run page load carries the verdict state', () => {
+  const run = { id: 4, detector: 'bot-account-detection', findingCount: 2 };
+  const runLoad = (runId = '4') =>
+    (load as unknown as (e: { params: { runId: string } }) => Promise<Record<string, unknown>>)({
+      params: { runId },
+    });
+
+  beforeEach(() => {
+    getAbuseRun.mockResolvedValue(run);
+    getAbuseFindings.mockResolvedValue({ findings: [], truncated: false });
+  });
+
+  it('passes the ruled/unruled counts through', async () => {
+    getAbuseVerdictSummary.mockResolvedValue({ ruled: 3, unruled: 9 });
+    await expect(runLoad()).resolves.toMatchObject({ verdicts: { ruled: 3, unruled: 9 } });
+    expect(getAbuseVerdictSummary).toHaveBeenCalledWith(4);
+  });
+
+  it('🔴 passes NULL through — the page must be able to tell "cannot rule" from "nothing ruled"', async () => {
+    // Zero is "everything here has been ruled on". Null is "this deployment has no verdict columns".
+    // Collapsing them would render the controls on a board where every click 503s.
+    getAbuseVerdictSummary.mockResolvedValue(null);
+    await expect(runLoad()).resolves.toMatchObject({ verdicts: null });
+  });
+
+  it('still 404s a run that does not exist', async () => {
+    getAbuseRun.mockResolvedValue(null);
+    await expect(runLoad()).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+/**
+ * 🔴 SOURCE-LEVEL, AND DELIBERATELY SO. These pin properties no executed test in this app can see,
+ * because the pages are unrendered and the framework's own middleware is not in the call graph here.
+ */
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP = join(HERE, '../../..'); // src/
+const read = (p: string) => readFileSync(join(APP, p), 'utf8');
+const RUN_PAGE = 'routes/abuse/[runId]/+page.svelte';
+
+describe('the page is wired to the rule it is tested on', () => {
+  it('renders the grouping from `$lib/abuse-decisions`, not a second copy of it', () => {
+    // 🔴 THE SEAM. `abuse-decisions.test.ts` proves the rule; this proves the page uses THAT rule.
+    // A `$derived` re-implementing it in the component would leave both files green while the screen
+    // grouped findings some other way — and this app has no render harness to catch it.
+    const src = read(RUN_PAGE);
+    expect(src).toMatch(/from '\$lib\/abuse-decisions'/);
+    expect(src).toMatch(/groupFindings\(data\.findings\)/);
+    expect(src).toMatch(/storedVerdict\(/);
+  });
+
+  it('offers exactly the shared verdict tuple — not a hand-written list of buttons', () => {
+    const src = read(RUN_PAGE);
+    expect(src).toMatch(/from '\$lib\/abuse-verdicts'/);
+    expect(src).toMatch(/\{#each ABUSE_VERDICTS as/);
+  });
+
+  it('withholds the controls where a ruling cannot be stored', () => {
+    // A button that always errors teaches a moderator the board is broken, when the board is fine
+    // and a one-line DDL has not been run.
+    const src = read(RUN_PAGE);
+    expect(src).toMatch(/\{#if data\.verdicts !== null\}/);
+  });
+
+  it('posts to the action this file tests', () => {
+    expect(read(RUN_PAGE)).toMatch(/method="POST" action="\?\/verdict"/);
+  });
+});
+
+describe('CSRF is the framework’s, and stays on', () => {
+  it('svelte.config.js does not disable the origin check', () => {
+    // 🔴 SvelteKit refuses a cross-origin form POST at `csrf.checkOrigin`, which is ON by default —
+    // the same protection the other thirty form actions in this app rely on, and the reason this
+    // route hand-rolls no token of its own. Turning it off for any reason would silently open ALL of
+    // them, this one included, which is why the assertion is on the config rather than on this route.
+    const config = readFileSync(join(APP, '../svelte.config.js'), 'utf8');
+    expect(config).not.toMatch(/checkOrigin\s*:\s*false/);
+    expect(config).not.toMatch(/csrf\s*:\s*false/);
+  });
+});
+
+/**
+ * 🔴 NO EXECUTION PATH FROM A PRODUCER-SUPPLIED VALUE TO AN ACCOUNT ACTION.
+ *
+ * Everything the detectors send — `reason`, `action`, and now `group_key` — is text written by an
+ * automated agent and rendered to a moderator. It is an INPUT TO A HUMAN DECISION and nothing else:
+ * no value arriving on this board may reach a mute, a ban or a restriction. The board grants nothing,
+ * and adding a write to it (this change adds the first one) is exactly the moment that could stop
+ * being true by accident.
+ *
+ * An asserted LEDGER of the imports, not a search for a forbidden word: a word list is walkable by
+ * spelling the hazard differently, while a new spelling is still a new member of a set. Modelled on
+ * `<civitai>/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts`, which
+ * makes the same claim about the producer end of this pipe.
+ */
+describe('the board executes nothing', () => {
+  const SURFACES = [
+    'routes/abuse/+page.server.ts',
+    'routes/abuse/[runId]/+page.server.ts',
+    'lib/server/abuse-detection.service.ts',
+    'lib/abuse-decisions.ts',
+    'lib/abuse-verdicts.ts',
+  ];
+
+  const importsOf = (src: string) =>
+    [...src.matchAll(/(?<![.\w$])(?:from|import|require)\s*\(?\s*['"]([^'"\n]+)['"]/g)].map(
+      (m) => m[1]
+    );
+
+  it('reads the files it claims to — positive control', () => {
+    // Every assertion below is a claim about a set of files. If the read returned nothing, all of
+    // them are vacuously true and this block reports success while checking nothing.
+    for (const s of SURFACES) expect(read(s).length, `${s} is empty`).toBeGreaterThan(200);
+    // And the scanner can see an import at all, on a source that definitely has one.
+    expect(importsOf(read('lib/server/abuse-detection.service.ts')).length).toBeGreaterThan(0);
+  });
+
+  it('the scanner can see a planted account-action import — negative control', () => {
+    // Proves the ledger can go red before its silence is believed, using the exact text a real
+    // regression would carry.
+    const planted = `import { applyPendingReviewMute } from '$lib/server/user-restriction.service';`;
+    expect(importsOf(planted)).toEqual(['$lib/server/user-restriction.service']);
+  });
+
+  it('imports nothing that can act on an account', () => {
+    const all = new Set(SURFACES.flatMap((s) => importsOf(read(s))));
+    expect([...all].sort()).toEqual([
+      '$lib/abuse-verdicts',
+      '$lib/server/abuse-detection.service',
+      '$lib/server/query',
+      './$types',
+      './abuse-detection-tables',
+      './abuse-verdicts',
+      './moderator-db',
+      '@civitai/moderation',
+      '@sveltejs/kit',
+      'zod',
+    ]);
+  });
+
+  it('names no account-action surface, on any of those files', () => {
+    // Redundant with the ledger by construction, and kept because its failure message names the
+    // hazard rather than showing a set diff. It is a word list and is not what holds the property.
+    for (const s of SURFACES) {
+      const src = read(s);
+      for (const forbidden of [
+        'userRestriction',
+        'applyPendingReviewMute',
+        'bulkBan',
+        'banUser',
+        'muted',
+        'proposed_action',
+      ])
+        expect(src.includes(forbidden), `${s} names ${forbidden}`).toBe(false);
+    }
+  });
+});

--- a/packages/civitai-moderation/src/schema.ts
+++ b/packages/civitai-moderation/src/schema.ts
@@ -86,6 +86,20 @@ const abuseFinding = z
     // and a producer serialising a nullable field emits `null`. Refusing that would lose every run
     // from the commonest possible payload.
     action: z.string().min(1).max(64).nullish(),
+    // 🔴 OPTIONAL, AND IT HAS TO STAY THAT WAY. Three detectors already post to this board and none
+    // of them sends this field; a required key here would 400 every one of their reports and take
+    // the whole surface down to add a feature none of them uses.
+    //
+    // What it is: the producer's own claim that several findings in THIS report are one actor, so a
+    // moderator rules them once instead of N times. An opaque key — the reader groups on equality
+    // and never parses it — scoped to the run by the reader, because the same key in two runs is two
+    // separate decisions over two different cohorts.
+    //
+    // 🔴 A PRODUCER MUST NOT PUT ANYTHING IN HERE THAT THE FINDING'S OWN `reason` DOES NOT ALREADY
+    // SAY. The key is rendered on a board with a wider audience than the investigative tools, so it
+    // is a disclosure surface, not just an identifier. `.nullish()` for the same reason `action` has
+    // it: a serialiser emitting `null` for an absent optional must not lose the report.
+    groupKey: z.string().min(1).max(200).nullish(),
   })
   .superRefine((f, ctx) => {
     // 🔴 `!= null`, NOT `!== undefined`. Loose equality is deliberate: it treats `null` and

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1212,6 +1212,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.4.6
+        version: 0.4.6
       '@sveltejs/adapter-node':
         specifier: ^5.3.2
         version: 5.5.4(@sveltejs/kit@2.66.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3(@typescript-eslint/types@8.60.1))(vite@6.4.3(@types/node@20.19.9)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(sugarss@5.0.1(postcss@8.5.23))(terser@5.51.2)(tsx@4.20.3)(yaml@2.8.1)))(svelte@5.56.3(@typescript-eslint/types@8.60.1))(typescript@5.9.2)(vite@6.4.3(@types/node@20.19.9)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(sugarss@5.0.1(postcss@8.5.23))(terser@5.51.2)(tsx@4.20.3)(yaml@2.8.1)))

--- a/src/server/services/bot-account-detection/__tests__/heuristics.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/heuristics.test.ts
@@ -8,9 +8,11 @@ import {
   DOMAIN_ZERO_AT,
   IP_ONE_AT,
   IP_ZERO_AT,
+  domainClusterIsNamedInReason,
   domainClusterSize,
   isCommonEmailDomain,
   largestIpCluster,
+  registrationClusterGroupKey,
   registrationClusterHeuristic,
 } from '../heuristics/clustering';
 import { rampScore } from '../heuristics/ramp';
@@ -561,5 +563,113 @@ describe('the three heuristics together', () => {
       ['content-templating', 1],
     ]);
     expect(result.confidence).toBeCloseTo(2 / 3, 12);
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// The cluster key the board rules on
+// ---------------------------------------------------------------------------------------------
+
+describe('registrationClusterGroupKey', () => {
+  const key = (m: BotAccountCohortMember, s: CohortSignals) => registrationClusterGroupKey(m, s);
+  const explain = (m: BotAccountCohortMember, s: CohortSignals) =>
+    registrationClusterHeuristic.explain?.(
+      evidence(m, s),
+      registrationClusterHeuristic.score(evidence(m, s))
+    ) ?? null;
+
+  it('names the shared domain once the cluster is big enough to be reported', () => {
+    // LITERAL size, so this is a statement about behaviour at four rather than about whatever
+    // `DOMAIN_ZERO_AT` happens to say — the constant is pinned separately above.
+    const s = signalsWith({ membersPerDomain: { 'ring.test': 4 } });
+    expect(key(member({ emailDomain: 'ring.test' }), s)).toBe('domain:ring.test');
+  });
+
+  it('returns nothing AT the boundary — a cluster of three is not reported, so it is not a key', () => {
+    // 🔴 THE OFF-BY-ONE. `DOMAIN_ZERO_AT` is the largest cluster still worth nothing, so three is
+    // silent and four speaks. A `>` → `>=` mutant groups every three-account coincidence into one
+    // ruling, and publishes a domain the reason never mentions.
+    const s = signalsWith({ membersPerDomain: { 'ring.test': 3 } });
+    expect(key(member({ emailDomain: 'ring.test' }), s)).toBeNull();
+  });
+
+  it.each([
+    ['an account whose domain nobody else shares', { 'ring.test': 1 }],
+    ['a domain absent from the index entirely', {}],
+  ])('returns nothing for %s', (_label, membersPerDomain) => {
+    expect(key(member({ emailDomain: 'ring.test' }), signalsWith({ membersPerDomain }))).toBeNull();
+  });
+
+  it('returns nothing for an account with no email domain at all', () => {
+    expect(key(member({ emailDomain: null }), signalsWith({ membersPerDomain: {} }))).toBeNull();
+  });
+
+  it('🔴 returns nothing for a COMMON provider, however large the cluster', () => {
+    // `gmail.com` is the largest cluster in every cohort, every day. Keying on it would collapse the
+    // day's most ordinary accounts into ONE ruling — a single click recording a verdict about
+    // hundreds of unrelated people.
+    const s = signalsWith({ membersPerDomain: { 'gmail.com': 250 } });
+    expect(key(member({ emailDomain: 'gmail.com' }), s)).toBeNull();
+  });
+
+  it('is IDENTICAL for every member of one cluster, and different across clusters', () => {
+    // Stability within a run is what makes one ruling cover the ring: two members deriving two
+    // strings would be two decisions wearing one name.
+    const s = signalsWith({ membersPerDomain: { 'ring.test': 9, 'other.test': 9 } });
+    const a = key(member({ userId: 1, emailDomain: 'ring.test' }), s);
+    const b = key(member({ userId: 2, emailDomain: 'ring.test' }), s);
+    const c = key(member({ userId: 3, emailDomain: 'other.test' }), s);
+    expect(a).toBe('domain:ring.test');
+    expect(b).toBe(a);
+    expect(c).not.toBe(a);
+  });
+
+  it('🔴 NEVER carries a domain the reason text does not already name — swept, both directions', () => {
+    // THE DISCLOSURE RULE. The board has a wider audience than the investigative tools, and a key is
+    // rendered. A key naming a domain the finding's own reason never mentions would be a disclosure
+    // the finding does not otherwise make — so the two must move together at EVERY size, not just at
+    // the one a single case happens to pick.
+    for (const size of [0, 1, 2, 3, 4, 5, 9, 15, 40]) {
+      const s = signalsWith({ membersPerDomain: { 'ring.test': size } });
+      const m = member({ emailDomain: 'ring.test' });
+      const named = (explain(m, s) ?? '').includes('ring.test');
+      expect(key(m, s) === null, `size ${size}: key present but domain unnamed in the reason`).toBe(
+        !named
+      );
+    }
+  });
+
+  it('the sweep above is not vacuous — the reason DOES name the domain at a reportable size', () => {
+    // 🔴 POSITIVE CONTROL. An `explain` that returned null at every size would satisfy the iff above
+    // by making both halves false forever, and it would read as coverage.
+    const s = signalsWith({ membersPerDomain: { 'ring.test': 9 } });
+    const m = member({ emailDomain: 'ring.test' });
+    expect(explain(m, s)).toContain('ring.test');
+    expect(key(m, s)).toBe('domain:ring.test');
+  });
+
+  it('🔴 never carries a registration IP, which the reason deliberately withholds', () => {
+    // The IP is the STRONGER signal and is left out of the reason on purpose — `explain` says so and
+    // points a moderator at the tool built for that lookup. Keying on it would publish, on the
+    // board, the one fact this heuristic goes out of its way not to publish.
+    const s = signalsWith({
+      ips: { 42: ['203.0.113.9'] },
+      membersPerIp: { '203.0.113.9': 40 },
+      membersPerDomain: {},
+      sources: { registrationIps: true },
+    });
+    const m = member({ emailDomain: null });
+    expect(registrationClusterHeuristic.score(evidence(m, s))).toBeGreaterThan(0);
+    expect(key(m, s)).toBeNull();
+  });
+});
+
+describe('domainClusterIsNamedInReason', () => {
+  it('is the one predicate both the reason clause and the key read', () => {
+    // Literal boundary, pinned here so a mutation to it fails with its own name attached rather than
+    // only as a knock-on somewhere else.
+    expect(domainClusterIsNamedInReason(3)).toBe(false);
+    expect(domainClusterIsNamedInReason(4)).toBe(true);
+    expect(domainClusterIsNamedInReason(0)).toBe(false);
   });
 });

--- a/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
@@ -788,6 +788,12 @@ describe('the detector has no write surface', () => {
       // with, shared rather than copied; a second hand-written copy is how two readers of one table
       // silently stop agreeing about what an address means.
       '@civitai/shared/clickhouse-ip-filters',
+      // Node's `crypto`, for `boundGroupKey`'s digest in `report.ts` — a cluster key over the wire
+      // contract's 200-character cap is hashed rather than truncated, because truncating an IDENTITY
+      // merges two unrelated clusters into one ruling. `createHash` is the only binding taken, it
+      // reaches no data system, and it cannot act on an account. The header's "which BINDING" caveat
+      // is why that is spelled out here rather than left to the specifier.
+      'crypto',
       '~/server/clickhouse/client',
       '~/server/db/client',
       '~/server/logging/client',

--- a/src/server/services/bot-account-detection/__tests__/report.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/report.test.ts
@@ -340,3 +340,57 @@ describe('buildReports', () => {
     expect(() => abuseReportInput.parse(reports[0])).not.toThrow();
   });
 });
+
+describe('buildFinding — the cluster key', () => {
+  it('carries the key it was given', () => {
+    const finding = buildFinding(member(), score(), STARTED, 'domain:ring.test');
+    expect(finding.groupKey).toBe('domain:ring.test');
+  });
+
+  it('OMITS the key entirely when there is no cluster', () => {
+    // Absent, not null — the same choice `action` makes above. An ungrouped finding must not be
+    // representable as "in a cluster called nothing", and the three detectors that never group are
+    // meant to look exactly like this.
+    const finding = buildFinding(member(), score(), STARTED);
+    expect(finding).not.toHaveProperty('groupKey');
+  });
+
+  it('omits it for an explicit null too', () => {
+    expect(buildFinding(member(), score(), STARTED, null)).not.toHaveProperty('groupKey');
+  });
+
+  it('🔴 defaults to ungrouped, so an existing caller is unchanged by the new parameter', () => {
+    // Two other detectors post to this board through the same contract. A required fourth argument —
+    // or a default of anything but "no cluster" — would silently group their findings.
+    const before = buildFinding(member(), score(), STARTED);
+    const explicit = buildFinding(member(), score(), STARTED, null);
+    expect(before).toEqual(explicit);
+  });
+
+  it('produces a payload the real wire contract accepts, key and all', () => {
+    const report = buildReports({
+      findings: [buildFinding(member(), score(), STARTED, 'domain:ring.test')],
+      startedAt: STARTED,
+      finishedAt: FINISHED,
+      counters: {},
+      summary: 'Scanned things.',
+    })[0];
+    // 🔴 READ OFF THE PARSED PAYLOAD, NOT THE BUILT ONE. Asserting the key on the object this file
+    // constructed proves only that this file constructed it; the contract is what the receiving app
+    // actually gets, and a zod object STRIPS a key it does not declare. Deleting `groupKey` from
+    // `packages/civitai-moderation/src/schema.ts` left the whole detector suite green while the
+    // board received nothing — the key was dropped in transit, silently.
+    const parsed = abuseReportInput.parse(report);
+    expect(parsed.findings[0].groupKey).toBe('domain:ring.test');
+  });
+
+  it('changes nothing else about the finding', () => {
+    // A key must not perturb the fields a moderator reads, and above all not `actioned`.
+    const grouped = buildFinding(member(), score(), STARTED, 'domain:ring.test');
+    const lone = buildFinding(member(), score(), STARTED);
+    expect(grouped.actioned).toBe(false);
+    expect(grouped.reason).toBe(lone.reason);
+    expect(grouped.confidence).toBe(lone.confidence);
+    expect(grouped.userId).toBe(lone.userId);
+  });
+});

--- a/src/server/services/bot-account-detection/__tests__/report.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/report.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import type { BotAccountCohortMember, PostCounts, SurfaceCounts } from '../cohort';
 import {
   BOT_ACCOUNT_DETECTOR,
+  HASHED_GROUP_KEY_PREFIX,
+  boundGroupKey,
   buildFinding,
   buildReports,
   chunkFindings,
@@ -392,5 +394,114 @@ describe('buildFinding — the cluster key', () => {
     expect(grouped.reason).toBe(lone.reason);
     expect(grouped.confidence).toBe(lone.confidence);
     expect(grouped.userId).toBe(lone.userId);
+  });
+});
+
+/**
+ * 🔴 AN UNBOUNDED CLUSTER KEY CAN ABORT A WHOLE DETECTOR RUN.
+ *
+ * `groupKey` is capped at 200 characters by the wire contract, and `normalizeEmailDomain` caps the
+ * domain at nothing — so `domain:${domain}` is producer-supplied and unbounded. Over the cap it does
+ * not lose the one finding: `abuseReportInput.safeParse` fails `too_big`, `run.ts` validates BEFORE
+ * the network call, and the throw aborts the run — losing that batch and every batch after it.
+ * Exactly the failure `truncateReason` exists to prevent for the OTHER producer-supplied string on
+ * this contract, in a second one that shipped without the same treatment.
+ *
+ * 🔴 AND IT IS HASHED, NOT TRUNCATED, because a key is an IDENTITY rather than prose. Two distinct
+ * domains sharing a long prefix would truncate to ONE key and merge two unrelated clusters into a
+ * single ruling — a moderator would rule a ring they never looked at, with one click.
+ */
+describe('boundGroupKey — the cluster key stays inside the wire contract', () => {
+  /** The measured boundary: 193 characters parse, 194 do not, once `domain:` is prepended. */
+  const CONTRACT_CAP = 200;
+  const longDomain = (n: number) => `${'a'.repeat(n - 4)}.com`;
+
+  const parses = (groupKey: string) =>
+    abuseReportInput.safeParse({
+      detector: 'bot-account-detection',
+      startedAt: '2026-09-03T03:20:00.000Z',
+      finishedAt: '2026-09-03T03:20:41.000Z',
+      findings: [{ userId: 1, confidence: 0.5, reason: 'r', actioned: false, groupKey }],
+    }).success;
+
+  it('negative control — the RAW key is what the contract refuses', () => {
+    // The hazard, demonstrated on the unbounded value, so the guard below is not asserted against a
+    // cap that was never reachable. 240 + `domain:` = 247 characters.
+    const raw = `domain:${longDomain(240)}`;
+    expect(raw).toHaveLength(247);
+    expect(parses(raw)).toBe(false);
+    // …and one character under the cap still parses, so the refusal is the LENGTH and not the shape.
+    expect(parses(`domain:${'b'.repeat(CONTRACT_CAP - 7)}`)).toBe(true);
+  });
+
+  it('leaves an ordinary key exactly as it was', () => {
+    // The overwhelmingly common case must not be perturbed: the key is rendered on the board, and a
+    // hash where a domain could have been shown is a worse row for no reason.
+    expect(boundGroupKey('domain:ring.test')).toBe('domain:ring.test');
+    expect(boundGroupKey('domain:' + 'b'.repeat(CONTRACT_CAP - 7))).toHaveLength(CONTRACT_CAP);
+  });
+
+  it('brings an over-long key inside the cap, and the contract then accepts it', () => {
+    const bounded = boundGroupKey(`domain:${longDomain(240)}`);
+    expect(bounded.length).toBeLessThanOrEqual(CONTRACT_CAP);
+    expect(bounded.startsWith(HASHED_GROUP_KEY_PREFIX)).toBe(true);
+    expect(parses(bounded)).toBe(true);
+  });
+
+  it('🔴 two members of ONE cluster still share a key — grouping survives the bound', () => {
+    // The property the whole feature rests on. A key that differed per member would give a ring of
+    // forty findings forty separate decisions, which is the state this feature exists to remove.
+    const domain = longDomain(240);
+    expect(boundGroupKey(`domain:${domain}`)).toBe(boundGroupKey(`domain:${domain}`));
+  });
+
+  it('🔴 two DIFFERENT clusters do not collide — which truncation would not give', () => {
+    // Same 193-character prefix, different domains. `slice(0, 199)` returns the identical string for
+    // both; the digest does not. This is the case that makes hashing the right instrument.
+    const shared = 'a'.repeat(193);
+    const a = `domain:${shared}alpha.com`;
+    const b = `domain:${shared}beta.com`;
+    expect(a.slice(0, 199)).toBe(b.slice(0, 199));
+    expect(boundGroupKey(a)).not.toBe(boundGroupKey(b));
+    // Both still inside the cap, so "they differ" is not achieved by leaving one unbounded.
+    for (const k of [boundGroupKey(a), boundGroupKey(b)])
+      expect(k.length).toBeLessThanOrEqual(CONTRACT_CAP);
+  });
+
+  it('a hashed key cannot be confused with a domain key', () => {
+    // Its own prefix, so the two namespaces cannot overlap however the digest comes out.
+    expect(boundGroupKey(`domain:${longDomain(240)}`).startsWith('domain:')).toBe(false);
+  });
+});
+
+describe('buildFinding bounds the key it is handed', () => {
+  it('🔴 a 240-character domain no longer refuses the whole report', () => {
+    // The end-to-end regression: the run builds a finding for a real cluster, and the report it goes
+    // into must be one the receiving contract accepts. Before the bound, `parse` threw here and
+    // `run.ts` — which validates before the network call — aborted the run and every batch after it.
+    const key = `domain:${'a'.repeat(236)}.com`;
+    expect(key).toHaveLength(247);
+    const report = buildReports({
+      findings: [buildFinding(member(), score(), STARTED, key)],
+      startedAt: STARTED,
+      finishedAt: FINISHED,
+      counters: {},
+      summary: 'Scanned things.',
+    })[0];
+
+    // 🔴 Read off the PARSED payload, for the reason the sibling case above documents: a zod object
+    // strips what it does not declare, so asserting on the built object proves only what this file
+    // constructed.
+    const parsed = abuseReportInput.parse(report);
+    expect(parsed.findings[0].groupKey).toBe(boundGroupKey(key));
+    expect((parsed.findings[0].groupKey as string).length).toBeLessThanOrEqual(200);
+  });
+
+  it('every member of one over-long cluster is emitted with the SAME key', () => {
+    const key = `domain:${'a'.repeat(236)}.com`;
+    const one = buildFinding(member({ userId: 1 }), score(), STARTED, key);
+    const two = buildFinding(member({ userId: 2 }), score(), STARTED, key);
+    expect(one.groupKey).toBe(two.groupKey);
+    expect(one.groupKey).not.toBe(key);
   });
 });

--- a/src/server/services/bot-account-detection/__tests__/report.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/report.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { MAX_FINDINGS_PER_REPORT, abuseReportInput } from '@civitai/moderation';
 import { describe, expect, it } from 'vitest';
 import type { BotAccountCohortMember, PostCounts, SurfaceCounts } from '../cohort';
@@ -12,6 +15,9 @@ import {
   truncateReason,
 } from '../report';
 import type { BotAccountScore } from '../scoring';
+
+/** This directory, so the doc-claim guard below can read the module it is asserting about. */
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 const at = (iso: string) => new Date(iso);
 const STARTED = at('2026-09-03T03:20:00.000Z');
@@ -471,6 +477,32 @@ describe('boundGroupKey — the cluster key stays inside the wire contract', () 
   it('a hashed key cannot be confused with a domain key', () => {
     // Its own prefix, so the two namespaces cannot overlap however the digest comes out.
     expect(boundGroupKey(`domain:${longDomain(240)}`).startsWith('domain:')).toBe(false);
+  });
+
+  it('🔴 the figure `report.ts` reports as MEASURED is the one this file measures', () => {
+    // The comment on `boundGroupKey` said a 240-character domain yields a **251**-character key. The
+    // prefix is 7 characters, so it is 247 — which is what the negative control above asserts, and
+    // the two sibling figures in the same sentence (193 / 194) are right, which is exactly what made
+    // the wrong one read as measured. A number a reader is told was measured has to have been.
+    //
+    // 🔴 THE WHOLE SENTENCE IS PINNED, not the digits. A guard on "247" alone is walkable by a
+    // reword that moves the claim somewhere else; this fails on any edit to it, which is the price
+    // of a machine-checkable claim about prose.
+    // Block-comment continuation markers stripped before collapsing whitespace, or a sentence that
+    // wraps across lines carries a `*` into the middle of itself and no assertion can match it.
+    const source = readFileSync(join(HERE, '../report.ts'), 'utf8')
+      .split('\n')
+      .map((line) => line.replace(/^\s*\*\s?/, ''))
+      .join(' ')
+      .replace(/\s+/g, ' ');
+    // Derived here, from the contract's own prefix and the case the sentence describes — never read
+    // back out of the source it is checking.
+    const measured = `domain:${longDomain(240)}`.length;
+    expect(measured).toBe(247);
+    expect(source).toContain(
+      `Measured: a 240-char email domain yields a ${measured}-character key and the whole report ` +
+        'is refused (boundary: 193 characters parses, 194 fails).'
+    );
   });
 });
 

--- a/src/server/services/bot-account-detection/__tests__/run.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/run.test.ts
@@ -1244,4 +1244,53 @@ describe('🔴 the cluster key reaches the board', () => {
     for (const report of scenario.reports)
       expect(() => abuseReportInput.parse(report)).not.toThrow();
   });
+
+  /**
+   * 🔴 A PATHOLOGICAL DOMAIN MUST NOT BE ABLE TO STOP THE DETECTOR.
+   *
+   * `normalizeEmailDomain` bounds the domain at nothing, so `domain:${domain}` was producer-supplied
+   * and unbounded against a contract that caps `groupKey` at 200 characters. Over the cap the report
+   * is REFUSED — and because this run validates before the network call, the throw takes the run
+   * down, losing that batch and every batch after it. Four accounts on one uncommon domain is all
+   * that is needed, and a wildcard-MX subdomain chain under an attacker-owned apex fits inside DNS's
+   * own 253-character limit: a denial-of-detection lever, not an edge case.
+   */
+  const ABSURD_DOMAIN = `${'a'.repeat(236)}.test`;
+
+  it('🔴 a ring on an absurdly long domain still produces a report the contract accepts', async () => {
+    expect(ABSURD_DOMAIN).toHaveLength(241);
+    const scenario = domainRun(ringAccounts(ABSURD_DOMAIN));
+    await scenario.result;
+
+    expect(scenario.reports).toHaveLength(1);
+    for (const report of scenario.reports)
+      expect(() => abuseReportInput.parse(report)).not.toThrow();
+  });
+
+  it('and every member of THAT ring still shares one key', async () => {
+    // Bounding is only useful if it keeps the grouping: a per-member key would give a forty-account
+    // ring forty separate decisions, which is the state this feature exists to remove.
+    const scenario = domainRun(ringAccounts(ABSURD_DOMAIN));
+    await scenario.result;
+
+    const keys = scenario.reports[0].findings.map((f) => f.groupKey);
+    expect(keys).toHaveLength(6);
+    expect(new Set(keys).size, 'the ring must still be ONE cluster').toBe(1);
+    // Inside the contract's cap, and not the raw key.
+    expect((keys[0] as string).length).toBeLessThanOrEqual(200);
+    expect(keys[0]).not.toBe(`domain:${ABSURD_DOMAIN}`);
+  });
+
+  it('a SECOND absurd domain gets a different key — the clusters do not merge', async () => {
+    // Truncation would give both the same 200-character string, and a moderator ruling one ring
+    // would rule the other. Two domains sharing a long prefix, which is the shape a subdomain chain
+    // under one apex actually has.
+    const other = `${'a'.repeat(230)}zzzzzz.test`;
+    expect(other).toHaveLength(241);
+    const a = domainRun(ringAccounts(ABSURD_DOMAIN));
+    await a.result;
+    const b = domainRun(ringAccounts(other));
+    await b.result;
+    expect(a.reports[0].findings[0].groupKey).not.toBe(b.reports[0].findings[0].groupKey);
+  });
 });

--- a/src/server/services/bot-account-detection/__tests__/run.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/run.test.ts
@@ -1153,3 +1153,95 @@ describe('the shadow-mode invariant: nothing is muted, banned or restricted', ()
     expect(payload).not.toContain('"action"');
   });
 });
+
+describe('🔴 the cluster key reaches the board', () => {
+  /**
+   * Six accounts registered on ONE uncommon email domain, run end to end through the PRODUCTION
+   * heuristic registry.
+   *
+   * Six, not four: `DOMAIN_ZERO_AT` is 3, so six overshoots the boundary rather than sitting on it —
+   * a fixture landing exactly ON a boundary cannot see a mutant that shifts it by one.
+   */
+  const RING_DOMAIN = 'ring-provider.test';
+  const ringAccounts = (domain: string, n = 6) =>
+    Array.from({ length: n }, (_, i) => ({ ...account(i + 1), email: `u${i + 1}@${domain}` }));
+
+  /**
+   * 🔴 AN EVIDENCE READER IS REQUIRED EVEN THOUGH IT RETURNS NOTHING, and finding that out is itself
+   * the point: `membersPerDomain` is built by `collectCohortSignals`, which `run.ts` only calls when
+   * `deps.evidence` is present. Without one the domain index is EMPTY, so a real six-account ring
+   * scores 0 and carries no key — the same reason the sibling block above needs a control arm. This
+   * reader answers both remote sources with nothing, so the IP and content halves stay at 0 and
+   * anything the findings carry came from the domain half alone.
+   */
+  const domainOnlyEvidence = {
+    hasRegistrationIps: false,
+    listRegistrationIps: async () => [],
+    listContentSamples: async () => [],
+  };
+
+  const domainRun = (accounts: NewAccountRow[]) => {
+    const { reader } = recordingReader(accounts);
+    const out = sink();
+    return {
+      ...out,
+      result: runBotAccountDetection(
+        { reader, evidence: domainOnlyEvidence, sendReport: out.sendReport, now: clock() },
+        { pageSize: 10, maxAccounts: 10, minConfidence: 0 }
+      ),
+    };
+  };
+
+  it('every member of the ring is emitted with the SAME key', async () => {
+    // 🔴 THE SEAM `run.ts` OWNS, and the mutant it exists for: handing `buildFinding` an empty
+    // signals index, or forgetting the argument entirely, leaves every finding ungrouped while
+    // `heuristics.test.ts` and `report.test.ts` both stay green — each covers one side and neither
+    // ever builds the combined state. Every ring on the board would then be ruled one account at a
+    // time, with nothing anywhere reporting a fault.
+    const scenario = domainRun(ringAccounts(RING_DOMAIN));
+    await scenario.result;
+
+    const findings = scenario.reports[0].findings;
+    expect(findings).toHaveLength(6);
+    // The LITERAL key, not a re-derivation: an assertion computed from the code under test cannot
+    // see the prefix change or the wrong attribute being used.
+    expect(findings.map((f) => f.groupKey)).toEqual(Array(6).fill('domain:ring-provider.test'));
+  });
+
+  it('🔴 the key names only what the reason already says — checked on the emitted finding', () => {
+    // The disclosure rule, asserted where it matters: on the payload that reaches the board.
+    const scenario = domainRun(ringAccounts(RING_DOMAIN));
+    return scenario.result.then(() => {
+      for (const f of scenario.reports[0].findings) {
+        expect(f.groupKey).toBe('domain:ring-provider.test');
+        expect(f.reason).toContain(RING_DOMAIN);
+      }
+    });
+  });
+
+  it('a cohort with DISTINCT domains is emitted ungrouped — the control', async () => {
+    // Without this the case above attributes nothing: findings carrying a key prove the wiring only
+    // if findings carry none when there is no ring, and "always sets a key" is a real mutant.
+    const scenario = domainRun(Array.from({ length: 6 }, (_, i) => account(i + 1)));
+    await scenario.result;
+
+    const findings = scenario.reports[0].findings;
+    expect(findings).toHaveLength(6);
+    expect(findings.every((f) => f.groupKey === undefined)).toBe(true);
+  });
+
+  it('a ring on a COMMON provider is emitted ungrouped', async () => {
+    // `gmail.com` is the largest cluster in every cohort, every day. A key there would collapse the
+    // day's most ordinary accounts into one ruling.
+    const scenario = domainRun(ringAccounts('gmail.com'));
+    await scenario.result;
+    expect(scenario.reports[0].findings.every((f) => f.groupKey === undefined)).toBe(true);
+  });
+
+  it('the payloads still satisfy the real wire contract', async () => {
+    const scenario = domainRun(ringAccounts(RING_DOMAIN));
+    await scenario.result;
+    for (const report of scenario.reports)
+      expect(() => abuseReportInput.parse(report)).not.toThrow();
+  });
+});

--- a/src/server/services/bot-account-detection/heuristics/clustering.ts
+++ b/src/server/services/bot-account-detection/heuristics/clustering.ts
@@ -311,6 +311,14 @@ export const domainClusterIsNamedInReason = (size: number): boolean => size > DO
  *
  * Prefixed, so a second kind of key could never collide with a domain that happened to look like
  * one. No second kind is added here — see the IP paragraph above for why that is not a gap.
+ *
+ * 🔴 UNBOUNDED ON PURPOSE, AND BOUNDED DOWNSTREAM. `normalizeEmailDomain` caps nothing, so a
+ * pathological domain produces a key longer than the wire contract's 200 characters — which would
+ * refuse the whole REPORT, not the one finding. `report.ts`'s `boundGroupKey` is where that is
+ * handled, next to `truncateReason`, because a finding is constructed in exactly one place and the
+ * contract's caps belong at that choke point. Capping the domain HERE instead would be worse: two
+ * different long domains would truncate to one string and silently merge two unrelated clusters
+ * into a single ruling.
  */
 export function registrationClusterGroupKey(
   member: { emailDomain: string | null },

--- a/src/server/services/bot-account-detection/heuristics/clustering.ts
+++ b/src/server/services/bot-account-detection/heuristics/clustering.ts
@@ -282,6 +282,46 @@ export function domainClusterSize(
   return membersPerDomain.get(emailDomain) ?? 0;
 }
 
+/**
+ * Whether a domain cluster of this size is NAMED IN THE REASON TEXT.
+ *
+ * 🔴 ONE RULE, ONE PLACE, and the place is here because two callers need the SAME answer for two
+ * different purposes: `explain` below uses it to decide whether to write the domain into the reason,
+ * and `registrationClusterGroupKey` uses it to decide whether the domain may be used as a group key.
+ * Those two must agree exactly — the group key is only allowed to carry what the reason already
+ * discloses — and open-coding `> DOMAIN_ZERO_AT` at both sites is how they would silently stop
+ * agreeing the first time either boundary moved.
+ */
+export const domainClusterIsNamedInReason = (size: number): boolean => size > DOMAIN_ZERO_AT;
+
+/**
+ * The cluster key for a finding: which RING this account belongs to, or `null` for none.
+ *
+ * 🔴 WHY THE EMAIL DOMAIN AND NOT THE REGISTRATION IP, when the IP is the stronger signal. The IP is
+ * DELIBERATELY not in the reason text — see `explain` below, which says so and points a moderator at
+ * `getAccountsOnIps` instead — so keying on it would publish, to the board's wider audience, the one
+ * fact this heuristic goes out of its way not to publish. The domain is already written into the
+ * reason whenever it scores, and only then. That is the whole rule, and it is why this returns `null`
+ * for a cluster too small to be named: a key on a domain the reason never mentions would be a
+ * disclosure the finding does not otherwise make.
+ *
+ * Stable within a run by construction: it is a pure function of the member's own domain and the
+ * run's `membersPerDomain` index, both fixed for the whole run, so every member of one cluster
+ * derives the identical string.
+ *
+ * Prefixed, so a second kind of key could never collide with a domain that happened to look like
+ * one. No second kind is added here — see the IP paragraph above for why that is not a gap.
+ */
+export function registrationClusterGroupKey(
+  member: { emailDomain: string | null },
+  signals: { membersPerDomain: Map<string, number> }
+): string | null {
+  const size = domainClusterSize(member.emailDomain, signals.membersPerDomain);
+  if (!domainClusterIsNamedInReason(size)) return null;
+  // `domainClusterSize` returns 0 for a null or common domain, so reaching here means there is one.
+  return `domain:${member.emailDomain}`;
+}
+
 export const registrationClusterHeuristic: BotAccountHeuristic = {
   id: REGISTRATION_CLUSTER_ID,
   description:
@@ -308,7 +348,7 @@ export const registrationClusterHeuristic: BotAccountHeuristic = {
     // than that tool.
     if (ip.size > IP_ZERO_AT)
       clauses.push(`${ip.size} new posting accounts share its registration IP`);
-    if (domain > DOMAIN_ZERO_AT)
+    if (domainClusterIsNamedInReason(domain))
       clauses.push(
         `${domain} share its email domain ${member.emailDomain ?? ''} (not a common provider)`
       );

--- a/src/server/services/bot-account-detection/heuristics/index.ts
+++ b/src/server/services/bot-account-detection/heuristics/index.ts
@@ -36,6 +36,8 @@ export const BOT_ACCOUNT_HEURISTICS: readonly BotAccountHeuristic[] = [
 export { postingVelocityHeuristic } from './velocity';
 export {
   registrationClusterHeuristic,
+  registrationClusterGroupKey,
+  domainClusterIsNamedInReason,
   isCommonEmailDomain,
   COMMON_EMAIL_DOMAINS,
 } from './clustering';

--- a/src/server/services/bot-account-detection/report.ts
+++ b/src/server/services/bot-account-detection/report.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { MAX_FINDINGS_PER_REPORT, type AbuseReportInput } from '@civitai/moderation';
 import type { BotAccountCohortMember, SurfaceCounts } from './cohort';
 import { renderNotes, renderSubScores, type BotAccountScore } from './scoring';
@@ -38,6 +39,41 @@ const MAX_REASON_LENGTH = 2_000;
 export function truncateReason(reason: string, max = MAX_REASON_LENGTH): string {
   if (reason.length <= max) return reason;
   return `${reason.slice(0, max - 1)}…`;
+}
+
+/** The wire contract's own cap on `groupKey`, restated for the same reason `MAX_REASON_LENGTH` is. */
+const MAX_GROUP_KEY_LENGTH = 200;
+
+/**
+ * The prefix a hashed key carries. Distinct from every key-kind prefix a producer may mint (today:
+ * `domain:`), so a hashed key can never be mistaken for, or collide with, an unhashed one.
+ */
+export const HASHED_GROUP_KEY_PREFIX = 'hashed:';
+
+/**
+ * 🔴 THE SAME HAZARD `truncateReason` EXISTS FOR, IN THE SECOND PRODUCER-SUPPLIED STRING THIS
+ * CONTRACT CARRIES. A `groupKey` over the contract's 200-character cap does not lose the one
+ * finding: `abuseReportInput.safeParse` fails `too_big`, `run.ts` validates BEFORE the network call,
+ * and the throw aborts the run — losing that batch and every batch after it. Measured: a 240-char
+ * email domain yields a 251-character key and the whole report is refused (boundary: 193 characters
+ * parses, 194 fails). Four accounts on one uncommon domain is all it takes to reach, and a
+ * wildcard-MX subdomain chain under an attacker-owned apex fits inside DNS's own 253-character
+ * limit — so an unbounded key is a denial-of-detection lever, not just an edge case.
+ *
+ * 🔴 HASHED, NOT TRUNCATED, AND THAT IS THE WHOLE DIFFERENCE FROM `truncateReason`. A reason is
+ * prose and cutting it costs the tail of a sentence. A group key is an IDENTITY: two distinct
+ * domains sharing a 193-character prefix truncate to the SAME string, which would merge two
+ * unrelated clusters into one decision and let a moderator rule a ring they never looked at with one
+ * click. A digest keeps both halves of what a key has to do — every member of one cluster derives
+ * the identical key, because this is a pure function of the key, and two different clusters do not
+ * collide.
+ *
+ * It also discloses strictly LESS than the key it replaces, which keeps the "a key must not carry
+ * anything the reason does not already say" rule satisfied by construction.
+ */
+export function boundGroupKey(key: string, max = MAX_GROUP_KEY_LENGTH): string {
+  if (key.length <= max) return key;
+  return `${HASHED_GROUP_KEY_PREFIX}${createHash('sha256').update(key).digest('hex')}`;
 }
 
 /** `3 comment(s), 0 model(s), 40 image(s)` — the per-surface breakdown, spelled one way. */
@@ -134,7 +170,11 @@ export function buildFinding(
     // Spread rather than `groupKey: groupKey ?? undefined`, for the same reason `action` is omitted
     // above: an ungrouped finding carries no key at all, so "no cluster" is unrepresentable as
     // anything other than an absent field.
-    ...(groupKey === null ? {} : { groupKey }),
+    //
+    // 🔴 BOUNDED HERE, beside `truncateReason` and for the identical reason — this is the single
+    // place a finding is constructed, so every producer-supplied string the contract caps is brought
+    // inside its cap at one choke point rather than at each site that mints one.
+    ...(groupKey === null ? {} : { groupKey: boundGroupKey(groupKey) }),
   };
 }
 

--- a/src/server/services/bot-account-detection/report.ts
+++ b/src/server/services/bot-account-detection/report.ts
@@ -55,7 +55,7 @@ export const HASHED_GROUP_KEY_PREFIX = 'hashed:';
  * CONTRACT CARRIES. A `groupKey` over the contract's 200-character cap does not lose the one
  * finding: `abuseReportInput.safeParse` fails `too_big`, `run.ts` validates BEFORE the network call,
  * and the throw aborts the run — losing that batch and every batch after it. Measured: a 240-char
- * email domain yields a 251-character key and the whole report is refused (boundary: 193 characters
+ * email domain yields a 247-character key and the whole report is refused (boundary: 193 characters
  * parses, 194 fails). Four accounts on one uncommon domain is all it takes to reach, and a
  * wildcard-MX subdomain chain under an attacker-owned apex fits inside DNS's own 253-character
  * limit — so an unbounded key is a denial-of-detection lever, not just an edge case.

--- a/src/server/services/bot-account-detection/report.ts
+++ b/src/server/services/bot-account-detection/report.ts
@@ -95,11 +95,18 @@ export function renderPostCounts(posts: BotAccountCohortMember['posts']): string
  *
  * `action` is OMITTED rather than set to null — both are accepted by the contract, and omitting it
  * makes the pair unrepresentable in the wrong combination rather than merely correct today.
+ *
+ * 🔴 `groupKey` IS SUPPLIED, NOT DERIVED HERE. It comes from the clustering heuristic, which owns the
+ * one predicate deciding whether a cluster is large enough to be named — the same predicate that
+ * decides whether the domain appears in the reason text. Re-deriving it here would be a second copy
+ * of that rule, and the two would disagree the first time either boundary moved. Defaulting to
+ * `null` keeps every existing caller (and the two other detectors on this board) unchanged.
  */
 export function buildFinding(
   member: BotAccountCohortMember,
   score: BotAccountScore,
-  observedAt: Date
+  observedAt: Date,
+  groupKey: string | null = null
 ): AbuseFinding {
   // Floored at zero: an account timestamped after the scan instant is clock skew between the app and
   // the database, not a negative age, and a negative figure in the reason reads as corrupt data.
@@ -124,6 +131,10 @@ export function buildFinding(
     confidence: score.confidence,
     reason,
     actioned: false,
+    // Spread rather than `groupKey: groupKey ?? undefined`, for the same reason `action` is omitted
+    // above: an ungrouped finding carries no key at all, so "no cluster" is unrepresentable as
+    // anything other than an absent field.
+    ...(groupKey === null ? {} : { groupKey }),
   };
 }
 

--- a/src/server/services/bot-account-detection/run.ts
+++ b/src/server/services/bot-account-detection/run.ts
@@ -13,7 +13,11 @@ import {
   emptyCohortSignals,
   type EvidenceReader,
 } from './evidence';
-import { BOT_ACCOUNT_HEURISTICS, isCommonEmailDomain } from './heuristics';
+import {
+  BOT_ACCOUNT_HEURISTICS,
+  isCommonEmailDomain,
+  registrationClusterGroupKey,
+} from './heuristics';
 import { BOT_ACCOUNT_DETECTOR, buildFinding, buildReports } from './report';
 import {
   MIN_REPORTED_CONFIDENCE,
@@ -214,11 +218,15 @@ export async function runBotAccountDetection(
   // below — a member nobody can see is a member nobody can grade, and grading is the entire purpose
   // of the shadow phase.
   const { reported, suppressed } = partitionByConfidence(scores, minConfidence);
-  const findings = reported.map((score) =>
+  const findings = reported.map((score) => {
     // Every score was built from a member, so the lookup cannot miss; the non-null assertion would
     // be the only place in this module where a missing key is silent, so it throws instead.
-    buildFinding(mustGet(memberById, score.userId), score, startedAt)
-  );
+    const member = mustGet(memberById, score.userId);
+    // 🔴 THE SAME `signals` THE SCORING SAW. A key derived from a different index — an empty one, or
+    // one rebuilt here — would group findings by something the reason text does not describe, which
+    // is the disclosure rule broken by accident rather than by design.
+    return buildFinding(member, score, startedAt, registrationClusterGroupKey(member, signals));
+  });
 
   const finishedAt = deps.now();
 


### PR DESCRIPTION
## What this is

The abuse-detection board at `/abuse` has been **read-only** since it shipped. Three automated detectors post findings to it; a moderator can read them and has no way to record whether any of them was right. Measuring a detector's false-positive rate currently means an offline CSV export, which is why it does not happen.

This adds the ruling. It benefits all three detectors already posting, not just the bot-account one.

- **`verdict`** — `tp` / `fp` / `skip`, or NULL for unruled — plus `verdict_by` and `verdict_at`.
- **`group_key`** — the producer's claim that several findings in one run are one actor, so a coordinated ring is ruled **once** instead of N times.
- `/abuse/[runId]` gains verdict controls, renders a cluster as one collapsed decision with its member count and a few examples, shows existing rulings on revisit, and reports how many findings in the run are still unruled.

## 🔴 The DDL is hand-applied, and the UI does nothing until it is

Same convention as the rest of this table — no `prisma migrate deploy`, no auto-run on deploy. Someone has to run it, **as the application role that `MODERATOR_DATABASE_URL` connects as** (the file's header explains why, and what to do if it was already run as the wrong role):

```
psql "$MODERATOR_DATABASE_URL" -f apps/moderator/abuse-detection/schema.sql
```

It is idempotent and safe to re-run — that is tested, by applying it three times to a real Postgres.

**Until it is applied**, the board keeps working and does not 500:

| | behaviour before the DDL is applied |
|---|---|
| Reading a run | Normal. Every finding renders, reported as unruled. |
| "Still to review" count | Hidden, replaced by a line naming the file to run. |
| Verdict buttons | **Withheld**, not shown-and-broken. |
| A ruling (if one is forced through) | **Refused**, with a message naming the file. A ruling reported as stored but never written is worse than one refused. |
| Detector reports arriving | Still accepted. A `42703` retries the write once without `group_key` and warns — a new column must not cost the surface its existing job. |

## 🔴 `verdict` is not `actioned`

`actioned`/`action` are the **producer's** self-report of what the detector did. The verdict is a **human's** judgement of whether that was right. They move independently, and the commonest row is one the detector deliberately left alone (`actioned = false`) that a moderator rules correct (`verdict = 'tp'`). Recording a verdict leaves the producer columns untouched — asserted in the schema tier, in the service tier, and in the compiled SQL.

## The cluster key, and what it may carry

The bot-account detector sets `group_key` from the shared **email domain** of a registration cluster, and only at a cluster size the finding's own `reason` text already names. The registration IP is the stronger signal and is deliberately **not** written into the reason (the board has a wider audience than the investigative tools), so it is deliberately not a key either. One shared predicate backs both the reason clause and the key, so the two cannot drift apart; a sweep asserts the biconditional at nine cluster sizes, with a positive control.

`groupKey` is **optional** on the wire contract — the two other detectors send nothing and are unchanged.

## Scoping — the part that would be expensive to get wrong

A ruling is scoped to the run taken from the **route**, never from the form body. The same ring reappears in the next day's cohort under the identical key, so an `UPDATE` matching `group_key` alone would rule *every day that ring has ever been seen*, from one page, on one day's evidence, with nothing on screen saying so. A NULL key is the *absence* of a group and is never used as a match value.

## Out of scope, deliberately

- **No permission change.** Whoever can open the board today can rule. Widening access is a separate human decision and is not pre-empted here.
- **No `proposed_action` column.** A column nothing writes and nothing may execute is speculative; it is left out rather than added dark. The guard it was meant to justify is in anyway, and is not vacuous: `action` and `reason` are *already* agent-supplied values rendered on this board.
- **No execution path at all.** An asserted import ledger over the five board surfaces fails if any of them ever imports a mute/ban/restriction module — it fails when the set grows *and* when it shrinks, with its own positive and negative controls.
- No auto-mute, no threshold or scoring change, no DDL applied anywhere.

## Test matrix

Run at `959960bc59` against `origin/main` at `c6b9e4c42d`.

| Suite | Before | After |
|---|---|---|
| `app:moderator`, abuse-scoped | 81 passed | **179 passed** |
| `app:moderator`, whole project | — | **596 passed, 38 skipped** (the skips are the pre-existing EXPLAIN tier, which needs a live database) |
| `unit`, bot-account-detection | 275 passed | **297 passed** |
| `unit`, + reaction-withdrawal-detection | — | **307 passed** |
| `pnpm typecheck` | — | **0 errors** (121 s, heap cap 8192 MB — the wrapper's own classification, not a bare exit code) |
| `apps/moderator` `svelte-check` | — | **0 errors / 9439 files** |
| `prettier-changed check`, eslint | — | clean |
| **GitHub CI on this PR** | — | **18 pass, 1 skipped, 0 failures** — all 19 checks terminal (ESLint+Prettier, App unit tests + typecheck, Package unit tests, Geometry, Unit tests 1–4, Schema drift, submodule pin, Windows dev-env ×2, tekton ×2, preview deploy + render/auth/component). The skip is `Typecheck (main pushes / fork PRs / non-main base)`, which does not apply to this PR. |

A new tier does something none of the existing three could: **it applies the real `schema.sql` to an in-process Postgres (PGlite) and runs the service's own query builders against it.** The two older tiers fake the builder or compile the SQL — neither has ever executed a statement, so before this nothing in the app had any claim on the DDL at all. It is also not skippable: it needs no server, so unlike the EXPLAIN tier it runs in CI.

<details>
<summary><b>Mutation matrix — 31 mutants, every one watched to fail, with the assertion that caught it</b></summary>

Each was applied to the real source, the suite run, and the source restored. "Killed by" names the test that went red and its message — not merely that *a* test failed.

### Schema (`abuse-detection/schema.sql`)

| # | Mutation | Killed by |
|---|---|---|
| M1 | CHECK admits a fourth verdict | `admits EXACTLY the set the application code offers` — `expected [ 'fp', 'maybe', 'skip', 'tp' ] to deeply equal [ 'fp', 'skip', 'tp' ]`; and `rejects an invented fourth verdict` — `promise resolved … instead of rejecting` |
| M2 | `\set ON_ERROR_STOP on` removed | `keeps \set ON_ERROR_STOP on` — `expected '-- Abuse-detection reports from autom…' to contain '\set ON_ERROR_STOP on'` |
| M3 | `ADD COLUMN` loses `IF NOT EXISTS` | `is RE-RUNNABLE` — `column "verdict" of relation "abuse_detection_finding" already exists` |
| M4 | the `DO $$` existence guard always fires | `is RE-RUNNABLE` — `constraint "abuse_detection_finding_verdict_valid" … already exists` |
| M5 | `verdict IS NULL OR` deleted | **SURVIVED — by design.** A CHECK passes when its expression is NULL, so the clause is explicitness, not enforcement. Documented as such in the file, rather than left implying a guard that is not there. |
| M5b | CHECK actively forbids NULL (`IS NOT NULL AND …`) | `accepts NULL — unruled is the state every finding starts in` — `violates check constraint "abuse_detection_finding_verdict_valid"` |
| M6 | the older `actioned`/`action` pairing CHECK neutered | `the CHECK pairing actioned with action still holds` — `promise resolved "1" instead of rejecting` |
| M7 | `group_key` column never added | `creates the four verdict columns` — `group_key is missing from the applied schema` (+9 more) |

### Service (`abuse-detection.service.ts`)

| # | Mutation | Killed by |
|---|---|---|
| S1 | target lookup drops the run predicate | `refuses a finding that belongs to another run` — `expected { updated: 3 } to deeply equal { updated: 0 }` |
| S2 | group UPDATE drops the run predicate | `🔴 does NOT reach the same cluster key in a DIFFERENT run` — `yesterday's run was ruled by a click on today's: expected 'tp' to be null` |
| S3 | NULL group key used as a match value | `rules exactly ONE finding when it carries no group key` — `expected { updated: 2 } to deeply equal { updated: 1 }` |
| S4b | a ruling also clears `actioned`/`action` (a *legal* pair, so no other constraint can fire instead) | `🔴 leaves the producer's actioned and action exactly as they were` — `to match object { actioned: true, … }`; and the compiled-SQL guard with its own message, `a ruling must not write "actioned"` |
| S5 | undefined-column detector reads `42704` | `the verdict summary answers null` — `promise rejected "column \"verdict\" does not exist"` |
| S6 | missing columns reported as a fully-ruled run | `the verdict summary answers null` — `expected { ruled: 0, unruled: 0 } to be null` |
| S7 | a ruling that was never stored reported as stored | `🔴 a WRITE is refused` — `promise resolved "{ updated: 1 }" instead of rejecting` |
| S8 | the read hardcodes every finding as unruled | `returns the verdict, the ruler and the group key` — `to match object { verdict: 'tp', … }` |
| S9 | the report write never stores `group_key` | `writes the reported group key on the finding row` — `expected undefined to be 'domain:ring.test'` |
| S10 | ingest stops instead of retrying ungrouped | `🔴 the detectors keep reporting — a run lands, UNGROUPED` — `promise rejected "column \"group_key\" … does not exist"` |
| S11 | the unruled count is not scoped to the run | `counts the whole run, ruled and unruled` — `expected { ruled: 3, unruled: 4 } to deeply equal { ruled: 3, unruled: 3 }` |
| S12 | a finding not on this run is ruled anyway | `refuses a finding that belongs to another run` — `expected { updated: 1 } to deeply equal { updated: 0 }` |
| S13 | an absent group key written as `undefined`, not NULL | `stores an ABSENT group key as NULL` — `expected undefined to be null` |

### Route (`/abuse/[runId]/+page.server.ts`)

| # | Mutation | Killed by |
|---|---|---|
| R1 | the run id taken from the form body | `🔴 IGNORES a runId smuggled into the form body` — `expected vi.fn() to be called with ObjectContaining {"runId": 4}`. **Initially SURVIVED** — no test had ever posted a `runId`; the case was added to close it. |
| R2 | any string accepted as a verdict | `refuses an invented verdict with a 400 and never calls the service` |
| R3 | zero rows reported as success | `turns zero rows into a 404 telling the moderator to reload` |
| R4 | the audit field loses the moderator's name | `passes the run from the URL, the finding and verdict from the form, and the moderator` |
| R5 | a non-numeric finding id reaches the database | `refuses a non-numeric finding id` (+4 sibling cases) |
| R6 | the page never learns whether a ruling can be stored | `🔴 passes NULL through — the page must be able to tell "cannot rule" from "nothing ruled"` |

### Collapsing rule (`$lib/abuse-decisions.ts`)

| # | Mutation | Killed by |
|---|---|---|
| D1 | an ungrouped finding bucketed on its bare id | `🔴 a producer key that looks like a row key cannot collide with one` |
| D2 | every ungrouped finding collapsed into one decision | `🔴 does NOT collapse ungrouped findings into one another` |
| D3 | one member's ruling presented as the whole cluster's | `🔴 reports mixed rather than presenting one member's ruling as the cluster's` |
| D4 | the rendered row is whichever member came first | `picks the cluster lead the same way, inside the cluster` |

### Producer

| # | Mutation | Killed by |
|---|---|---|
| P1 | the cluster-key boundary shifts by one (`>` → `>=`) | `returns nothing AT the boundary — a cluster of three is not reported` |
| P2 | a key emitted for every account with a domain | `🔴 returns nothing for a COMMON provider, however large the cluster` (+6) |
| P3 | `run.ts` never hands the key to the finding builder | `every member of the ring is emitted with the SAME key` — `expected [ undefined, … ] to deeply equal [ 'domain:ring-provider.test', … ]` |
| P4 | the key derived from an index the scoring never saw | same test, same message |
| P5 | an ungrouped finding carries an explicit null key | `OMITS the key entirely when there is no cluster` |
| P6 | the wire contract strips the key it was sent | `produces a payload the real wire contract accepts, key and all` — `expected undefined to be 'domain:ring.test'`. **Initially SURVIVED** against the producer suite, because the assertion read the *built* payload rather than the *parsed* one; the assertion was moved onto the parse to close it. |
| P7 | an empty group key accepted | `rejects an EMPTY group key` |

</details>

## What I did NOT verify

- **Nothing was run against a real database.** The DDL was applied only to an in-process PGlite instance. PGlite is a real Postgres build, and the CHECK violations come back with the real `23514`, but it is not this deployment's server and I did not connect to one.
- **The page was never rendered.** This app has no component render harness, which is why the collapsing rule was extracted into `$lib/abuse-decisions.ts` and tested as a pure function, with source-level assertions pinning that the page uses *that* function and posts to *that* action. Nobody has looked at the buttons in a browser.
- **CSRF is asserted structurally, not exercised.** The check is that `svelte.config.js` does not disable SvelteKit's `csrf.checkOrigin`, which is on by default and is what the app's other thirty form actions rely on. No cross-origin POST was actually attempted.
- **`verdict_at` monotonicity under a real clock.** The tests pin exact timestamps with a faked `Date`; the server's real clock was not exercised.
- **The `42703` retry path in `recordAbuseRun` was tested by dropping the columns**, which reproduces the table shape exactly but is not the same event as a deploy landing ahead of the DDL.
- I did not measure how many findings in a typical run actually carry a `group_key` — the fixtures are constructed rings, not production cohorts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
