### PR TITLE
chore(mod-actions): remove dead training moderation commands

### DIFF
--- a/.claude/skills/mod-actions/SKILL.md
+++ b/.claude/skills/mod-actions/SKILL.md
@@ -38,7 +38,7 @@ cp .claude/skills/mod-actions/.env.example .claude/skills/mod-actions/.env
 | `images.mjs` | Image moderation | review-queue, review-counts, moderate, tos-violation, rescan, report-csam, poi-tags, user-images, rating-requests, ingestion-errors, resolve-ingestion, downleveled, pending-ingestion, toggle-flag |
 | `reports.mjs` | Report handling | list, set-status, bulk-status, update, appeals, appeal-details, resolve-appeal |
 | `generation.mjs` | Generation moderation | flagged-consumers, flagged-reasons, consumer-strikes, review-strikes, user-generations, restrictions, resolve-restriction, allowlist-add, debug-audit, todays-counts, suspicious-matches |
-| `content.mjs` | Content & training | models, flagged-models, resolve-flagged, model-versions, rescan-model, restore-model, toggle-cannot-promote, toggle-cannot-publish, articles, training-models, approve-training, deny-training, mod-rule |
+| `content.mjs` | Content moderation | models, flagged-models, resolve-flagged, model-versions, rescan-model, restore-model, toggle-cannot-promote, toggle-cannot-publish, articles, mod-rule |
 | `model3ds.mjs` | 3D Models moderation | list, get, files, unpublish, delete, restore, set-nsfw-level, toggle-tos, toggle-poi, toggle-minor, toggle-nsfw, toggle-unlisted |
 | `csam.mjs` | NCMEC/CSAM reporting | reports, stats, image-resources, create-report |
 
@@ -200,7 +200,7 @@ node .claude/skills/mod-actions/generation.mjs allowlist-add --trigger "girl" --
 
 ---
 
-## content.mjs — Content & Training Moderation
+## content.mjs — Content Moderation
 
 ```bash
 node .claude/skills/mod-actions/content.mjs <command> [options]
@@ -217,18 +217,17 @@ node .claude/skills/mod-actions/content.mjs <command> [options]
 | `toggle-cannot-promote <id>` | WRITE | Toggle promotion eligibility |
 | `toggle-cannot-publish <id>` | WRITE | Toggle publish ability |
 | `articles` | READ | Articles for mod review |
-| `training-models` | READ | Training models for review |
-| `approve-training <id>` | WRITE | Approve training data |
-| `deny-training <id>` | WRITE | Deny training data |
 | `mod-rule <id>` | READ | Get moderation rule |
 
 **Options:** `--ids`, `--page`, `--limit`, `--json`, `--dry-run`
 
+Training moderation (list / approve / deny training data) moved to the moderator spoke
+(`/audit/training-models`, `/audit/training-data`) in the moderator-app migration and is no
+longer reachable via tRPC — see `docs/moderator-app/page-migration-checklist.md`.
+
 ```bash
 node .claude/skills/mod-actions/content.mjs flagged-models --limit 10
 node .claude/skills/mod-actions/content.mjs resolve-flagged --ids 1,2,3 --dry-run
-node .claude/skills/mod-actions/content.mjs training-models --limit 20
-node .claude/skills/mod-actions/content.mjs approve-training 456
 node .claude/skills/mod-actions/content.mjs rescan-model 789
 ```
 

--- a/.claude/skills/mod-actions/content.mjs
+++ b/.claude/skills/mod-actions/content.mjs
@@ -13,10 +13,11 @@
  *   toggle-cannot-promote <id>       Toggle cannot-promote flag
  *   toggle-cannot-publish <id>       Toggle cannot-publish flag
  *   articles                         List articles for moderation
- *   training-models                  List training models
- *   approve-training <id>            Approve training data
- *   deny-training <id>               Deny training data
  *   mod-rule <id>                    Get a moderation rule by ID
+ *
+ * Training moderation (training-models / approve-training / deny-training) moved to the
+ * moderator spoke (/audit/training-models, /audit/training-data) in the moderator-app
+ * migration and no longer has a tRPC procedure — see docs/moderator-app/page-migration-checklist.md.
  *
  * Options:
  *   --json                Output raw JSON
@@ -44,7 +45,6 @@ Commands (READ):
   flagged-models                   List flagged models
   model-versions                   List model versions
   articles                         List articles for moderation
-  training-models                  List training models
   mod-rule <id>                    Get a moderation rule by ID
 
 Commands (WRITE):
@@ -53,8 +53,6 @@ Commands (WRITE):
   restore-model <id>               Restore a removed model
   toggle-cannot-promote <id>       Toggle cannot-promote flag on a model
   toggle-cannot-publish <id>       Toggle cannot-publish flag on a model
-  approve-training <id>            Approve training data
-  deny-training <id>               Deny training data
 
 Options:
   --json                Output raw JSON
@@ -74,9 +72,6 @@ Examples:
   node content.mjs toggle-cannot-promote 456
   node content.mjs toggle-cannot-publish 456
   node content.mjs articles --limit 10
-  node content.mjs training-models
-  node content.mjs approve-training 321
-  node content.mjs deny-training 321 --dry-run
   node content.mjs mod-rule 5 --json
 
 Configuration:
@@ -131,12 +126,6 @@ async function main() {
 
     case 'articles': {
       const result = await trpcCall('moderator.articles.query', pagination(), 'GET');
-      output(result, jsonMode);
-      break;
-    }
-
-    case 'training-models': {
-      const result = await trpcCall('moderator.models.queryTraining', pagination(), 'GET');
       output(result, jsonMode);
       break;
     }
@@ -217,32 +206,6 @@ async function main() {
 
       const result = await trpcCall('model.toggleCannotPublish', { id }, 'POST');
       output(result, jsonMode, () => `Toggled cannot-publish for model ${id}`);
-      break;
-    }
-
-    case 'approve-training': {
-      const id = requireId('Training data ID');
-
-      if (dryRun) {
-        console.log(`[DRY RUN] Would approve training data: ${id}`);
-        break;
-      }
-
-      const result = await trpcCall('moderator.trainingData.approve', { id }, 'POST');
-      output(result, jsonMode, () => `Approved training data ${id}`);
-      break;
-    }
-
-    case 'deny-training': {
-      const id = requireId('Training data ID');
-
-      if (dryRun) {
-        console.log(`[DRY RUN] Would deny training data: ${id}`);
-        break;
-      }
-
-      const result = await trpcCall('moderator.trainingData.deny', { id }, 'POST');
-      output(result, jsonMode, () => `Denied training data ${id}`);
       break;
     }
 


### PR DESCRIPTION
Training moderation commands (training-models, approve-training, deny-training)
called tRPC procedures that were deleted during the moderator-app migration.
Training moderation is now handled by the moderator spoke at /audit/training-models
and /audit/training-data, accessible only as SvelteKit server functions.

Remove the dead command implementations and update documentation to clarify that
training moderation is no longer available through this skill. Update content.mjs
scope from "Content & Training" to "Content" to reflect the actual commands provided.

See docs/moderator-app/page-migration-checklist.md for details on the moderator-app
migration and the relocation of training moderation endpoints.

Refs: 868m06gk2