### PR TITLE
feat(models): opt-in reciprocal suggested resources

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260911150000_model_associations_unique/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260911150000_model_associations_unique/migration.sql
@@ -1,0 +1,21 @@
+-- Deduplicate, then make (fromModelId, toModelId, type) unique so a back-link written by the
+-- "link both ways" save can never double up. Model-to-article rows have a NULL "toModelId" and
+-- are therefore unaffected: Postgres treats NULLs as distinct in a unique index.
+--
+-- APPLY THE TWO STATEMENTS SEPARATELY. CREATE INDEX CONCURRENTLY cannot run inside a
+-- transaction block, so it must not be sent in the same multi-statement batch as the DELETE.
+-- Run the DELETE first and confirm it reports 5 rows before creating the index; the index
+-- creation fails outright if any duplicate remains.
+
+-- Statement 1 — 5 duplicate rows on production as of 2026-09-11.
+DELETE FROM "ModelAssociations" a
+USING "ModelAssociations" b
+WHERE a."toModelId" IS NOT NULL
+  AND a."fromModelId" = b."fromModelId"
+  AND a."toModelId" = b."toModelId"
+  AND a."type" = b."type"
+  AND a."id" > b."id";
+
+-- Statement 2 — name matches what Prisma derives from @@unique, so a later introspection agrees.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "ModelAssociations_fromModelId_toModelId_type_key"
+  ON "ModelAssociations" ("fromModelId", "toModelId", "type");

--- a/packages/civitai-db-schema/prisma/migrations/20260911150000_model_associations_unique/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260911150000_model_associations_unique/migration.sql
@@ -2,6 +2,12 @@
 -- "link both ways" save can never double up. Model-to-article rows have a NULL "toModelId" and
 -- are therefore unaffected: Postgres treats NULLs as distinct in a unique index.
 --
+-- APPLY THIS BEFORE DEPLOYING THE CODE THAT USES IT. The reciprocal write inserts with
+-- ON CONFLICT DO NOTHING, which is valid syntax with no unique index but conflicts with
+-- nothing — so with the code deployed first, duplicate back-links can be minted in the
+-- window, and CREATE INDEX CONCURRENTLY validates only at the end of a full build, so one
+-- of them fails the index after the whole build has been paid for.
+--
 -- APPLY THE TWO STATEMENTS SEPARATELY. CREATE INDEX CONCURRENTLY cannot run inside a
 -- transaction block, so it must not be sent in the same multi-statement batch as the DELETE.
 -- Run the DELETE first and confirm it reports 5 rows before creating the index; the index
@@ -16,6 +22,11 @@ WHERE a."toModelId" IS NOT NULL
   AND a."type" = b."type"
   AND a."id" > b."id";
 
--- Statement 2 — name matches what Prisma derives from @@unique, so a later introspection agrees.
+-- The 5 is a point-in-time count, not a gate: re-check it rather than treating it as pass/fail.
+--
+-- Statement 2 — the name Prisma derives from @@unique, so the follow-up that declares
+-- @@unique in schema.full.prisma introspects clean. A cancelled or interrupted
+-- CREATE INDEX CONCURRENTLY leaves an INVALID index behind that must be dropped before retrying:
+--   DROP INDEX CONCURRENTLY IF EXISTS "ModelAssociations_fromModelId_toModelId_type_key";
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "ModelAssociations_fromModelId_toModelId_type_key"
   ON "ModelAssociations" ("fromModelId", "toModelId", "type");

--- a/packages/civitai-db-schema/prisma/migrations/20260911150000_model_associations_unique/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260911150000_model_associations_unique/migration.sql
@@ -24,9 +24,19 @@ WHERE a."toModelId" IS NOT NULL
 
 -- The 5 is a point-in-time count, not a gate: re-check it rather than treating it as pass/fail.
 --
--- Statement 2 — the name Prisma derives from @@unique, so the follow-up that declares
--- @@unique in schema.full.prisma introspects clean. A cancelled or interrupted
--- CREATE INDEX CONCURRENTLY leaves an INVALID index behind that must be dropped before retrying:
---   DROP INDEX CONCURRENTLY IF EXISTS "ModelAssociations_fromModelId_toModelId_type_key";
-CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "ModelAssociations_fromModelId_toModelId_type_key"
+-- Statement 2 — RUN THIS FIRST ON ANY RETRY, AND ONLY ON A RETRY.
+-- A cancelled or interrupted CREATE INDEX CONCURRENTLY leaves an INVALID index behind under
+-- the same name. It is not dropped for you, it enforces nothing, and the planner never uses
+-- it. Note that `IF NOT EXISTS` is deliberately absent from statement 3 for this reason:
+-- Postgres matches it on NAME, not on validity, so a bare re-run would report success over
+-- the broken index and everything downstream would believe duplicate suppression is live.
+DROP INDEX CONCURRENTLY IF EXISTS "ModelAssociations_fromModelId_toModelId_type_key";
+
+-- Statement 3 — the name Prisma derives from @@unique, so the follow-up that declares
+-- @@unique in schema.full.prisma introspects clean.
+CREATE UNIQUE INDEX CONCURRENTLY "ModelAssociations_fromModelId_toModelId_type_key"
   ON "ModelAssociations" ("fromModelId", "toModelId", "type");
+
+-- Confirm it is usable before trusting it. `indisvalid` false means the build did not finish:
+--   SELECT indisvalid FROM pg_index
+--    WHERE indexrelid = '"ModelAssociations_fromModelId_toModelId_type_key"'::regclass;

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -1417,7 +1417,10 @@ model ModelAssociations {
   type           AssociationType
   index          Int?
 
-  @@unique([fromModelId, toModelId, type])
+  // The unique index on (fromModelId, toModelId, type) is created by migration
+  // 20260911150000_model_associations_unique. It is NOT declared here yet: declaring a
+  // uniqueness constraint the live database does not have is `enforced` drift, which the
+  // schema-drift gate blocks on merge. Add @@unique in a follow-up once the index is applied.
   @@index([toModelId], type: Hash)
   @@index([fromModelId], type: Hash)
   @@index([toArticleId], type: Hash)

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -1417,6 +1417,7 @@ model ModelAssociations {
   type           AssociationType
   index          Int?
 
+  @@unique([fromModelId, toModelId, type])
   @@index([toModelId], type: Hash)
   @@index([fromModelId], type: Hash)
   @@index([toArticleId], type: Hash)

--- a/src/components/AssociatedModels/AssociateModels.tsx
+++ b/src/components/AssociatedModels/AssociateModels.tsx
@@ -72,11 +72,17 @@ export function AssociateModels({
           message: `${atLimit} of the creator's models already have ${limit} suggested resources, so this model was not added to them.`,
         });
 
-      queryUtils.model.getAssociatedResourcesSimple.setData(
-        { fromId, type, browsingLevel: allBrowsingLevelsFlag },
-        () => associatedResources as ModelGetAssociatedResourcesSimple
-      );
-      await queryUtils.model.getAssociatedResourcesCardData.invalidate({ fromId, type });
+      // Refetch rather than seeding the cache with the local rows: they carry no association
+      // ids, and `staleTime` is Infinity, so writing them back makes every row look newly
+      // added the next time this modal opens on the same page.
+      await Promise.all([
+        queryUtils.model.getAssociatedResourcesSimple.invalidate({
+          fromId,
+          type,
+          browsingLevel: allBrowsingLevelsFlag,
+        }),
+        queryUtils.model.getAssociatedResourcesCardData.invalidate({ fromId, type }),
+      ]);
       setChanged(false);
       setReciprocal(false);
       onSave?.();
@@ -135,7 +141,9 @@ export function AssociateModels({
         resourceType,
         resourceId: item.id,
       })),
-      reciprocal,
+      // The checkbox unmounts when the last new row is removed, but its state does not reset
+      // with it; send what the user can currently see, not what they ticked earlier.
+      reciprocal: reciprocal && addedCount > 0,
     });
   };
 
