### PR TITLE
feat(generation): add Ideogram 4 generation support

### DIFF
--- a/packages/civitai-shared/src/basemodel.constants.ts
+++ b/packages/civitai-shared/src/basemodel.constants.ts
@@ -1192,7 +1192,8 @@ export const ecosystemSupport: EcosystemSupport[] = [
   // Mage-Flow - LORA training (AI Toolkit only)
   { ecosystemId: ECO.MageFlow, supportType: 'training', modelTypes: loraOnly },
 
-  // Ideogram 4 - LORA training (AI Toolkit only)
+  // Ideogram 4 - checkpoint and LORA; LORA training (AI Toolkit only)
+  { ecosystemId: ECO.Ideogram, supportType: 'generation', modelTypes: checkpointAndLora },
   { ecosystemId: ECO.Ideogram, supportType: 'training', modelTypes: loraOnly },
 
   // PonyV7 - checkpoint and LORA (based on AuraFlow)
@@ -1347,6 +1348,13 @@ export const ecosystemSettings: EcosystemSettings[] = [
     ecosystemId: ECO.Krea2,
     defaults: {
       model: { id: 3072329 },
+    },
+  },
+  {
+    ecosystemId: ECO.Ideogram,
+    defaults: {
+      model: { id: 3246186 },
+      modelLocked: true,
     },
   },
   {

--- a/src/components/Model/BaseModelWarningAlert/BaseModelWarningAlert.tsx
+++ b/src/components/Model/BaseModelWarningAlert/BaseModelWarningAlert.tsx
@@ -1,8 +1,18 @@
 import type { AlertProps } from '@mantine/core';
-import { List, Text } from '@mantine/core';
-import { IconAlertTriangle } from '@tabler/icons-react';
-import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
+import { Alert } from '@mantine/core';
 import { getBaseModelWarning } from '~/shared/constants/base-model-warnings.constants';
+
+export function BaseModelWarningPoints({ points }: { points: string[] }) {
+  return (
+    <ul className="m-0 flex min-w-0 list-disc flex-col gap-1 pl-4 text-sm">
+      {points.map((point) => (
+        <li key={point} className="break-words">
+          {point}
+        </li>
+      ))}
+    </ul>
+  );
+}
 
 export function BaseModelWarningAlert({
   baseModel,
@@ -12,21 +22,8 @@ export function BaseModelWarningAlert({
   if (!warning) return null;
 
   return (
-    <AlertWithIcon
-      icon={<IconAlertTriangle size={20} />}
-      iconColor="red"
-      color="red"
-      size="sm"
-      title={warning.title}
-      {...alertProps}
-    >
-      <List size="sm" spacing={4} mt={4}>
-        {warning.points.map((point) => (
-          <List.Item key={point}>
-            <Text size="sm">{point}</Text>
-          </List.Item>
-        ))}
-      </List>
-    </AlertWithIcon>
+    <Alert color="red" radius="sm" title={warning.title} {...alertProps}>
+      <BaseModelWarningPoints points={warning.points} />
+    </Alert>
   );
 }

--- a/src/components/form-graph/generation/FormFooter.tsx
+++ b/src/components/form-graph/generation/FormFooter.tsx
@@ -53,6 +53,7 @@ import {
 } from '~/components/ImageGeneration/utils/generationRequestHooks';
 import { BuzzTypeSelector, useSelectedBuzzType } from '~/components/generation_v2/FormFooter';
 import { ExperimentalAlerts } from '~/components/generation_v2/Experimental';
+import { EcosystemBaseModelWarnings } from '~/components/generation_v2/BaseModelWarnings';
 import { DismissibleAlert } from '~/components/DismissibleAlert/DismissibleAlert';
 import { useResourceDataContext } from '~/components/generation_v2/inputs/ResourceDataProvider';
 import { filterSnapshotForSubmit } from '~/components/generation_v2/utils';
@@ -292,6 +293,7 @@ function PriorityAlertSpace({
     <>
       <QueueSnackbar right={snackbarRight} />
       <ExperimentalWarnings />
+      <BaseModelWarnings />
       {priorityAlert}
     </>
   );
@@ -304,6 +306,16 @@ function ExperimentalWarnings() {
       graph={generationHub}
       names={['ecosystem', 'workflow', 'model', 'resources', 'vae'] as const}
       render={({ values }) => <ExperimentalAlerts selection={values} />}
+    />
+  );
+}
+
+function BaseModelWarnings() {
+  return (
+    <Controller
+      graph={generationHub}
+      name="ecosystem"
+      render={({ value: ecosystem }) => <EcosystemBaseModelWarnings ecosystem={ecosystem} />}
     />
   );
 }

--- a/src/components/generation_v2/BaseModelWarnings.tsx
+++ b/src/components/generation_v2/BaseModelWarnings.tsx
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import { DismissibleAlert } from '~/components/DismissibleAlert/DismissibleAlert';
+import { BaseModelWarningPoints } from '~/components/Model/BaseModelWarningAlert/BaseModelWarningAlert';
+import { getBaseModelWarning } from '~/shared/constants/base-model-warnings.constants';
+import { ecosystemByKey, getBaseModelsByEcosystemId } from '~/shared/constants/basemodel.constants';
+
+export function EcosystemBaseModelWarnings({ ecosystem }: { ecosystem?: string }) {
+  const warnings = useMemo(() => {
+    const ecosystemId = ecosystem ? ecosystemByKey.get(ecosystem)?.id : undefined;
+    if (ecosystemId == null) return [];
+    return getBaseModelsByEcosystemId(ecosystemId).flatMap((baseModel) => {
+      const warning = getBaseModelWarning(baseModel.name);
+      return warning ? [{ baseModel: baseModel.name, warning }] : [];
+    });
+  }, [ecosystem]);
+
+  if (!warnings.length) return null;
+
+  return (
+    <>
+      {warnings.map(({ baseModel, warning }) => (
+        <DismissibleAlert
+          key={baseModel}
+          id={`base-model-warning-${baseModel}`}
+          color="red"
+          size="sm"
+          title={warning.title}
+        >
+          <BaseModelWarningPoints points={warning.points} />
+        </DismissibleAlert>
+      ))}
+    </>
+  );
+}

--- a/src/components/generation_v2/FormFooter.tsx
+++ b/src/components/generation_v2/FormFooter.tsx
@@ -106,6 +106,7 @@ import {
 } from '~/shared/constants/generation.constants';
 import { DismissibleAlert } from '~/components/DismissibleAlert/DismissibleAlert';
 import { ExperimentalAlerts } from '~/components/generation_v2/Experimental';
+import { EcosystemBaseModelWarnings } from '~/components/generation_v2/BaseModelWarnings';
 import { WORKFLOW_TAGS } from '~/shared/constants/generation.constants';
 import {
   openCompatibilityConfirmModal,
@@ -651,16 +652,17 @@ function PriorityAlertSpace({
     );
   }
 
-  // Experimental warnings sit alongside the priority alert rather than inside the
-  // chain above, for the same reason QueueSnackbar does: the chain is exclusive
-  // and ordered by urgency of the moment, and its first branch (`missingFieldMessage`)
-  // fires whenever a required field is blank. Joining it would hide the warning
-  // for anyone who hasn't written a prompt yet — the moment it's most worth
-  // reading, since nothing has been invested in the selection yet.
+  // Experimental and base-model warnings sit alongside the priority alert rather
+  // than inside the chain above, for the same reason QueueSnackbar does: the chain
+  // is exclusive and ordered by urgency of the moment, and its first branch
+  // (`missingFieldMessage`) fires whenever a required field is blank. Joining it
+  // would hide the warning for anyone who hasn't written a prompt yet — the moment
+  // it's most worth reading, since nothing has been invested in the selection yet.
   return (
     <>
       <QueueSnackbar right={snackbarRight} />
       <ExperimentalWarnings />
+      <BaseModelWarnings />
       {priorityAlert}
     </>
   );
@@ -1033,6 +1035,15 @@ function ExperimentalWarnings() {
       render={({ values }) => <ExperimentalAlerts selection={values} />}
     />
   );
+}
+
+function BaseModelWarnings() {
+  const graph = useGraph<GenerationGraphTypes>();
+  const { ecosystem } = useGraphSubscriptions(graph, ['ecosystem'] as const) as {
+    ecosystem?: string;
+  };
+
+  return <EcosystemBaseModelWarnings ecosystem={ecosystem} />;
 }
 
 // =============================================================================

--- a/src/server/services/orchestrator/ecosystems/ideogram.handler.ts
+++ b/src/server/services/orchestrator/ecosystems/ideogram.handler.ts
@@ -1,0 +1,45 @@
+/**
+ * Ideogram Ecosystem Handler
+ *
+ * Handles Ideogram 4 workflows using imageGen step type.
+ * Uses the comfy engine with ComfyIdeogram4CreateImageGenInput.
+ */
+
+import type { ComfyIdeogram4CreateImageGenInput, ImageGenStepTemplate } from '@civitai/client';
+import { removeEmpty } from '~/utils/object-helpers';
+import type { GenerationGraphTypes } from '~/shared/data-graph/generation/generation-graph';
+import type { ResourceData } from '~/shared/data-graph/generation/common';
+import { defineHandler } from './handler-factory';
+
+type EcosystemGraphOutput = Extract<GenerationGraphTypes['Ctx'], { ecosystem: string }>;
+type IdeogramCtx = EcosystemGraphOutput & { ecosystem: 'Ideogram' };
+
+export const createIdeogramInput = defineHandler<IdeogramCtx, [ImageGenStepTemplate]>(
+  (data, ctx) => {
+    const loras: Record<string, number> = {};
+    if ('resources' in data && Array.isArray(data.resources)) {
+      for (const resource of data.resources as ResourceData[]) {
+        loras[ctx.airs.getOrThrow(resource.id)] = resource.strength ?? 1;
+      }
+    }
+
+    // No `diffusionModel`: the official checkpoint bundles the conditional and
+    // unconditional weights in several precisions, so its AIR names no single file.
+    const input: ComfyIdeogram4CreateImageGenInput = {
+      engine: 'comfy',
+      ecosystem: 'ideogram4',
+      operation: 'createImage',
+      prompt: data.prompt,
+      width: data.aspectRatio?.width,
+      height: data.aspectRatio?.height,
+      cfgScale: data.cfgScale,
+      steps: data.steps,
+      seed: data.seed,
+      quantity: data.quantity ?? 1,
+      outputFormat: data.outputFormat,
+      loras: Object.keys(loras).length > 0 ? loras : undefined,
+    };
+
+    return [{ $type: 'imageGen', input: removeEmpty(input) }];
+  }
+);

--- a/src/server/services/orchestrator/ecosystems/index.ts
+++ b/src/server/services/orchestrator/ecosystems/index.ts
@@ -45,6 +45,7 @@ import { createNanoBananaInput } from './nano-banana.handler';
 import { createAnimaInput } from './anima.handler';
 import { createChromaInput } from './chroma.handler';
 import { createErnieInput } from './ernie.handler';
+import { createIdeogramInput } from './ideogram.handler';
 import { createLensInput } from './lens.handler';
 import { createKrea2Input } from './krea2.handler';
 import { createMAIInput } from './mai.handler';
@@ -166,6 +167,9 @@ export type PonyV7Ctx = EcosystemGraphOutput & { ecosystem: 'PonyV7' };
 /** Ernie context */
 export type ErnieCtx = EcosystemGraphOutput & { ecosystem: 'Ernie' };
 
+/** Ideogram context */
+export type IdeogramCtx = EcosystemGraphOutput & { ecosystem: 'Ideogram' };
+
 /** Lens context */
 export type LensCtx = EcosystemGraphOutput & { ecosystem: 'Lens' };
 
@@ -264,6 +268,7 @@ export { createHiDreamInput } from './hi-dream.handler';
 export { createHiDreamO1Input } from './hi-dream-o1.handler';
 export { createPonyV7Input } from './pony-v7.handler';
 export { createErnieInput } from './ernie.handler';
+export { createIdeogramInput } from './ideogram.handler';
 export { createLensInput } from './lens.handler';
 export { createKrea2Input } from './krea2.handler';
 export { createMAIInput } from './mai.handler';
@@ -447,6 +452,10 @@ async function createEcosystemStep(
     // Ernie
     case 'Ernie':
       return createErnieInput(normalizedData, handlerCtx);
+
+    // Ideogram 4 (comfy)
+    case 'Ideogram':
+      return createIdeogramInput(normalizedData, handlerCtx);
 
     // Lens (Civitai-internal, comfy)
     case 'Lens':

--- a/src/server/services/orchestrator/form-graph/__tests__/handlers.differential.test.ts
+++ b/src/server/services/orchestrator/form-graph/__tests__/handlers.differential.test.ts
@@ -159,6 +159,17 @@ const CASES: Record<string, unknown>[] = [
     resources: [{ id: 444, baseModel: 'Ernie', model: { type: 'LORA' }, strength: 0.7 }],
   },
   { workflow: 'txt2img', ecosystem: 'Ernie', prompt: 'a cat', seed: 42, model: 2863892 },
+  // Ideogram: locked checkpoint, with and without LoRA
+  { workflow: 'txt2img', ecosystem: 'Ideogram', prompt: 'a cat', seed: 42 },
+  {
+    workflow: 'txt2img',
+    ecosystem: 'Ideogram',
+    prompt: 'a cat',
+    seed: 42,
+    cfgScale: 6,
+    steps: 30,
+    resources: [{ id: 555, baseModel: 'Ideogram 4.0', model: { type: 'LORA' }, strength: 0.6 }],
+  },
   { workflow: 'txt2img', ecosystem: 'Seedream', prompt: 'a cat', seed: 42 },
   {
     workflow: 'txt2img',

--- a/src/server/services/orchestrator/form-graph/ideogram.handler.ts
+++ b/src/server/services/orchestrator/form-graph/ideogram.handler.ts
@@ -1,0 +1,30 @@
+/** Ideogram 4 handler for the form-graph lane — comfy imageGen. */
+
+import type { ComfyIdeogram4CreateImageGenInput, ImageGenStepTemplate } from '@civitai/client';
+import { removeEmpty } from '~/utils/object-helpers';
+import { defineHandler } from '../ecosystems/handler-factory';
+import { resourcesToLoras } from './types';
+import type { EcosystemData } from './types';
+
+export const createIdeogramInput = defineHandler<EcosystemData<'Ideogram'>, [ImageGenStepTemplate]>(
+  (data, ctx) => {
+    // No `diffusionModel`: the official checkpoint bundles the conditional and
+    // unconditional weights in several precisions, so its AIR names no single file.
+    const input: ComfyIdeogram4CreateImageGenInput = {
+      engine: 'comfy',
+      ecosystem: 'ideogram4',
+      operation: 'createImage',
+      prompt: data.prompt ?? '',
+      width: data.aspectRatio?.width,
+      height: data.aspectRatio?.height,
+      cfgScale: data.cfgScale,
+      steps: data.steps,
+      seed: data.seed,
+      quantity: data.quantity ?? 1,
+      outputFormat: data.outputFormat,
+      loras: resourcesToLoras(data.resources, ctx.airs),
+    };
+
+    return [{ $type: 'imageGen', input: removeEmpty(input) }];
+  }
+);

--- a/src/server/services/orchestrator/form-graph/index.ts
+++ b/src/server/services/orchestrator/form-graph/index.ts
@@ -26,6 +26,7 @@ import { createReveInput } from './reve.handler';
 import { createMuseImageInput } from './muse-image.handler';
 import { createMAIInput } from './mai.handler';
 import { createErnieInput } from './ernie.handler';
+import { createIdeogramInput } from './ideogram.handler';
 import { createSeedreamInput } from './seedream.handler';
 import { createAnimaInput } from './anima.handler';
 import { createMageFlowInput } from './mage-flow.handler';
@@ -77,6 +78,7 @@ export { createReveInput } from './reve.handler';
 export { createMuseImageInput } from './muse-image.handler';
 export { createMAIInput } from './mai.handler';
 export { createErnieInput } from './ernie.handler';
+export { createIdeogramInput } from './ideogram.handler';
 export { createSeedreamInput } from './seedream.handler';
 export { createAnimaInput } from './anima.handler';
 export { createMageFlowInput } from './mage-flow.handler';
@@ -209,6 +211,9 @@ function createStep(
 
     case 'Ernie':
       return createErnieInput(data, handlerCtx);
+
+    case 'Ideogram':
+      return createIdeogramInput(data, handlerCtx);
 
     case 'Seedream':
       return createSeedreamInput(data, handlerCtx);

--- a/src/shared/data-graph/generation/config/workflows.ts
+++ b/src/shared/data-graph/generation/config/workflows.ts
@@ -108,6 +108,7 @@ const TXT2IMG_IDS = [
   ECO.Grok,
   ECO.WanImage27,
   ECO.Ernie,
+  ECO.Ideogram,
   ECO.Lens,
   ECO.Krea2,
   ECO.MAI,

--- a/src/shared/data-graph/generation/ecosystem-graph.ts
+++ b/src/shared/data-graph/generation/ecosystem-graph.ts
@@ -69,6 +69,7 @@ import { veo3Graph } from './veo3-graph';
 import { animaGraph } from './anima-graph';
 import { grokGraph } from './grok-graph';
 import { ernieGraph } from './ernie-graph';
+import { ideogramGraph } from './ideogram-graph';
 import { lensGraph } from './lens-graph';
 import { krea2Graph } from './krea2-graph';
 import { maiGraph } from './mai-graph';
@@ -393,6 +394,7 @@ export const ecosystemGraph = new DataGraph<
     { values: ['PonyV7'] as const, graph: ponyV7Graph },
     { values: ['Anima'] as const, graph: animaGraph },
     { values: ['Ernie'] as const, graph: ernieGraph },
+    { values: ['Ideogram'] as const, graph: ideogramGraph },
     { values: ['Lens'] as const, graph: lensGraph },
     { values: ['Krea2'] as const, graph: krea2Graph },
     { values: ['MAI'] as const, graph: maiGraph },

--- a/src/shared/data-graph/generation/ideogram-graph.ts
+++ b/src/shared/data-graph/generation/ideogram-graph.ts
@@ -1,0 +1,42 @@
+/**
+ * Ideogram Family Graph
+ *
+ * Controls for the Ideogram 4 ecosystem (comfy engine). Locked to the Civitai-hosted
+ * checkpoint; LoRAs supported. No negative prompt, sampler or scheduler —
+ * ComfyIdeogram4CreateImageGenInput takes none of them.
+ */
+
+import { DataGraph } from '~/libs/data-graph/data-graph';
+import type { GenerationCtx } from './context';
+import {
+  aspectRatioNode,
+  createCheckpointGraph,
+  createResourcesGraph,
+  promptGraph,
+  seedNode,
+  sliderNode,
+  snippetsGraph,
+  triggerWordsGraph,
+} from './common';
+import { sdxlAspectRatioBuckets } from '~/shared/constants/generation.constants';
+
+/** Ideogram 4 model version ID (CivitaiOfficial) */
+export const ideogramVersionId = 3246186;
+
+export const ideogramGraph = new DataGraph<{ ecosystem: string; workflow: string }, GenerationCtx>()
+  .merge(
+    () =>
+      createCheckpointGraph({
+        modelLocked: true,
+        defaultModelId: ideogramVersionId,
+      }),
+    []
+  )
+  .merge(createResourcesGraph())
+  .node('aspectRatio', aspectRatioNode({ options: sdxlAspectRatioBuckets, defaultValue: '1:1' }))
+  .node('cfgScale', sliderNode({ min: 1, max: 10, defaultValue: 4, step: 0.5 }))
+  .node('steps', sliderNode({ min: 1, max: 50, defaultValue: 25 }))
+  .merge(triggerWordsGraph)
+  .merge(snippetsGraph)
+  .merge(promptGraph)
+  .node('seed', seedNode());

--- a/src/shared/form-graph/generation/__tests__/image-parity.test.ts
+++ b/src/shared/form-graph/generation/__tests__/image-parity.test.ts
@@ -261,6 +261,7 @@ const ECOSYSTEMS = [
   'MuseImage',
   'MAI',
   'Ernie',
+  'Ideogram',
   'Seedream',
   'Anima',
   'MageFlow',

--- a/src/shared/form-graph/generation/image/hub.graph.ts
+++ b/src/shared/form-graph/generation/image/hub.graph.ts
@@ -21,6 +21,7 @@ import { reve } from './reve.graph';
 import { museImage } from './muse-image.graph';
 import { mai } from './mai.graph';
 import { ernie } from './ernie.graph';
+import { ideogram } from './ideogram.graph';
 import { seedream } from './seedream.graph';
 import { anima } from './anima.graph';
 import { mageFlow } from './mage-flow.graph';
@@ -94,6 +95,7 @@ export const imageHub = defineGraph<RootCtx>()
       [['MuseImage'], museImage],
       [['MAI'], mai],
       [['Ernie'], ernie],
+      [['Ideogram'], ideogram],
       [['Seedream'], seedream],
       [['Anima'], anima],
       [['MageFlow'], mageFlow],

--- a/src/shared/form-graph/generation/image/ideogram.graph.ts
+++ b/src/shared/form-graph/generation/image/ideogram.graph.ts
@@ -1,0 +1,38 @@
+import { defineGraph } from 'form-graph';
+import { checkpointDef } from '../checkpoint';
+import { SDXL_SQUARE_AR, SEED } from '../defs';
+import {
+  familyResources,
+  familyScope,
+  perModelSlider,
+  promptOnlyTextBlock,
+  type FamilyExt,
+} from '../shared';
+
+/**
+ * Ideogram 4, ported from `ideogram-graph.ts`. Comfy engine, locked checkpoint,
+ * LoRAs; no negative prompt, sampler or scheduler.
+ */
+
+// ---- copied from ideogram-graph.ts, which dies with the data-graph engine ---
+
+export const ideogramVersionId = 3246186;
+
+// ---- end of ideogram-graph.ts copies ----------------------------------------
+
+export const ideogram = defineGraph<FamilyExt>({ scope: familyScope })
+  .field('model', ({ _ext }) =>
+    checkpointDef({
+      ecosystem: _ext.ecosystem,
+      workflow: _ext.workflow,
+      ext: _ext,
+      modelLocked: true,
+      defaultModelId: ideogramVersionId,
+    })
+  )
+  .field('resources', familyResources)
+  .field('aspectRatio', SDXL_SQUARE_AR)
+  .field('cfgScale', perModelSlider({ min: 1, max: 10, step: 0.5, default: 4 }))
+  .field('steps', perModelSlider({ min: 1, max: 50, default: 25 }))
+  .use(promptOnlyTextBlock)
+  .field('seed', SEED);


### PR DESCRIPTION
Wires Ideogram 4 (comfy, ComfyIdeogram4CreateImageGenInput) into both the data-graph and form-graph generators, locked to the CivitaiOfficial checkpoint (version 3246186) with LoRA support. Defaults: cfg 4, steps 25, 1MP SDXL aspect buckets. No negative prompt, sampler or scheduler — the input type takes none of them.

The base-model warning (SFW only, censorship blocks are not refunded) now renders in the generator as a dismissible alert in both FormFooters, beside the experimental warnings so a missing-prompt message cannot hide it. The shared BaseModelWarningAlert drops its icon and wraps its text.

Requires a manual "EcosystemCheckpoints" row for version 3246186 while the checkpoint is unpublished.

ClickUp: 868ktt5cw