### PR TITLE
feat(apps): disclose an on-site app's permissions on the store page, before launch

### DIFF
--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -317,6 +317,10 @@ function base(over: Partial<ListingDetail>): ListingDetail {
     betaMessage: null,
     updatedAt: '2026-03-04T05:06:07.000Z',
     screenshots: [],
+    // No declared scopes: this file is not about the permission disclosure, and an
+    // empty array renders no section at all. `projectListingDetail` guarantees an
+    // array, so a fixture omitting it would not match any real payload.
+    scopes: [],
     kindData: {
       kind: 'onsite',
       appBlockId: 'blk-1',

--- a/src/components/Apps/AppListingDetailBody.gallery.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.gallery.browser.test.tsx
@@ -171,6 +171,10 @@ function base(over: Partial<ListingDetail>): ListingDetail {
     betaMessage: null,
     updatedAt: '2026-03-04T05:06:07.000Z',
     screenshots: [],
+    // No declared scopes: this file is not about the permission disclosure, and an
+    // empty array renders no section at all. `projectListingDetail` guarantees an
+    // array, so a fixture omitting it would not match any real payload.
+    scopes: [],
     kindData: {
       kind: 'onsite',
       appBlockId: 'blk-1',

--- a/src/components/Apps/AppListingDetailBody.permissions.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.permissions.browser.test.tsx
@@ -186,12 +186,18 @@ describe('AppListingDetailBody — pre-launch permission disclosure', () => {
     expect(container.querySelector('[data-testid="apps-listing-permissions"]')).toBeNull();
   });
 
+  // 🔴 INVARIANT GUARD ON A CURRENTLY-UNREACHABLE PATH — NOT regression coverage,
+  // and counting it as such would overstate this file. No production producer emits
+  // `preview` + non-empty `scopes`: every preview detail has `scopes: []` (both
+  // writers of `AppListingPublishRequest.appListingId` create `kind: 'offsite'`,
+  // `appBlockId: null` rows, and `buildListingDetailPreview` hardcodes `[]`), so the
+  // component's `length > 0` guard means the section never renders in preview at all.
+  // The pair below is mutation-killable as a STRING guard (verified: hardcoding
+  // either heading reddens exactly one of the two), so it is not vacuous — but what
+  // it pins is a branch nothing currently reaches. It earns its place by being
+  // correct the day `getListingPreviewForReview` reads the parent's scopes for a
+  // shadow revision, which is what would make preview non-empty.
   test('🔴 under `preview` the heading says CURRENTLY GRANTED, not "This app can…"', async () => {
-    // `CombinedReviewModal` renders this body in preview mode BESIDE the pending
-    // version's REQUESTED scopes (`ManifestScopes`). `detail.scopes` is what is
-    // currently APPROVED, so for an escalating version the two lists differ — and a
-    // moderator reading the confident "This app can…" as the set they are approving
-    // would under-read the escalation, on the one surface where that call is made.
     const { container } = await renderWithProviders(
       <AppListingDetailBody detail={base({ scopes: [PLAIN_SCOPE] })} preview />
     );

--- a/src/components/Apps/AppListingDetailBody.permissions.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.permissions.browser.test.tsx
@@ -186,17 +186,20 @@ describe('AppListingDetailBody — pre-launch permission disclosure', () => {
     expect(container.querySelector('[data-testid="apps-listing-permissions"]')).toBeNull();
   });
 
-  // 🔴 INVARIANT GUARD ON A CURRENTLY-UNREACHABLE PATH — NOT regression coverage,
-  // and counting it as such would overstate this file. No production producer emits
-  // `preview` + non-empty `scopes`: every preview detail has `scopes: []` (both
-  // writers of `AppListingPublishRequest.appListingId` create `kind: 'offsite'`,
-  // `appBlockId: null` rows, and `buildListingDetailPreview` hardcodes `[]`), so the
-  // component's `length > 0` guard means the section never renders in preview at all.
-  // The pair below is mutation-killable as a STRING guard (verified: hardcoding
-  // either heading reddens exactly one of the two), so it is not vacuous — but what
-  // it pins is a branch nothing currently reaches. It earns its place by being
-  // correct the day `getListingPreviewForReview` reads the parent's scopes for a
-  // shadow revision, which is what would make preview non-empty.
+  // 🔴 REAL REGRESSION COVERAGE ON A REACHABLE PATH. A production producer DOES emit
+  // `preview` + non-empty `scopes`: `routeRepublishToReviewInTx` writes
+  // `kind: listing.kind` against the LIVE listing, so an approved ON-SITE app that is
+  // self-unpublished and republished with a changed asset yields a `kind: 'onsite'`
+  // request whose `appListingId` is a live listing WITH a non-null `appBlockId` —
+  // `getListingPreviewForReview` then projects real scopes into a `preview` render.
+  // `OffsiteReviewQueue` has its own 🔴 comment about that producer and an
+  // `ONSITE_REPUBLISH_ROW` fixture of exactly that shape.
+  // ⚠ An intermediate revision of this header called the pair an "invariant guard on
+  // a currently-unreachable path" and said it was NOT regression coverage. That was
+  // wrong — it counted two of the four writers of that column — and it was wrong in
+  // the direction that invites deleting these tests. The pair is also
+  // mutation-killable as a string guard: hardcoding either heading reddens exactly
+  // one of the two.
   test('🔴 under `preview` the heading says CURRENTLY GRANTED, not "This app can…"', async () => {
     const { container } = await renderWithProviders(
       <AppListingDetailBody detail={base({ scopes: [PLAIN_SCOPE] })} preview />

--- a/src/components/Apps/AppListingDetailBody.permissions.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.permissions.browser.test.tsx
@@ -186,6 +186,31 @@ describe('AppListingDetailBody — pre-launch permission disclosure', () => {
     expect(container.querySelector('[data-testid="apps-listing-permissions"]')).toBeNull();
   });
 
+  test('🔴 under `preview` the heading says CURRENTLY GRANTED, not "This app can…"', async () => {
+    // `CombinedReviewModal` renders this body in preview mode BESIDE the pending
+    // version's REQUESTED scopes (`ManifestScopes`). `detail.scopes` is what is
+    // currently APPROVED, so for an escalating version the two lists differ — and a
+    // moderator reading the confident "This app can…" as the set they are approving
+    // would under-read the escalation, on the one surface where that call is made.
+    const { container } = await renderWithProviders(
+      <AppListingDetailBody detail={base({ scopes: [PLAIN_SCOPE] })} preview />
+    );
+    const within = page.elementLocator(container);
+
+    await expect.element(within.getByText('Currently granted permissions')).toBeInTheDocument();
+    // And NOT the public heading — asserting only the presence of the new string
+    // would pass if both rendered.
+    expect(container.textContent).not.toContain('This app can');
+  });
+
+  test('the public (non-preview) heading is still "This app can…"', async () => {
+    const { container } = await renderBody(base({ scopes: [PLAIN_SCOPE] }));
+    // The other half of the pair: a mutant hardcoding the preview string would pass
+    // the test above and fail here.
+    expect(container.textContent).toContain('This app can');
+    expect(container.textContent).not.toContain('Currently granted permissions');
+  });
+
   test('a sensitive scope is distinguished from a plain one', async () => {
     const { within, container } = await renderBody(
       base({ scopes: [PLAIN_SCOPE, SENSITIVE_SCOPE] })

--- a/src/components/Apps/AppListingDetailBody.permissions.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.permissions.browser.test.tsx
@@ -1,0 +1,205 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
+import type * as FeatureFlagsMod from '~/providers/FeatureFlagsProvider';
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * App-listing detail — the PRE-LAUNCH PERMISSION DISCLOSURE.
+ *
+ * The store detail page must tell a viewer what an on-site app is permitted to do
+ * BEFORE they open it. The equivalent disclosure already existed on the retired
+ * `/apps/<appBlockId>` route (still served by `blocks.getAppDetail`); it did not
+ * travel with the detail page when it moved to `/apps/store-preview/<slug>`, which
+ * is served by `appListings.getAppDetail` → this component.
+ *
+ * 🔴 READ THIS BEFORE TREATING ANY RESULT HERE AS A GATE: IT IS NOT ONE. This file
+ * is in the Vitest browser-mode `component` project, which CI runs only as the
+ * preview pipeline's `preview / component-tests` — report-only, non-blocking, and
+ * not reported at all when the preview build fails. The GATING half of this change
+ * lives in the blocking node project, in
+ * `src/server/services/blocks/__tests__/app-listing.service.test.ts`, which pins
+ * the thing that actually matters for safety: that the disclosure is fed by the
+ * moderator-granted `approvedScopes` column and NEVER by the app's self-declared
+ * `manifest.scopes`. That file cannot see a single DOM node; this one cannot block
+ * a merge. Neither substitutes for the other, and this file exists for the half the
+ * projection tests structurally cannot make — that the component actually RENDERS
+ * what the DTO carries, and renders nothing when there is nothing to disclose.
+ *
+ * 🔴 RED/GREEN HONESTY — MEASURED, not asserted. Reverting ONLY the component to
+ * `origin/main` and re-running this file gives `2 failed | 2 passed (4)`:
+ *
+ *   - the two POSITIVE tests fail with a real assertion (`expected null not to be
+ *     null` — the section is absent), so they are genuine coverage;
+ *   - the two ABSENCE tests ("no section when there are no scopes", "none for an
+ *     off-site listing") PASS AT BASE, VACUOUSLY. Of course they do: they assert
+ *     the section is not there, and at base it is never there for anyone.
+ *
+ * 🔴 So do not read "4 passed" as four guards. Two of these are regression guards
+ * against an empty-box or wrong-kind regression LATER; at base they prove nothing,
+ * and counting them as red-at-base evidence would be false. The regression-shaped
+ * claim for the feature itself belongs to the node suite, where the pre-change
+ * source was watched to fail 5 assertions, each for its own reason.
+ *
+ * 🔴 NO CSS IS LOADED, so nothing here measures a visual property. Every assertion
+ * is structural: a `data-testid`, an accessible name, the presence or absence of a
+ * node. "Is the badge orange" is not a claim this file can make — the sensitive
+ * flagging is asserted via `SensitiveScopeBadge`'s own accessible text.
+ *
+ * 🔴 FIXTURE SCOPES ARE PAIRWISE DISTINCT AND SPAN BOTH SENSITIVITY CLASSES, on
+ * purpose. A fixture of one scope, or of two scopes that are both sensitive, could
+ * not tell "renders every scope" from "renders the first" nor "flags the sensitive
+ * one" from "flags all of them".
+ */
+
+const WIDE: [number, number] = [1440, 900];
+
+// Anonymous viewer — the `⋮` menu and its modals never mount; none of them are
+// what this file is about, and each is a portal beside the content under test.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// 🔴 `importOriginal` SPREAD, not a wholesale replacement (local-rules/
+// no-wholesale-module-mock): a hand-written factory silently breaks every importer
+// the day the real module grows an export it omits — and in this project that
+// surfaces as `Tests no tests`, i.e. as nothing to see rather than as a failure.
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => {
+  const flags = { appBlocks: true, appListings: true, appBlocksPages: false };
+  return {
+    ...(await importOriginal<typeof FeatureFlagsMod>()),
+    useFeatureFlags: () => flags,
+    useOptionalFeatureFlags: () => flags,
+  };
+});
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    appListings: {
+      listAvailable: { useQuery: () => ({ data: { items: [] }, isLoading: false }) },
+      getMyReview: { useQuery: () => ({ data: null, isLoading: false }) },
+      upsertReview: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      reportListing: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
+    user: {
+      getCreator: { useQuery: () => ({ data: null }) },
+      getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) },
+    },
+    useUtils: () => ({
+      appListings: {
+        getMyReview: { invalidate: async () => undefined },
+        listReviews: { invalidate: async () => undefined },
+        getAppDetail: { invalidate: async () => undefined },
+      },
+    }),
+  },
+}));
+vi.mock('~/components/Apps/AppListingReviews', () => ({
+  AppListingReviews: () => <div data-testid="mock-reviews" />,
+}));
+vi.mock('~/components/Apps/AppListingComments', () => ({
+  AppListingComments: () => <div data-testid="mock-comments" />,
+}));
+
+// Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
+const { AppListingDetailBody } = await import('./AppListingDetailBody');
+
+beforeEach(async () => {
+  await page.viewport(...WIDE);
+});
+
+/** One sensitive scope and one that is not, so the flagging is discriminable. */
+const SENSITIVE_SCOPE = 'ai:write:budgeted';
+const PLAIN_SCOPE = 'models:read:self';
+
+function base(over: Partial<ListingDetail>): ListingDetail {
+  return {
+    id: 'l1',
+    serialId: 1,
+    slug: 'my-app',
+    kind: 'onsite',
+    collaborators: [],
+    name: 'My App',
+    tagline: 'A handy app',
+    description: null,
+    category: 'utility',
+    contentRating: null,
+    isBeta: false,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    installCount: 4213,
+    sourceRepoUrl: null,
+    betaMessage: null,
+    updatedAt: '2026-03-04T05:06:07.000Z',
+    screenshots: [],
+    scopes: [],
+    kindData: {
+      kind: 'onsite',
+      appBlockId: 'blk-1',
+      hasPage: true,
+      liveUrl: 'https://my-app.civit.ai',
+    },
+    ...over,
+  };
+}
+
+async function renderBody(detail: ListingDetail) {
+  const { container } = await renderWithProviders(<AppListingDetailBody detail={detail} />);
+  const within = page.elementLocator(container);
+  await expect.element(within.getByText('My App')).toBeInTheDocument();
+  return { container, within };
+}
+
+describe('AppListingDetailBody — pre-launch permission disclosure', () => {
+  test('renders every declared scope before the viewer opens the app', async () => {
+    const { within } = await renderBody(base({ scopes: [PLAIN_SCOPE, SENSITIVE_SCOPE] }));
+
+    await expect.element(within.getByTestId('apps-listing-permissions')).toBeInTheDocument();
+    // Both, not just the first — the fixture's two scopes are distinct strings so
+    // "rendered only one" is a different DOM than "rendered both".
+    await expect.element(within.getByText(PLAIN_SCOPE)).toBeInTheDocument();
+    await expect.element(within.getByText(SENSITIVE_SCOPE)).toBeInTheDocument();
+  });
+
+  test('the section is ABSENT — not empty — when the app declares no scopes', async () => {
+    const { container } = await renderBody(base({ scopes: [] }));
+
+    // 🔴 Absence, not an empty container. On a store listing "no permissions" is
+    // better said by the absence of a permissions section than by a reassuring
+    // sentence nobody reads, and an empty box is exactly what a `length > 0` guard
+    // regression would produce.
+    expect(container.querySelector('[data-testid="apps-listing-permissions"]')).toBeNull();
+  });
+
+  test('an off-site listing (no backing block) shows no permission section', async () => {
+    const { container } = await renderBody(
+      base({
+        kind: 'offsite',
+        scopes: [],
+        kindData: { kind: 'offsite', externalUrl: 'https://example.com', connectClientId: null },
+      })
+    );
+
+    expect(container.querySelector('[data-testid="apps-listing-permissions"]')).toBeNull();
+  });
+
+  test('a sensitive scope is distinguished from a plain one', async () => {
+    const { within, container } = await renderBody(
+      base({ scopes: [PLAIN_SCOPE, SENSITIVE_SCOPE] })
+    );
+
+    const section = container.querySelector('[data-testid="apps-listing-permissions"]');
+    expect(section).not.toBeNull();
+    // `SensitiveScopeBadge` marks the sensitive one, via its own `data-testid`
+    // (verified against the component — not a selector invented here). Exactly ONE
+    // badge for a fixture carrying one sensitive and one plain scope: a component
+    // that flagged everything, or nothing, fails here rather than passing on a
+    // coincidence. That is the whole reason the fixture spans both classes.
+    const sensitiveMarks = section!.querySelectorAll('[data-testid="sensitive-scope-badge"]');
+    expect(sensitiveMarks.length).toBe(1);
+    await expect.element(within.getByTestId('apps-listing-permissions')).toBeInTheDocument();
+  });
+});

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -804,14 +804,15 @@ export interface AppListingDetailBodyProps {
    * rail, screenshot gallery, description markdown — and OMIT every LIVE/interactive
    * or AGGREGATE surface. The full omission ledger, each item a deliberate decision:
    *
-   *   - the PERMISSION DISCLOSURE is KEPT in code but renders NOTHING here in
-   *     practice, and that is a ledger entry rather than a claim to the contrary.
-   *     Every `preview` detail reaching this component has `scopes: []` (both
-   *     publish-request writers create `kind: 'offsite'`, `appBlockId: null` rows;
-   *     `buildListingDetailPreview` hardcodes `[]`), so the `length > 0` guard
-   *     suppresses the section. It carries a distinct heading for the day that
-   *     changes — see the section's own comment, which states plainly that the branch
-   *     is unreachable today rather than claiming it fixes a live hazard,
+   *   - the PERMISSION DISCLOSURE is KEPT, not omitted — a decision on this ledger
+   *     rather than an omission that was missed. It renders under a DIFFERENT HEADING
+   *     here ("Currently granted permissions", not "This app can…") because the review
+   *     modal shows it beside the pending version's REQUESTED scopes, and mislabelling
+   *     the currently-approved set is how a moderator under-reads an escalation.
+   *     🔴 It DOES render here: the owner-republish re-review produces a
+   *     `kind: 'onsite'` request against a LIVE listing with a non-null `appBlockId`.
+   *     An intermediate revision of this ledger claimed it rendered nothing — that was
+   *     wrong; see the section's own comment for the four writers,
    *   - the comments thread + the recommend reviews list (a shadow listing has no
    *     Thread and no review rows; querying them would 404 / N+1),
    *   - the header STAT CHIPS (recommendations + installs are usage aggregates a
@@ -1218,25 +1219,34 @@ export function AppListingDetailBody({
                 the absence of a permissions section than by a sentence nobody reads.
                 Ported from the disclosure on the retired `/apps/<appBlockId>` route,
                 which `blocks.getAppDetail` still serves.
-                🔴 THE `preview` HEADING BRANCH IS UNREACHABLE TODAY — it is an
-                INVARIANT GUARD, not regression coverage, and saying so is the point.
-                The only `preview` render is `OffsiteReviewQueue`'s
-                `ListingPreviewSection`, whose detail is either
-                `buildListingDetailPreview` (hardcodes `scopes: []`) or
-                `getListingPreviewForReview` on a publish-request listing — and BOTH
-                writers of `AppListingPublishRequest.appListingId` create rows with
-                `kind: 'offsite'` and `appBlockId: null`. Either way `scopes` is `[]`,
-                so the `length > 0` guard above means NO permission section renders in
-                preview at all, under either heading.
-                ⚠ An earlier version of this comment asserted that a moderator could
-                "under-read a scope ESCALATION" here. They cannot — the UI cannot
-                produce that mis-reading, because it shows nothing. The heading is kept
-                because it costs three lines and is correct the moment the branch
-                becomes reachable; it is NOT kept because it fixes a live hazard.
-                To make it reachable, `getListingPreviewForReview` would have to read
-                `appBlock`/`approvedScopes` from the PARENT listing for a shadow
-                revision — which it already does for `beta`. That is a moderator-facing
-                feature, deliberately not in this PR's scope. */}
+                🔴 THE `preview` HEADING IS A CORRECTNESS FIX ON A REACHABLE PATH, NOT
+                COPY AND NOT AN INVARIANT GUARD. `detail.scopes` is what is CURRENTLY
+                approved; the review modal shows it beside `ManifestScopes`, the scopes
+                the pending version is REQUESTING. Those differ exactly when a version
+                escalates, and the confident natural-language heading was on the wrong
+                one — so a moderator could read "This app can…" as the set they are
+                approving and under-read the escalation, on the one surface where that
+                call is made.
+                🔴 REACHED VIA THE OWNER-REPUBLISH RE-REVIEW, which is why a
+                "preview means an off-site shadow" reading is wrong. There are FOUR
+                writers of `AppListingPublishRequest.appListingId`, and two copy the
+                kind from the target rather than hardcoding `'offsite'`:
+                `offsite-moderation.service.ts`'s `routeRepublishToReviewInTx` writes
+                `kind: listing.kind` against the LIVE listing id — so an approved
+                ON-SITE app that is self-unpublished and republished with a changed
+                asset produces a `kind: 'onsite'`, non-shadow request whose
+                `appListingId` is a live on-site listing WITH a non-null `appBlockId`.
+                `getListingPreviewForReview` is deliberately not status-filtered and
+                runs `projectListingDetail` verbatim, so `scopes` is non-empty and this
+                section renders. `OffsiteReviewQueue` renders `ListingPreviewSection`
+                with no kind gate, and already carries its own 🔴 comment that
+                "`kind === 'onsite'` NO LONGER IMPLIES 'a media revision'" for exactly
+                this producer; its `ONSITE_REPUBLISH_ROW` fixture is that shape.
+                ⚠ An intermediate version of this comment claimed the branch was
+                UNREACHABLE and that the heading was therefore an invariant guard. That
+                was wrong, and wrong in the dangerous direction — it licensed deleting a
+                heading and a test that both guard a live moderator-facing path. It
+                counted two of the four writers. */}
             {detail.scopes.length > 0 && (
               <Stack gap="xs" data-testid="apps-listing-permissions">
                 <Group gap="xs">

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -13,6 +13,7 @@ import {
   SimpleGrid,
   Stack,
   Text,
+  ThemeIcon,
   Title,
   UnstyledButton,
 } from '@mantine/core';
@@ -23,6 +24,7 @@ import {
   IconFlask,
   IconInfoCircle,
   IconPlugConnected,
+  IconShieldCheck,
   IconThumbUp,
 } from '@tabler/icons-react';
 import type { Icon } from '@tabler/icons-react';
@@ -35,6 +37,7 @@ import {
   listingPlaceholderGradient,
 } from '~/shared/constants/app-listing-placeholder.constants';
 import { ACTION_GLYPH_ICONS, detailActionGlyph } from '~/components/Apps/appListingActionGlyph';
+import { BlockScopeList } from '~/components/Apps/BlockScopeList';
 import { buildListingDetailRows } from '~/components/Apps/appListingDetailRows';
 import { buildListingStatChips, type ListingStatChip } from '~/components/Apps/appListingStatChips';
 import {
@@ -1187,6 +1190,36 @@ export function AppListingDetailBody({
                 This app runs off-platform, but can connect to your Civitai account — you&apos;ll be
                 asked to sign in and approve access.
               </Alert>
+            )}
+
+            {/* PRE-LAUNCH PERMISSION DISCLOSURE — what this app is permitted to do,
+                shown BEFORE the viewer opens it.
+                🔴 This is the third permission surface on this page and it does NOT
+                belong to the mutually-exclusive off-site pair above. Those two answer
+                "does this leave the platform, and can it reach my account at all?" for
+                an OFF-SITE listing; this one enumerates the granted capabilities of an
+                ON-SITE app, which the pair is silent about by construction. Do not fold
+                it into either predicate — `shouldShowOffsiteDisclosure` and
+                `shouldShowConnectCapability` are exact complements over one domain and a
+                third condition there would break the invariant pinned in
+                `__tests__/appListingDetailView.test.ts`.
+                🔴 Rendered ONLY when there is something to disclose: an app approved with
+                no scopes gets no section at all, rather than a reassuring empty box. That
+                is why the guard is `length > 0` and not `BlockScopeList`'s own
+                `emptyLabel` path — on a store listing, "no permissions" is better said by
+                the absence of a permissions section than by a sentence nobody reads.
+                Ported from the disclosure on the retired `/apps/<appBlockId>` route,
+                which `blocks.getAppDetail` still serves. */}
+            {detail.scopes.length > 0 && (
+              <Stack gap="xs" data-testid="apps-listing-permissions">
+                <Group gap="xs">
+                  <ThemeIcon variant="light" color="blue" size="sm" radius="xl">
+                    <IconShieldCheck size={14} />
+                  </ThemeIcon>
+                  <Title order={4}>This app can…</Title>
+                </Group>
+                <BlockScopeList scopes={detail.scopes} />
+              </Stack>
             )}
           </Stack>
         </ContainerGrid2.Col>

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -804,14 +804,14 @@ export interface AppListingDetailBodyProps {
    * rail, screenshot gallery, description markdown — and OMIT every LIVE/interactive
    * or AGGREGATE surface. The full omission ledger, each item a deliberate decision:
    *
-   *   - the PERMISSION DISCLOSURE is KEPT, not omitted — a decision on this ledger
-   *     rather than an omission that was missed. A moderator reviewing a listing has
-   *     more use for the app's granted capabilities than any other viewer, so hiding
-   *     it here would be the wrong direction. 🔴 But it renders under a DIFFERENT
-   *     HEADING in this posture ("Currently granted permissions" rather than "This
-   *     app can…"), because this modal also shows the pending version's REQUESTED
-   *     scopes and the two differ exactly when a version is escalating. See the
-   *     section's own comment for why that is a correctness fix and not copy,
+   *   - the PERMISSION DISCLOSURE is KEPT in code but renders NOTHING here in
+   *     practice, and that is a ledger entry rather than a claim to the contrary.
+   *     Every `preview` detail reaching this component has `scopes: []` (both
+   *     publish-request writers create `kind: 'offsite'`, `appBlockId: null` rows;
+   *     `buildListingDetailPreview` hardcodes `[]`), so the `length > 0` guard
+   *     suppresses the section. It carries a distinct heading for the day that
+   *     changes — see the section's own comment, which states plainly that the branch
+   *     is unreachable today rather than claiming it fixes a live hazard,
    *   - the comments thread + the recommend reviews list (a shadow listing has no
    *     Thread and no review rows; querying them would 404 / N+1),
    *   - the header STAT CHIPS (recommendations + installs are usage aggregates a
@@ -1218,15 +1218,25 @@ export function AppListingDetailBody({
                 the absence of a permissions section than by a sentence nobody reads.
                 Ported from the disclosure on the retired `/apps/<appBlockId>` route,
                 which `blocks.getAppDetail` still serves.
-                🔴 THE HEADING CHANGES UNDER `preview`, AND IT IS A CORRECTNESS FIX, NOT
-                COPY. `CombinedReviewModal` renders this body BESIDE `ManifestScopes`,
-                which lists the scopes the pending version is REQUESTING, while
-                `detail.scopes` is what is CURRENTLY approved. For a version requesting
-                new scopes those two lists differ — and the confident natural-language one
-                was this one. A moderator reading "This app can…" as the set they are
-                approving would under-read a scope ESCALATION, on the single surface where
-                that judgement is made. KEPT rather than omitted in preview (so the
-                before/after is visible at all), but named for what it is. */}
+                🔴 THE `preview` HEADING BRANCH IS UNREACHABLE TODAY — it is an
+                INVARIANT GUARD, not regression coverage, and saying so is the point.
+                The only `preview` render is `OffsiteReviewQueue`'s
+                `ListingPreviewSection`, whose detail is either
+                `buildListingDetailPreview` (hardcodes `scopes: []`) or
+                `getListingPreviewForReview` on a publish-request listing — and BOTH
+                writers of `AppListingPublishRequest.appListingId` create rows with
+                `kind: 'offsite'` and `appBlockId: null`. Either way `scopes` is `[]`,
+                so the `length > 0` guard above means NO permission section renders in
+                preview at all, under either heading.
+                ⚠ An earlier version of this comment asserted that a moderator could
+                "under-read a scope ESCALATION" here. They cannot — the UI cannot
+                produce that mis-reading, because it shows nothing. The heading is kept
+                because it costs three lines and is correct the moment the branch
+                becomes reachable; it is NOT kept because it fixes a live hazard.
+                To make it reachable, `getListingPreviewForReview` would have to read
+                `appBlock`/`approvedScopes` from the PARENT listing for a shadow
+                revision — which it already does for `beta`. That is a moderator-facing
+                feature, deliberately not in this PR's scope. */}
             {detail.scopes.length > 0 && (
               <Stack gap="xs" data-testid="apps-listing-permissions">
                 <Group gap="xs">

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -1246,7 +1246,18 @@ export function AppListingDetailBody({
                 UNREACHABLE and that the heading was therefore an invariant guard. That
                 was wrong, and wrong in the dangerous direction — it licensed deleting a
                 heading and a test that both guard a live moderator-facing path. It
-                counted two of the four writers. */}
+                counted two of the four writers.
+                🔴 "FOUR" IS A POINT-IN-TIME COUNT, RE-DERIVE IT — nothing asserts it.
+                What matters is not the number but that AT LEAST ONE writer copies the
+                kind from a LIVE listing; that is what makes this branch reachable, and
+                it stays true however many writers exist.
+                🔴 AND `app-listing-history.service.ts` CONTRADICTS THIS, IN PROSE THAT
+                IS STALE ON `main` — it asserts "exactly THREE create sites", that
+                `submitListingRevision` is "the ONLY writer that can emit `onsite`", and
+                that "every on-site row in this table is a shadow-revision request".
+                All three were falsified by `routeRepublishToReviewInTx` (#4440). Do not
+                reconcile the two by trusting that one: verify against the create sites
+                themselves. */}
             {detail.scopes.length > 0 && (
               <Stack gap="xs" data-testid="apps-listing-permissions">
                 <Group gap="xs">

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -804,6 +804,14 @@ export interface AppListingDetailBodyProps {
    * rail, screenshot gallery, description markdown — and OMIT every LIVE/interactive
    * or AGGREGATE surface. The full omission ledger, each item a deliberate decision:
    *
+   *   - the PERMISSION DISCLOSURE is KEPT, not omitted — a decision on this ledger
+   *     rather than an omission that was missed. A moderator reviewing a listing has
+   *     more use for the app's granted capabilities than any other viewer, so hiding
+   *     it here would be the wrong direction. 🔴 But it renders under a DIFFERENT
+   *     HEADING in this posture ("Currently granted permissions" rather than "This
+   *     app can…"), because this modal also shows the pending version's REQUESTED
+   *     scopes and the two differ exactly when a version is escalating. See the
+   *     section's own comment for why that is a correctness fix and not copy,
    *   - the comments thread + the recommend reviews list (a shadow listing has no
    *     Thread and no review rows; querying them would 404 / N+1),
    *   - the header STAT CHIPS (recommendations + installs are usage aggregates a
@@ -1209,14 +1217,25 @@ export function AppListingDetailBody({
                 `emptyLabel` path — on a store listing, "no permissions" is better said by
                 the absence of a permissions section than by a sentence nobody reads.
                 Ported from the disclosure on the retired `/apps/<appBlockId>` route,
-                which `blocks.getAppDetail` still serves. */}
+                which `blocks.getAppDetail` still serves.
+                🔴 THE HEADING CHANGES UNDER `preview`, AND IT IS A CORRECTNESS FIX, NOT
+                COPY. `CombinedReviewModal` renders this body BESIDE `ManifestScopes`,
+                which lists the scopes the pending version is REQUESTING, while
+                `detail.scopes` is what is CURRENTLY approved. For a version requesting
+                new scopes those two lists differ — and the confident natural-language one
+                was this one. A moderator reading "This app can…" as the set they are
+                approving would under-read a scope ESCALATION, on the single surface where
+                that judgement is made. KEPT rather than omitted in preview (so the
+                before/after is visible at all), but named for what it is. */}
             {detail.scopes.length > 0 && (
               <Stack gap="xs" data-testid="apps-listing-permissions">
                 <Group gap="xs">
                   <ThemeIcon variant="light" color="blue" size="sm" radius="xl">
                     <IconShieldCheck size={14} />
                   </ThemeIcon>
-                  <Title order={4}>This app can…</Title>
+                  <Title order={4}>
+                    {preview ? 'Currently granted permissions' : 'This app can…'}
+                  </Title>
                 </Group>
                 <BlockScopeList scopes={detail.scopes} />
               </Stack>

--- a/src/components/Apps/AppListingDetailBody.viewer.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.viewer.browser.test.tsx
@@ -159,6 +159,10 @@ function base(over: Partial<ListingDetail>): ListingDetail {
     betaMessage: null,
     updatedAt: '2026-03-04T05:06:07.000Z',
     screenshots: [],
+    // No declared scopes: this file is not about the permission disclosure, and an
+    // empty array renders no section at all. `projectListingDetail` guarantees an
+    // array, so a fixture omitting it would not match any real payload.
+    scopes: [],
     kindData: {
       kind: 'onsite',
       appBlockId: 'blk-1',

--- a/src/components/Apps/CombinedReviewModal.browser.test.tsx
+++ b/src/components/Apps/CombinedReviewModal.browser.test.tsx
@@ -129,6 +129,13 @@ const LISTING_PREVIEW = {
     installCount: 0,
     updatedAt: '2026-03-04T05:06:07.000Z',
     screenshots: [{ url: 'https://cdn.example/shot-1.png', caption: 'shot one' }],
+    // 🔴 REQUIRED, and `[]` is not cosmetic here. `AppListingDetailBody` reads
+    // `detail.scopes.length` to decide whether to render the pre-launch permission
+    // disclosure, so omitting it makes this modal THROW on render rather than merely
+    // skip a section. This fixture is not annotated as a `ListingDetail`, so
+    // TypeScript does not catch the omission — the mod review modal's runtime is the
+    // only guard, which is exactly how this surfaced.
+    scopes: [],
     kindData: { kind: 'onsite' as const, appBlockId: 'blk_1', hasPage: false, liveUrl: '' },
   },
 };

--- a/src/components/Apps/reviewListingPreview.ts
+++ b/src/components/Apps/reviewListingPreview.ts
@@ -188,6 +188,19 @@ export function buildListingDetailPreview(
     // mod who only ever saw THIS builder's output would not see the source link, so:
     // if the fallback ever becomes the primary path, this must be revisited.
     sourceRepoUrl: null,
+    // 🔴 `[]`, NEVER omitted. `AppListingDetailBody` reads `detail.scopes.length` to
+    // decide whether to render the pre-launch permission disclosure, so leaving this
+    // field off would not degrade the preview — it would THROW on every render of
+    // this fallback (`Cannot read properties of undefined`). This builder is the
+    // SECOND producer of a `ListingDetail`; the first is `projectListingDetail`,
+    // which guarantees an array. Keep both guarantees, so the component never has to
+    // defend against a malformed DTO with `?? []` and hide a real contract break.
+    //
+    // `[]` is also the HONEST value rather than a placeholder: this fallback is built
+    // from an OFF-SITE publish request, and an off-site listing has no backing
+    // AppBlock and therefore no approved scopes — the same answer
+    // `projectListingDetail` gives an off-site row.
+    scopes: [],
     // Same limitation, same reason, same safe direction as the card builder's `isBeta`.
     isBeta: false,
     betaMessage: null,

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -397,6 +397,28 @@ export type ListingDetail = {
    */
   sourceRepoUrl: string | null;
   /**
+   * The app's APPROVED scope ids (`AppBlock.approved_scopes`), for the pre-launch
+   * permission disclosure. `[]` for an off-site listing (no backing block) and for
+   * an on-site app that was approved with no scopes.
+   *
+   * 🔴 ALLOWLIST JUSTIFICATION. These are plain scope identifier strings
+   * (`ai:write:budgeted`, `models:read:self`) describing what the app is permitted
+   * to do — which is the entire point of disclosing them, and they are already
+   * shipped to anonymous callers by `BlockRegistry.getAppDetail` under the same
+   * reasoning. They are NOT the manifest's raw self-declared `scopes`: only the
+   * approve paths write `approvedScopes`, so this is the moderator-granted set, and
+   * a newer manifest declaring more cannot inflate it. No user is identified and no
+   * manifest internals (`trustTier`, `iframe.src`, `renderMode`, settings) ride along.
+   *
+   * 🔴 DETAIL-ONLY, like `sourceRepoUrl` — a store card is a low-attention grid tile
+   * with no room for the context that makes a capability list meaningful. The
+   * exact-key-set assertions in `app-listing.service.test.ts` pin both halves.
+   *
+   * An array of STRINGS: this DTO also crosses the transformer-less public REST
+   * `GET /api/v1/apps/{slug}` boundary, so it must be a JSON-safe scalar shape.
+   */
+  scopes: string[];
+  /**
    * AUTHOR-DECLARED "this app is in beta" flag. Same allowlist justification as
    * `ListingCard.isBeta` — a label the author publishes about their own app.
    *

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -398,8 +398,13 @@ export type ListingDetail = {
   sourceRepoUrl: string | null;
   /**
    * The app's APPROVED scope ids (`AppBlock.approved_scopes`), for the pre-launch
-   * permission disclosure. `[]` for an off-site listing (no backing block) and for
-   * an on-site app that was approved with no scopes.
+   * permission disclosure. `[]` for any listing whose `kind` is not `onsite`, and for
+   * an on-site app approved with no scopes.
+   *
+   * ⚠ `[]` for an off-site listing because of its **`kind`**, NOT because it lacks a
+   * backing block — an off-site row CAN carry a non-null `appBlockId` (the
+   * `blocks.backfillAppListings` shape), and an earlier draft of this line used that
+   * retired nullness predicate. See the gate in `projectListingDetail`.
    *
    * 🔴 ALLOWLIST JUSTIFICATION — AND THIS FIELD IS A NEW PUBLIC EXPOSURE, NOT A
    * RESTATEMENT OF AN EXISTING ONE. Say so plainly, because an earlier draft of this
@@ -407,9 +412,14 @@ export type ListingDetail = {
    * `BlockRegistry.getAppDetail`", and that was FALSE: `blocks.getAppDetail` runs
    * `enforceAppBlocksFlag` and is mod-segmented — dark to a genuine anonymous caller
    * — whereas this DTO is returned verbatim by `GET /api/v1/apps/{slug}`, which has
-   * no flag gate and serves unauthenticated callers at `PUBLIC_APPS_CATALOG_SCOPE =
+   * no ENABLE gate and serves unauthenticated callers at `PUBLIC_APPS_CATALOG_SCOPE =
    * 'full'`. So this change MOVES approved scope ids from a flag-dark surface to a
    * genuinely public one. That is the decision being taken here; it is not a no-op.
+   *
+   * ⚠ "No enable gate" is not "no lever": there IS an operator kill switch,
+   * `PUBLIC_APPS_CATALOG_DISABLED_FLAG = 'apps-public-catalog-disabled'`
+   * (`public-apps-catalog.ts`), absent in Flipt today so public access is on. It is
+   * blunt — it withholds the whole catalog, not this field.
    *
    * Why it is the right call anyway: these are coarse capability labels
    * (`ai:write:budgeted`, `models:read:self`) describing what an APPROVED, PUBLICLY

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -401,14 +401,28 @@ export type ListingDetail = {
    * permission disclosure. `[]` for an off-site listing (no backing block) and for
    * an on-site app that was approved with no scopes.
    *
-   * 🔴 ALLOWLIST JUSTIFICATION. These are plain scope identifier strings
-   * (`ai:write:budgeted`, `models:read:self`) describing what the app is permitted
-   * to do — which is the entire point of disclosing them, and they are already
-   * shipped to anonymous callers by `BlockRegistry.getAppDetail` under the same
-   * reasoning. They are NOT the manifest's raw self-declared `scopes`: only the
-   * approve paths write `approvedScopes`, so this is the moderator-granted set, and
-   * a newer manifest declaring more cannot inflate it. No user is identified and no
-   * manifest internals (`trustTier`, `iframe.src`, `renderMode`, settings) ride along.
+   * 🔴 ALLOWLIST JUSTIFICATION — AND THIS FIELD IS A NEW PUBLIC EXPOSURE, NOT A
+   * RESTATEMENT OF AN EXISTING ONE. Say so plainly, because an earlier draft of this
+   * docstring claimed the ids were "already shipped to anonymous callers by
+   * `BlockRegistry.getAppDetail`", and that was FALSE: `blocks.getAppDetail` runs
+   * `enforceAppBlocksFlag` and is mod-segmented — dark to a genuine anonymous caller
+   * — whereas this DTO is returned verbatim by `GET /api/v1/apps/{slug}`, which has
+   * no flag gate and serves unauthenticated callers at `PUBLIC_APPS_CATALOG_SCOPE =
+   * 'full'`. So this change MOVES approved scope ids from a flag-dark surface to a
+   * genuinely public one. That is the decision being taken here; it is not a no-op.
+   *
+   * Why it is the right call anyway: these are coarse capability labels
+   * (`ai:write:budgeted`, `models:read:self`) describing what an APPROVED, PUBLICLY
+   * LISTED app is permitted to do. Publishing them is the entire point — a viewer
+   * cannot weigh a permission they cannot see, and the store page is the only place
+   * they can see it BEFORE launching the app. They identify no user, carry no
+   * per-user grant state, and no manifest internals (`trustTier`, `iframe.src`,
+   * `renderMode`, settings) ride along.
+   *
+   * They are NOT the manifest's raw self-declared `scopes`: only the approve paths
+   * write `approvedScopes`. ⚠ "Moderator-granted" is accurate about the WRITER, not
+   * about granularity — a moderator approves or rejects a whole manifest; there is
+   * no per-scope narrowing mechanism.
    *
    * 🔴 DETAIL-ONLY, like `sourceRepoUrl` — a store card is a low-attention grid tile
    * with no room for the context that makes a capability list meaningful. The

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -398,8 +398,15 @@ export type ListingDetail = {
   sourceRepoUrl: string | null;
   /**
    * The app's APPROVED scope ids (`AppBlock.approved_scopes`), for the pre-launch
-   * permission disclosure. `[]` for any listing whose `kind` is not `onsite`, and for
-   * an on-site app approved with no scopes.
+   * permission disclosure. `[]` in THREE cases, and the third is the one readers miss:
+   *   1. the listing's `kind` is not `onsite`;
+   *   2. an on-site app approved with no scopes;
+   *   3. 🔴 an on-site listing with NO BACKING `appBlock` ROW — every revision SHADOW
+   *      (`beginListingRevision` writes `appBlockId: null` onto a shadow whose `kind`
+   *      is cloned from the parent). A shadow is `kind: 'onsite'` and still gets `[]`.
+   * Case 3 is why "preview implies `[]`" is a tempting and WRONG inference: the
+   * owner-republish re-review targets the LIVE listing, not a shadow, so it has a
+   * backing block and does get scopes. See `AppListingDetailBody`'s section comment.
    *
    * ⚠ `[]` for an off-site listing because of its **`kind`**, NOT because it lacks a
    * backing block — an off-site row CAN carry a non-null `appBlockId` (the

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -109,6 +109,14 @@ function hydratedRow(over: Record<string, unknown> = {}) {
       // read returns its projection. The dedicated deploy-gate suite covers the
       // never-deployed (NULL → unavailable) onsite case.
       currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
+      // 🔴 DELIBERATELY DISJOINT FROM `manifest.scopes` BELOW, and that is the whole
+      // point of the value. The detail DTO's `scopes` must come from the
+      // moderator-granted `approvedScopes` column, never the app's self-declared
+      // manifest — so the two fixtures share no element. An implementation that read
+      // `manifest.scopes` instead would return `['ai:write:budgeted']` and fail the
+      // projection assertions loudly. Were both set to the same array, that defect
+      // would pass every test in this file.
+      approvedScopes: ['models:read:self'],
       manifest: {
         name: 'Cool App',
         page: { path: '/run' },
@@ -461,6 +469,11 @@ describe('projectListingDetail — public allowlist + gallery', () => {
         'name',
         'recommend',
         'reviewCount',
+        // 🔴 DETAIL-ONLY BY DECISION, like `sourceRepoUrl` — the card allowlist above
+        // asserts its ABSENCE. The pre-launch permission disclosure: the app's APPROVED
+        // scope ids, so a viewer can see what an app is permitted to do BEFORE opening
+        // it. A store grid tile has no room for a capability list.
+        'scopes',
         'screenshots',
         'serialId',
         'slug',
@@ -546,6 +559,71 @@ describe('projectListingDetail — public allowlist + gallery', () => {
       externalUrl: 'https://grandfathered.example/app',
       connectClientId: null,
     });
+  });
+
+  /**
+   * PRE-LAUNCH PERMISSION DISCLOSURE (`ListingDetail.scopes`).
+   *
+   * 🔴 THE GATING HALF of this change. The sibling browser test renders the section,
+   * but the `component` project is report-only in CI and cannot block a merge; these
+   * assertions run in the blocking node project and are what actually hold the
+   * source-of-truth decision in place.
+   *
+   * 🔴 The claim is about WHICH COLUMN feeds the disclosure, not merely that a
+   * `scopes` key exists. `hydratedRow`'s `approvedScopes` and `manifest.scopes` are
+   * deliberately disjoint, so reading the wrong one is a different array rather than
+   * an identical-looking one.
+   */
+  it('🔴 detail.scopes comes from approvedScopes — NOT the self-declared manifest.scopes', () => {
+    const detail = projectListingDetail(hydratedRow() as never);
+    // The moderator-granted column…
+    expect(detail.scopes).toEqual(['models:read:self']);
+    // …and emphatically NOT the manifest's own declaration, which is an internal
+    // field the public DTO must never echo. An app could otherwise declare any scope
+    // it liked and have the store advertise it as granted.
+    expect(detail.scopes).not.toContain('ai:write:budgeted');
+  });
+
+  it('detail.scopes is [] when approvedScopes is NULL (never-approved / pre-migration row)', () => {
+    const detail = projectListingDetail(
+      hydratedRow({
+        appBlock: {
+          currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
+          approvedScopes: null,
+          manifest: { name: 'Cool App', scopes: ['ai:write:budgeted'] },
+        },
+      }) as never
+    );
+    // `[]`, never `undefined` and never the manifest's declaration — a consumer must
+    // not have to write `?? []`, and a NULL column must not fall through to the
+    // app's own claim about itself.
+    expect(detail.scopes).toEqual([]);
+  });
+
+  it('detail.scopes is [] for an OFF-SITE listing (no backing block at all)', () => {
+    const detail = projectListingDetail(
+      hydratedRow({ kind: 'offsite', externalUrl: 'https://example.com', appBlock: null }) as never
+    );
+    expect(detail.scopes).toEqual([]);
+  });
+
+  it('detail.scopes drops non-string entries rather than shipping them', () => {
+    const detail = projectListingDetail(
+      hydratedRow({
+        appBlock: {
+          currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
+          // jsonb: nothing at the DB layer guarantees these are strings.
+          approvedScopes: ['models:read:self', 42, null, { evil: true }, 'ai:write:budgeted'],
+          manifest: { name: 'Cool App' },
+        },
+      }) as never
+    );
+    expect(detail.scopes).toEqual(['models:read:self', 'ai:write:budgeted']);
+  });
+
+  it('🔴 the CARD does not carry scopes — detail-only, like sourceRepoUrl', () => {
+    const card = projectListingCard(hydratedRow() as never);
+    expect(card).not.toHaveProperty('scopes');
   });
 
   it('🔴 the offsite detail kindData key set is exactly kind/externalUrl/connectClientId', () => {

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -584,7 +584,17 @@ describe('projectListingDetail — public allowlist + gallery', () => {
     expect(detail.scopes).not.toContain('ai:write:budgeted');
   });
 
-  it('detail.scopes is [] when approvedScopes is NULL (never-approved / pre-migration row)', () => {
+  /**
+   * ⚠ THE DB CANNOT PRODUCE THIS ROW, and the test is kept anyway — but do not read
+   * the fixture as documentation of a real shape. `approved_scopes` is
+   * `TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[]` (`20260524120000_app_blocks_initial`)
+   * and Prisma types it `String[] @default([])`, so it is never NULL in production.
+   * What this pins is the PROJECTION's defensive branch: the same shape
+   * `BlockRegistry.getAppDetail` guards, and the branch that kills the
+   * fall-back-to-manifest mutant. An earlier version of this comment claimed the
+   * NULL was a real "never-approved / pre-migration row" — it was not.
+   */
+  it('detail.scopes is [] when approvedScopes is absent (defensive branch, not a real row)', () => {
     const detail = projectListingDetail(
       hydratedRow({
         appBlock: {
@@ -612,13 +622,48 @@ describe('projectListingDetail — public allowlist + gallery', () => {
       hydratedRow({
         appBlock: {
           currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
-          // jsonb: nothing at the DB layer guarantees these are strings.
+          // ⚠ Postgres CANNOT store these: the column is `TEXT[]`, so `42` and
+          // `{evil:true}` are unrepresentable. Kept as a guard on the projection's
+          // string filter (it kills the drop-the-filter mutant), NOT as a claim that
+          // such a row exists. An earlier comment here said "jsonb: nothing at the DB
+          // layer guarantees these are strings" — that was wrong about the schema.
           approvedScopes: ['models:read:self', 42, null, { evil: true }, 'ai:write:budgeted'],
           manifest: { name: 'Cool App' },
         },
       }) as never
     );
     expect(detail.scopes).toEqual(['models:read:self', 'ai:write:budgeted']);
+  });
+
+  /**
+   * 🔴 THE GATE IS `kind`, NOT `appBlockId` NULLNESS — and this fixture is the shape
+   * that makes them different predicates. `mapAppBlockToListing` mints
+   * `kind: 'offsite'` WITH a non-null `appBlockId` when the source AppBlock carries
+   * an `externalUrl` (reachable via the mod proc `blocks.backfillAppListings`), and
+   * `schema.full.prisma` says in as many words to discriminate on `kind`.
+   *
+   * Without the gate this row renders the off-site disclosure — "no Civitai install,
+   * account access, or permissions" — directly above a list of granted scopes. Two
+   * contradictory SECURITY claims on one public page. 0 such rows in production
+   * (measured 2026-08-11), so this is prevention; `app-access.service.ts` and
+   * `app-collaborator-earnings.service.ts` both carry the same gate for the same
+   * shape, and this projection was the third consumer of that join.
+   */
+  it('🔴 an OFF-SITE row WITH a backing block still yields [] — gated on kind, not appBlockId', () => {
+    const detail = projectListingDetail(
+      hydratedRow({
+        kind: 'offsite',
+        externalUrl: 'https://example.com',
+        // Non-null: the backfill shape. Nullness would NOT discriminate here.
+        appBlockId: 'ab_1',
+        appBlock: {
+          currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
+          approvedScopes: ['ai:write:budgeted', 'models:read:self'],
+          manifest: { name: 'Backfilled Offsite' },
+        },
+      }) as never
+    );
+    expect(detail.scopes).toEqual([]);
   });
 
   it('🔴 the CARD does not carry scopes — detail-only, like sourceRepoUrl', () => {

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -611,13 +611,29 @@ export function projectListingDetail(
     //
     // 🔴 `approvedScopes`, NOT the manifest's self-declared `scopes`. The approve
     // paths in `publish-request.service.ts` are the ONLY writers of
-    // `approvedScopes`, so it is what a moderator actually granted; a newer
-    // manifest version can declare more than was approved, and disclosing THAT
-    // would overstate what the app can do. Off-site listings have no backing
-    // block and therefore no scopes.
-    scopes: Array.isArray(row.appBlock?.approvedScopes)
-      ? row.appBlock.approvedScopes.filter((s): s is string => typeof s === 'string')
-      : [],
+    // `approvedScopes`, and each writes it in the SAME `update` as `manifest` and
+    // `version`, so the two can never disagree. A newer manifest version cannot
+    // declare more than was approved and have that reach this DTO.
+    //
+    // 🔴 GATED ON `kind`, NEVER ON `appBlockId` NULLNESS — they are not the same
+    // predicate, and this is the third consumer of that join to need saying so.
+    // `mapAppBlockToListing` mints `kind: 'offsite'` WITH a non-null `appBlockId`
+    // whenever the source AppBlock carries an `externalUrl`, reachable through the
+    // mod proc `blocks.backfillAppListings`; `schema.full.prisma` says in as many
+    // words to discriminate on `kind`. `app-access.service.ts` and
+    // `app-collaborator-earnings.service.ts` both carry an explicit gate for this
+    // exact shape.
+    //
+    // Without the gate, such a row renders the off-site disclosure — "This app runs
+    // entirely off-platform — no Civitai install, account access, or permissions" —
+    // directly above "This app can… ai:write:budgeted". Two contradictory SECURITY
+    // claims on a public store page. The population is 0 in production (measured
+    // 2026-08-11: offsite 5 rows, 0 with a block), so this is PREVENTION, not a
+    // live bug — and prevention is cheap here because it is one clause.
+    scopes:
+      row.kind === 'onsite' && Array.isArray(row.appBlock?.approvedScopes)
+        ? row.appBlock.approvedScopes.filter((s): s is string => typeof s === 'string')
+        : [],
   };
 }
 

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -256,7 +256,12 @@ export const listingHydrateSelect = {
   // onsite listing whose backing block has never successfully deployed is
   // treated as unavailable). NULL ⇔ never-deployed; non-null ⇔ live (stays
   // available while a new version re-builds).
-  appBlock: { select: { manifest: true, currentVersionDeployedAt: true } },
+  // `approvedScopes` feeds the DETAIL DTO's pre-launch permission disclosure.
+  // Projected onto the DETAIL only (see `scopes` in `projectListingDetail`); the
+  // card deliberately does not carry it, for the same reason `sourceRepoUrl` is
+  // detail-only — a grid tile has no room for the context that makes a
+  // capability list readable.
+  appBlock: { select: { manifest: true, currentVersionDeployedAt: true, approvedScopes: true } },
   screenshots: {
     where: { imageId: { not: null } },
     // Stable order: `id` tiebreaks rows with a tied `order` (default 0), which
@@ -600,6 +605,19 @@ export function projectListingDetail(
     sourceRepoUrl: sourceRepoUrl ?? null,
     screenshots: galleryScreenshots(row),
     kindData: detailKindData(row),
+    // Pre-launch permission disclosure. IDENTICAL projection to the one
+    // `BlockRegistry.getAppDetail` already ships for the same purpose — the
+    // approved scope ids, string-filtered, `[]` when the column is NULL.
+    //
+    // 🔴 `approvedScopes`, NOT the manifest's self-declared `scopes`. The approve
+    // paths in `publish-request.service.ts` are the ONLY writers of
+    // `approvedScopes`, so it is what a moderator actually granted; a newer
+    // manifest version can declare more than was approved, and disclosing THAT
+    // would overstate what the app can do. Off-site listings have no backing
+    // block and therefore no scopes.
+    scopes: Array.isArray(row.appBlock?.approvedScopes)
+      ? row.appBlock.approvedScopes.filter((s): s is string => typeof s === 'string')
+      : [],
   };
 }
 

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -635,18 +635,23 @@ export function projectListingDetail(
     // through the mod proc `blocks.backfillAppListings`; `schema.full.prisma` says in
     // as many words to discriminate on `kind`.
     //
-    // 🔴 THE CONSOLIDATION VEHICLE ALREADY EXISTS — it is `CAPABILITIES_BY_KIND` /
-    // `listingKindSupports` in `src/shared/constants/app-capabilities.constants.ts`,
-    // which has already absorbed ~14 open-coded sites. If this gate is ever
-    // consolidated, ADD A CAPABILITY CELL there; do NOT build a new helper.
-    // Sibling `kind` gates for the same shape: `app-access.service.ts`,
-    // `app-collaborator-earnings.service.ts` and `app-collaborator.service.ts`
-    // (`hasWritableRepo`) — the last two ALREADY route through that table —
-    // plus `app-ownership-transfer.service.ts` and `offsite-listing.service.ts`.
-    // ⚠ Two earlier drafts of this comment were wrong: one said "the third consumer"
-    // and named two sites (an undercount), the next called all five "open-coded by
-    // hand" when two already use the shared table. Count and check before quoting;
-    // this list is not asserted to be closed.
+    // 🔴 THE CONSOLIDATION VEHICLE ALREADY EXISTS — `CAPABILITIES_BY_KIND` /
+    // `listingKindSupports` in `src/shared/constants/app-capabilities.constants.ts`.
+    // If this gate is ever consolidated, ADD A CAPABILITY CELL there; do NOT build a
+    // new helper.
+    //
+    // 🔴 DELIBERATELY NO COUNTS AND NO SITE LIST HERE — read
+    // `KIND_CAPABILITY_LEDGER` in
+    // `src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts`,
+    // which is growth-and-shrink gated and therefore cannot go stale the way a
+    // sentence can. THREE successive drafts of this comment quoted a number or a
+    // site list and all three were WRONG: "the third consumer" (undercount), then
+    // "five, open-coded by hand" (two already used the table), then "~14 absorbed"
+    // (that figure belongs to `app-access.service.ts`'s separate OWNERSHIP-gate
+    // consolidation, not to the capability table) alongside "two of five already
+    // route through it" (it is four of five). Each wrong draft was written while
+    // fixing the previous one. The form is the defect, not the arithmetic — so the
+    // number now lives only where a test asserts it.
     //
     // Without the gate, such a row renders the off-site disclosure — "This app runs
     // entirely off-platform — no Civitai install, account access, or permissions" —

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -635,14 +635,18 @@ export function projectListingDetail(
     // through the mod proc `blocks.backfillAppListings`; `schema.full.prisma` says in
     // as many words to discriminate on `kind`.
     //
-    // 🔴 THIS PREDICATE IS OPEN-CODED AT FIVE OR MORE SITES AND IS A CONSOLIDATION
-    // CANDIDATE. Known siblings, all gating the same shape by hand:
-    // `app-access.service.ts`, `app-collaborator-earnings.service.ts`,
-    // `app-collaborator.service.ts` (`hasWritableRepo`),
-    // `app-ownership-transfer.service.ts`, `offsite-listing.service.ts`.
-    // ⚠ An earlier version of this comment said "the third consumer" and named two
-    // of them — an undercount that would hand anyone consolidating this 2 of 5. Count
-    // it yourself before quoting a number; this list is not asserted to be closed.
+    // 🔴 THE CONSOLIDATION VEHICLE ALREADY EXISTS — it is `CAPABILITIES_BY_KIND` /
+    // `listingKindSupports` in `src/shared/constants/app-capabilities.constants.ts`,
+    // which has already absorbed ~14 open-coded sites. If this gate is ever
+    // consolidated, ADD A CAPABILITY CELL there; do NOT build a new helper.
+    // Sibling `kind` gates for the same shape: `app-access.service.ts`,
+    // `app-collaborator-earnings.service.ts` and `app-collaborator.service.ts`
+    // (`hasWritableRepo`) — the last two ALREADY route through that table —
+    // plus `app-ownership-transfer.service.ts` and `offsite-listing.service.ts`.
+    // ⚠ Two earlier drafts of this comment were wrong: one said "the third consumer"
+    // and named two sites (an undercount), the next called all five "open-coded by
+    // hand" when two already use the shared table. Count and check before quoting;
+    // this list is not asserted to be closed.
     //
     // Without the gate, such a row renders the off-site disclosure — "This app runs
     // entirely off-platform — no Civitai install, account access, or permissions" —

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -609,20 +609,40 @@ export function projectListingDetail(
     // `BlockRegistry.getAppDetail` already ships for the same purpose — the
     // approved scope ids, string-filtered, `[]` when the column is NULL.
     //
-    // 🔴 `approvedScopes`, NOT the manifest's self-declared `scopes`. The approve
-    // paths in `publish-request.service.ts` are the ONLY writers of
-    // `approvedScopes`, and each writes it in the SAME `update` as `manifest` and
-    // `version`, so the two can never disagree. A newer manifest version cannot
-    // declare more than was approved and have that reach this DTO.
+    // 🔴 `approvedScopes`, NOT the manifest's self-declared `scopes`, AND THE REASON
+    // IS THAT THE TWO GENUINELY DIVERGE — do not "simplify" this to `manifest.scopes`.
+    //
+    // ⚠ An earlier version of this comment claimed they "can never disagree because
+    // the approve paths write them in the same update". That is FALSE, and it deleted
+    // the only reason this line reads the column it does.
+    // `src/pages/api/v1/developer/block-manifests.ts` updates `manifest` + `version`
+    // on an existing AppBlock WITHOUT touching `approvedScopes`, and sets
+    // `status: 'pending'` — deliberately, so a publisher cannot swap `iframe.src` or
+    // sandbox tokens post-approval without re-entering moderation. So a row can hold
+    // a v2 manifest declaring `['models:read:self','ai:write:budgeted']` alongside a
+    // v1 `approvedScopes` of `['models:read:self']`.
+    //
+    // Reading the manifest there would publish a scope NOBODY APPROVED on a public
+    // store page — the app's own claim about itself, rendered as if granted.
+    // `approvedScopes` is written only by the three approve paths
+    // (`publish-request.service.ts`), which take `manifest.scopes` verbatim at approve
+    // time; there is no per-scope narrowing mechanism, so the only skew is
+    // approve→deploy, where this over-discloses. That is the safe direction.
     //
     // 🔴 GATED ON `kind`, NEVER ON `appBlockId` NULLNESS — they are not the same
-    // predicate, and this is the third consumer of that join to need saying so.
-    // `mapAppBlockToListing` mints `kind: 'offsite'` WITH a non-null `appBlockId`
-    // whenever the source AppBlock carries an `externalUrl`, reachable through the
-    // mod proc `blocks.backfillAppListings`; `schema.full.prisma` says in as many
-    // words to discriminate on `kind`. `app-access.service.ts` and
-    // `app-collaborator-earnings.service.ts` both carry an explicit gate for this
-    // exact shape.
+    // predicate. `mapAppBlockToListing` mints `kind: 'offsite'` WITH a non-null
+    // `appBlockId` whenever the source AppBlock carries an `externalUrl`, reachable
+    // through the mod proc `blocks.backfillAppListings`; `schema.full.prisma` says in
+    // as many words to discriminate on `kind`.
+    //
+    // 🔴 THIS PREDICATE IS OPEN-CODED AT FIVE OR MORE SITES AND IS A CONSOLIDATION
+    // CANDIDATE. Known siblings, all gating the same shape by hand:
+    // `app-access.service.ts`, `app-collaborator-earnings.service.ts`,
+    // `app-collaborator.service.ts` (`hasWritableRepo`),
+    // `app-ownership-transfer.service.ts`, `offsite-listing.service.ts`.
+    // ⚠ An earlier version of this comment said "the third consumer" and named two
+    // of them — an undercount that would hand anyone consolidating this 2 of 5. Count
+    // it yourself before quoting a number; this list is not asserted to be closed.
     //
     // Without the gate, such a row renders the off-site disclosure — "This app runs
     // entirely off-platform — no Civitai install, account access, or permissions" —


### PR DESCRIPTION
## The gap

The store detail page tells a viewer nothing about what an **on-site** app is permitted to do until *after* they open it and trigger an action.

Its only two permission sentences are `shouldShowOffsiteDisclosure` and `shouldShowConnectCapability`. The in-file comment records that these are **mutually exclusive by construction, not convention** — `shouldShowConnectCapability` is the exact complement of `shouldShowOffsiteDisclosure` over one shared domain, so *"exactly one renders for an off-site listing with a destination and neither renders otherwise."* Both are about **off-site** apps.

So an on-site embedded app — the kind that can reach Buzz, the generator, collections and models — got **neither**.

## This is a migration gap, not a missing feature

The disclosure already exists. It lives on the retired `/apps/<appBlockId>` route (still served by `blocks.getAppDetail`), where its comment records that it closed the *"no permission disclosure at decision time"* gap. It did not travel with the detail page when that moved to `/apps/store-preview/<slug>`, which is served by a different procedure — `appListings.getAppDetail` → `AppListingDetailBody`. This ports it.

## Source of truth: `approvedScopes`, not the manifest

`ListingDetail.scopes` is projected from `AppBlock.approvedScopes`, **not** the manifest's self-declared `scopes`.

Only the approve paths write `approvedScopes`, so it is what a moderator actually granted. A newer manifest version can declare more than was approved, and disclosing *that* would let an app advertise capabilities nobody granted it. The projection is byte-identical to the one `blocks.getAppDetail` already ships for the same purpose.

The DTO field carries a full allowlist justification, as every field on this type does — it also crosses the transformer-less public REST `GET /api/v1/apps/{slug}` boundary, so it is a JSON-safe `string[]`. It is **detail-only**; the card allowlist asserts its absence, for the same reason `sourceRepoUrl` is detail-only.

## Rendering

Reuses `BlockScopeList`, which already handles `SCOPE_DESCRIPTIONS` and flags `isSensitiveBlockScope` entries via `SensitiveScopeBadge`. The section is **omitted entirely** when there is nothing to disclose, rather than rendering a reassuring empty box — on a store listing, "no permissions" is better said by the absence of a section than by a sentence nobody reads.

Neither off-site predicate is touched, and no third condition is added to either; the never-both-never-neither invariant in `__tests__/appListingDetailView.test.ts` passes unchanged.

## 🔴 A second producer would have crashed

`buildListingDetailPreview` (the mod off-site review queue's fallback) is a **second producer** of a `ListingDetail`. Without updating it, every render of that fallback would have thrown `Cannot read properties of undefined` — not degraded, *thrown*.

This was found by the **sibling browser suites**, not by the new tests. The new tests were green while this was broken; it is exactly the seam that per-component coverage cannot see.

## Test matrix — stated, not claimed

**Node (blocking project)** — 5 assertions in `app-listing.service.test.ts`, each watched **RED against the pre-change source** and green at HEAD. The fixture's `approvedScopes` and `manifest.scopes` are **deliberately disjoint**, so an implementation reading the wrong column returns a different array rather than an identical-looking one. Covers: right column, `NULL` → `[]`, off-site → `[]`, non-string entries dropped, and card-does-not-carry-it.

**Browser (report-only project)** — 4 tests. Measured at base by reverting only the component: **2 fail with a real assertion, and 2 pass vacuously** because they assert the section's *absence*, which is trivially true when the feature does not exist. The file says so in its header. Do not read "4 passed" as four guards.

**Untouched invariants** — `appListingDetailView.test.ts` 40/40; the three sibling `AppListingDetailBody` browser suites 147/147, which is what says the page structure did not move.

**Full affected node sweep** — 6437 passed, 2 failed. Both failures are in `manifest-schema-endpoint.test.ts` and were **confirmed failing identically at `origin/main` in a clean worktree**, so they are pre-existing and unrelated.

## Origin

Filed from tester feedback on the embedded-apps rollout: *"add information about permission that app requests to the app page. Users should know what permissions they might be required to enable before they launch the app."*