@@ -213,6 +221,11 @@ export function AssociateModels({
                                 <Badge size="xs">
                                   {'type' in association.item ? association.item.type : 'Article'}
                                 </Badge>
+                                {association.id === undefined && (
+                                  <Badge size="xs" color="blue">
+                                    New
+                                  </Badge>
+                                )}
                                 <Badge size="xs" pl={4}>
                                   <Group gap={2}>
                                     <IconUser size={12} strokeWidth={2.5} />
@@ -254,15 +267,15 @@ export function AssociateModels({
             setChanged(true);
           }}
           label="Link both ways"
-          description={
+          description={`${
             ownAddedCount === addedCount
               ? `Also adds this model to the suggested resources of ${
-                  addedCount === 1
-                    ? 'the model you just added'
-                    : `the ${addedCount} models you just added`
-                }. Links added this way stay on the other model until you remove them there.`
-              : `Also adds this model to the suggested resources of the ${ownAddedCount} of ${addedCount} models you just added that this creator owns. The rest are left alone. Links added this way stay on the other model until you remove them there.`
-          }
+                  addedCount === 1 ? 'the model' : `the ${addedCount} models`
+                } marked New above.`
+              : `Also adds this model to the suggested resources of the ${ownAddedCount} of ${addedCount} models marked New above that ${
+                  currentUser?.id === ownerId ? 'you own' : 'this creator owns'
+                }. The rest are left alone.`
+          } Resources already on the list are untouched, and a link added this way stays on the other model until it is removed there.`}
         />
       )}
 

--- a/src/components/AssociatedModels/AssociateModels.tsx
+++ b/src/components/AssociatedModels/AssociateModels.tsx
@@ -40,14 +40,15 @@ type State = Array<Omit<ModelGetAssociatedResourcesSimple[number], 'id'> & { id?
 export function AssociateModels({
   fromId,
   type,
+  ownerId,
   onSave,
-  limit = constants.modelAssociations.limit,
 }: {
   fromId: number;
   type: AssociationType;
+  ownerId: number;
   onSave?: () => void;
-  limit?: number;
 }) {
+  const limit = constants.modelAssociations.limit;
   const currentUser = useCurrentUser();
   const queryUtils = trpc.useUtils();
   const [changed, setChanged] = useState(false);
@@ -68,7 +69,7 @@ export function AssociateModels({
       if (atLimit)
         showWarningNotification({
           title: 'Some links back were skipped',
-          message: `${atLimit} of your resources already have ${limit} suggested resources, so this model was not added to them.`,
+          message: `${atLimit} of the creator's models already have ${limit} suggested resources, so this model was not added to them.`,
         });
 
       queryUtils.model.getAssociatedResourcesSimple.setData(
@@ -77,6 +78,7 @@ export function AssociateModels({
       );
       await queryUtils.model.getAssociatedResourcesCardData.invalidate({ fromId, type });
       setChanged(false);
+      setReciprocal(false);
       onSave?.();
     },
   });
