### PR TITLE
fix(apps): surface consented apps on the permissions tab so the Buzz budget is settable

### DIFF
--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.browser.test.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.browser.test.tsx
@@ -193,7 +193,10 @@ describe('AppPermissionsActivityDrawer (Part B — per-app permissions & activit
     await expect
       .element(
         page.getByText(
-          'No permissions recorded from an install of this app — which is not the same as no access. Anything it has actually done on your account is listed under Recent activity below.'
+          // Widened from "from an install of this app" with the data source: a consented
+          // full-page app now resolves a row instead of reaching this label, so the label's
+          // remaining population is "neither an install NOR a consent".
+          'No permissions recorded from an install or consent for this app — which is not the same as no access. Anything it has actually done on your account is listed under Recent activity below.'
         )
       )
       .toBeInTheDocument();

--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
@@ -118,14 +118,30 @@ function DrawerBody({ appBlockId, appName }: { appBlockId: string; appName?: str
              consent grant, where absence of a row is still not absence of access.
 
              🔴 `grant.scopes` IS THE APP'S MANIFEST-DECLARED SET, NOT THE VIEWER'S GRANTED SET.
-             Granted ⊆ manifest by construction (`recordInstallConsent` grants
-             `consentGatedScopes(manifest ∩ approvedScopes)`, and a manifest that later adds a
-             scope leaves the old grant standing until re-consent), so this can OVERSTATE what
-             the viewer agreed to. Pre-existing, and deliberately NOT changed here: the grant's
-             own `grantedScopes` is empty for an install-backed row that carries no consent
-             grant, so swapping the field would blank those rows instead. Widening the
-             population makes this the common case rather than a ~4-row edge, so it is recorded
-             as an open decision rather than silently expanded — see the PR discussion. */
+             ⚠️ AN EARLIER REVISION OF THIS COMMENT SAID "granted ⊆ manifest BY CONSTRUCTION".
+             THAT IS FALSE and the containment holds only AT GRANT TIME. Two writes break it
+             afterwards, and they compose: `recordScopeGrant` UNIONS on re-consent
+             (`grantedScopes = existing ∪ incoming`, `scope-grant.service.ts:232` and `:263`)
+             and nothing ever writes a non-null `revoked_at`, so the granted set only GROWS;
+             meanwhile a subsequent approved version REPLACES `manifest` + `approvedScopes`
+             IN PLACE on the same `AppBlock` row (`publish-request.service.ts`, "Subsequent
+             version: refresh manifest + version + approvedScopes"), while the grant is unique
+             on `(userId, appBlockId)` and survives. So a publisher who DROPS a scope in v2
+             leaves the viewer holding a granted scope that is no longer in the manifest.
+
+             Consequence for this list, in BOTH directions: it OVERSTATES when the manifest
+             declares more than the viewer granted (the ordinary case), and UNDERSTATES when a
+             version removed a scope the viewer still holds — the second being the one a
+             "permissions you granted" surface most needs to show, since nothing else reveals
+             it and a later version re-declaring that scope is signed through by
+             `partitionByConsent` with NO fresh prompt.
+
+             Pre-existing, and deliberately NOT changed here: `grantedScopes` is not on
+             `ScopeGrantSurface` at all, and it is EMPTY for an install-backed row carrying no
+             consent grant, so this is a new field plus a per-row choice of which set to show —
+             not a swap. Widening the population makes it the common case rather than a
+             ~4-row edge, so it is recorded as an open decision rather than silently
+             expanded — see the PR discussion. */
           <BlockScopeList
             scopes={grant?.scopes ?? []}
             emptyLabel="No permissions recorded from an install or consent for this app — which is not the same as no access. Anything it has actually done on your account is listed under Recent activity below."

--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
@@ -80,17 +80,20 @@ function DrawerBody({ appBlockId, appName }: { appBlockId: string; appName?: str
     <Stack gap="lg">
       {appName && (
         <Text size="sm" c="dimmed">
-          The permissions <strong>{appName}</strong> carries through your own installs, and what it
-          has done recently. Only you can see this.
+          The permissions <strong>{appName}</strong> carries through your own installs and consents,
+          and what it has done recently. Only you can see this.
         </Text>
       )}
 
       <Stack gap="xs">
-        {/* "…from your installs", not "Granted permissions" — the section's only source is
-            install-backed, so the wider heading was the same overstatement as the empty
-            label it sits above. */}
+        {/* "…from your installs and consents". #4722 narrowed this to "from your installs"
+            because the section's only source WAS install-backed; `listMyScopeGrants` now also
+            enumerates live `app_user_scope_grants` rows, so install-only is the narrow
+            overstatement in the other direction. Still not the bare "Granted permissions"
+            #4722 rejected: the list below is the app's MANIFEST set, not the user's granted
+            set — see the comment on `BlockScopeList` below. */}
         <Text fw={600} size="sm">
-          Permissions from your installs
+          Permissions from your installs and consents
         </Text>
         {!isAuthed ? (
           <Text size="xs" c="dimmed" fs="italic">
@@ -103,17 +106,29 @@ function DrawerBody({ appBlockId, appName }: { appBlockId: string; appName?: str
         ) : (
           /* 🔴 THE EMPTY LABEL IS NOT "no permissions granted", AND THE PANEL BELOW IS WHY.
              `grant` is `grants.find(g => g.appBlockId === appBlockId)` over
-             `listMyScopeGrants`, whose only source is the viewer's OWN
-             `block_user_subscriptions` rows. A full-page app has no install, so that lookup
-             is `undefined` for every such app — and the drawer then claimed the viewer had
-             granted it nothing WHILE `AppActivityPanel` a few lines down listed the
-             scope-gated calls that same app had just made, possibly minutes after they
-             accepted its consent modal. Two halves of one drawer contradicting each other.
-             Absence of an install-backed row is not absence of granted permission; the label
-             says which of the two it is and sends the reader to the half that knows. */
+             `listMyScopeGrants`.
+             ⚠️ THE PREVIOUS SENTENCE HERE — "whose only source is the viewer's OWN
+             `block_user_subscriptions` rows" — WAS TRUE WHEN #4722 WROTE IT AND IS NOW FALSE.
+             That function also enumerates live (non-revoked) `app_user_scope_grants` rows, so
+             a full-page app the viewer CONSENTED to now resolves here instead of falling
+             through to the empty label. The contradiction #4722 described — this half claiming
+             the viewer granted nothing while `AppActivityPanel` below listed that same app's
+             scope-gated calls — is fixed at the source rather than described.
+             The label still matters for what remains: an app with NEITHER an install NOR a
+             consent grant, where absence of a row is still not absence of access.
+
+             🔴 `grant.scopes` IS THE APP'S MANIFEST-DECLARED SET, NOT THE VIEWER'S GRANTED SET.
+             Granted ⊆ manifest by construction (`recordInstallConsent` grants
+             `consentGatedScopes(manifest ∩ approvedScopes)`, and a manifest that later adds a
+             scope leaves the old grant standing until re-consent), so this can OVERSTATE what
+             the viewer agreed to. Pre-existing, and deliberately NOT changed here: the grant's
+             own `grantedScopes` is empty for an install-backed row that carries no consent
+             grant, so swapping the field would blank those rows instead. Widening the
+             population makes this the common case rather than a ~4-row edge, so it is recorded
+             as an open decision rather than silently expanded — see the PR discussion. */
           <BlockScopeList
             scopes={grant?.scopes ?? []}
-            emptyLabel="No permissions recorded from an install of this app — which is not the same as no access. Anything it has actually done on your account is listed under Recent activity below."
+            emptyLabel="No permissions recorded from an install or consent for this app — which is not the same as no access. Anything it has actually done on your account is listed under Recent activity below."
           />
         )}
       </Stack>

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -556,14 +556,16 @@ describe('Apps & permissions — the per-app daily Buzz limit', () => {
       .toHaveTextContent('Daily Buzz limit: 750 Buzz/day');
   });
 
-  // 🔴 THE DISCRIMINATING HALF. The fixture holds TWO apps and only one has the spend
+  // 🔴 THE DISCRIMINATING HALF. The fixture holds THREE apps and only one has the spend
   // scope GRANTED, so exactly one control may render. Without this, a control rendered
   // unconditionally would pass the test above.
+  // (⚠️ Said TWO until the grant-only fixture was added below and this count was left
+  // behind — a claim staled by the same commit that added the third card.)
   test('renders NO limit control for an app without the granted spend scope', async () => {
     renderWithProviders(<AppActivityPage />);
     await expect.element(page.getByTestId('apps-installed-grants-grid')).toBeInTheDocument();
-    // Positive control: BOTH apps really rendered, so "one control" is a fact about the
-    // grant and not about a panel that only drew one card.
+    // Positive control: ALL THREE apps really rendered, so "one control" is a fact about
+    // the grant and not about a panel that only drew one card.
     expect(page.getByTestId('app-budget-value').elements()).toHaveLength(1);
     const names = Array.from(
       document.querySelectorAll('[data-testid="apps-installed-grants-grid"] .truncate')

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -146,6 +146,37 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
               buzzBudgetPerDay: 750,
               spendScopeGranted: true,
             },
+            // 🔴 THE GRANT-ONLY SHAPE — `0` installs AND `0` subscription scopes. This is the
+            // row `listMyScopeGrants` only began emitting when it started enumerating
+            // `app_user_scope_grants`, and by the production counts it is the DOMINANT
+            // population, not an edge case. Without it no fixture at this tier renders the
+            // card the change exists to create, so a regression in how it renders — the
+            // surface line, the budget control, an empty scope list — ships green.
+            // Distinct from `apb_spend` in exactly the field under test: that row also has
+            // `modelInstallCount: 0` but carries a subscription scope, so it cannot
+            // exercise the `0 / 0` branch of `buildSurfaceLine`.
+            //
+            // 🔴 `spendScopeGranted: false` DELIBERATELY, and this is a REAL COVERAGE GAP,
+            // not a tidy choice — recorded rather than glossed. With it `true` the card
+            // renders an `AppBudgetControl` (a null budget still emits `app-budget-row` AND
+            // `app-budget-value`, showing the "none" copy), which would flip the two
+            // `toHaveLength(1)` assertions below to 2 and make `app-budget-edit` ambiguous
+            // for the Save test's `.click()`. Those counts are the discriminating half of
+            // the budget tests, so quietly relaxing them to 2 would weaken a real guard to
+            // admit a fixture. RESIDUAL: no component-tier case renders a budget control on
+            // a GRANT-ONLY card. That combination is covered at the service tier
+            // (`user-app-surface.orchestration.test.ts` asserts `spendScopeGranted: true`
+            // plus a budget for a grant-only row), and the service tier cannot see the card.
+            {
+              appBlockId: 'apb_grant_only',
+              blockId: 'consented',
+              name: 'Consented Only',
+              slug: 'consented-only',
+              scopes: ['ai:write:budgeted'],
+              surfaces: { modelInstallCount: 0, subscriptionScopes: [] },
+              buzzBudgetPerDay: null,
+              spendScopeGranted: false,
+            },
           ]
         : [],
     'blocks.listMyAppActivity': () => ({ pages: [{ items: [], nextCursor: null }] }),
@@ -539,6 +570,22 @@ describe('Apps & permissions — the per-app daily Buzz limit', () => {
     ).map((el) => el.textContent?.trim());
     expect(names).toContain('Demo App');
     expect(names).toContain('Spender');
+    // 🔴 THE GRANT-ONLY CARD RENDERS AT ALL. Before `listMyScopeGrants` enumerated
+    // `app_user_scope_grants`, a row with no install and no subscription could not exist,
+    // so nothing at this tier ever drew this card — and by the production counts it is the
+    // dominant population. Asserting it here is what makes the two length checks below
+    // "one control across THREE cards" rather than "one control across the two that
+    // happened to render".
+    expect(names).toContain('Consented Only');
+    // Its surface line names the provenance it actually came from. Pinned as the whole
+    // string: a keyword match would pass on the previous text ("Subscriptions: none"),
+    // which on a consent surface reads as a claim that the app has no access.
+    expect(
+      Array.from(document.querySelectorAll('[data-testid="apps-installed-grants-grid"]')).some(
+        (el) => el.textContent?.includes('Granted at consent · no install or subscription')
+      ),
+      'the grant-only card must name its provenance, not report "Subscriptions: none"'
+    ).toBe(true);
     expect(page.getByTestId('app-budget-row').elements()).toHaveLength(1);
   });
 

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -623,12 +623,17 @@ describe('Apps & permissions — the per-app daily Buzz limit', () => {
  * above and confirm your new wording is still TRUE before updating the literal.
  */
 describe('🔴 the revoke instruction is retracted, not reworded', () => {
+  // 🔴 WIDENED WITH THE DATA SOURCE, NOT REWORDED FOR STYLE. `listMyScopeGrants` now also
+  // enumerates live `app_user_scope_grants` rows, so "installed or subscribed to" described a
+  // population narrower than the one the panel below it lists — the same overstatement this
+  // block exists to catch, pointing the other way. The whole-string pin is doing exactly its
+  // job here: this literal had to move because the claim moved.
   const PERMISSIONS_TAB_COPY =
-    "The apps you've installed or subscribed to, the permissions each one declares it may " +
-    'use, and where you have it. Removing an install on the Installs tab takes the app off ' +
-    'that surface, but it does not withdraw a permission you have already granted — ' +
-    'withdrawing one is not possible yet. Recent activity is the full record of what apps ' +
-    'have actually done on your account.';
+    "The apps you've installed, subscribed to, or granted permissions to, what each one " +
+    'declares it may use, and where you have it. Removing an install on the Installs tab ' +
+    'takes the app off that surface, but it does not withdraw a permission you have already ' +
+    'granted — withdrawing one is not possible yet. Recent activity is the full record of ' +
+    'what apps have actually done on your account.';
 
   test('the panel states plainly that withdrawing a permission is not possible', async () => {
     // `Tabs.Panel` is `keepMounted` by default, so the permissions panel's copy is in the

--- a/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
+++ b/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
@@ -454,13 +454,16 @@ describe('the masker (validate the instrument before reading its verdict)', () =
     //
     // ⚠️ KNOWN COST, recorded rather than discovered later: 0.70 is less sensitive to a
     // PARTIAL, late-file desync than 0.65 was — a blanking confined to the tail can now
-    // pass. ⚠️ NO PERCENTAGE IS QUOTED ON PURPOSE: the naive model (`L + p(1−L) = 0.70`)
-    // overstates the sensitivity badly, because the tail of this file is comment- and
-    // JSX-dense and so is ALREADY mostly spaces after masking, and two revisions of this
-    // clause have now put a wrong figure here. Measure it against the masked text if it
-    // ever matters. Accepted regardless: 0.65 was unusable at the headroom above, and the
-    // functional check in this test is the `features.appBlocks` occurrence count, not the
-    // ratio.
+    // pass. Measured at `775abdfe34` by two independent re-implementations of the masker:
+    // a trailing desync must cover ≈19.6% of the file before it trips 0.70. POINT-IN-TIME
+    // — it moves with `L` and with the tail's own density, exactly like the ratios above,
+    // so re-measure rather than trusting it.
+    // ⚠️ Do NOT re-derive it from `L + p(1−L) = 0.70`; that model gives ≈11.8% because it
+    // assumes the blanked tail becomes ALL spaces, whereas this file's tail is comment- and
+    // JSX-dense and already ≈0.77 spaces after masking. One earlier revision of this clause
+    // carried the naive figure (`≲13%`) for that reason.
+    // Accepted regardless: 0.65 was unusable at the headroom above, and the functional
+    // check in this test is the `features.appBlocks` occurrence count, not the ratio.
     const spaceRatio = (text: string) =>
       text.split('').filter((c) => c === ' ').length / text.length;
     expect(spaceRatio(masked)).toBeLessThan(0.7);

--- a/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
+++ b/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
@@ -433,18 +433,34 @@ describe('the masker (validate the instrument before reading its verdict)', () =
     // intermediate — then 0.8482, then 0.8499 after one more paragraph landed here); every
     // line added to `activity.tsx`, code or comment, moves both. The BOUNDS are asserted in
     // code below and cannot go stale; the ratios are outputs. Re-derive rather than trusting
-    // a number in prose:
-    //   node -e 'const f=require("fs").readFileSync("src/pages/apps/activity.tsx","utf8"),
-    //     r=t=>t.split("").filter(c=>c===" ").length/t.length, i=f.indexOf("app's");
-    //     console.log(r(f.slice(0,i)+f.slice(i).replace(/[^\n]/g," ")))'
+    // a number in prose — run this from the repo root:
+    //   node -e "const f=require('fs').readFileSync('src/pages/apps/activity.tsx','utf8'),
+    //     r=t=>t.split('').filter(c=>c===' ').length/t.length,
+    //     i=f.indexOf(String.fromCharCode(97,112,112,39,115));
+    //     console.log(r(f.slice(0,i)+f.slice(i).replace(/[^\n]/g,' ')))"
+    // ⚠️ THE `String.fromCharCode` IS NOT AFFECTATION — it spells the apostrophe in `app's`,
+    // and an earlier revision of this command wrote that literal inside a SINGLE-quoted
+    // `node -e '…'`. The apostrophe closed the shell string, so pasting it gave
+    // `unexpected EOF` and printed nothing: a re-derivation instruction that could not be
+    // run, replacing figures that were merely stale. Verified by RUNNING the form above, as
+    // written, in both bash and zsh — test the pasted form, not the program.
     // That prints the CONTROL; the live masked ratio is whatever this test reports when the
-    // bound below fails. A bound set just above whatever the file currently reads would be
-    // the 0.0018-headroom mistake again.
+    // bound below fails. A bound set just above whatever the file currently reads would
+    // repeat the no-headroom mistake — for the 0.55 bound that margin was 0.0014 (see five
+    // paragraphs up); against 0.65 on `origin/main` it was ≈0.0049, per the measurement
+    // above. (An earlier revision wrote 0.0018 here, which is the margin at THIS PR's own
+    // round-1 commit — a tree this comment never names, and irreconcilable with the ≈0.645
+    // figure 25 lines up.)
     //
     // ⚠️ KNOWN COST, recorded rather than discovered later: 0.70 is less sensitive to a
-    // PARTIAL, late-file desync — one blanking ≲13% of the tail now passes. Accepted
-    // because 0.65 was unusable at 0.0018 headroom, and because the functional check in
-    // this test is the `features.appBlocks` occurrence count above, not the ratio.
+    // PARTIAL, late-file desync than 0.65 was — a blanking confined to the tail can now
+    // pass. ⚠️ NO PERCENTAGE IS QUOTED ON PURPOSE: the naive model (`L + p(1−L) = 0.70`)
+    // overstates the sensitivity badly, because the tail of this file is comment- and
+    // JSX-dense and so is ALREADY mostly spaces after masking, and two revisions of this
+    // clause have now put a wrong figure here. Measure it against the masked text if it
+    // ever matters. Accepted regardless: 0.65 was unusable at the headroom above, and the
+    // functional check in this test is the `features.appBlocks` occurrence count, not the
+    // ratio.
     const spaceRatio = (text: string) =>
       text.split('').filter((c) => c === ' ').length / text.length;
     expect(spaceRatio(masked)).toBeLessThan(0.7);

--- a/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
+++ b/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
@@ -414,17 +414,37 @@ describe('the masker (validate the instrument before reading its verdict)', () =
     // is a fact about comment density and nothing to do with the masker. Measured here
     // after the `/apps/activity` rename: 0.5648.
     //
-    // 🔴 AND IT MOVED AGAIN, 0.65 → 0.70, FOR THE CAUSE THE PARAGRAPH ABOVE PREDICTS.
-    // Widening the permissions copy (three longer user-facing strings, which mask as
-    // blanks) plus the comments recording why took the live ratio to 0.6558 — measured,
-    // after trimming that prose to its load-bearing claims, from 0.6624 before the trim.
-    // The alternative was deleting documentation an audit round had just required, which
-    // would be relaxing the file to fit the gate rather than the gate to fit the file.
+    // 🔴 AND IT MOVED AGAIN, 0.65 → 0.70, FOR THE CAUSE THE PARAGRAPH ABOVE PREDICTS —
+    // BUT NOT MOSTLY BECAUSE OF THE CHANGE THAT TRIPPED IT. ⚠️ The `0.5648` above is STALE
+    // (it dates from #4699). Measured with this file's own masker at the moment of the
+    // re-cut: `origin/main` ALREADY read ≈0.645 — under 0.005 of headroom on the old 0.65
+    // bound — and the permissions-copy widening moved it by ≈0.01, not by the ≈0.09 an
+    // earlier revision of this paragraph claimed by differencing against the stale figure.
+    // So the bound was going to trip for whoever added the next comment either way, which
+    // is exactly the failure the paragraph above describes. (Point-in-time, and rounded on
+    // purpose — see the next paragraph on why exact ratios do not survive in prose here.)
     //
-    // 🔴 RE-CUT AGAINST THE CONTROL, NOT AGAINST THE NEW VALUE. The negative control below
-    // measures 0.8510 on this same file, so 0.70 keeps ~0.15 of real separation from the
-    // defect state and ~0.04 from the live one. A bound set just above whatever the file
-    // currently reads would be the 0.0014-headroom mistake again.
+    // 🔴 RE-CUT AGAINST THE CONTROL, NOT AGAINST THE NEW VALUE — the control sits far above
+    // the bound while the live value sits below it, which is the property that matters.
+    //
+    // ⚠️ DELIBERATELY NOT QUOTING THE TWO MEASUREMENTS AS PINNED NUMBERS, because they DRIFT
+    // WITH THIS FILE AND KEEP FALSIFYING THE COMMENT. Three successive revisions quoted a
+    // control figure and each was stale within one edit (0.8510 — an uncommitted
+    // intermediate — then 0.8482, then 0.8499 after one more paragraph landed here); every
+    // line added to `activity.tsx`, code or comment, moves both. The BOUNDS are asserted in
+    // code below and cannot go stale; the ratios are outputs. Re-derive rather than trusting
+    // a number in prose:
+    //   node -e 'const f=require("fs").readFileSync("src/pages/apps/activity.tsx","utf8"),
+    //     r=t=>t.split("").filter(c=>c===" ").length/t.length, i=f.indexOf("app's");
+    //     console.log(r(f.slice(0,i)+f.slice(i).replace(/[^\n]/g," ")))'
+    // That prints the CONTROL; the live masked ratio is whatever this test reports when the
+    // bound below fails. A bound set just above whatever the file currently reads would be
+    // the 0.0018-headroom mistake again.
+    //
+    // ⚠️ KNOWN COST, recorded rather than discovered later: 0.70 is less sensitive to a
+    // PARTIAL, late-file desync — one blanking ≲13% of the tail now passes. Accepted
+    // because 0.65 was unusable at 0.0018 headroom, and because the functional check in
+    // this test is the `features.appBlocks` occurrence count above, not the ratio.
     const spaceRatio = (text: string) =>
       text.split('').filter((c) => c === ' ').length / text.length;
     expect(spaceRatio(masked)).toBeLessThan(0.7);
@@ -437,8 +457,9 @@ describe('the masker (validate the instrument before reading its verdict)', () =
     const desynced = raw.slice(0, apostrophe) + raw.slice(apostrophe).replace(/[^\n]/g, ' ');
     // 🔴 THE SAME NUMBER AS THE LIVE BOUND, DELIBERATELY. If this stayed at 0.65 while the
     // bound above moved to 0.70, the control would no longer prove separation — a desync
-    // measuring 0.66 would satisfy BOTH, so the pair would assert nothing. Measured here:
-    // 0.8510. Move the two together or the control stops being one.
+    // measuring 0.66 would satisfy BOTH, so the pair would assert nothing. Move the two
+    // together or the control stops being one. (No measured ratio quoted here either — see
+    // the paragraph above on why those figures drift.)
     expect(spaceRatio(desynced)).toBeGreaterThan(0.7);
   });
 

--- a/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
+++ b/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
@@ -414,13 +414,20 @@ describe('the masker (validate the instrument before reading its verdict)', () =
     // is a fact about comment density and nothing to do with the masker. Measured here
     // after the `/apps/activity` rename: 0.5648.
     //
-    // The re-cut bound is still discriminating, and the control below is what proves it
-    // rather than asserting it: the defect this test exists for — a phantom string opened
-    // by the ASCII apostrophe running to EOF — blanks the whole tail of the file and lands
-    // far above 0.65.
+    // 🔴 AND IT MOVED AGAIN, 0.65 → 0.70, FOR THE CAUSE THE PARAGRAPH ABOVE PREDICTS.
+    // Widening the permissions copy (three longer user-facing strings, which mask as
+    // blanks) plus the comments recording why took the live ratio to 0.6558 — measured,
+    // after trimming that prose to its load-bearing claims, from 0.6624 before the trim.
+    // The alternative was deleting documentation an audit round had just required, which
+    // would be relaxing the file to fit the gate rather than the gate to fit the file.
+    //
+    // 🔴 RE-CUT AGAINST THE CONTROL, NOT AGAINST THE NEW VALUE. The negative control below
+    // measures 0.8510 on this same file, so 0.70 keeps ~0.15 of real separation from the
+    // defect state and ~0.04 from the live one. A bound set just above whatever the file
+    // currently reads would be the 0.0014-headroom mistake again.
     const spaceRatio = (text: string) =>
       text.split('').filter((c) => c === ' ').length / text.length;
-    expect(spaceRatio(masked)).toBeLessThan(0.65);
+    expect(spaceRatio(masked)).toBeLessThan(0.7);
 
     // 🔴 NEGATIVE CONTROL, ON THE REAL FILE: a bound nobody has watched fire is a claim
     // about a number. Reproduce the historical desync — everything after the apostrophe
@@ -428,7 +435,11 @@ describe('the masker (validate the instrument before reading its verdict)', () =
     const apostrophe = raw.indexOf("app's");
     expect(apostrophe, 'the trigger moved; re-point this control').toBeGreaterThan(-1);
     const desynced = raw.slice(0, apostrophe) + raw.slice(apostrophe).replace(/[^\n]/g, ' ');
-    expect(spaceRatio(desynced)).toBeGreaterThan(0.65);
+    // 🔴 THE SAME NUMBER AS THE LIVE BOUND, DELIBERATELY. If this stayed at 0.65 while the
+    // bound above moved to 0.70, the control would no longer prove separation — a desync
+    // measuring 0.66 would satisfy BOTH, so the pair would assert nothing. Measured here:
+    // 0.8510. Move the two together or the control stops being one.
+    expect(spaceRatio(desynced)).toBeGreaterThan(0.7);
   });
 
   it('nested quotes, templates and regex literals do not desync it either', () => {

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -547,12 +547,16 @@ function ScopeGrantsPanel() {
   }
   if (!grants || grants.length === 0) {
     /* 🔴 NOT "no app has any access to your account" — that is the claim this string used
-       to make, and it was false. `listMyScopeGrants` reads `block_user_subscriptions`
-       ONLY, so an empty result means "no install or subscription of your own", which is
-       silent about full-page apps and about blocks other people installed. Naming the
-       tab's actual population and pointing at the feed is what keeps the sentence true. */
+       to make, and it was false.
+       ⚠️ THE REASON HAS NARROWED, SO THE SENTENCE HAS WIDENED. #4722 wrote "reads
+       `block_user_subscriptions` ONLY … silent about full-page apps", which was true then;
+       `listMyScopeGrants` now also enumerates live `app_user_scope_grants`, so a full-page
+       app the viewer consented to DOES appear and is no longer part of the silence. What an
+       empty result still cannot speak for is blocks OTHER people installed, which carry no
+       row of the viewer's at all. The label names the population it actually covers and
+       points at the feed that knows the rest. */
     return (
-      <EmptyState label="No apps installed or subscribed yet. This tab covers your own installs — Recent activity is the full record of what apps have done on your account." />
+      <EmptyState label="No apps installed, subscribed to, or granted permissions yet. This tab covers your own installs and consents — Recent activity is the full record of what apps have done on your account." />
     );
   }
   return (
@@ -840,11 +844,11 @@ export default function AppActivityPage() {
             <Tabs.Panel value="permissions" pt="md">
               <Stack gap="sm">
                 <Text size="sm" c="dimmed">
-                  The apps you've installed or subscribed to, the permissions each one declares it
-                  may use, and where you have it. Removing an install on the Installs tab takes the
-                  app off that surface, but it does not withdraw a permission you have already
-                  granted — withdrawing one is not possible yet. Recent activity is the full record
-                  of what apps have actually done on your account.
+                  The apps you've installed, subscribed to, or granted permissions to, what each one
+                  declares it may use, and where you have it. Removing an install on the Installs
+                  tab takes the app off that surface, but it does not withdraw a permission you have
+                  already granted — withdrawing one is not possible yet. Recent activity is the full
+                  record of what apps have actually done on your account.
                 </Text>
                 <ScopeGrantsPanel />
               </Stack>

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -559,11 +559,16 @@ function ScopeGrantsPanel() {
        `listMyScopeGrants` now also enumerates live `app_user_scope_grants`, so a consented
        full-page app DOES appear and is no longer part of the silence. ⚠️ TWO populations
        remain, not one: (a) blocks OTHER people installed, which carry no row of the
-       viewer's; and (b) an app whose scopes are ALL in `CONSENT_EXEMPT_SCOPES`
-       (`scope-grant.service.ts`), for which `partitionByConsent` returns `missing: []`, so no
-       modal fires, `recordInstallConsent` is never reached, and it writes to the account with
-       NO grant row. The string stays true — they granted nothing — but the silence is wider
-       than "other people's installs". */
+       viewer's; and (b) an app the viewer NEVER installed or subscribed to whose scopes are
+       ALL in `CONSENT_EXEMPT_SCOPES` (`scope-grant.service.ts`) — `partitionByConsent`
+       returns `missing: []`, so no consent modal fires and nothing writes a grant row, yet
+       exempt scopes like `collections:write:self` still write to the account.
+       ⚠️ The "never installed" half is load-bearing and an earlier draft omitted it: install
+       and subscribe call `recordInstallConsent` UNCONDITIONALLY (`block-registry.service.ts`
+       :2285, :2921 — not on the modal path), and `recordScopeGrant` has no empty-scopes early
+       return, so an INSTALLED all-exempt app does get a row, with `grantedScopes: []`.
+       The string stays true — they granted nothing — but the silence is wider than
+       "other people's installs". */
     return (
       <EmptyState label="No apps installed, subscribed to, or granted permissions yet. This tab covers your own installs and consents — Recent activity is the full record of what apps have done on your account." />
     );

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -374,7 +374,13 @@ function buildSurfaceLine(surfaces: {
         .join(' / ')}`
     );
   } else if (surfaces.modelInstallCount === 0) {
-    parts.push('Subscriptions: none');
+    /* 🔴 THE GRANT-ONLY ROW — a consented full-page app, which THIS PR makes reachable for
+       the first time: every earlier row came from a subscription, seeded with either
+       `modelInstallCount > 0` or one scope, so `0 / 0` could not occur and the previous text
+       ("Subscriptions: none") was unreachable. Replaced because on a consent surface it
+       reads as "this app has no access", under copy promising "…and where you have it".
+       This is the one copy site a literal sweep cannot find — it is computed. */
+    parts.push('Granted at consent · no install or subscription');
   }
   return parts.join(' · ');
 }
@@ -550,11 +556,14 @@ function ScopeGrantsPanel() {
        to make, and it was false.
        ⚠️ THE REASON HAS NARROWED, SO THE SENTENCE HAS WIDENED. #4722 wrote "reads
        `block_user_subscriptions` ONLY … silent about full-page apps", which was true then;
-       `listMyScopeGrants` now also enumerates live `app_user_scope_grants`, so a full-page
-       app the viewer consented to DOES appear and is no longer part of the silence. What an
-       empty result still cannot speak for is blocks OTHER people installed, which carry no
-       row of the viewer's at all. The label names the population it actually covers and
-       points at the feed that knows the rest. */
+       `listMyScopeGrants` now also enumerates live `app_user_scope_grants`, so a consented
+       full-page app DOES appear and is no longer part of the silence. ⚠️ TWO populations
+       remain, not one: (a) blocks OTHER people installed, which carry no row of the
+       viewer's; and (b) an app whose scopes are ALL in `CONSENT_EXEMPT_SCOPES`
+       (`scope-grant.service.ts`), for which `partitionByConsent` returns `missing: []`, so no
+       modal fires, `recordInstallConsent` is never reached, and it writes to the account with
+       NO grant row. The string stays true — they granted nothing — but the silence is wider
+       than "other people's installs". */
     return (
       <EmptyState label="No apps installed, subscribed to, or granted permissions yet. This tab covers your own installs and consents — Recent activity is the full record of what apps have done on your account." />
     );

--- a/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
@@ -245,10 +245,17 @@ describe('listMyScopeGrants', () => {
   });
 
   /**
-   * A grant row whose AppBlock join does not resolve (a `Restrict`-deleted app, or the
-   * FK pointing at a row the select could not read) must be SKIPPED, not rendered as a
-   * card with no name. Mirrors the `if (!row.appBlock) continue` the subscription leg
-   * already applies.
+   * ⚠️ INVARIANT GUARD, NOT REGRESSION COVERAGE — and an earlier draft of this docblock got
+   * the mechanism wrong, so the correction is recorded rather than quietly swapped. It said
+   * "a `Restrict`-deleted app". The relation is `onDelete: Cascade` and REQUIRED
+   * (`packages/civitai-db-schema/prisma/schema.full.prisma`), with no `relationMode`
+   * override, so Postgres deletes the grant row along with its AppBlock instead of orphaning
+   * it: this state is not reachable in production. The subscription leg's
+   * `if (!row.appBlock) continue` is unreachable for the same reason — precedent for the
+   * shape, not evidence that the state occurs.
+   *
+   * What it pins is the intent that an unresolvable row is SKIPPED rather than rendered as a
+   * card with no name, which is what the manifest-or-blockId fallback would otherwise produce.
    */
   it('skips a grant-only row whose AppBlock does not resolve', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');

--- a/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
@@ -133,10 +133,137 @@ describe('listMyScopeGrants', () => {
     ]);
     const result = await listMyScopeGrants(42);
     expect(result[0].buzzBudgetPerDay).toBe(750);
-    // Scoped to the apps actually in the result — never an unbounded scan.
+    // 🔴 THIS ASSERTION USED TO REQUIRE `appBlockId: { in: [...] }`, AND THAT BOUND WAS
+    // THE DEFECT — it is deliberately inverted, not deleted. Filtering the grant read by
+    // the INSTALL set meant a grant for a never-installed app was never queried, so the
+    // budget editor could not render for it (see the service docblock). The read is now
+    // keyed on `userId` alone, which is the same `(user_id, app_block_id)` index with a
+    // cheaper predicate and is bounded by the viewer's own grant count.
     expect(mockDbRead.appUserScopeGrant.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { userId: 42, appBlockId: { in: ['apb_1'] } } })
+      expect.objectContaining({ where: { userId: 42 } })
     );
+  });
+
+  /**
+   * 🔴 THE GRANT-ONLY APP. This is the regression the whole change exists for, and the
+   * shape that shipped broken: a full-page app at `/apps/run/<slug>` is CONSENTED to,
+   * never installed, so it has a live `app_user_scope_grants` row and NO
+   * `block_user_subscriptions` row. Aggregating installs alone returned `[]`, the
+   * permissions panel rendered "No apps installed or subscribed yet.", and
+   * `AppBudgetControl` — which renders only from these rows — never appeared. The user
+   * could consent, generate and SPEND with no surface on which to bound it.
+   *
+   * Measured in production 2026-09-11: 4 subscription rows platform-wide against 29
+   * grants, so this was very nearly every consenting user rather than an edge case.
+   *
+   * RED AT BASE: on the pre-change service every assertion below fails at the first —
+   * `result` is `[]`, because `byAppBlock` is built from subscriptions and the grant
+   * read is filtered to its keys.
+   */
+  it('🔴 surfaces an app the viewer GRANTED but never installed, with its budget control data', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    // No installs, no subscriptions — the full-page-app shape.
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([]);
+    mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([
+      {
+        appBlockId: 'apb_9',
+        buzzBudgetPerDay: 1200,
+        revokedAt: null,
+        grantedScopes: ['ai:write:budgeted', 'buzz:read:self'],
+        appBlock: appBlock({
+          id: 'apb_9',
+          blockId: 'sensei',
+          manifest: { name: 'Sensei', scopes: ['ai:write:budgeted'] },
+          approvedScopes: ['ai:write:budgeted'],
+        }),
+      },
+    ]);
+
+    const result = await listMyScopeGrants(42);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].appBlockId).toBe('apb_9');
+    expect(result[0].slug).toBe('sensei');
+    expect(result[0].name).toBe('Sensei');
+    // The two fields the budget editor keys off. Without BOTH, the control does not
+    // render even when the row exists.
+    expect(result[0].spendScopeGranted).toBe(true);
+    expect(result[0].buzzBudgetPerDay).toBe(1200);
+    // Honest surface counts — it really is installed nowhere.
+    expect(result[0].surfaces.modelInstallCount).toBe(0);
+    expect(result[0].surfaces.subscriptionScopes).toEqual([]);
+  });
+
+  /**
+   * The grant leg must not CLOBBER the subscription leg for an app that has both —
+   * a plain `set()` would zero the install counts. Distinct non-zero fixture values
+   * (2 pinned models, a blanket scope) so a mutant that resets either one is visible.
+   */
+  it('keeps install/subscription counts for an app that has BOTH a grant and installs', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
+      pinnedSub({ targetModelIds: [100, 101] }),
+      blanketSub(),
+    ]);
+    mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([
+      {
+        appBlockId: 'apb_1',
+        buzzBudgetPerDay: 300,
+        revokedAt: null,
+        grantedScopes: ['ai:write:budgeted'],
+        appBlock: appBlock(),
+      },
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result).toHaveLength(1);
+    expect(result[0].surfaces.modelInstallCount).toBe(2);
+    expect(result[0].surfaces.subscriptionScopes).toEqual(['viewer_personal']);
+    expect(result[0].buzzBudgetPerDay).toBe(300);
+  });
+
+  /**
+   * ⚠️ INVARIANT GUARD, NOT REGRESSION COVERAGE — labelled so nobody counts it as the
+   * latter. Nothing in this repo writes a non-null `revoked_at`, so this state is not
+   * currently reachable in production. It pins the intent that a revoked grant conveys
+   * nothing: it must not mint a row whose only reason to exist is a consent that was
+   * withdrawn, which would offer a budget control for an app that cannot spend.
+   */
+  it('does NOT surface a grant-only app whose grant is revoked (invariant guard)', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([]);
+    mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([
+      {
+        appBlockId: 'apb_9',
+        buzzBudgetPerDay: 1200,
+        revokedAt: new Date('2026-01-01T00:00:00Z'),
+        grantedScopes: ['ai:write:budgeted'],
+        appBlock: appBlock({ id: 'apb_9', blockId: 'sensei' }),
+      },
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result).toEqual([]);
+  });
+
+  /**
+   * A grant row whose AppBlock join does not resolve (a `Restrict`-deleted app, or the
+   * FK pointing at a row the select could not read) must be SKIPPED, not rendered as a
+   * card with no name. Mirrors the `if (!row.appBlock) continue` the subscription leg
+   * already applies.
+   */
+  it('skips a grant-only row whose AppBlock does not resolve', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([]);
+    mockDbRead.appUserScopeGrant.findMany.mockResolvedValue([
+      {
+        appBlockId: 'apb_gone',
+        buzzBudgetPerDay: 500,
+        revokedAt: null,
+        grantedScopes: ['ai:write:budgeted'],
+        appBlock: null,
+      },
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result).toEqual([]);
   });
 
   it('reports null when the app has no grant row', async () => {

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -255,6 +255,17 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
       // `revoked_at` today, so this is an invariant guard, not a reachable branch —
       // labelled as such rather than counted as coverage.)
       //
+      // ⚠️ `g.appBlock` IS A SECOND INVARIANT GUARD, NOT A REACHABLE BRANCH — stated because
+      // an earlier revision of this comment implied otherwise. `AppUserScopeGrant.appBlock`
+      // is a REQUIRED relation with `onDelete: Cascade`
+      // (`packages/civitai-db-schema/prisma/schema.full.prisma`), and the datasource sets no
+      // `relationMode`, so Postgres enforces the FK: deleting an AppBlock deletes the grant
+      // row rather than orphaning it. The subscription leg's own `if (!row.appBlock) continue`
+      // is unreachable for exactly the same reason — it is precedent for the shape, NOT
+      // evidence that the state occurs. (Migrations here are applied by hand per environment,
+      // so "the constraint exists in prod" is not verifiable from the schema alone; the guard
+      // costs nothing and is kept for that residual.)
+      //
       // The `has` check keeps the subscription leg authoritative for apps that have
       // BOTH: that entry already carries real `modelInstallCount`/`subscriptionScopes`,
       // and overwriting it here would zero them.

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -83,15 +83,32 @@ export type ScopeGrantSurface = {
 };
 
 /**
- * Aggregates one row per AppBlock the user has either installed on a
- * model or subscribed to. Same app counted across multiple installs +
- * subscriptions collapses to a single row with denormalised counts.
+ * Aggregates one row per AppBlock the user has installed on a model,
+ * subscribed to, OR granted scopes to at a consent prompt. Same app counted
+ * across multiple installs + subscriptions collapses to a single row with
+ * denormalised counts.
  *
  * `enabled=false` model installs are excluded — a user-facing surface
  * for "what an app can do today" shouldn't surface installs the user
  * has explicitly toggled off. Subscriptions are included regardless of
  * the enabled flag because the row IS the user's claim of intent (the
  * toggle on `/apps/activity` already lets them turn it off).
+ *
+ * 🔴 THE GRANT LEG IS NOT A NICETY — WITHOUT IT THE BUDGET EDITOR IS UNREACHABLE FOR
+ * ESSENTIALLY EVERYONE, AND THAT SHIPPED. This aggregated installs ONLY, while the
+ * per-app daily Buzz budget lives on `app_user_scope_grants`. A full-page app
+ * (`/apps/run/<slug>`) is consented to, never installed, so it produced NO row here —
+ * and `ScopeGrantsPanel`, whose only read is this function, renders `AppBudgetControl`
+ * exclusively from these rows. Measured in production 2026-09-11: the whole platform
+ * held **4** `block_user_subscriptions` rows against **29** `app_user_scope_grants`,
+ * and the account that had just spent 28 Buzz through a consented app saw
+ * "No apps installed or subscribed yet." So the user could consent, generate and
+ * spend, and had no surface on which to bound it — the exact "a budget nobody can set
+ * is inert" failure the consent-budget work was meant to avoid.
+ *
+ * A grant-only app is therefore a first-class row with `modelInstallCount: 0` and no
+ * subscription scopes. It is NOT synthesised from the manifest: it exists only when the
+ * viewer has a live (non-revoked) grant row, which is their own recorded consent.
  */
 export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurface[]> {
   // Post kill_per_model_installs: every install — blanket OR per-model-
@@ -159,27 +176,46 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
   }
 
   // The consent BUDGET lives on the grant row, not on the subscription rows this
-  // function aggregates — one indexed read for every app in the result, rather than
-  // an N+1 per row. Apps with no grant row simply do not appear in the map and
-  // report `null`, which is the same thing "no budget set" means everywhere else.
+  // function aggregates — ONE indexed read for the viewer's whole grant set, rather
+  // than an N+1 per row.
+  //
+  // 🔴 THIS READ IS NO LONGER BOUNDED BY `byAppBlock` AND THAT IS THE FIX. It used to
+  // filter `appBlockId: { in: Array.from(byAppBlock.keys()) }` and to run at all only
+  // when `byAppBlock.size > 0`, so a grant for an app the viewer had NOT installed was
+  // never even queried — which is every full-page app. Both bounds are gone: the query
+  // is keyed on `userId` alone (covered by the `(user_id, app_block_id)` unique index,
+  // so this is the same index and a cheaper predicate), and grant-only apps are folded
+  // into `byAppBlock` below.
   const budgetByAppBlock = new Map<string, number | null>();
   const spendGrantedByAppBlock = new Set<string>();
-  if (byAppBlock.size > 0) {
+  {
     type GrantRow = {
       appBlockId: string;
       buzzBudgetPerDay: number | null;
       revokedAt: Date | null;
       grantedScopes: string[];
+      appBlock: AppBlockRow | null;
     };
     let grants: GrantRow[] = [];
     try {
       grants = (await dbRead.appUserScopeGrant.findMany({
-        where: { userId, appBlockId: { in: Array.from(byAppBlock.keys()) } },
+        where: { userId },
         select: {
           appBlockId: true,
           buzzBudgetPerDay: true,
           revokedAt: true,
           grantedScopes: true,
+          // Needed only for the grant-only apps below — a subscription-backed app
+          // already carries its AppBlock from the `subs` read. Selected here rather
+          // than fetched per-app so the grant leg stays a single query.
+          appBlock: {
+            select: {
+              id: true,
+              blockId: true,
+              manifest: true,
+              approvedScopes: true,
+            },
+          },
         },
       })) as GrantRow[];
     } catch (err) {
@@ -208,6 +244,26 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
       // Mirror `getGrantedScopes`: a revoked row grants nothing.
       if (!g.revokedAt && (g.grantedScopes ?? []).includes('ai:write:budgeted')) {
         spendGrantedByAppBlock.add(g.appBlockId);
+      }
+
+      // A live grant for an app with no install/subscription is still a thing the
+      // viewer consented to and can spend through, so it gets its own row.
+      //
+      // 🔴 REVOKED ROWS ARE SKIPPED, matching `getGrantedScopes`/`getConsentBuzzBudget`:
+      // a revoked grant conveys nothing, so surfacing it would offer a budget control
+      // for an app that cannot spend. (Nothing in the repo writes a non-null
+      // `revoked_at` today, so this is an invariant guard, not a reachable branch —
+      // labelled as such rather than counted as coverage.)
+      //
+      // The `has` check keeps the subscription leg authoritative for apps that have
+      // BOTH: that entry already carries real `modelInstallCount`/`subscriptionScopes`,
+      // and overwriting it here would zero them.
+      if (!g.revokedAt && g.appBlock && !byAppBlock.has(g.appBlockId)) {
+        byAppBlock.set(g.appBlockId, {
+          appBlock: g.appBlock,
+          modelInstallCount: 0,
+          subscriptionScopes: new Set(),
+        });
       }
     }
   }


### PR DESCRIPTION
## The defect

`listMyScopeGrants` aggregated **installs only**, while the per-app daily Buzz budget lives on `app_user_scope_grants`. A full-page app at `/apps/run/<slug>` is **consented to and never installed**, so it produced no row — and `ScopeGrantsPanel`, whose only read is this function, renders `AppBudgetControl` exclusively from these rows.

So a user could consent, generate, and **spend**, with no surface on which to bound it. That is precisely the *"a budget nobody can set is inert"* failure the consent-budget work set out to avoid.

## How it was found

Driving the real flow in production as a widened-cohort account (non-moderator, id `11072787`), not by reading code.

Measured on prod the same minute:

| table | rows for that user |
|---|---|
| `app_user_scope_grants` — where `buzz_budget_per_day` lives | **2**, both live, `sensei` holding `ai:write:budgeted` |
| `block_user_subscriptions` — what the editor enumerated | **0** |

That account had just spent **28 Buzz** through `sensei` (six debits, confirmed in the `buzz-db` ledger) and its permissions tab said *"No apps installed or subscribed yet."*

**Platform-wide: 4 subscription rows against 29 grants.** This was very nearly every consenting user, not an edge case.

## The change

Two bounds removed from the grant read:

- it no longer filters `appBlockId: { in: Array.from(byAppBlock.keys()) }`, and no longer runs only `if (byAppBlock.size > 0)` — so a grant for a never-installed app is actually queried. It is keyed on `userId` alone: the same `(user_id, app_block_id)` index with a cheaper predicate, bounded by the viewer's own grant count.
- live, non-revoked grants are folded into the aggregate as first-class rows with `modelInstallCount: 0` and no subscription scopes.

Guards, each mirroring an existing rule rather than inventing one:

- **revoked grants are skipped**, matching `getGrantedScopes` / `getConsentBuzzBudget` — a revoked grant must not offer a budget control for an app that cannot spend;
- **a grant whose `AppBlock` join does not resolve is skipped**, as the subscription leg already does;
- **the subscription leg stays authoritative** for apps that have both, so install counts are never zeroed by the grant leg.

`byAppBlock` is populated *before* the grant read, so the existing `P2022` guard still renders subscription-backed apps when `buzz_budget_per_day` is absent.

## Test matrix — stated honestly

**RED at `origin/main`, green at HEAD** (real regression coverage):

- `surfaces an app the viewer GRANTED but never installed` — fails at base with `expected [] to have a length of 1`
- `surfaces the consent budget from the grant row` — its assertion is **inverted, not deleted**: it used to *require* the `appBlockId: { in: ... }` bound that caused this defect

**Reachable guards proven by mutation, but NOT red at base** — they pass at base for the wrong reason (base returns `[]` for all three), so they are guards, not regression coverage:

| mutation | test that killed it |
|---|---|
| drop `!g.revokedAt` | revoked grant-only row is not surfaced |
| drop `g.appBlock` | grant-only row with unresolved AppBlock is skipped |
| drop `!byAppBlock.has(...)` | app with BOTH keeps its install counts |

Each mutant produced **exactly one** failing test — its own — so none died for another guard's reason.

## Verification

- Unit tier: **249 files / 6084 tests pass** (`src/server/services/blocks/`, `src/components/Apps/__tests__/`).
- `typecheck`: **0 errors.** ⚠️ A first run showed 10 errors, all in `src/server/services/image.service.ts`, caused by the `event-engine-common` **submodule** being unpopulated in a fresh worktree. None named a file in this diff; clean after `submodule update --init`.
- `eslint`: one `consistent-type-imports` error at line 16 (`import { Prisma }`). **Pre-existing** — verified by linting the base file, which reports the identical error. My diff touches 0 `Prisma` lines. Left alone rather than widening the diff.
- ⚠️ **Component/browser tier NOT run locally** — the nix-pinned Playwright browsers don't match the installed Playwright (`chromium_headless_shell-1200` absent; the store has `-1228`). CI owns that tier. Reasoning, not a green run: both browser consumers (`AppActivityPage.browser.test.tsx:123`, `AppPermissionsActivityDrawer.browser.test.tsx:69`) **mock `blocks.listMyScopeGrants` at the tRPC boundary** and never invoke the real service, so a server-side change cannot reach them.

## 🔴 Interaction with #4722 — please read before merging either

**#4722 independently diagnosed this same root cause and chose honest copy over a data fix.** Its own comment says it plainly: *"`listMyScopeGrants`, whose only source is the viewer's OWN `block_user_subscriptions` rows. A full-page app has no install, so that lookup is `undefined` for every such app."*

The two changes are **file-disjoint** — this PR touches only the service and its test; #4722 touches `activity.tsx`, `AppPermissionsActivityDrawer.tsx`, `appsActivityTabs.ts` and two browser tests. `user-app-surface.service.ts` appears in **0** of #4722's files. But disjoint files are not safety, and there is a real **semantic** overlap:

- #4722 widens copy to say the surface is install-backed (*"The apps you've installed or subscribed to…"*, *"Permissions from your installs"*). After this PR that framing is **too narrow** — the surface also lists apps you granted scopes to. One clause needs widening whichever merges second.
- #4722's new empty label in the drawer (*"No permissions recorded from an install of this app…"*) exists because `grants.find(...)` returns `undefined` for full-page apps. After this PR that lookup **resolves**, so the label correctly appears far less often. This PR removes the cause that #4722 mitigates; they are complementary, not competing.

#4722 is currently `CONFLICTING`/`DIRTY` against `main` independent of this PR, so it needs a rebase regardless — that is the moment to reconcile the copy.

Not stacked: this branches directly off `main`.

## Deliberately not in scope

- **Revocation.** Nothing in the repo writes a non-null `revoked_at`; #4722 states withdrawing a permission is not possible yet. The revoked branch here is an invariant guard, labelled as such.
- **Copy changes on `/apps/activity`.** Kept off that file entirely to avoid colliding with #4722. `buildSurfaceLine` already renders `0 installs / no scopes` as `"Subscriptions: none"`, which is accurate for a grant-only app if terse — worth a follow-up pass once #4722 lands.