@@ -120,6 +122,7 @@ export function AssociateModels({
 
   const handleReset = () => {
     setChanged(false);
+    setReciprocal(false);
     setAssociatedResources(data);
   };
 
@@ -146,9 +149,13 @@ export function AssociateModels({
   }, [data]);
 
   const onlyMe = searchMode === 'me';
-  const models = associatedResources.filter(({ resourceType }) => resourceType === 'model');
-  const modelCount = models.length;
-  const ownModelCount = models.filter(({ item }) => item.user.id === currentUser?.id).length;
+  // A row with no association id has not been saved yet, so it is one added during this edit.
+  // Only those can receive a back-link — matches the server's own scoping.
+  const addedModels = associatedResources.filter(
+    ({ resourceType, id }) => resourceType === 'model' && id === undefined
+  );
+  const addedCount = addedModels.length;
+  const ownAddedCount = addedModels.filter(({ item }) => item.user.id === ownerId).length;
 
   return (
     <Stack>
@@ -239,7 +246,7 @@ export function AssociateModels({
           )}
         </Stack>
       )}
-      {modelCount > 0 && (
+      {addedCount > 0 && (
         <Checkbox
           checked={reciprocal}
           onChange={(event) => {
@@ -248,9 +255,13 @@ export function AssociateModels({
           }}
           label="Link both ways"
           description={
-            ownModelCount === modelCount
-              ? 'Also adds this model to the suggested resources of each one above.'
-              : `Also adds this model to the suggested resources of the ${ownModelCount} of ${modelCount} above that you own. The rest are left alone.`
+            ownAddedCount === addedCount
+              ? `Also adds this model to the suggested resources of ${
+                  addedCount === 1
+                    ? 'the model you just added'
+                    : `the ${addedCount} models you just added`
+                }. Links added this way stay on the other model until you remove them there.`
+              : `Also adds this model to the suggested resources of the ${ownAddedCount} of ${addedCount} models you just added that this creator owns. The rest are left alone. Links added this way stay on the other model until you remove them there.`
           }
         />
       )}

--- a/src/components/AssociatedModels/AssociateModels.tsx
+++ b/src/components/AssociatedModels/AssociateModels.tsx
@@ -2,7 +2,19 @@ import type { DragEndEvent, UniqueIdentifier } from '@dnd-kit/core';
 import { closestCenter, DndContext, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type { ComboboxItem } from '@mantine/core';
-import { Stack, Text, Card, Group, Button, Center, Loader, Alert, Badge, Box } from '@mantine/core';
+import {
+  Stack,
+  Text,
+  Card,
+  Group,
+  Button,
+  Center,
+  Loader,
+  Alert,
+  Badge,
+  Box,
+  Checkbox,
+} from '@mantine/core';
 import type { AssociationType } from '~/shared/utils/prisma/enums';
 import { IconGripVertical, IconTrash, IconUser } from '@tabler/icons-react';
 import { isEqual } from 'lodash-es';
@@ -20,6 +32,8 @@ import {
 } from '~/shared/constants/browsingLevel.constants';
 import type { SearchIndexDataMap } from '~/components/Search/search.utils2';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { constants } from '~/server/common/constants';
+import { showWarningNotification } from '~/utils/notifications';
 
 type State = Array<Omit<ModelGetAssociatedResourcesSimple[number], 'id'> & { id?: number }>;
 
@@ -27,7 +41,7 @@ export function AssociateModels({
   fromId,
   type,
   onSave,
-  limit = 10,
+  limit = constants.modelAssociations.limit,
 }: {
   fromId: number;
   type: AssociationType;
@@ -46,9 +60,17 @@ export function AssociateModels({
   });
   const [associatedResources, setAssociatedResources] = useState<State>(data);
   const [searchMode, setSearchMode] = useState<'me' | 'all'>('all');
+  const [reciprocal, setReciprocal] = useState(false);
 
   const { mutate, isPending: isSaving } = trpc.model.setAssociatedResources.useMutation({
-    onSuccess: async () => {
+    onSuccess: async (result) => {
+      const atLimit = result.reciprocal.skipped.filter((x) => x.reason === 'atLimit').length;
+      if (atLimit)
+        showWarningNotification({
+          title: 'Some links back were skipped',
+          message: `${atLimit} of your resources already have ${limit} suggested resources, so this model was not added to them.`,
+        });
+
       queryUtils.model.getAssociatedResourcesSimple.setData(
         { fromId, type, browsingLevel: allBrowsingLevelsFlag },
         () => associatedResources as ModelGetAssociatedResourcesSimple
@@ -110,6 +132,7 @@ export function AssociateModels({
         resourceType,
         resourceId: item.id,
       })),
+      reciprocal,
     });
   };
 
@@ -123,6 +146,9 @@ export function AssociateModels({
   }, [data]);
 
   const onlyMe = searchMode === 'me';
+  const models = associatedResources.filter(({ resourceType }) => resourceType === 'model');
+  const modelCount = models.length;
+  const ownModelCount = models.filter(({ item }) => item.user.id === currentUser?.id).length;
 
   return (
     <Stack>
@@ -213,6 +239,22 @@ export function AssociateModels({
           )}
         </Stack>
       )}
+      {modelCount > 0 && (
+        <Checkbox
+          checked={reciprocal}
+          onChange={(event) => {
+            setReciprocal(event.currentTarget.checked);
+            setChanged(true);
+          }}
+          label="Link both ways"
+          description={
+            ownModelCount === modelCount
+              ? 'Also adds this model to the suggested resources of each one above.'
+              : `Also adds this model to the suggested resources of the ${ownModelCount} of ${modelCount} above that you own. The rest are left alone.`
+          }
+        />
+      )}
+
       {changed && (
         <Group justify="flex-end">
           <Button variant="default" onClick={handleReset}>

--- a/src/components/AssociatedModels/AssociatedModels.tsx
+++ b/src/components/AssociatedModels/AssociatedModels.tsx
@@ -38,7 +38,7 @@ export function AssociatedModels({
   });
 
   const handleManageClick = () => {
-    openAssociateModelsModal({ props: { fromId, type } });
+    openAssociateModelsModal({ props: { fromId, type, ownerId } });
   };
 
   if (!isOwnerOrModerator && !recommendedResources.length) return null;

--- a/src/components/Modals/AssociateModelsModal.tsx
+++ b/src/components/Modals/AssociateModelsModal.tsx
@@ -6,9 +6,11 @@ import { useDialogContext } from '~/components/Dialog/DialogProvider';
 export default function AssociateModelsModal({
   fromId,
   type,
+  ownerId,
 }: {
   fromId: number;
   type: AssociationType;
+  ownerId: number;
 }) {
   const dialog = useDialogContext();
 
@@ -19,7 +21,7 @@ export default function AssociateModelsModal({
           <Text>{`Manage ${type} Resources`}</Text>
           <CloseButton onClick={dialog.onClose} />
         </Group>
-        <AssociateModels fromId={fromId} type={type} onSave={dialog.onClose} />
+        <AssociateModels fromId={fromId} type={type} ownerId={ownerId} onSave={dialog.onClose} />
       </Stack>
     </Modal>
   );

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -197,6 +197,12 @@ export const constants = {
     'Enhancement LoRA': 14,
     Other: 15,
   },
+  modelAssociations: {
+    limit: 10,
+    // Server ceiling, deliberately above the UI limit: 9 models already hold 11-12
+    // associations, and rejecting their saves would strand them.
+    maxPerSave: 20,
+  },
   cardSizes: {
     model: 320,
     image: 320,

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -411,7 +411,10 @@ export const setAssociatedResourcesSchema = z.object({
       resourceId: z.number(),
       resourceType: z.enum(['model', 'article']),
     })
-    .array(),
+    .array()
+    .max(constants.modelAssociations.maxPerSave),
+  // Also add this model to the list of every associated model the same owner holds.
+  reciprocal: z.boolean().optional(),
 });
 // #endregion
 

--- a/src/server/services/__tests__/model-association-reciprocal.test.ts
+++ b/src/server/services/__tests__/model-association-reciprocal.test.ts
@@ -6,7 +6,7 @@ const STRANGER = 200;
 const SOURCE = 1;
 
 const plan = (
-  candidates: Array<{ modelId: number; ownerId: number | null }>,
+  candidates: Array<{ modelId: number; ownerId: number }>,
   {
     existingCounts = new Map<number, number>(),
     alreadyLinked = new Set<number>(),
@@ -48,13 +48,6 @@ describe('planReciprocalAssociations', () => {
     expect(skipped).toEqual([{ modelId: 3, reason: 'notOwned' }]);
   });
 
-  it('treats an unowned model as someone else, not as the owner', () => {
-    const { create, skipped } = plan([{ modelId: 3, ownerId: null }]);
-
-    expect(create).toEqual([]);
-    expect(skipped).toEqual([{ modelId: 3, reason: 'notOwned' }]);
-  });
-
   it('does not link a model to itself', () => {
     const { create, skipped } = plan([{ modelId: SOURCE, ownerId: OWNER }]);
 
@@ -82,7 +75,7 @@ describe('planReciprocalAssociations', () => {
     expect(skipped).toEqual([{ modelId: 2, reason: 'atLimit' }]);
   });
 
-  it('appends after the target list rather than colliding with index 0', () => {
+  it('indexes the back-link at the size of the target list, not at 0', () => {
     const { create } = plan([{ modelId: 2, ownerId: OWNER }], {
       existingCounts: new Map([[2, 4]]),
     });
@@ -90,13 +83,26 @@ describe('planReciprocalAssociations', () => {
     expect(create).toEqual([{ fromModelId: 2, toModelId: SOURCE, index: 4 }]);
   });
 
+  // The only control against a cap that is one too STRICT. Without it, `count >= limit - 1`
+  // ships green and silently refuses the last slot on every list.
+  it('still links a target sitting one below the limit', () => {
+    const { create, skipped } = plan([{ modelId: 2, ownerId: OWNER }], {
+      existingCounts: new Map([[2, 9]]),
+      limit: 10,
+    });
+
+    expect(create).toEqual([{ fromModelId: 2, toModelId: SOURCE, index: 9 }]);
+    expect(skipped).toEqual([]);
+  });
+
   it('writes one back-link when the same target is listed twice', () => {
-    const { create } = plan([
+    const { create, skipped } = plan([
       { modelId: 2, ownerId: OWNER },
       { modelId: 2, ownerId: OWNER },
     ]);
 
-    expect(create).toHaveLength(1);
+    expect(create).toEqual([{ fromModelId: 2, toModelId: SOURCE, index: 0 }]);
+    expect(skipped).toEqual([]);
   });
 
   it('saves the owned links even when the selection is mixed', () => {

--- a/src/server/services/__tests__/model-association-reciprocal.test.ts
+++ b/src/server/services/__tests__/model-association-reciprocal.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { planReciprocalAssociations } from '~/server/services/model-association.utils';
+
+const OWNER = 100;
+const STRANGER = 200;
+const SOURCE = 1;
+
+const plan = (
+  candidates: Array<{ modelId: number; ownerId: number | null }>,
+  {
+    existingCounts = new Map<number, number>(),
+    alreadyLinked = new Set<number>(),
+    limit = 10,
+  }: {
+    existingCounts?: Map<number, number>;
+    alreadyLinked?: Set<number>;
+    limit?: number;
+  } = {}
+) =>
+  planReciprocalAssociations({
+    sourceModelId: SOURCE,
+    ownerId: OWNER,
+    candidates,
+    existingCounts,
+    alreadyLinked,
+    limit,
+  });
+
+describe('planReciprocalAssociations', () => {
+  it('writes a back-link on a model the owner owns', () => {
+    const { create, skipped } = plan([{ modelId: 2, ownerId: OWNER }]);
+
+    expect(create).toEqual([{ fromModelId: 2, toModelId: SOURCE, index: 0 }]);
+    expect(skipped).toEqual([]);
+  });
+
+  // The safety boundary this whole feature turns on. Before it, nothing in the codebase
+  // could write an association row into a model the acting user does not own; reciprocal
+  // insertion is the first path that addresses another model at all. If you are here to
+  // relax this, the ask that produced it was explicitly "only ones that are theirs".
+  it('never writes a back-link on a model owned by someone else', () => {
+    const { create, skipped } = plan([
+      { modelId: 2, ownerId: OWNER },
+      { modelId: 3, ownerId: STRANGER },
+    ]);
+
+    expect(create.map((x) => x.fromModelId)).toEqual([2]);
+    expect(skipped).toEqual([{ modelId: 3, reason: 'notOwned' }]);
+  });
+
+  it('treats an unowned model as someone else, not as the owner', () => {
+    const { create, skipped } = plan([{ modelId: 3, ownerId: null }]);
+
+    expect(create).toEqual([]);
+    expect(skipped).toEqual([{ modelId: 3, reason: 'notOwned' }]);
+  });
+
+  it('does not link a model to itself', () => {
+    const { create, skipped } = plan([{ modelId: SOURCE, ownerId: OWNER }]);
+
+    expect(create).toEqual([]);
+    expect(skipped).toEqual([]);
+  });
+
+  it('skips a target that already carries the back-link', () => {
+    const { create, skipped } = plan([{ modelId: 2, ownerId: OWNER }], {
+      alreadyLinked: new Set([2]),
+      existingCounts: new Map([[2, 3]]),
+    });
+
+    expect(create).toEqual([]);
+    expect(skipped).toEqual([{ modelId: 2, reason: 'alreadyLinked' }]);
+  });
+
+  it('skips a target whose own list is already at the limit', () => {
+    const { create, skipped } = plan([{ modelId: 2, ownerId: OWNER }], {
+      existingCounts: new Map([[2, 10]]),
+      limit: 10,
+    });
+
+    expect(create).toEqual([]);
+    expect(skipped).toEqual([{ modelId: 2, reason: 'atLimit' }]);
+  });
+
+  it('appends after the target list rather than colliding with index 0', () => {
+    const { create } = plan([{ modelId: 2, ownerId: OWNER }], {
+      existingCounts: new Map([[2, 4]]),
+    });
+
+    expect(create).toEqual([{ fromModelId: 2, toModelId: SOURCE, index: 4 }]);
+  });
+
+  it('writes one back-link when the same target is listed twice', () => {
+    const { create } = plan([
+      { modelId: 2, ownerId: OWNER },
+      { modelId: 2, ownerId: OWNER },
+    ]);
+
+    expect(create).toHaveLength(1);
+  });
+
+  it('saves the owned links even when the selection is mixed', () => {
+    const { create, skipped } = plan([
+      { modelId: 2, ownerId: STRANGER },
+      { modelId: 3, ownerId: OWNER },
+      { modelId: 4, ownerId: STRANGER },
+      { modelId: 5, ownerId: OWNER },
+    ]);
+
+    expect(create.map((x) => x.fromModelId)).toEqual([3, 5]);
+    expect(skipped.map((x) => x.modelId)).toEqual([2, 4]);
+  });
+});

--- a/src/server/services/__tests__/set-associated-resources.wiring.test.ts
+++ b/src/server/services/__tests__/set-associated-resources.wiring.test.ts
@@ -94,11 +94,14 @@ const MODERATOR = 900;
 const owner = { id: OWNER, isModerator: false } as SessionUser;
 const moderator = { id: MODERATOR, isModerator: true } as SessionUser;
 
-/** The model being edited, and what it currently points at. */
-function givenSourceModel(associations: number[] = []) {
+/**
+ * The model being edited, and what it currently points at: `[associationRowId, toModelId]`
+ * pairs, matching the shape the service selects.
+ */
+function givenSourceModel(associations: Array<[number, number | null]> = []) {
   dbMock.dbWrite.model.findUnique.mockResolvedValue({
     userId: OWNER,
-    associations: associations.map((id) => ({ id })),
+    associations: associations.map(([id, toModelId]) => ({ id, toModelId })),
   });
 }
 
@@ -112,9 +115,19 @@ function givenSourceModel(associations: number[] = []) {
 function givenTargets(targets: Array<{ id: number; userId: number }>) {
   dbMock.dbWrite.model.findMany.mockImplementation(async (args: unknown) => {
     const ids = (args as { where?: { id?: { in?: number[] } } })?.where?.id?.in;
-    return ids ? targets.filter((target) => ids.includes(target.id)) : targets;
+    if (!ids) throw new Error('model.findMany called without where.id.in');
+    return targets.filter((target) => ids.includes(target.id));
   });
   dbMock.dbWrite.modelAssociations.findMany.mockResolvedValue([]);
+}
+
+/** Rows the targets' own suggested-resource lists already hold. */
+function givenTargetLists(rows: Array<{ fromModelId: number; toModelId: number | null }>) {
+  dbMock.dbWrite.modelAssociations.findMany.mockImplementation(async (args: unknown) => {
+    const ids = (args as { where?: { fromModelId?: { in?: number[] } } })?.where?.fromModelId?.in;
+    if (!ids) throw new Error('modelAssociations.findMany called without where.fromModelId.in');
+    return rows.filter((row) => ids.includes(row.fromModelId));
+  });
 }
 
 const save = (
@@ -174,10 +187,12 @@ describe('setAssociatedResources — reciprocal wiring', () => {
       { reciprocal: true, user: moderator }
     );
 
-    expect(createdRows().map((row) => row.fromModelId)).toEqual([2]);
+    expect(createdRows()).toEqual([
+      { fromModelId: 2, toModelId: SOURCE, index: 0, type: 'Suggested', associatedById: MODERATOR },
+    ]);
   });
 
-  it('derives ownership from the database, not from the request', async () => {
+  it('asks the database for each target owner', async () => {
     givenTargets([{ id: 2, userId: 555 }]);
 
     await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
@@ -200,13 +215,42 @@ describe('setAssociatedResources — reciprocal wiring', () => {
     expect(dbMock.dbRead.modelAssociations.findMany).not.toHaveBeenCalled();
   });
 
+  // The target's OWN list is what decides both of these, and both were previously derived
+  // from a read the suite never populated — every test ran with it empty, so a mutation that
+  // counted the wrong column, or inverted the already-linked check, shipped green and wrote a
+  // second back-link into someone else's model on every repeat save.
+  it('does not write a back-link the target already holds', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+    givenTargetLists([{ fromModelId: 2, toModelId: SOURCE }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(dbMock.dbWrite.modelAssociations.createMany).not.toHaveBeenCalled();
+  });
+
+  it('appends after the rows the target already holds', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+    givenTargetLists([
+      { fromModelId: 2, toModelId: 71 },
+      { fromModelId: 2, toModelId: 72 },
+      { fromModelId: 2, toModelId: null },
+      { fromModelId: 99, toModelId: 73 },
+    ]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(createdRows()).toEqual([
+      { fromModelId: 2, toModelId: SOURCE, index: 3, type: 'Suggested', associatedById: OWNER },
+    ]);
+  });
+
   // Scope decided by Justin on 2026-09-11: the checkbox acts on what you just added, not on
   // the whole saved list. Our modal saves the entire list, so without this a user who ticks
   // the box while changing something unrelated retroactively back-links resources they linked
   // months ago and never touched this session. If you widen this to every association, that is
   // the behaviour you are bringing back.
   it('back-links only resources added in this edit, never ones already on the list', async () => {
-    givenSourceModel([11]);
+    givenSourceModel([[11, 2]]);
     givenTargets([
       { id: 2, userId: OWNER },
       { id: 3, userId: OWNER },
@@ -221,6 +265,20 @@ describe('setAssociatedResources — reciprocal wiring', () => {
     );
 
     expect(createdRows().map((row) => row.fromModelId)).toEqual([3]);
+  });
+
+  // The reachable version of the same bug, and the reason the rule is derived from model ids
+  // rather than from association ids. The component used to write its own id-less rows into a
+  // query cache with staleTime Infinity, so on a second open every saved row presented itself
+  // as new. The client is fixed, but the server must not depend on the client being right:
+  // an association id is a claim, and the model ids the database holds are not.
+  it('ignores a claim of newness when the model is already on the list', async () => {
+    givenSourceModel([[11, 2]]);
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(dbMock.dbWrite.modelAssociations.createMany).not.toHaveBeenCalled();
   });
 
   it('ignores articles when choosing reciprocal targets', async () => {
@@ -246,7 +304,10 @@ describe('setAssociatedResources — reciprocal wiring', () => {
   // If you are here to add symmetric removal, that is the tradeoff you are re-opening, and it
   // needs a marker column to tell which rows were safe to delete.
   it('deletes only from the edited model, never from a model it links to', async () => {
-    givenSourceModel([11, 12]);
+    givenSourceModel([
+      [11, 2],
+      [12, 5],
+    ]);
     givenTargets([{ id: 2, userId: OWNER }]);
 
     await save([{ resourceId: 2, resourceType: 'model', id: 11 }], { reciprocal: true });

--- a/src/server/services/__tests__/set-associated-resources.wiring.test.ts
+++ b/src/server/services/__tests__/set-associated-resources.wiring.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Wiring tests for setAssociatedResources — specifically the reciprocal ("link both ways")
+// write, whose safety property lives in how its inputs are DERIVED, not in the planner that
+// consumes them. planReciprocalAssociations is tested separately and thoroughly; every one of
+// its callers could still be wrong without a single assertion moving, which is what this file
+// closes. model.service.ts has a very large import graph, so its transitive service/search
+// dependencies are stubbed below to keep this a unit test.
+
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  preventReplicationLag: vi.fn(),
+  getDbWithoutLag: vi.fn(async () => dbMock.dbRead),
+  preventModelVersionLagBatch: vi.fn(),
+}));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {}, pgDbReadLong: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null, Tracker: class {} }));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(() => false), FLIPT_FEATURE_FLAGS: {} }));
+vi.mock('~/server/metrics', () => ({ modelMetrics: {} }));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: {},
+  modelTagCache: { refresh: vi.fn() },
+  modelVotableTagsCache: { bust: vi.fn() },
+  userBasicCache: {},
+  userModelCountCache: { refresh: vi.fn() },
+}));
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+  imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+  modelsSearchIndex: { queueUpdate: vi.fn() },
+}));
+vi.mock('~/server/services/auction.service', () => ({
+  deleteBidsForModel: vi.fn(),
+  getLastAuctionReset: vi.fn(),
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getMultiAccountTransactionsByPrefix: vi.fn(),
+  getUserBuzzAccountByAccountTypes: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+}));
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTagsForModels: vi.fn(),
+}));
+vi.mock('~/server/services/blocklist.service', () => ({
+  throwOnBlockedLinkDomain: vi.fn(),
+  throwOnBlockedUserContent: vi.fn(),
+}));
+vi.mock('~/server/services/collection.service', () => ({
+  getAvailableCollectionItemsFilterForUser: vi.fn(),
+  getUserCollectionPermissionsById: vi.fn(),
+  saveItemInCollections: vi.fn(),
+}));
+vi.mock('~/server/services/cosmetic.service', () => ({ getCosmeticsForEntity: vi.fn() }));
+vi.mock('~/server/services/creator-program.service', () => ({
+  getValidCreatorMembershipMap: vi.fn(),
+}));
+vi.mock('~/server/services/generation/generation.service', () => ({
+  getUnavailableResources: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(),
+  getImagesForModelVersionCache: {},
+  queueImageSearchIndexUpdate: vi.fn(),
+}));
+vi.mock('~/server/services/model-file.service', () => ({ getFilesForModelVersionCache: {} }));
+vi.mock('~/server/services/model-version.service', () => ({
+  bustMvCache: vi.fn(),
+  bustPublicModelResponseCache: vi.fn(),
+  createModelVersionPostFromTraining: vi.fn(),
+  publishModelVersionsWithEarlyAccess: vi.fn(),
+}));
+vi.mock('~/server/services/subscriptions.service', () => ({ getHighestTierSubscription: vi.fn() }));
+vi.mock('~/server/services/system-cache', () => ({ getCategoryTags: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({
+  deleteBasicDataForUser: vi.fn(),
+  getCosmeticsForUsers: vi.fn(),
+  getProfilePicturesForUsers: vi.fn(),
+}));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  bustFetchThroughCache: vi.fn(),
+  fetchThroughCache: vi.fn(),
+}));
+vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
+vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));
+
+import { setAssociatedResources } from '~/server/services/model.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import type { SessionUser } from '~/types/session';
+
+const SOURCE = 1;
+const OWNER = 100;
+const MODERATOR = 900;
+
+const owner = { id: OWNER, isModerator: false } as SessionUser;
+const moderator = { id: MODERATOR, isModerator: true } as SessionUser;
+
+/** The model being edited, and what it currently points at. */
+function givenSourceModel(associations: number[] = []) {
+  dbMock.dbWrite.model.findUnique.mockResolvedValue({
+    userId: OWNER,
+    associations: associations.map((id) => ({ id })),
+  });
+}
+
+/**
+ * What the writer reports for the reciprocal targets and their current lists.
+ *
+ * Honours the `where.id.in` the service passes. A fake that returns every row regardless of
+ * the query would let a test pass while the service asked for the wrong ids — which is the
+ * decision these tests exist to check.
+ */
+function givenTargets(targets: Array<{ id: number; userId: number }>) {
+  dbMock.dbWrite.model.findMany.mockImplementation(async (args: unknown) => {
+    const ids = (args as { where?: { id?: { in?: number[] } } })?.where?.id?.in;
+    return ids ? targets.filter((target) => ids.includes(target.id)) : targets;
+  });
+  dbMock.dbWrite.modelAssociations.findMany.mockResolvedValue([]);
+}
+
+const save = (
+  associations: Array<{ resourceId: number; resourceType: 'model' | 'article'; id?: number }>,
+  { reciprocal, user = owner }: { reciprocal?: boolean; user?: SessionUser } = {}
+) => setAssociatedResources({ fromId: SOURCE, type: 'Suggested', associations, reciprocal }, user);
+
+const createdRows = () =>
+  (dbMock.dbWrite.modelAssociations.createMany.mock.calls[0]?.[0]?.data ?? []) as Array<{
+    fromModelId: number;
+  }>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  givenSourceModel();
+  givenTargets([]);
+});
+
+describe('setAssociatedResources — reciprocal wiring', () => {
+  // The opt-in itself. Deleting the `reciprocal` ternary in model.service.ts makes every
+  // Suggested-Resources save on the site rewrite other models' lists; before this test, that
+  // mutation turned nothing red. If you are removing the flag, you are removing the opt-in.
+  it('writes no back-link at all when the checkbox was not ticked', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }]);
+
+    expect(dbMock.dbWrite.modelAssociations.createMany).not.toHaveBeenCalled();
+  });
+
+  it('writes the back-link when it was ticked', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(dbMock.dbWrite.modelAssociations.createMany).toHaveBeenCalledTimes(1);
+    expect(createdRows()).toEqual([
+      { fromModelId: 2, toModelId: SOURCE, index: 0, type: 'Suggested', associatedById: OWNER },
+    ]);
+  });
+
+  // Ownership is scoped to the OWNER of the edited model, never to whoever is clicking. A
+  // moderator may edit someone else's model; the back-links belong to that creator's models,
+  // not to the moderator's. Swapping `fromModel.userId` for `user?.id` at the call site is a
+  // one-identifier change that this is the only assertion standing in front of.
+  it('scopes ownership to the model owner, not the acting moderator', async () => {
+    givenTargets([
+      { id: 2, userId: OWNER },
+      { id: 3, userId: MODERATOR },
+    ]);
+
+    await save(
+      [
+        { resourceId: 2, resourceType: 'model' },
+        { resourceId: 3, resourceType: 'model' },
+      ],
+      { reciprocal: true, user: moderator }
+    );
+
+    expect(createdRows().map((row) => row.fromModelId)).toEqual([2]);
+  });
+
+  it('derives ownership from the database, not from the request', async () => {
+    givenTargets([{ id: 2, userId: 555 }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(dbMock.dbWrite.model.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ select: { id: true, userId: true } })
+    );
+    expect(dbMock.dbWrite.modelAssociations.createMany).not.toHaveBeenCalled();
+  });
+
+  // Ownership and existing-link reads must not go to a replica: a model that just changed
+  // hands would report its previous owner, and a back-link committed moments earlier would be
+  // invisible and written twice.
+  it('reads ownership from the writer, never the replica', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(dbMock.dbRead.model.findMany).not.toHaveBeenCalled();
+    expect(dbMock.dbRead.modelAssociations.findMany).not.toHaveBeenCalled();
+  });
+
+  // Scope decided by Justin on 2026-09-11: the checkbox acts on what you just added, not on
+  // the whole saved list. Our modal saves the entire list, so without this a user who ticks
+  // the box while changing something unrelated retroactively back-links resources they linked
+  // months ago and never touched this session. If you widen this to every association, that is
+  // the behaviour you are bringing back.
+  it('back-links only resources added in this edit, never ones already on the list', async () => {
+    givenSourceModel([11]);
+    givenTargets([
+      { id: 2, userId: OWNER },
+      { id: 3, userId: OWNER },
+    ]);
+
+    await save(
+      [
+        { resourceId: 2, resourceType: 'model', id: 11 },
+        { resourceId: 3, resourceType: 'model' },
+      ],
+      { reciprocal: true }
+    );
+
+    expect(createdRows().map((row) => row.fromModelId)).toEqual([3]);
+  });
+
+  it('ignores articles when choosing reciprocal targets', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save(
+      [
+        { resourceId: 2, resourceType: 'model' },
+        { resourceId: 7, resourceType: 'article' },
+      ],
+      { reciprocal: true }
+    );
+
+    expect(dbMock.dbWrite.model.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: { in: [2] } } })
+    );
+  });
+
+  // Removal is deliberately NOT symmetric: once written, a back-link is an entry in the other
+  // model's own list and is removed from there. Justin decided this on 2026-09-11 rather than
+  // match MNeMiC's RelatedContentBidirectionalTest, because symmetric removal means a delete
+  // that reaches into a model the request never named — the one thing this feature keeps shut.
+  // If you are here to add symmetric removal, that is the tradeoff you are re-opening, and it
+  // needs a marker column to tell which rows were safe to delete.
+  it('deletes only from the edited model, never from a model it links to', async () => {
+    givenSourceModel([11, 12]);
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save([{ resourceId: 2, resourceType: 'model', id: 11 }], { reciprocal: true });
+
+    expect(dbMock.dbWrite.modelAssociations.deleteMany).toHaveBeenCalledTimes(1);
+    expect(dbMock.dbWrite.modelAssociations.deleteMany).toHaveBeenCalledWith({
+      where: { fromModelId: SOURCE, type: 'Suggested', id: { in: [12] } },
+    });
+  });
+});

--- a/src/server/services/model-association.utils.ts
+++ b/src/server/services/model-association.utils.ts
@@ -1,0 +1,57 @@
+export type ReciprocalSkipReason = 'notOwned' | 'alreadyLinked' | 'atLimit';
+
+export type ReciprocalCandidate = { modelId: number; ownerId: number | null };
+
+export type ReciprocalPlan = {
+  create: Array<{ fromModelId: number; toModelId: number; index: number }>;
+  skipped: Array<{ modelId: number; reason: ReciprocalSkipReason }>;
+};
+
+/**
+ * Decides which back-links a "link both ways" save may write.
+ *
+ * `ownerId` is the owner of the model being edited, not the acting user — a moderator
+ * editing someone else's model still links that owner's models together, never their own.
+ */
+export function planReciprocalAssociations({
+  sourceModelId,
+  ownerId,
+  candidates,
+  existingCounts,
+  alreadyLinked,
+  limit,
+}: {
+  sourceModelId: number;
+  ownerId: number;
+  candidates: ReciprocalCandidate[];
+  existingCounts: Map<number, number>;
+  alreadyLinked: Set<number>;
+  limit: number;
+}): ReciprocalPlan {
+  const plan: ReciprocalPlan = { create: [], skipped: [] };
+  const seen = new Set<number>();
+
+  for (const { modelId, ownerId: candidateOwnerId } of candidates) {
+    if (modelId === sourceModelId || seen.has(modelId)) continue;
+    seen.add(modelId);
+
+    if (candidateOwnerId !== ownerId) {
+      plan.skipped.push({ modelId, reason: 'notOwned' });
+      continue;
+    }
+    if (alreadyLinked.has(modelId)) {
+      plan.skipped.push({ modelId, reason: 'alreadyLinked' });
+      continue;
+    }
+
+    const count = existingCounts.get(modelId) ?? 0;
+    if (count >= limit) {
+      plan.skipped.push({ modelId, reason: 'atLimit' });
+      continue;
+    }
+
+    plan.create.push({ fromModelId: modelId, toModelId: sourceModelId, index: count });
+  }
+
+  return plan;
+}

--- a/src/server/services/model-association.utils.ts
+++ b/src/server/services/model-association.utils.ts
@@ -1,6 +1,6 @@
 export type ReciprocalSkipReason = 'notOwned' | 'alreadyLinked' | 'atLimit';
 
-export type ReciprocalCandidate = { modelId: number; ownerId: number | null };
+export type ReciprocalCandidate = { modelId: number; ownerId: number };
 
 export type ReciprocalPlan = {
   create: Array<{ fromModelId: number; toModelId: number; index: number }>;

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -20,6 +20,8 @@ import { ModelSort, SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { toApiModelFile } from '~/server/common/model-helpers';
 import type { Context } from '~/server/createContext';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { planReciprocalAssociations } from '~/server/services/model-association.utils';
+import type { AssociationType } from '~/shared/utils/prisma/enums';
 import {
   getDbWithoutLag,
   preventModelVersionLagBatch,
@@ -4067,7 +4069,7 @@ export const getAssociatedResourcesSimple = async ({
 };
 
 export const setAssociatedResources = async (
-  { fromId, type, associations }: SetAssociatedResourcesInput,
+  { fromId, type, associations, reciprocal }: SetAssociatedResourcesInput,
   user?: SessionUser
 ) => {
   const fromModel = await dbWrite.model.findUnique({
@@ -4091,7 +4093,7 @@ export const setAssociatedResources = async (
     (existingToId) => !associations.find((item) => item.id === existingToId)
   );
 
-  return await dbWrite.$transaction([
+  const result = await dbWrite.$transaction([
     // remove associated resources not included in payload
     dbWrite.modelAssociations.deleteMany({
       where: {
@@ -4114,6 +4116,82 @@ export const setAssociatedResources = async (
       });
     }),
   ]);
+
+  const reciprocalResult = reciprocal
+    ? await addReciprocalAssociations({
+        fromId,
+        ownerId: fromModel.userId,
+        type,
+        targetIds: associations
+          .filter((association) => association.resourceType === 'model')
+          .map((association) => association.resourceId),
+        actorId: user?.id,
+      })
+    : { linked: 0, skipped: [] };
+
+  return { associations: result, reciprocal: reciprocalResult };
+};
+
+/**
+ * Writes the "link both ways" back-links: adds `fromId` to the suggested-resource list of
+ * every target that `ownerId` also owns. Targets owned by anyone else are skipped, not
+ * rejected, so a mixed selection still saves its forward links.
+ *
+ * This is the only path that writes an association whose `fromModelId` is a model the
+ * request did not name, so ownership is re-derived here from the database rather than
+ * trusted from the caller.
+ */
+const addReciprocalAssociations = async ({
+  fromId,
+  ownerId,
+  type,
+  targetIds,
+  actorId,
+}: {
+  fromId: number;
+  ownerId: number;
+  type: AssociationType;
+  targetIds: number[];
+  actorId?: number;
+}) => {
+  const ids = [...new Set(targetIds)].filter((id) => id !== fromId);
+  if (!ids.length) return { linked: 0, skipped: [] };
+
+  const [targets, existing] = await Promise.all([
+    dbRead.model.findMany({ where: { id: { in: ids } }, select: { id: true, userId: true } }),
+    dbRead.modelAssociations.findMany({
+      where: { fromModelId: { in: ids }, type },
+      select: { fromModelId: true, toModelId: true },
+    }),
+  ]);
+
+  const existingCounts = new Map<number, number>();
+  const alreadyLinked = new Set<number>();
+  for (const association of existing) {
+    existingCounts.set(
+      association.fromModelId,
+      (existingCounts.get(association.fromModelId) ?? 0) + 1
+    );
+    if (association.toModelId === fromId) alreadyLinked.add(association.fromModelId);
+  }
+
+  const { create, skipped } = planReciprocalAssociations({
+    sourceModelId: fromId,
+    ownerId,
+    candidates: targets.map((target) => ({ modelId: target.id, ownerId: target.userId })),
+    existingCounts,
+    alreadyLinked,
+    limit: constants.modelAssociations.limit,
+  });
+
+  if (create.length) {
+    await dbWrite.modelAssociations.createMany({
+      data: create.map((row) => ({ ...row, type, associatedById: actorId })),
+      skipDuplicates: true,
+    });
+  }
+
+  return { linked: create.length, skipped };
 };
 // #endregion
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -4122,8 +4122,17 @@ export const setAssociatedResources = async (
         fromId,
         ownerId: fromModel.userId,
         type,
+        // Only resources added during this edit, never the ones already on the list. An
+        // association the model already held is one the creator linked at some earlier point
+        // and chose not to link back then; a later save of an unrelated change must not
+        // retroactively reach into those models. Derived from the rows the database reports,
+        // not from whether the client sent an id.
         targetIds: associations
-          .filter((association) => association.resourceType === 'model')
+          .filter(
+            (association) =>
+              association.resourceType === 'model' &&
+              (association.id === undefined || !existingAssociations.includes(association.id))
+          )
           .map((association) => association.resourceId),
         actorId: user?.id,
       })
@@ -4157,9 +4166,13 @@ const addReciprocalAssociations = async ({
   const ids = [...new Set(targetIds)].filter((id) => id !== fromId);
   if (!ids.length) return { linked: 0, skipped: [] };
 
+  // Both reads go to the writer. Ownership decides whether a row may be written into a model
+  // the request never named, and a replica within its lag window can report the previous owner
+  // of a model that just changed hands. The same lag would hide a back-link committed moments
+  // earlier, which is what stops a second save duplicating it.
   const [targets, existing] = await Promise.all([
-    dbRead.model.findMany({ where: { id: { in: ids } }, select: { id: true, userId: true } }),
-    dbRead.modelAssociations.findMany({
+    dbWrite.model.findMany({ where: { id: { in: ids } }, select: { id: true, userId: true } }),
+    dbWrite.modelAssociations.findMany({
       where: { fromModelId: { in: ids }, type },
       select: { fromModelId: true, toModelId: true },
     }),

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -4078,7 +4078,7 @@ export const setAssociatedResources = async (
       userId: true,
       associations: {
         where: { type },
-        select: { id: true },
+        select: { id: true, toModelId: true },
         orderBy: { index: 'asc' },
       },
     },
@@ -4089,6 +4089,9 @@ export const setAssociatedResources = async (
   if (!user?.isModerator && fromModel.userId !== user?.id) throw throwAuthorizationError();
 
   const existingAssociations = fromModel.associations.map((x) => x.id);
+  const existingModelTargets = new Set(
+    fromModel.associations.map((x) => x.toModelId).filter(isDefined)
+  );
   const associationsToRemove = existingAssociations.filter(
     (existingToId) => !associations.find((item) => item.id === existingToId)
   );
@@ -4125,13 +4128,19 @@ export const setAssociatedResources = async (
         // Only resources added during this edit, never the ones already on the list. An
         // association the model already held is one the creator linked at some earlier point
         // and chose not to link back then; a later save of an unrelated change must not
-        // retroactively reach into those models. Derived from the rows the database reports,
-        // not from whether the client sent an id.
+        // retroactively reach into those models.
+        //
+        // This is the whole enforcement of that rule, and it deliberately asks the database
+        // which models are already linked rather than trusting the payload's association ids.
+        // Those ids are absent for a row the client believes is new, and the client is wrong
+        // about that more often than it looks: it writes its own id-less array into the query
+        // cache after a save, so a second save in the same page session presents every row as
+        // new. Comparing model ids is immune to that, and to a caller omitting an id on purpose.
         targetIds: associations
           .filter(
             (association) =>
               association.resourceType === 'model' &&
-              (association.id === undefined || !existingAssociations.includes(association.id))
+              !existingModelTargets.has(association.resourceId)
           )
           .map((association) => association.resourceId),
         actorId: user?.id,


### PR DESCRIPTION
Adds MNeMiC's "link both ways" to Suggested Resources — ClickUp [868m45x6m](https://app.clickup.com/t/868m45x6m), from a Discord DM on 2026-09-10.

Ticking **Link both ways** in the associate modal also adds the model you are editing to the Suggested Resources of **each resource you added during this edit** — the rows marked **New** — that the same creator owns. Resources owned by anyone else are left alone, and the checkbox's description says so with the counts.

The "this edit only" scope is deliberate and was Justin's call. Our modal saves the whole list, unlike MNeMiC's select-and-confirm, so applying the checkbox to every association would let someone who ticks it while changing something unrelated retroactively reach into models they linked months ago. The checkbox does not render at all until something new is added.

### The part worth reviewing

This is the first write in the codebase whose `fromModelId` is a model the request never named. `setAssociatedResources` authorizes on the source model only and has no check on `toModelId` — deliberately, since pointing at a stranger's model is the normal case. Reciprocal insertion inverts the roles, so ownership is re-derived from the database in `addReciprocalAssociations` rather than trusted from the client; client-side visibility is presentation only.

The decision logic is a pure function, `planReciprocalAssociations`, so the ownership rule is testable without mocking the service graph. Reverting the ownership branch turns three of its assertions red naming the wrong model ids (verified, not assumed).

**Removal is deliberately not symmetric.** Once created, a back-link is an entry in that model's own list and is removed from there. Symmetric removal would require a delete that reaches into another model's list — the one path this change keeps shut — and would need a marker column to know which rows were safe to remove. Agreed with Justin before implementation; the test named for it says so.

Both reciprocal reads go to `dbWrite`, not the replica. Ownership decides whether a row may be written into a model the request never named, and a replica inside its lag window reports the previous owner of a model that just changed hands; the same lag would hide a back-link committed moments earlier and let a second save duplicate it.

### What the review changed

Five adversarial lanes ran over `b71c2053`. In order of consequence:

- **The schema change failed `test:packages:run`, a suite I had not run.** Declaring `@@unique` on live columns is enforced drift and the gate blocks it. Verified by reverting that single line: 6 failed → 102 passed. Removed, index ships as SQL.
- **Scope** — see above.
- **Ownership was derived twice and disagreed.** The checkbox counted the acting user's models while the server scoped to the model's owner, so a moderator read "0 of 3 you own" over a save that linked all three.
- **Both reciprocal reads were on the replica.**
- **The wiring had no test.** Six separate mutations of `setAssociatedResources` — removing the opt-in ternary, swapping owner for actor, moving reads back to the replica, dropping the article filter, dropping the this-edit filter, widening the delete — every one of them was green. `set-associated-resources.wiring.test.ts` closes that; all six now turn it red.
- I said the migration ordering did not matter. It does; corrected above.

A second round over those fixes found two more, both of which would have shipped:

- **The scope rule did not hold.** It tested `association.id === undefined`, which is "did the client send an id" — while the commit message claimed it was derived from the database. And the client was wrong about that routinely, not maliciously: this modal wrote its own id-less rows into a `staleTime: Infinity` query cache and never refetched, so a second open on the same page presented every saved row as new. Add A, save unticked, reopen, add B, tick — and A was back-linked too, with no attacker involved. Fixed at both ends: the server excludes any target whose model id the edited model already points at, and the component invalidates instead of seeding the cache.
- **`CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS` reports success over an INVALID index.** Postgres matches `IF NOT EXISTS` on *name*, not validity, so an operator interrupted once and re-running gets a clean exit over an index that enforces nothing — while everything downstream, including the `ON CONFLICT DO NOTHING` this whole migration exists for, believes suppression is live. `IF NOT EXISTS` is gone, the drop is a numbered retry step rather than a comment, and there is an `indisvalid` query to confirm.
- **The duplicate-prevention derivation was covered by nothing.** The test fake hard-coded the target-list read empty in every test, so counting the wrong column, inverting the already-linked check, or querying the wrong column were all green — each one a second back-link written into another user's model on a repeat save. Both fakes now throw a *named* error when asked without a scoped `where`, rather than returning every row.

A claim in the earlier version of this description that the index was not load-bearing on day one was wrong and has been rewritten.

### Also in here

- **Unique index on `("fromModelId", "toModelId", type)`**, which the table never had. Production carries 5 duplicate rows; an additive endpoint makes a double-click enough to create more. Model-to-article rows have a NULL `toModelId` and are unaffected. The index ships as migration SQL only — `@@unique` is **not** declared in `schema.full.prisma`, because the drift gate treats a uniqueness constraint declared on live columns as *enforced* drift and blocks on it. It is right to: the schema would be promising something the database does not have. Declaring it belongs in a follow-up once the index is applied.
- **Server-side cap** on the association array. It was bounded only by the modal hiding its search box. Set at 20 rather than the UI's 10 on purpose: 9 models already hold 11–12 associations and a cap of 10 would reject their owners' saves.

### Migration — applied by hand

`20260911150000_model_associations_unique`. **Run the two statements separately** — `CREATE INDEX CONCURRENTLY` cannot run inside a transaction block, so it must not share a multi-statement batch with the DELETE. The DELETE should report 5 rows; the index creation fails outright if any duplicate remains.

**Apply the migration BEFORE the deploy.** An earlier version of this note said the ordering did not matter, and that was wrong. `ON CONFLICT DO NOTHING` is valid syntax with or without the constraint, but with no unique index it conflicts with nothing — so the reciprocal path stops deduplicating and can mint fresh duplicate rows in the window. `CREATE INDEX CONCURRENTLY` validates at the end of a full build, so a duplicate created in that window fails the index after paying for the whole thing.

Measured on the prod replica: the DELETE plans as a serial merge join at **1.03 s** (DML is never parallelised) over 571,187 rows / 47 MB heap, taking `RowExclusiveLock` plus 5 row locks. `CREATE UNIQUE INDEX CONCURRENTLY` is two heap scans and a ~20 MB btree at `ShareUpdateExclusiveLock`, which blocks neither reads nor writes; its only stall mode is waiting out transactions older than its snapshots.

### Verification

```
typecheck: OK — 0 type errors
lint: no findings in any changed file (repo-wide errors are pre-existing)

test:unit:run
  Test Files  1 failed | 1754 passed | 3 skipped (1758)
  Tests  1 failed | 40018 passed | 35 skipped (40054)

test:packages:run
  Test Files  89 passed | 3 skipped (92)
  Tests  1243 passed | 8 skipped (1251)        exit 0

schema-drift gate.test.ts
  Tests  102 passed (102)                      exit 0
```

Every assertion added here has a positive control: the five service mutations listed above were each applied and each turned the wiring suite red before being reverted, and reverting the planner's ownership branch turns three of its assertions red naming the wrong model ids.

Reciprocal write cost, measured on the prod replica at the worst-case input (the 20 models with the most associations): `ModelAssociations` read **0.650 ms** via `Index Scan using "ModelAssociations_fromModelId_idx"`, `Model` read **0.126 ms** via pkey, plus one `createMany`. Three round trips, ~1 ms of database time, on a Save click rather than a page view.

The one failure is `src/server/integrations/__tests__/moderation-cache-probe.test.ts`, a `vi.waitFor` against Redis that passes in isolation (402 tests green re-running it alongside `blocks.router.workflow`). It has failed in all three full-suite runs and passed in isolation each time; nothing in this diff imports anything it imports, and it touches no Redis, flag, or moderation path. I did **not** run a full suite from a clean base to confirm that directly — the evidence is the isolated pass plus the absence of any import path. `blocks.router.workflow.test.ts` collected **380 tests**, so the submodule is initialised and the run means something.

### Two review remedies deliberately not taken

Both findings were right; the fixes attached to them were not, and the reasoning belongs here rather than in a thread, because in both cases the absence looks like an oversight.

- **A `notFound` skip reason for target ids the database does not return.** A target that is deleted, or simply does not exist, vanishes from the plan with no `create` and no `skipped` entry, so the summary returned to the client is not a complete account of what did not link. Correct, but the suggested fix — filtering the reciprocal read on `deletedAt`/`status` — puts a filter on one side of a pair whose forward path has none. Adding it here would mean a resource you can still add to your own list cannot receive a back-link, for reasons nothing in the UI explains. That asymmetry is worse than the incomplete count. If this is worth fixing it should be fixed on both paths at once.
- **Converting the test file's hand-listed `vi.mock` factories to `importOriginal` spreads.** The hazard behind the suggestion is real and stands: four of the mocked modules are hubs, and the day `model.service.ts` imports one more export from any of them this file dies at load and collects **zero tests** — no red, just a suite that quietly stops existing, with typecheck and lint still green. But `importOriginal` *loads the real module*, and load-time construction is exactly why those four are stubbed; CLAUDE.md's own example names `~/server/search-index` → `meilisearch/client` as the module that builds `pLimit` and prom collectors at import. Spreading it would defeat the mock. Repo precedent (`bust-public-model-response-cache.service.test.ts`) uses bare factories for these and `importOriginal` only for the leaf `~/server/prom/client`. The remedy does not address the hazard; the hazard remains unaddressed.
- **Catching the reciprocal write's throw.** It runs outside the main `$transaction`, so if it fails the mutation rejects while the forward associations are already committed: the user sees a failed save that actually landed. Wrapping it in a try/catch would convert that into an accurate partial success — and would also swallow a real database error on a write path, which is a worse bug than the one it hides, and would need its own control to be worth anything. Left as-is, recorded as a known limitation. State self-heals on retry: `existingAssociations` is re-read from the writer, and the first attempt's rows carry ids the client does not hold, so they are removed and recreated.

### Not in scope

Filename-based auto-search, the second half of the original request. Model file names are not in the Meilisearch index at all — the indexer drops `files`, and searchable fields are name/username/hashes/triggerWords — so matching on them needs a new field plus a full reindex. Justin scoped it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQN1cL4E2b1XveUdu7egt5
