### PR TITLE
feat(blocks): windowed collection popularity — a `period` param served from ClickHouse

### DIFF
--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -20,6 +20,10 @@ import {
   hydrateBlockSubject,
   toCoverFields,
 } from '~/server/services/blocks/block-collections.service';
+import {
+  getWindowedCollectionRanking,
+  isWindowedPeriod,
+} from '~/server/services/blocks/block-collection-popularity.service';
 import { resolveCatalogBrowsingLevel } from '~/server/utils/block-catalog-maturity';
 import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
@@ -28,10 +32,11 @@ import {
   CollectionItemStatus,
   CollectionReadConfiguration,
   CollectionType,
+  MetricTimeframe,
 } from '~/shared/utils/prisma/enums';
 
 /**
- * GET /api/v1/blocks/collections?mode=public|mine&query&sort&cursor&limit
+ * GET /api/v1/blocks/collections?mode=public|mine&query&sort&period&cursor&limit
  *
  * Block-token collection DISCOVERY for App Blocks. Scope `collections:read:self`.
  *
@@ -40,6 +45,48 @@ import {
  *   - mode=mine   → the SUBJECT's OWN collections (public + private) via the
  *     existing `getUserCollectionsWithPermissions` service, keyed on the verified
  *     token subject (never a client-supplied userId).
+ *
+ * PERIOD — "popular this day / week / month / year / all time".
+ *
+ * 🔴 AN ABSENT `period` IS NOT `AllTime` WITH EXTRA STEPS — IT TAKES LITERALLY THE
+ * SAME CODE PATH AS BEFORE THIS PARAMETER EXISTED, AND EMITS THE SAME BODY. There
+ * is no default value: `windowedPeriod` below is `null` for an absent period, for
+ * `AllTime`, for `mode=mine` and for any sort other than the popularity one, and
+ * every one of those falls into the untouched Postgres walk. The `period` /
+ * `source` / `sourceReason` response fields are emitted ONLY when a `period` was
+ * supplied, so an existing caller's response is byte-identical to what it was.
+ * That is the whole compatibility contract and it is pinned by a test that diffs
+ * the two bodies key-for-key.
+ *
+ * 🔴 `period` MODIFIES POPULARITY, SO IT IS HONOURED ONLY FOR THE POPULARITY SORT
+ * (`sort=popular` / `Most Followers`). `sort=newest&period=week` does NOT silently
+ * become a popularity feed — "newest" would stop meaning newest. A period sent
+ * with any other sort is accepted and ignored, and the response says which source
+ * actually served it, so the no-op is visible from the outside rather than being a
+ * parameter that mysteriously does nothing.
+ *
+ * 🔴 DAY/WEEK/MONTH/YEAR COME FROM CLICKHOUSE, ALL-TIME FROM POSTGRES, AND THAT
+ * SPLIT IS FORCED BY THE DATA. `entityMetricDailyAgg_history_v2` begins 2025-11-06,
+ * so a ClickHouse "all time" would silently mean "since November". All-time keeps
+ * the pre-existing `getAllCollections` ordering. See
+ * `~/server/services/blocks/block-collection-popularity.service` for the window
+ * arithmetic and why the table choice matters.
+ *
+ * 🔴 CLICKHOUSE RANKS IDS WITH NO NOTION OF PRIVACY OR TYPE. Every id it returns is
+ * re-read through `getAllCollections` with `privacy: [Public]` + `types: [Image]`
+ * — the SAME predicates the untouched path uses — so a private or Model/Article
+ * collection that ranks first is simply absent from the hydrate and is walked past
+ * like a maturity-clamped row. Nothing from ClickHouse is rendered directly.
+ *
+ * 🔴 THE CURSOR MEANS DIFFERENT THINGS ON THE TWO PATHS, DELIBERATELY. The Postgres
+ * path keeps its inclusive KEYSET cursor on collection id (both its orderings are
+ * id/createdAt-monotonic, so a keyset works and is cheap). A ClickHouse ranking is
+ * ordered by summed followers, which is neither monotonic in id nor stable enough
+ * to keyset on, so that path uses an OFFSET into the bounded top-N leaderboard
+ * instead. A client round-trips whatever `nextCursor` it was handed, and a feed
+ * does not change its `period` mid-scroll, so the two never mix in practice — but
+ * do not "unify" them: an offset fed to the keyset path silently returns the wrong
+ * page rather than an error.
  *
  * Maturity: collections whose own `nsfwLevel` exceeds the token's clamped ceiling
  * (`claims.maxBrowsingLevel`, region-narrowed) are dropped — a SFW-domain block
@@ -58,7 +105,10 @@ import {
  * CEILING, sampled — see `MIN_PLAYABLE_FRACTION` and `PLAYABLE_SAMPLE_SIZE`.
  *
  * Response: `{ items: [{ id, name, description, coverImageUrl, coverNsfwLevel?,
- *   itemCount, curator:{ userId, username }, isPublic, followed }], nextCursor }`.
+ *   itemCount, curator:{ userId, username }, isPublic, followed }], nextCursor }`
+ *   — plus `period`, `source` (`'clickhouse' | 'postgres'`) and, when the request
+ *   did not get the source it asked for, `sourceReason`. Those three appear ONLY
+ *   when the request supplied a `period`; see the compatibility note above.
  *
  * 🔴 `coverNsfwLevel` IS THE LEVEL OF THE COVER BEING SERVED — NOT THE
  * COLLECTION'S `nsfwLevel`, AND THE NAME IS DELIBERATE. The collection-level value
@@ -148,10 +198,52 @@ const querySchema = z.object({
     (v) => (typeof v === 'string' ? SORT_ALIAS[v.toLowerCase()] ?? v : v),
     z.enum(CollectionSort).default(CollectionSort.Newest)
   ),
-  // Keyset cursor on the collection id (both modes order by id DESC).
+  // 🔴 NO `.default()`, ON PURPOSE. An absent `period` has to stay distinguishable
+  // from an explicit `AllTime` at runtime — not because they order differently
+  // (they do not), but because the `source`/`period` response fields are emitted
+  // only for an explicit request, which is what keeps an existing caller's body
+  // byte-identical. A `.default(AllTime)` here would erase that distinction and
+  // change every legacy response.
+  period: z.enum(MetricTimeframe).optional(),
+  // Cursor. Postgres path: an inclusive KEYSET cursor on the collection id (both
+  // modes order id DESC). ClickHouse path: an OFFSET into the bounded windowed
+  // leaderboard. See the header note — same field, two meanings, one per path.
   cursor: z.coerce.number().int().positive().optional(),
   limit: z.coerce.number().int().min(1).max(100).default(24),
 });
+
+/** The pre-existing Postgres over-fetch. Unchanged; extracted only to be named. */
+const overfetchWidth = (limit: number) => limit * 4 + 1;
+
+/** Hard ceiling on how many ranked ids one request may hydrate. See below. */
+const CH_HYDRATE_MAX = 1000;
+
+/**
+ * How many RANKED IDS the ClickHouse path hydrates per request.
+ *
+ * 🔴 SIX TIMES THE POSTGRES OVER-FETCH, BECAUSE THE TWO PATHS DISCARD ROWS AT
+ * WILDLY DIFFERENT RATES AND SHARING A MULTIPLIER WOULD HAVE SHIPPED A 4-ITEM
+ * PAGE. The Postgres walk over-fetches `limit * 4 + 1` because it loses only the
+ * maturity clamp and the playable floor — its source query already applied
+ * `privacy` and `types` as SQL predicates, so nothing it fetches is a type reject.
+ * A ClickHouse ranking has not applied them at all: measured on the production
+ * replica 2026-09-11, the Month window's top 1,000 ids are 100% `Public` but only
+ * **81** are `CollectionType.Image` — 914 are Model collections. A `limit * 4 + 1`
+ * window (97 ids) hydrates **21** showable rows against a default `limit` of 24,
+ * i.e. every page short, forever.
+ *
+ * At `limit * 24 + 1` a default page hydrates 577 ids for 53 showable rows and
+ * fills. Cost of the widening, measured on the replica over the same window (the
+ * hydrate is an `id IN (…)` primary-key scan, so it barely notices): 97 ids →
+ * 5.3-5.9 ms, 577 ids → 22.3-23.1 ms, 1,000 ids → 14.3-14.5 ms. All of them are
+ * two orders of magnitude under the 3,123-4,375 ms the pre-existing popularity
+ * page-1 query costs.
+ *
+ * The cap keeps a caller-supplied `limit=100` from turning into a 2,401-id `IN`
+ * list. That page comes back short (~81 rows) and says so by advancing its cursor;
+ * a short page is a contract this endpoint already has.
+ */
+const chHydrateWidth = (limit: number) => Math.min(limit * 24 + 1, CH_HYDRATE_MAX);
 
 const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -182,7 +274,23 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     res.status(400).json({ error: 'Invalid query parameters', details: parsed.error.flatten() });
     return;
   }
-  const { mode, query, sort, cursor, limit } = parsed.data;
+  const { mode, query, sort, period, cursor, limit } = parsed.data;
+
+  // Does the requested period actually change anything? Four ways it does not, and
+  // all four land on the untouched Postgres path:
+  //   - absent               → the pre-existing behaviour, bit for bit
+  //   - AllTime              → ClickHouse history starts 2025-11-06; PG owns all-time
+  //   - mode=mine            → a period ranks DISCOVERY; "mine" is the viewer's own list
+  //   - a non-popularity sort→ a period modifies popularity, not recency
+  //
+  // Written as a NARROWING ternary rather than a boolean so `windowedPeriod` carries
+  // the `WindowedPeriod` type into the ranking call — a `boolean` here would force a
+  // second, independently-written check at the call site, which is how the two
+  // spellings of "windowed" drift apart.
+  const windowedPeriod =
+    mode === 'public' && sort === CollectionSort.MostContributors && isWindowedPeriod(period)
+      ? period
+      : null;
 
   // Per-instance rate limit (shared blocks catalog limiter) — bounds a block
   // hammering this private,no-store route onto the origin.
@@ -203,6 +311,56 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   }
 
   try {
+    // ── PERIOD RESOLUTION ────────────────────────────────────────────────────
+    // Resolved for BOTH modes in one place so `mode=mine` can report the same
+    // "your period was ignored, here is what served you" answer as a non-popularity
+    // sort, instead of silently dropping the parameter.
+    //
+    // `rankedIds === null` after this block means the request is served by the
+    // PRE-EXISTING Postgres ordering — whether because no period was asked for, or
+    // because ClickHouse could not answer. There is exactly one way to get a
+    // ClickHouse-ordered page and it is `rankedIds` being non-null.
+    let rankedIds: number[] | null = null;
+    let source: 'clickhouse' | 'postgres' = 'postgres';
+    let sourceReason: string | undefined;
+    if (period) {
+      if (windowedPeriod) {
+        const ranking = await getWindowedCollectionRanking({ period: windowedPeriod });
+        if (ranking.ids === null) {
+          // 🔴 DEGRADE TO A STATED ORDERING, NEVER TO AN EMPTY GRID. `clickhouse` is
+          // `undefined` in any deployment without CLICKHOUSE_HOST/USERNAME (and during
+          // a Next build), and a live query can fail. Either way the viewer still gets
+          // collections — ordered all-time — and the response carries the reason, so
+          // "the popular-this-week tab looks like the all-time tab" is answerable from
+          // the response body rather than only from a server log.
+          sourceReason = ranking.reason;
+        } else if (ranking.ids.length === 0) {
+          // A window with no rows at all. Possible in principle; in practice far more
+          // often the daily aggregate has not sealed yet than a real zero. Same
+          // degrade, DIFFERENT reason, so the two stay separable.
+          sourceReason = 'empty-window';
+        } else {
+          rankedIds = ranking.ids;
+          source = 'clickhouse';
+        }
+      } else if (period === MetricTimeframe.AllTime) {
+        sourceReason = 'all-time-served-from-postgres';
+      } else if (mode !== 'public') {
+        sourceReason = 'period-ignored-outside-public-discovery';
+      } else {
+        sourceReason = 'period-ignored-for-non-popularity-sort';
+      }
+    }
+
+    // 🔴 EMITTED ONLY WHEN A `period` WAS SUPPLIED. This empty-object-spread is the
+    // whole backward-compatibility mechanism: a caller that never sends `period`
+    // gets a response with no `period`, `source` or `sourceReason` key — the same
+    // body shape it got before this parameter existed. Giving `period` a default,
+    // or emitting `source` unconditionally, would change every legacy response.
+    const periodFields = period
+      ? { period, source, ...(sourceReason ? { sourceReason } : {}) }
+      : {};
+
     if (mode === 'public') {
       // Over-fetch so the maturity clamp can't under-fill the page and terminate
       // pagination early (which would make later public collections unreachable).
@@ -212,13 +370,43 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       // cursor at that first-unconsumed row resumes exactly there — no gap (the
       // clamped-out rows before it were already walked past) and no duplicate (it
       // was not shown on this page).
-      const OVERFETCH = limit * 4 + 1;
+      const OVERFETCH = overfetchWidth(limit);
+
+      // On the ClickHouse path Postgres is no longer choosing the order — it is
+      // HYDRATING AND FILTERING a slice of the ranked ids. One query either way,
+      // the SAME privacy/type predicates either way; only the selection differs
+      // (`ids` + no cursor, instead of a keyset walk).
+      const chSlice = rankedIds
+        ? rankedIds.slice(cursor ?? 0, (cursor ?? 0) + chHydrateWidth(limit))
+        : null;
+
+      // 🔴 AN EMPTY SLICE MUST NOT REACH `getAllCollections`. Its id clause is
+      // `ids && ids.length > 0 ? { in: ids } : undefined` — so an empty array means
+      // "no id filter at all", i.e. the entire public catalogue in createdAt order,
+      // returned under a popularity feed's banner. Walking past the end of the
+      // bounded leaderboard is an ordinary end-of-feed, so answer it as one.
+      if (chSlice && chSlice.length === 0) {
+        res.status(200).json({ items: [], ...periodFields });
+        return;
+      }
+
       const rows = await getAllCollections({
         input: {
-          limit: OVERFETCH,
-          cursor,
+          limit: chSlice ? chSlice.length : OVERFETCH,
+          cursor: chSlice ? undefined : cursor,
+          ids: chSlice ?? undefined,
           query,
-          sort,
+          // 🔴 THE HYDRATE DELIBERATELY DOES NOT ASK FOR THE POPULARITY SORT ON
+          // THE CLICKHOUSE PATH, AND THAT IS A COST DECISION, NOT A BEHAVIOUR ONE.
+          // `CollectionSort.MostContributors` makes `getAllCollections` order by
+          // `contributors._count`, i.e. a LEFT JOIN + GROUP BY over
+          // `CollectionContributor` — the table with no index on `collectionId`,
+          // and the exact join shape whose cost is the ~31x regression recorded on
+          // `PLAYABLE_SAMPLE_SIZE`. Here that work would be pure waste: the rows
+          // come back and are IMMEDIATELY re-projected onto the ClickHouse rank
+          // order below, so whatever order Postgres chose is discarded. Asking for
+          // the cheap `Newest` ordering buys the identical result set.
+          sort: chSlice ? CollectionSort.Newest : sort,
           privacy: [CollectionReadConfiguration.Public],
           // MEDIA collections only — a Model/Article/Post collection renders an
           // empty player (the detail endpoint drops non-image items), so restrict
@@ -261,43 +449,82 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       const playableSample = await getCollectionPlayableSample(candidateIds, browsingLevel);
 
       const items: typeof rows = [];
-      let firstUnconsumedId: number | undefined;
-      for (let i = 0; i < rows.length; i++) {
-        if (items.length >= limit) {
-          firstUnconsumedId = rows[i].id;
-          break;
-        }
-        if (!ceilingOk(rows[i])) continue;
-        // 🔴 THE DROP, AND WHY IT IS INSIDE THIS WALK RATHER THAN AFTER IT. The
-        // sample map is absent-means-nothing-sampled (the lateral emits no row for
-        // a collection with no accepted items), which `meetsPlayableFloor` reads as
-        // "nothing to judge, keep". Filtering here means a dropped row is walked
-        // PAST like a clamped-out one, so the page still fills to `limit` and
-        // `firstUnconsumedId` still advances — filtering the sliced page afterwards
-        // would return short pages and, on a page that filtered to empty, emit no
-        // cursor at all and TERMINATE the feed while qualifying collections
-        // remained.
-        const sample = playableSample.get(rows[i].id);
-        if (!meetsPlayableFloor(sample?.sampled ?? 0, sample?.playable ?? 0)) continue;
-        items.push(rows[i]);
-      }
-
       let nextCursor: number | undefined;
-      if (firstUnconsumedId !== undefined) {
-        // Page filled AND at least one fetched row remains → clean inclusive resume.
-        nextCursor = firstUnconsumedId;
-      } else if (rows.length === OVERFETCH) {
-        // Consumed the ENTIRE over-fetch without filling `limit` (a very heavy
-        // clamp) yet the source returned a full batch → more may remain. Resume
-        // from the last fetched row (inclusive → re-fetched next page; the client
-        // dedups by id). No longer rare: the playable floor drops far more rows
-        // than the ceiling alone did, so a page CAN come back short — but it comes
-        // back with a cursor that advanced by OVERFETCH-1 rows, which is what
-        // keeps the rest of the feed reachable. Short page, live feed.
-        nextCursor = rows[rows.length - 1]?.id;
+
+      if (chSlice) {
+        // ── ClickHouse-ranked page ───────────────────────────────────────────
+        // 🔴 WALK THE RANKED ID LIST, NOT THE HYDRATED ROWS. `rows` came back in
+        // Postgres' own order and is MISSING every id the privacy/type predicates
+        // rejected. Iterating `rows` would therefore serve a "popular this week"
+        // feed sorted by createdAt, and would advance the offset by the number of
+        // SURVIVING rows rather than the number of ranked ids consumed — so a
+        // heavily-filtered page would re-serve the same ids forever.
+        const byId = new Map(rows.map((c) => [c.id, c] as const));
+        const offset = cursor ?? 0;
+        let walked = 0;
+        for (let i = 0; i < chSlice.length; i++) {
+          if (items.length >= limit) break;
+          walked = i + 1;
+          const c = byId.get(chSlice[i]);
+          // 🔴 THIS IS THE PRIVACY AND TYPE GATE, AND IT IS AN ABSENCE RATHER THAN
+          // A TEST. ClickHouse ranks ids with no idea what they are; the hydrate
+          // above asked for `privacy: [Public]` + `types: [Image]` over exactly
+          // these ids, so a private collection or a Model/Article/Post collection
+          // simply has no row and arrives here as `undefined`. Do not "improve"
+          // this into reading `c.read` / `c.type` — the check that matters already
+          // happened in the database, and a missing row is the only correct
+          // interpretation of a rejected id. A deleted collection lands here too.
+          if (!c) continue;
+          if (!ceilingOk(c)) continue;
+          const sample = playableSample.get(c.id);
+          if (!meetsPlayableFloor(sample?.sampled ?? 0, sample?.playable ?? 0)) continue;
+          items.push(c);
+        }
+        // FILTERING SHRINKS THE SET, so this page can come back short — the same
+        // trade the Postgres walk makes below. What keeps the feed alive is that
+        // the cursor advances by every ranked id WALKED (rejects included), not by
+        // the rows shown, so the next page starts past them. Exhausting the bounded
+        // leaderboard emits no cursor, which ends the windowed feed by design.
+        const consumedTo = offset + walked;
+        if (consumedTo < (rankedIds?.length ?? 0)) nextCursor = consumedTo;
+      } else {
+        let firstUnconsumedId: number | undefined;
+        for (let i = 0; i < rows.length; i++) {
+          if (items.length >= limit) {
+            firstUnconsumedId = rows[i].id;
+            break;
+          }
+          if (!ceilingOk(rows[i])) continue;
+          // 🔴 THE DROP, AND WHY IT IS INSIDE THIS WALK RATHER THAN AFTER IT. The
+          // sample map is absent-means-nothing-sampled (the lateral emits no row for
+          // a collection with no accepted items), which `meetsPlayableFloor` reads as
+          // "nothing to judge, keep". Filtering here means a dropped row is walked
+          // PAST like a clamped-out one, so the page still fills to `limit` and
+          // `firstUnconsumedId` still advances — filtering the sliced page afterwards
+          // would return short pages and, on a page that filtered to empty, emit no
+          // cursor at all and TERMINATE the feed while qualifying collections
+          // remained.
+          const sample = playableSample.get(rows[i].id);
+          if (!meetsPlayableFloor(sample?.sampled ?? 0, sample?.playable ?? 0)) continue;
+          items.push(rows[i]);
+        }
+
+        if (firstUnconsumedId !== undefined) {
+          // Page filled AND at least one fetched row remains → clean inclusive resume.
+          nextCursor = firstUnconsumedId;
+        } else if (rows.length === OVERFETCH) {
+          // Consumed the ENTIRE over-fetch without filling `limit` (a very heavy
+          // clamp) yet the source returned a full batch → more may remain. Resume
+          // from the last fetched row (inclusive → re-fetched next page; the client
+          // dedups by id). No longer rare: the playable floor drops far more rows
+          // than the ceiling alone did, so a page CAN come back short — but it comes
+          // back with a cursor that advanced by OVERFETCH-1 rows, which is what
+          // keeps the rest of the feed reachable. Short page, live feed.
+          nextCursor = rows[rows.length - 1]?.id;
+        }
+        // else: rows.length < OVERFETCH and the page wasn't over-consumed → the
+        // source is exhausted → no nextCursor.
       }
-      // else: rows.length < OVERFETCH and the page wasn't over-consumed → the
-      // source is exhausted → no nextCursor.
 
       const ids = items.map((c) => c.id);
       // Cover fallback + MATURITY CLAMP: a cover is usable only when it exists AND
@@ -339,6 +566,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
           followed: followed.has(c.id),
         })),
         nextCursor,
+        ...periodFields,
       });
       return;
     }
@@ -420,6 +648,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
         followed: followed.has(c.id),
       })),
       nextCursor,
+      ...periodFields,
     });
     return;
   } catch (error) {

--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -445,7 +445,27 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       // figure that had been measured WITHOUT the ordering.
       const ceilingOk = (c: (typeof rows)[number]) =>
         collectionWithinCeiling(c.nsfwLevel ?? 0, browsingLevel);
-      const candidateIds = rows.filter(ceilingOk).map((c) => c.id);
+      // 🔴 THE SAMPLE'S BUDGET IS CAPPED AT THE *POSTGRES* OVER-FETCH ON BOTH PATHS,
+      // WHICH IS THE ONE PLACE THE WIDER CLICKHOUSE HYDRATE COULD HAVE LEAKED COST.
+      // The sample's price scales with the number of ids handed to it (~400 ms for
+      // 97), and the ClickHouse path hydrates up to `CH_HYDRATE_MAX` ids rather
+      // than `OVERFETCH` — so passing every survivor straight through would have
+      // made this the most expensive query on the new path, quietly, and only on
+      // whichever window happened to survive filtering best. Capping it changes
+      // nothing on the Postgres path, where `rows` is already at most `OVERFETCH`.
+      //
+      // Taking the candidates IN RANK ORDER is what makes the cap harmless: the
+      // walk below consumes in that same order and stops at `limit`, so the cap
+      // only ever bites on rows a full page never reaches. A row past it has no
+      // sample entry, which `meetsPlayableFloor` reads as "nothing to judge, keep"
+      // — a weakened RANKING heuristic on the deep tail, never a weakened gate.
+      // Nothing on this path protects a viewer from mature media (per-item maturity
+      // is enforced on the detail endpoint and on the cover), so the degradation is
+      // cosmetic by construction.
+      const rankOf = chSlice ? new Map(chSlice.map((id, i) => [id, i] as const)) : null;
+      const candidates = rows.filter(ceilingOk);
+      if (rankOf) candidates.sort((a, b) => rankOf.get(a.id)! - rankOf.get(b.id)!);
+      const candidateIds = candidates.slice(0, OVERFETCH).map((c) => c.id);
       const playableSample = await getCollectionPlayableSample(candidateIds, browsingLevel);
 
       const items: typeof rows = [];

--- a/src/server/services/blocks/__tests__/block-collection-popularity.test.ts
+++ b/src/server/services/blocks/__tests__/block-collection-popularity.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Unit coverage for the ClickHouse-backed windowed collection ranking.
+ *
+ * The two things worth pinning here are the ones a reader cannot check by eye:
+ * WHICH WINDOW each period resolves to (a date literal that has to be exact, not
+ * "a date"), and WHAT HAPPENS WHEN THE STORE IS ABSENT — the `clickhouse ===
+ * undefined` branch, which is a normal deployment state rather than an error and
+ * must be reported as such rather than silently returning nothing.
+ *
+ * The clock is frozen because every assertion in the window block is a claim about
+ * a date arithmetic result. Without a freeze these tests pass on most days and go
+ * red at a month or year boundary, which is the worst possible failure mode: a
+ * flake that is actually correct.
+ */
+
+const { mockQuery, clickhouseBox } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  clickhouseBox: { client: undefined as unknown },
+}));
+
+// A GETTER, not a value: the module binding has to be re-read per call so a test
+// can flip the client to `undefined` mid-suite and exercise the disabled branch.
+vi.mock('~/server/clickhouse/client', () => ({
+  get clickhouse() {
+    return clickhouseBox.client;
+  },
+}));
+// `~/server/logging/client` is NOT mocked here on purpose: `src/__tests__/setup.ts`
+// registers the canonical mock for it worker-wide (only `logToAxiom` is stubbed, so
+// the module's other six exports stay real). A per-file `vi.mock` of a canonical
+// specifier freezes this file's shape into every later file in the same worker —
+// which is exactly what `no-direct-shared-module-mock` exists to stop.
+
+import {
+  CH_RANKING_DEPTH,
+  PERIOD_WINDOW_DAYS,
+  getWindowedCollectionRanking,
+  isWindowedPeriod,
+  windowStartDate,
+} from '~/server/services/blocks/block-collection-popularity.service';
+import { MetricTimeframe } from '~/shared/utils/prisma/enums';
+
+/** 2026-09-11T12:00:00Z — mid-day, mid-month, so no boundary flatters the maths. */
+const NOW = new Date('2026-09-11T12:00:00.000Z');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  clickhouseBox.client = { $query: mockQuery };
+  mockQuery.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('isWindowedPeriod', () => {
+  it('is true for exactly the four ClickHouse-servable periods', () => {
+    expect(isWindowedPeriod(MetricTimeframe.Day)).toBe(true);
+    expect(isWindowedPeriod(MetricTimeframe.Week)).toBe(true);
+    expect(isWindowedPeriod(MetricTimeframe.Month)).toBe(true);
+    expect(isWindowedPeriod(MetricTimeframe.Year)).toBe(true);
+  });
+
+  it('is false for AllTime — history begins 2025-11-06, so ClickHouse cannot answer it', () => {
+    expect(isWindowedPeriod(MetricTimeframe.AllTime)).toBe(false);
+  });
+
+  it('is false for an absent period', () => {
+    expect(isWindowedPeriod(undefined)).toBe(false);
+  });
+});
+
+describe('windowStartDate', () => {
+  /**
+   * The exact literal, per period, against a frozen clock. Asserting the STRING is
+   * the point: a test that only checked "the SQL contains a date" would pass with
+   * every period resolving to the same window, which is precisely the bug a
+   * windowed feature can ship with and nobody notices.
+   */
+  it.each([
+    [MetricTimeframe.Day, '2026-09-10'],
+    [MetricTimeframe.Week, '2026-09-04'],
+    [MetricTimeframe.Month, '2026-08-12'],
+    [MetricTimeframe.Year, '2025-09-11'],
+  ])('%s resolves to %s', (period, expected) => {
+    expect(windowStartDate(period as never, NOW)).toBe(expected);
+  });
+
+  it('the four windows are all DIFFERENT — no two periods share a bound', () => {
+    const bounds = (
+      [
+        MetricTimeframe.Day,
+        MetricTimeframe.Week,
+        MetricTimeframe.Month,
+        MetricTimeframe.Year,
+      ] as const
+    ).map((p) => windowStartDate(p, NOW));
+    expect(new Set(bounds).size).toBe(4);
+  });
+
+  it('defaults `now` to the current clock', () => {
+    expect(windowStartDate(MetricTimeframe.Day)).toBe('2026-09-10');
+  });
+
+  it('the bound is inclusive of the seal lag — Day reaches yesterday, not only today', () => {
+    // The daily aggregate seals late: measured 2026-09-11, the newest `day` present
+    // for Collection/followerCount was 2026-09-10. An exclusive "today only" bound
+    // would therefore return an empty Day window for most of every day.
+    expect(PERIOD_WINDOW_DAYS[MetricTimeframe.Day]).toBe(1);
+    expect(windowStartDate(MetricTimeframe.Day, NOW) < NOW.toISOString().slice(0, 10)).toBe(true);
+  });
+});
+
+describe('getWindowedCollectionRanking', () => {
+  it('queries the HISTORY table, sums the per-day delta, and bounds the window', async () => {
+    await getWindowedCollectionRanking({ period: MetricTimeframe.Month, now: NOW });
+    const sql = mockQuery.mock.calls[0][0] as string;
+    // The history table, not `entityMetricDailyAgg_v2` — the latter holds only the
+    // current day and reads exactly like "there is no history here".
+    expect(sql).toContain('entityMetricDailyAgg_history_v2');
+    // `total` is a PER-DAY DELTA, so a window is a SUM, never a latest-row read.
+    expect(sql).toContain('sum(total)');
+    expect(sql).toContain("toDate('2026-08-12')");
+    expect(sql).toContain("entityType = 'Collection'");
+    expect(sql).toContain("metricType = 'followerCount'");
+    expect(sql).toContain(`LIMIT ${CH_RANKING_DEPTH}`);
+  });
+
+  it('breaks ties on entityId so offset pagination sees one total order', async () => {
+    await getWindowedCollectionRanking({ period: MetricTimeframe.Week, now: NOW });
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('ORDER BY sum(total) DESC, entityId DESC');
+  });
+
+  it.each([
+    [MetricTimeframe.Day, '2026-09-10'],
+    [MetricTimeframe.Week, '2026-09-04'],
+    [MetricTimeframe.Month, '2026-08-12'],
+    [MetricTimeframe.Year, '2025-09-11'],
+  ])('%s sends its own window bound (%s) to ClickHouse', async (period, expected) => {
+    await getWindowedCollectionRanking({ period: period as never, now: NOW });
+    expect(mockQuery.mock.calls[0][0] as string).toContain(`toDate('${expected}')`);
+  });
+
+  it('returns the ids in the order ClickHouse ranked them', async () => {
+    mockQuery.mockResolvedValueOnce([{ id: 7 }, { id: 3 }, { id: 91 }]);
+    const result = await getWindowedCollectionRanking({ period: MetricTimeframe.Month, now: NOW });
+    expect(result).toEqual({ ids: [7, 3, 91], source: 'clickhouse' });
+  });
+
+  it('reports `clickhouse-disabled` when the client is undefined — it does NOT query', async () => {
+    // The real shape of this: `shouldConnect` is false without CLICKHOUSE_HOST /
+    // CLICKHOUSE_USERNAME, and during a Next build. A deployment without the
+    // analytics store is not broken, and must not be answered with an empty grid.
+    clickhouseBox.client = undefined;
+    const result = await getWindowedCollectionRanking({ period: MetricTimeframe.Month, now: NOW });
+    expect(result).toEqual({ ids: null, source: 'unavailable', reason: 'clickhouse-disabled' });
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('reports `clickhouse-error` when the query throws, rather than propagating', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('connection reset'));
+    const result = await getWindowedCollectionRanking({ period: MetricTimeframe.Year, now: NOW });
+    expect(result).toEqual({ ids: null, source: 'unavailable', reason: 'clickhouse-error' });
+  });
+
+  it('DISTINGUISHES disabled from error — the two degrade the same way but are different facts', async () => {
+    clickhouseBox.client = undefined;
+    const disabled = await getWindowedCollectionRanking({ period: MetricTimeframe.Day, now: NOW });
+    clickhouseBox.client = { $query: mockQuery };
+    mockQuery.mockRejectedValueOnce(new Error('boom'));
+    const errored = await getWindowedCollectionRanking({ period: MetricTimeframe.Day, now: NOW });
+    expect(disabled).not.toEqual(errored);
+  });
+
+  it('an empty window is an EMPTY LIST, not an unavailability — the caller decides', async () => {
+    mockQuery.mockResolvedValueOnce([]);
+    const result = await getWindowedCollectionRanking({ period: MetricTimeframe.Day, now: NOW });
+    expect(result).toEqual({ ids: [], source: 'clickhouse' });
+  });
+
+  it('carries no caller-supplied text into the SQL — depth is truncated to an integer', async () => {
+    // `$query` interpolates rather than binds. Nothing here takes a caller string,
+    // and the one numeric knob is floored, so a fractional value cannot smuggle
+    // characters into the statement.
+    await getWindowedCollectionRanking({ period: MetricTimeframe.Day, now: NOW, depth: 12.9 });
+    expect(mockQuery.mock.calls[0][0] as string).toContain('LIMIT 12');
+  });
+});

--- a/src/server/services/blocks/block-collection-popularity.service.ts
+++ b/src/server/services/blocks/block-collection-popularity.service.ts
@@ -1,0 +1,175 @@
+import { clickhouse } from '~/server/clickhouse/client';
+import { logToAxiom } from '~/server/logging/client';
+import { MetricTimeframe } from '~/shared/utils/prisma/enums';
+
+/**
+ * WINDOWED COLLECTION POPULARITY, FROM CLICKHOUSE.
+ *
+ * Produces a RANKED LIST OF COLLECTION IDS for a time window — "most followed this
+ * day / week / month / year" — for the App Blocks discovery grid. It answers with
+ * ids and nothing else: every id it returns is still hydrated and filtered through
+ * the caller's own Postgres predicates before anything is shown.
+ *
+ * 🔴 THIS IS A RANKING SOURCE, NOT AN AUTHORIZATION SOURCE. ClickHouse holds no
+ * notion of a collection's privacy, its type, its maturity or whether it still
+ * exists. An id coming back from here is a CANDIDATE. The caller
+ * (`src/pages/api/v1/blocks/collections/index.ts`) re-reads every id through
+ * `getAllCollections` with `privacy: [Public]` + `types: [Image]`, so a private or
+ * non-Image collection that ranks first here simply does not come back from the
+ * hydrate and is walked past. Never render an id from this module directly.
+ *
+ * 🔴 ALL-TIME IS DELIBERATELY NOT SERVED HERE, AND THAT IS NOT AN OVERSIGHT.
+ * `entityMetricDailyAgg_history_v2` begins 2025-11-06 (measured 2026-09-11: 280
+ * distinct days for `followerCount`). Summing the whole table would produce a
+ * number that LOOKS like an all-time total and is actually "since November", with
+ * nothing in the response to say so. All-time keeps the caller's existing Postgres
+ * ordering, unchanged. {@link isWindowedPeriod} is the one predicate that splits
+ * the two, so the rule cannot be re-derived differently at a second call site.
+ *
+ * 🔴 `total` IS A PER-DAY DELTA, NOT A CUMULATIVE SNAPSHOT. Sampled on one
+ * collection it reads 15, 24, 18, 22, 25, 32 on successive days. So a window is
+ * `SUM(total) … GROUP BY entityId`, never "read the latest row".
+ *
+ * 🔴 READ THE `_history_` TABLE. `entityMetricDailyAgg_v2` holds only the CURRENT
+ * day (`first_day == last_day`), which reads exactly like "there is no history
+ * here" and sends the reader off to build a Postgres job instead.
+ */
+
+/**
+ * Days of history summed for each windowed period.
+ *
+ * 🔴 THE BOUND IS INCLUSIVE ON BOTH ENDS — `day >= today() - N` — so the window
+ * spans N+1 calendar days, not N. That extra day is deliberate slack for the
+ * DAILY SEAL'S LAG: the aggregate for the current day is written late, so an
+ * exclusive `day > today() - 1` window for `Day` resolves to "today only" and
+ * comes back EMPTY for most of the day. A tolerant lower bound costs one day of
+ * over-inclusion on a ranking; an intolerant one costs the whole feature.
+ */
+export const PERIOD_WINDOW_DAYS = {
+  [MetricTimeframe.Day]: 1,
+  [MetricTimeframe.Week]: 7,
+  [MetricTimeframe.Month]: 30,
+  [MetricTimeframe.Year]: 365,
+} as const;
+
+export type WindowedPeriod = keyof typeof PERIOD_WINDOW_DAYS;
+
+/**
+ * How deep the windowed leaderboard goes. Pagination on this path is an OFFSET
+ * into this bounded list (see the caller's cursor comment), so this constant is
+ * also the hard end of the windowed feed.
+ *
+ * 🔴 TEN THOUSAND, NOT A THOUSAND, AND THE REASON IS NOT "more is better" — IT IS
+ * THAT NINE IN TEN RANKED IDS ARE NOT SHOWABLE. Measured on the production replica
+ * 2026-09-11 over the Month window's top 1,000 ids: every one of them is `Public`
+ * (privacy rejects ZERO here), but only **81** are `CollectionType.Image`. The
+ * other 919 are Model (914), Post (4) and Article (1) collections, which this
+ * endpoint has always excluded because they render an empty player. So the
+ * leaderboard's usable yield is ~4.5%, and a 1,000-deep list is a feed of ~81
+ * collections — three and a bit pages.
+ *
+ * Cumulative Image+Public survivors by depth, same window and measurement:
+ *
+ *     depth      97   385  1000  2500  5000  10000
+ *     survivors  21    42    81   337   396    446
+ *
+ * 🔴 AND DEPTH IS VERY NEARLY FREE, WHICH IS WHAT MAKES THIS THE RIGHT LEVER. The
+ * `GROUP BY entityId` scans the window regardless; `LIMIT` only trims the sorted
+ * output. Measured server-side elapsed, depth 1,000 vs 10,000: Day 15.1 → 12.3 ms,
+ * Month 102.7 → 33.5 ms, Year 143.0 → 138.2 ms. Ten times the feed for no
+ * measurable query cost. (Day tops out at 2,770 collections with any follower gain
+ * at all, so it is bounded by the data rather than by this number.)
+ */
+export const CH_RANKING_DEPTH = 10_000;
+
+/**
+ * Is this period one ClickHouse can serve?
+ *
+ * `AllTime` and an absent period are BOTH false — the caller must take its
+ * existing Postgres path for either. Keeping this as one exported predicate is
+ * what stops "windowed" being spelled a second, subtly different way at another
+ * call site.
+ */
+export function isWindowedPeriod(period: MetricTimeframe | undefined): period is WindowedPeriod {
+  return period !== undefined && period !== MetricTimeframe.AllTime;
+}
+
+/**
+ * The inclusive lower bound of the window, as a `YYYY-MM-DD` UTC date literal.
+ *
+ * Exported so a test can pin the exact literal each period produces against a
+ * frozen clock, rather than asserting that "a date" appeared in the SQL.
+ */
+export function windowStartDate(period: WindowedPeriod, now: Date = new Date()): string {
+  const start = new Date(now.getTime() - PERIOD_WINDOW_DAYS[period] * 24 * 60 * 60 * 1000);
+  return start.toISOString().slice(0, 10);
+}
+
+export type WindowedRankingResult =
+  | { ids: number[]; source: 'clickhouse' }
+  /**
+   * ClickHouse could not answer. `reason` is carried all the way to the response
+   * body by the caller — an unavailable analytics store must degrade to a
+   * DIFFERENT, STATED ordering, never to a mysteriously empty grid.
+   */
+  | { ids: null; source: 'unavailable'; reason: 'clickhouse-disabled' | 'clickhouse-error' };
+
+/**
+ * Rank collection ids by followers gained inside `period`'s window.
+ *
+ * Returns at most {@link CH_RANKING_DEPTH} ids, most-followed first. Ties break on
+ * `entityId DESC` so the ordering is TOTAL and therefore STABLE across the
+ * offset-paginated requests that walk it — without that tiebreak two pages of the
+ * same feed can disagree about where a tied block of ids sits and silently drop or
+ * repeat one.
+ *
+ * 🔴 `clickhouse.$query` INTERPOLATES, IT DOES NOT BIND. Nothing user-supplied
+ * reaches this SQL: `period` is a key into {@link PERIOD_WINDOW_DAYS} (it selects a
+ * number, it is never printed), the date is produced by {@link windowStartDate}
+ * from a `Date`, and the depth is a module constant. Keep it that way — if this
+ * ever needs a caller-supplied value, quote it, do not template it.
+ */
+export async function getWindowedCollectionRanking({
+  period,
+  now,
+  depth = CH_RANKING_DEPTH,
+}: {
+  period: WindowedPeriod;
+  now?: Date;
+  depth?: number;
+}): Promise<WindowedRankingResult> {
+  // The client is `undefined` whenever `shouldConnect` is false (no CLICKHOUSE_HOST
+  // / username, or a Next build). That is a normal deployment state, not a fault —
+  // report it and let the caller fall back to its Postgres ordering.
+  if (!clickhouse) return { ids: null, source: 'unavailable', reason: 'clickhouse-disabled' };
+
+  const since = windowStartDate(period, now);
+  const query = `
+    SELECT entityId AS id
+    FROM entityMetricDailyAgg_history_v2
+    WHERE entityType = 'Collection'
+      AND metricType = 'followerCount'
+      AND day >= toDate('${since}')
+    GROUP BY entityId
+    HAVING sum(total) > 0
+    ORDER BY sum(total) DESC, entityId DESC
+    LIMIT ${Math.trunc(depth)}
+  `;
+
+  try {
+    const rows = await clickhouse.$query<{ id: number }>(query);
+    return { ids: rows.map((r) => Number(r.id)), source: 'clickhouse' };
+  } catch (error) {
+    // Swallowed on purpose: discovery must keep serving. The caller degrades to
+    // its Postgres ordering and SAYS SO in the response, so the degradation is
+    // observable from the outside rather than only in this log line.
+    logToAxiom({
+      name: 'block-collection-ranking-degraded',
+      type: 'error',
+      message: error instanceof Error ? error.message : String(error),
+      period,
+      since,
+    }).catch(() => null);
+    return { ids: null, source: 'unavailable', reason: 'clickhouse-error' };
+  }
+}

--- a/src/tests/api/v1/blocks/collections-period.test.ts
+++ b/src/tests/api/v1/blocks/collections-period.test.ts
@@ -1,0 +1,607 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+import type * as PopularityService from '~/server/services/blocks/block-collection-popularity.service';
+
+/**
+ * `period` coverage for GET /api/v1/blocks/collections.
+ *
+ * Four things are pinned here and nothing else belongs in this file:
+ *
+ *  1. THE NO-CHANGE PROOF. A request with no `period` must produce the response it
+ *     produced before this parameter existed — same keys, same order, same source
+ *     query shape — and must not touch ClickHouse at all.
+ *  2. WINDOW SELECTION. Each period reaches the ranking service as itself, and the
+ *     order ClickHouse returns is the order the endpoint serves.
+ *  3. THE LEAK GUARD. A private or non-Image collection ranked FIRST by ClickHouse
+ *     must not surface. This is the one with teeth, so the `getAllCollections`
+ *     double below is a REAL filter over `privacy` / `types` rather than a canned
+ *     row list — a stub that returned rows regardless of the predicate would pass
+ *     this test while the endpoint leaked.
+ *  4. THE DEGRADED PATHS. `clickhouse === undefined`, a failing query and an empty
+ *     window each fall back to the all-time Postgres ordering and SAY SO. An empty
+ *     grid is never an acceptable answer to any of them.
+ */
+
+function createMocks({
+  method = 'GET',
+  query = {},
+}: { method?: string; query?: Record<string, unknown> } = {}) {
+  const req = {
+    method,
+    query,
+    headers: {},
+    socket: { remoteAddress: '203.0.113.7' },
+  } as unknown as Record<string, unknown>;
+  let statusCode = 200;
+  let payload: unknown;
+  const headers: Record<string, string> = {};
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+    _headers: () => headers,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+
+class ForbiddenError extends Error {
+  readonly status = 403 as const;
+}
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+  parseSubjectUserId: (sub: string): number | null => {
+    if (sub === 'anon') return null;
+    if (!/^user:\d+$/.test(sub)) throw new ForbiddenError('malformed sub claim');
+    return Number.parseInt(sub.slice('user:'.length), 10);
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const {
+  mockGetAll,
+  mockItemCount,
+  mockUserCollections,
+  mockHydrate,
+  mockFollowed,
+  mockRate,
+  mockMaturity,
+  mockFallbackCovers,
+  mockPlayableSample,
+  mockRanking,
+} = vi.hoisted(() => ({
+  mockGetAll: vi.fn(),
+  mockItemCount: vi.fn(),
+  mockUserCollections: vi.fn(),
+  mockHydrate: vi.fn(),
+  mockFollowed: vi.fn(),
+  mockRate: vi.fn(),
+  mockMaturity: vi.fn(),
+  mockFallbackCovers: vi.fn(),
+  mockPlayableSample: vi.fn(),
+  mockRanking: vi.fn(),
+}));
+
+vi.mock('~/server/services/collection.service', () => ({
+  getAllCollections: mockGetAll,
+  getCollectionItemCount: mockItemCount,
+  getUserCollectionsWithPermissions: mockUserCollections,
+}));
+vi.mock('~/server/services/blocks/block-collections.service', () => ({
+  hydrateBlockSubject: mockHydrate,
+  getFollowedCollectionIds: mockFollowed,
+  getFallbackCoverImages: mockFallbackCovers,
+  getCollectionPlayableSample: mockPlayableSample,
+  toCoverFields: (img: any) => {
+    const coverImageUrl = img?.url ? `edge:${img.url}` : null;
+    if (coverImageUrl === null) return { coverImageUrl: null };
+    return { coverImageUrl, coverNsfwLevel: img?.nsfwLevel ?? 0 };
+  },
+  collectionWithinCeiling: (nsfwLevel: number, level: number) =>
+    !nsfwLevel || (nsfwLevel & level) !== 0,
+}));
+/**
+ * 🔴 ONLY the ranking call is doubled. `isWindowedPeriod` stays REAL — it is the
+ * predicate that decides which periods ClickHouse may serve, i.e. the rule under
+ * test. Stubbing it would let the double decide the answer.
+ */
+vi.mock('~/server/services/blocks/block-collection-popularity.service', async (importOriginal) => {
+  const actual = await importOriginal<typeof PopularityService>();
+  return { ...actual, getWindowedCollectionRanking: mockRanking };
+});
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: mockRate,
+}));
+vi.mock('~/server/utils/block-catalog-maturity', () => ({
+  resolveCatalogBrowsingLevel: mockMaturity,
+}));
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: () => ({}),
+  isRegionRestricted: () => false,
+}));
+
+import handler from '~/pages/api/v1/blocks/collections/index';
+import { CollectionSort } from '~/server/common/enums';
+import { MetricTimeframe } from '~/shared/utils/prisma/enums';
+
+type Fixture = {
+  id: number;
+  read: 'Public' | 'Private' | 'Unlisted';
+  type: 'Image' | 'Model' | 'Post' | 'Article';
+  nsfwLevel?: number;
+};
+
+/**
+ * The collection table this suite's `getAllCollections` double reads.
+ *
+ * The shape is taken from the live population measured on the production replica
+ * 2026-09-11: over the Month window's top 1,000 ranked ids, 100% were `Public` but
+ * only 81 were `Image` — 914 were `Model`. So the interesting reject here is a
+ * TYPE reject, and the fixture leads with one, with a private collection alongside
+ * it because ClickHouse cannot tell them apart either.
+ */
+const TABLE: Fixture[] = [
+  { id: 500, read: 'Private', type: 'Image' },
+  { id: 501, read: 'Public', type: 'Model' },
+  { id: 502, read: 'Public', type: 'Image' },
+  { id: 503, read: 'Unlisted', type: 'Image' },
+  { id: 504, read: 'Public', type: 'Article' },
+  { id: 505, read: 'Public', type: 'Image' },
+  { id: 506, read: 'Public', type: 'Image' },
+  { id: 507, read: 'Public', type: 'Image' },
+];
+
+/**
+ * A FAITHFUL double for `getAllCollections`: it applies `ids`, `privacy` and
+ * `types` exactly as the real service's `where` clause does, including the
+ * `ids && ids.length > 0` branch that turns an EMPTY id array into "no filter at
+ * all". That last detail is load-bearing — it is what makes the empty-slice guard
+ * in the endpoint observable from a test instead of being a comment.
+ */
+function installCollectionsDouble(table: Fixture[] = TABLE) {
+  mockGetAll.mockImplementation(async ({ input }: any) => {
+    const { ids, privacy, types, limit, cursor } = input;
+    let rows = table.slice();
+    if (ids && ids.length > 0) rows = rows.filter((c) => ids.includes(c.id));
+    if (privacy && privacy.length > 0) rows = rows.filter((c) => privacy.includes(c.read));
+    if (types && types.length > 0) rows = rows.filter((c) => types.includes(c.type));
+    if (cursor) rows = rows.filter((c) => c.id <= cursor);
+    // The real service orders id-monotonically for both of its sorts; the
+    // ClickHouse path re-projects onto rank order, so this only has to be STABLE
+    // and deliberately NOT rank order — a handler that forgot to re-project would
+    // then visibly serve the wrong order.
+    rows.sort((a, b) => b.id - a.id);
+    return rows.slice(0, limit).map((c) => ({
+      id: c.id,
+      name: `C${c.id}`,
+      description: null,
+      read: c.read,
+      nsfwLevel: c.nsfwLevel ?? 1,
+      userId: 1,
+      user: { id: 1, username: 'a' },
+      image: null,
+    }));
+  });
+}
+
+function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'jti',
+    blockId: 'blk',
+    appId: 'app',
+    appBlockId: 'apb_test',
+    blockInstanceId: 'bki_test',
+    ctx: {},
+    scopes: ['collections:read:self'],
+    maxBrowsingLevel: 3,
+    ...over,
+  } as BlockTokenClaims;
+}
+
+const ids = (body: any) => body.items.map((i: any) => i.id);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimsBox.claims = fakeClaims();
+  mockRate.mockResolvedValue({ allowed: true });
+  mockMaturity.mockReturnValue({ browsingLevel: 3, isSfwCeiling: true });
+  mockHydrate.mockResolvedValue({ id: 42, username: 'mod', isModerator: false });
+  mockFollowed.mockResolvedValue(new Set<number>());
+  mockFallbackCovers.mockResolvedValue(new Map());
+  mockPlayableSample.mockResolvedValue(new Map());
+  mockItemCount.mockResolvedValue([]);
+  installCollectionsDouble();
+  mockRanking.mockResolvedValue({ ids: [], source: 'clickhouse' });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. THE NO-CHANGE PROOF
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('an unspecified period behaves exactly as before the parameter existed', () => {
+  it('emits NO period/source/sourceReason keys — the body has the pre-existing shape', async () => {
+    const { req, res } = createMocks({ query: { mode: 'public', sort: 'popular', limit: '2' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    const body = res._json() as any;
+    // A literal key list, not a derived one: this is the contract an existing
+    // caller depends on, so it is written out rather than computed from the code.
+    expect(Object.keys(body).sort()).toEqual(['items', 'nextCursor']);
+    expect(body).not.toHaveProperty('period');
+    expect(body).not.toHaveProperty('source');
+    expect(body).not.toHaveProperty('sourceReason');
+  });
+
+  it('never consults ClickHouse', async () => {
+    const { req, res } = createMocks({ query: { mode: 'public', sort: 'popular' } });
+    await handler(req as never, res as never);
+    expect(mockRanking).not.toHaveBeenCalled();
+  });
+
+  it('queries Postgres with the pre-existing shape: keyset cursor, requested sort, no id list', async () => {
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', limit: '3', cursor: '507' },
+    });
+    await handler(req as never, res as never);
+    const input = mockGetAll.mock.calls[0][0].input;
+    expect(input.ids).toBeUndefined();
+    expect(input.cursor).toBe(507);
+    expect(input.sort).toBe(CollectionSort.MostContributors);
+    // The unchanged over-fetch: limit * 4 + 1.
+    expect(input.limit).toBe(3 * 4 + 1);
+  });
+
+  it('serves the Postgres order and the keyset cursor, not a ranking', async () => {
+    const { req, res } = createMocks({ query: { mode: 'public', sort: 'popular', limit: '2' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    // The double returns Public+Image rows id-DESC: 507, 506, 505, 502.
+    expect(ids(body)).toEqual([507, 506]);
+    // Keyset: the first UNCONSUMED row's id, inclusive.
+    expect(body.nextCursor).toBe(505);
+  });
+
+  it('mode=mine with no period is equally untouched', async () => {
+    mockUserCollections.mockResolvedValue([
+      { id: 9, name: 'mine', description: null, read: 'Public', userId: 42, image: null },
+    ]);
+    const { req, res } = createMocks({ query: { mode: 'mine' } });
+    await handler(req as never, res as never);
+    expect(Object.keys(res._json() as any).sort()).toEqual(['items', 'nextCursor']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. WINDOW SELECTION
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('period selects the window and ClickHouse orders the page', () => {
+  it.each([MetricTimeframe.Day, MetricTimeframe.Week, MetricTimeframe.Month, MetricTimeframe.Year])(
+    '%s is passed through to the ranking service as itself',
+    async (period) => {
+      mockRanking.mockResolvedValueOnce({ ids: [505], source: 'clickhouse' });
+      const { req, res } = createMocks({ query: { mode: 'public', sort: 'popular', period } });
+      await handler(req as never, res as never);
+      expect(mockRanking).toHaveBeenCalledWith({ period });
+      const body = res._json() as any;
+      expect(body.period).toBe(period);
+      expect(body.source).toBe('clickhouse');
+      expect(body).not.toHaveProperty('sourceReason');
+    }
+  );
+
+  it('serves the RANK order, not the order Postgres returned the rows in', async () => {
+    // The double returns id-DESC (507, 506, 505). ClickHouse ranks the reverse.
+    mockRanking.mockResolvedValueOnce({ ids: [505, 506, 507], source: 'clickhouse' });
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Month, limit: '3' },
+    });
+    await handler(req as never, res as never);
+    expect(ids(res._json())).toEqual([505, 506, 507]);
+  });
+
+  it('hydrates by id and does NOT ask Postgres for the expensive contributor ordering', async () => {
+    mockRanking.mockResolvedValueOnce({ ids: [505, 506], source: 'clickhouse' });
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Week },
+    });
+    await handler(req as never, res as never);
+    const input = mockGetAll.mock.calls[0][0].input;
+    expect(input.ids).toEqual([505, 506]);
+    expect(input.cursor).toBeUndefined();
+    // 🔴 The COST pin. `MostContributors` makes the service order by
+    // `contributors._count` — a LEFT JOIN + GROUP BY over a table with no index on
+    // `collectionId`. On this path that work is discarded by the rank re-projection,
+    // so asking for it would be pure waste on the discovery front door.
+    expect(input.sort).toBe(CollectionSort.Newest);
+    expect(input.privacy).toEqual(['Public']);
+    expect(input.types).toEqual(['Image']);
+  });
+
+  it('AllTime keeps the Postgres source and says so', async () => {
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', period: MetricTimeframe.AllTime },
+    });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(mockRanking).not.toHaveBeenCalled();
+    expect(body.source).toBe('postgres');
+    expect(body.sourceReason).toBe('all-time-served-from-postgres');
+    expect(mockGetAll.mock.calls[0][0].input.sort).toBe(CollectionSort.MostContributors);
+  });
+
+  it('a period on a NON-popularity sort is ignored, and the response says which source served it', async () => {
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'newest', period: MetricTimeframe.Week },
+    });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(mockRanking).not.toHaveBeenCalled();
+    expect(body.source).toBe('postgres');
+    expect(body.sourceReason).toBe('period-ignored-for-non-popularity-sort');
+    expect(mockGetAll.mock.calls[0][0].input.sort).toBe(CollectionSort.Newest);
+  });
+
+  it('a period on mode=mine is ignored, and the response says so', async () => {
+    mockUserCollections.mockResolvedValue([
+      { id: 9, name: 'mine', description: null, read: 'Public', userId: 42, image: null },
+    ]);
+    const { req, res } = createMocks({
+      query: { mode: 'mine', sort: 'popular', period: MetricTimeframe.Month },
+    });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(mockRanking).not.toHaveBeenCalled();
+    expect(body.sourceReason).toBe('period-ignored-outside-public-discovery');
+    expect(ids(body)).toEqual([9]);
+  });
+
+  it('rejects a period outside the five MetricTimeframe values', async () => {
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', period: 'Fortnight' },
+    });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+    expect((res._json() as any).details.fieldErrors).toHaveProperty('period');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. THE LEAK GUARD
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('no private and no non-Image collection can reach the response via ClickHouse', () => {
+  it('drops a PRIVATE collection that ClickHouse ranked FIRST', async () => {
+    // 500 is Private, 503 is Unlisted. ClickHouse has no idea and ranks them top.
+    mockRanking.mockResolvedValueOnce({ ids: [500, 503, 505, 506], source: 'clickhouse' });
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Month, limit: '10' },
+    });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(ids(body)).toEqual([505, 506]);
+    expect(ids(body)).not.toContain(500);
+    expect(ids(body)).not.toContain(503);
+  });
+
+  it('drops a MODEL / ARTICLE collection that ClickHouse ranked first', async () => {
+    // The dominant live reject: 914 of the top 1,000 ranked ids are Model collections.
+    mockRanking.mockResolvedValueOnce({ ids: [501, 504, 507], source: 'clickhouse' });
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Month, limit: '10' },
+    });
+    await handler(req as never, res as never);
+    expect(ids(res._json())).toEqual([507]);
+  });
+
+  it('asks Postgres for the Public+Image predicates over exactly the ranked ids', async () => {
+    mockRanking.mockResolvedValueOnce({ ids: [500, 501, 502], source: 'clickhouse' });
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Day },
+    });
+    await handler(req as never, res as never);
+    const input = mockGetAll.mock.calls[0][0].input;
+    expect(input.privacy).toEqual(['Public']);
+    expect(input.types).toEqual(['Image']);
+    expect(input.ids).toEqual([500, 501, 502]);
+  });
+
+  it('a rejected id still ADVANCES the cursor — the feed cannot loop on it', async () => {
+    // limit 1: the page fills on 505, having walked past the two rejects before it.
+    mockRanking.mockResolvedValueOnce({ ids: [500, 501, 505, 506], source: 'clickhouse' });
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Month, limit: '1' },
+    });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(ids(body)).toEqual([505]);
+    // Three ranked ids consumed (500, 501, 505) → the next page starts at offset 3.
+    expect(body.nextCursor).toBe(3);
+  });
+
+  it('a page that filters to EMPTY still advances, rather than terminating the feed', async () => {
+    // 🔴 THE SHAPE THAT MATTERS IS A *PARTIAL* SLICE. At limit 1 the hydrate window
+    // is 1 * 24 + 1 = 25 ids, so a 40-deep ranking whose first 25 entries are all
+    // rejects produces an empty page with 15 ranked ids still to come. If the
+    // cursor did not advance past the rejects the feed would re-serve the same
+    // dead window forever; if it terminated instead, the 15 remaining ids —
+    // including every showable one — would be unreachable.
+    const deadIds = Array.from({ length: 30 }, (_, i) => 9000 + i); // absent from TABLE
+    mockRanking.mockResolvedValueOnce({
+      ids: [...deadIds, 505, 506, 507, 502, 500, 501, 503, 504, 9100, 9101],
+      source: 'clickhouse',
+    });
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Month, limit: '1' },
+    });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items).toEqual([]);
+    // The whole 25-id slice was walked and more leaderboard remains → a cursor.
+    expect(body.nextCursor).toBe(25);
+
+    // …and following it reaches the showable collections that sat behind the wall.
+    const next = createMocks({
+      query: {
+        mode: 'public',
+        sort: 'popular',
+        period: MetricTimeframe.Month,
+        limit: '1',
+        cursor: '25',
+      },
+    });
+    mockRanking.mockResolvedValueOnce({
+      ids: [...deadIds, 505, 506, 507, 502, 500, 501, 503, 504, 9100, 9101],
+      source: 'clickhouse',
+    });
+    await handler(next.req as never, next.res as never);
+    expect(ids(next.res._json())).toEqual([505]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. PAGINATION AND THE DEGRADED PATHS
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('offset pagination over the bounded leaderboard', () => {
+  it('the cursor is an OFFSET into the ranking, and resumes past what was shown', async () => {
+    mockRanking.mockResolvedValue({ ids: [505, 506, 507, 502], source: 'clickhouse' });
+    const first = createMocks({
+      query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Month, limit: '2' },
+    });
+    await handler(first.req as never, first.res as never);
+    const page1 = first.res._json() as any;
+    expect(ids(page1)).toEqual([505, 506]);
+    expect(page1.nextCursor).toBe(2);
+
+    const second = createMocks({
+      query: {
+        mode: 'public',
+        sort: 'popular',
+        period: MetricTimeframe.Month,
+        limit: '2',
+        cursor: String(page1.nextCursor),
+      },
+    });
+    await handler(second.req as never, second.res as never);
+    const page2 = second.res._json() as any;
+    // No overlap with page 1 and no gap.
+    expect(ids(page2)).toEqual([507, 502]);
+    expect(page2.nextCursor).toBeUndefined();
+  });
+
+  it('exhausting the leaderboard emits NO cursor', async () => {
+    mockRanking.mockResolvedValueOnce({ ids: [505, 506], source: 'clickhouse' });
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Month, limit: '10' },
+    });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    // 🔴 THE LAST THREE ASSERTIONS ARE NOT DECORATION. An absent `nextCursor` is
+    // ALSO what the untouched Postgres walk emits when its source is exhausted, so
+    // this test passed against the pre-`period` endpoint — measured, it was the one
+    // vacuous guard in this file. Pinning the source and the id-list hydrate is
+    // what makes it a claim about the ClickHouse path rather than about "no cursor".
+    expect(body.nextCursor).toBeUndefined();
+    expect(body.source).toBe('clickhouse');
+    expect(ids(body)).toEqual([505, 506]);
+    expect(mockGetAll.mock.calls[0][0].input.ids).toEqual([505, 506]);
+  });
+
+  it('a cursor past the end of the leaderboard is an empty page, NOT the whole catalogue', async () => {
+    // 🔴 The guard this pins: an empty id array reaches `getAllCollections` as
+    // "no id filter", which would return every public Image collection under a
+    // popularity feed's banner. The endpoint must short-circuit instead.
+    mockRanking.mockResolvedValueOnce({ ids: [505, 506], source: 'clickhouse' });
+    const { req, res } = createMocks({
+      query: {
+        mode: 'public',
+        sort: 'popular',
+        period: MetricTimeframe.Month,
+        limit: '5',
+        cursor: '99',
+      },
+    });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items).toEqual([]);
+    expect(body.nextCursor).toBeUndefined();
+    expect(body.source).toBe('clickhouse');
+    expect(mockGetAll).not.toHaveBeenCalled();
+  });
+});
+
+describe('degraded sources still serve collections, and say why', () => {
+  it.each([['clickhouse-disabled' as const], ['clickhouse-error' as const]])(
+    '%s falls back to the all-time Postgres ordering with a stated reason',
+    async (reason) => {
+      mockRanking.mockResolvedValueOnce({ ids: null, source: 'unavailable', reason });
+      const { req, res } = createMocks({
+        query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Month, limit: '2' },
+      });
+      await handler(req as never, res as never);
+      const body = res._json() as any;
+      expect(body.source).toBe('postgres');
+      expect(body.sourceReason).toBe(reason);
+      // 🔴 NOT AN EMPTY GRID. The viewer still gets collections, ordered all-time.
+      expect(ids(body)).toEqual([507, 506]);
+      const input = mockGetAll.mock.calls[0][0].input;
+      expect(input.ids).toBeUndefined();
+      expect(input.sort).toBe(CollectionSort.MostContributors);
+    }
+  );
+
+  it('an empty window degrades too, under its OWN reason', async () => {
+    // Separable from unavailability on purpose: an empty window is far more often
+    // the daily aggregate not having sealed yet than a real zero.
+    mockRanking.mockResolvedValueOnce({ ids: [], source: 'clickhouse' });
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Day, limit: '2' },
+    });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.source).toBe('postgres');
+    expect(body.sourceReason).toBe('empty-window');
+    expect(body.items.length).toBeGreaterThan(0);
+  });
+
+  it('the three degrade reasons are all DISTINCT — one cannot be read as another', async () => {
+    const reasons = new Set<string>();
+    for (const r of [
+      { ids: null, source: 'unavailable', reason: 'clickhouse-disabled' },
+      { ids: null, source: 'unavailable', reason: 'clickhouse-error' },
+      { ids: [], source: 'clickhouse' },
+    ]) {
+      mockRanking.mockResolvedValueOnce(r as never);
+      const { req, res } = createMocks({
+        query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Month },
+      });
+      await handler(req as never, res as never);
+      reasons.add((res._json() as any).sourceReason);
+    }
+    expect(reasons.size).toBe(3);
+  });
+});

--- a/src/tests/api/v1/blocks/collections-period.test.ts
+++ b/src/tests/api/v1/blocks/collections-period.test.ts
@@ -341,6 +341,32 @@ describe('period selects the window and ClickHouse orders the page', () => {
     expect(input.types).toEqual(['Image']);
   });
 
+  it('caps the playable-sample budget at the POSTGRES over-fetch, in RANK order', async () => {
+    // 🔴 The cost pin for the wider hydrate. The sample's price scales with the id
+    // count (~400 ms for 97), and this path hydrates up to 1,000 ids rather than
+    // `limit * 4 + 1`. Handing every survivor to the sample would make it the most
+    // expensive query on the new path — silently, and only on whichever window
+    // survives filtering best.
+    const many = Array.from({ length: 60 }, (_, i) => 600 + i);
+    installCollectionsDouble(
+      many.map((id) => ({ id, read: 'Public' as const, type: 'Image' as const }))
+    );
+    // Ranked in an order the double will NOT return them in (it sorts id-DESC).
+    mockRanking.mockResolvedValueOnce({ ids: many, source: 'clickhouse' });
+    const { req, res } = createMocks({
+      query: { mode: 'public', sort: 'popular', period: MetricTimeframe.Month, limit: '2' },
+    });
+    await handler(req as never, res as never);
+    const sampled = mockPlayableSample.mock.calls[0][0] as number[];
+    // limit 2 → the Postgres over-fetch is 2 * 4 + 1 = 9, so 60 survivors are
+    // trimmed to the 9 the walk could possibly reach…
+    expect(sampled).toHaveLength(9);
+    // …and they are the top NINE BY RANK, not the nine Postgres happened to return
+    // first. Ordering the cap by the double's id-DESC output would have sampled
+    // 659…651 and left the actual page-1 collections unjudged.
+    expect(sampled).toEqual(many.slice(0, 9));
+  });
+
   it('AllTime keeps the Postgres source and says so', async () => {
     const { req, res } = createMocks({
       query: { mode: 'public', sort: 'popular', period: MetricTimeframe.AllTime },


### PR DESCRIPTION
Adds `period` to `GET /api/v1/blocks/collections`, so an App Block can ask for **popular this day / week / month / year / all time** instead of only "most followed, ever".

## Which source serves each period

| `period` | source | why |
|---|---|---|
| `Day` | ClickHouse | `entityMetricDailyAgg_history_v2`, `SUM(total)` over the window |
| `Week` | ClickHouse | same |
| `Month` | ClickHouse | same |
| `Year` | ClickHouse | same |
| `AllTime` | **Postgres** (unchanged) | that ClickHouse history begins **2025-11-06**, so a ClickHouse "all time" would silently mean "since November" |
| *absent* | **Postgres** (unchanged) | the pre-existing path, byte-for-byte |

The response says which one actually served it: `source: 'clickhouse' | 'postgres'`, plus a `sourceReason` when the request did not get what it asked for.

`total` in that table is a **per-day delta**, not a cumulative snapshot, so a window is a `SUM … GROUP BY entityId`. The `_history_` table is the right one — `entityMetricDailyAgg_v2` holds only the current day and reads exactly like "there is no history here".

## An unspecified `period` behaves exactly as today — proven, not asserted

`period` has **no default**. An absent period, `AllTime`, `mode=mine`, and any sort other than the popularity one all fall into the untouched Postgres walk, and the `period` / `source` / `sourceReason` keys are emitted **only** when a period was supplied — so an existing caller's body is unchanged in shape.

Five tests pin this, and they are **green against `origin/main` with the endpoint unmodified**, which is what makes them a claim about compatibility rather than about the new code:

- `emits NO period/source/sourceReason keys — the body has the pre-existing shape`
- `never consults ClickHouse`
- `queries Postgres with the pre-existing shape: keyset cursor, requested sort, no id list`
- `serves the Postgres order and the keyset cursor, not a ranking`
- `mode=mine with no period is equally untouched`

They are **invariant guards**, not regression guards, and are labelled as such. What makes them non-vacuous is mutation M1 below: emitting the new fields unconditionally turns the first one red.

## Cost measurement

Measured on the production replica (`EXPLAIN (ANALYZE, BUFFERS)`, inlined literal id lists — no id-selection subquery) and against ClickHouse Cloud, 2026-09-11. The window is the real page-1 window: default `limit` 24.

**BEFORE — today's page 1 under this endpoint's own popularity sort** (`sort=Most Followers`, over-fetch `24*4+1 = 97`). Prisma renders `orderBy: { contributors: { _count: 'desc' } }` as a `LEFT JOIN` onto a full `GROUP BY` of `CollectionContributor`:

| run | Execution Time |
|---|---|
| 1 (cold) | **4,374.7 ms** |
| 2 | **3,148.2 ms** |
| 3 | **3,123.3 ms** |

The plan hash-aggregates 1,825,517 groups over a 2.33M-row index-only scan per worker, ~1.28M shared buffers.

**AFTER — the ClickHouse path.** Two queries replace it:

1. The ranking, server-side `elapsed`:

| period | window bound | depth 1,000 | depth 10,000 (shipped) |
|---|---|---|---|
| Day | `today-1` | 15.1 ms | **12.3 ms** |
| Week | `today-7` | 15.9 ms | — |
| Month | `today-30` | 102.7 ms | **33.5 ms** |
| Year | `today-365` | 143.0 ms | **138.2 ms** |

2. The Postgres hydrate — an `id IN (…)` primary-key scan with the same `privacy`/`types` predicates:

| ids hydrated | Execution Time | rows surviving |
|---|---|---|
| 97 | 5.3 / 5.7 / 5.9 ms | 21 |
| 577 (shipped default) | 22.3 / 23.1 ms | 53 |
| 1,000 (cap) | 14.3 / 14.5 ms | 81 |

**So the windowed page 1 costs ~34 ms (ClickHouse) + ~23 ms (Postgres) ≈ 57 ms, against 3,123–4,375 ms for the all-time page 1 it sits beside.** The discovery front door is not regressed; the new path is roughly **55× cheaper** than the existing popularity page it shares a screen with.

That is partly because the hydrate deliberately does **not** ask for `CollectionSort.MostContributors`: on this path Postgres is only fetching rows, the rank order is re-projected in the handler, so the contributor join would be pure waste. (`CollectionContributor` is `@@index([userId], type: Hash)` — no index on `collectionId` and none on `createdAt`; that join shape is the one that cost this endpoint a measured ~31× regression once already. There is **no** on-request Postgres window anywhere in this change.)

## The finding that changed the design

Over the Month window's **top 1,000 ranked ids**, measured on the replica:

```
present in Postgres   1000
read = Public         1000      ← privacy rejects ZERO
type = Image            81      ← 914 Model, 4 Post, 1 Article
```

Cumulative showable collections by ranking depth:

```
depth      97   385  1000  2500  5000  10000
survivors  21    42    81   337   396    446
```

So the real filter is **type, not privacy**, and it removes ~95%. Two consequences, both deliberate:

- **`CH_RANKING_DEPTH = 10,000`, not 1,000.** A 1,000-deep leaderboard is a feed of 81 collections — three pages. Depth is nearly free (the `GROUP BY` scans the window regardless; `LIMIT` only trims the sorted output), so ten times the feed costs no measurable query time.
- **The ClickHouse path hydrates `limit * 24 + 1` ids (capped at 1,000), not `limit * 4 + 1`.** Sharing the Postgres multiplier would have shipped a permanently 21-item window against a default `limit` of 24 — every page short, forever.

**The wider hydrate forced one more change (second commit).** The playable-fraction sample's cost scales with the id count handed to it (~400 ms for 97), and every survivor of the privacy/type filter was reaching it — which would have made the sample the most expensive query on the new path, silently, and only on whichever window survived filtering best. Candidates are now taken **in rank order** and trimmed to the same `limit * 4 + 1` budget the Postgres path already pays (a no-op there, where `rows` is already at most that long). Rank order is what makes the trim harmless: the walk consumes in the same order and stops at `limit`, so it only ever bites on rows a full page never reaches, and such a row is left unjudged by a *ranking heuristic* — never by a gate.

## Privacy / type leak guard

ClickHouse ranks ids with no notion of privacy, type, maturity, or whether the collection still exists. Every ranked id is re-read through `getAllCollections` with `privacy: [Public]` + `types: [Image]` — **the same predicates the untouched path uses** — so a rejected id simply has no row and is walked past. The gate is an absence, not a test, and the code says so.

The tests pin it with a `getAllCollections` double that is a **real filter** over `privacy`/`types` (a stub returning canned rows would pass while the endpoint leaked), including a private collection and a Model collection ranked **first** by ClickHouse.

## Pagination and the short-page problem

The Postgres path keeps its inclusive keyset cursor on collection id. A ClickHouse ranking is ordered by summed followers, which is neither monotonic in id nor keyset-able, so **that path's cursor is an offset into the bounded top-N** — documented in the header, and the two never mix because a feed does not change `period` mid-scroll.

Filtering shrinks the set, so a page can come back short. What keeps the feed alive is that **the cursor advances by every ranked id walked, rejects included**, never by the rows shown — otherwise a heavily-filtered page would re-serve the same dead window forever. Exhausting the leaderboard emits no cursor, which ends the windowed feed by design. A cursor past the end short-circuits to an empty page: an empty `ids` array reaching `getAllCollections` means "no id filter at all", i.e. the whole public catalogue under a popularity feed's banner.

## `clickhouse` can be `undefined`

It is `undefined` whenever `shouldConnect` is false (no `CLICKHOUSE_HOST`/`CLICKHOUSE_USERNAME`, or during a Next build). That is a normal deployment state, not a fault. The request **degrades to the all-time Postgres ordering and says so** — `source: 'postgres'`, `sourceReason: 'clickhouse-disabled'`. Silently returning an empty grid would be indistinguishable from "nobody followed anything this week", which is a different fact.

Three degrade reasons, kept distinct on purpose (a test asserts they cannot collapse into one):

- `clickhouse-disabled` — no client
- `clickhouse-error` — the query failed (logged to Axiom as `block-collection-ranking-degraded`)
- `empty-window` — the window returned nothing, far more often a daily-seal lag than a real zero

Plus `all-time-served-from-postgres`, `period-ignored-for-non-popularity-sort` and `period-ignored-outside-public-discovery` for the periods that are accepted and deliberately do not change the ordering.

## Verification

**Red at `origin/main`, green at HEAD.** Both new test files were copied onto a detached worktree at `origin/main` (the new service too, so imports resolve — **the endpoint itself left unmodified**):

| | at `origin/main` | at HEAD |
|---|---|---|
| `collections-period.test.ts` | **22 failed**, 5 passed | 27 passed |
| `block-collection-popularity.test.ts` | 22 passed (new unit coverage of a new module — it cannot be red at base) | 22 passed |

The 5 that pass at base are exactly the five no-change guards listed above, which is the correct result for them. One guard (`exhausting the leaderboard emits NO cursor`) was found passing vacuously at base and was strengthened until it did not.

**Mutation sweep — 12 mutants, all KILLED by their *named* guard** (baseline 0 failing):

| mutant | guard that went red |
|---|---|
| M1 emit period fields unconditionally | `emits NO period/source/sourceReason keys` |
| M2 drop the `privacy` predicate on the CH path | `drops a PRIVATE collection that ClickHouse ranked FIRST` |
| M3 drop the `types` predicate on the CH path | `drops a MODEL / ARTICLE collection that ClickHouse ranked first` |
| M4 walk `rows` instead of the ranked id list | `serves the RANK order, not the order Postgres returned the rows in` |
| M5 remove the empty-slice short-circuit | `a cursor past the end … is an empty page, NOT the whole catalogue` |
| M6 make the Week window 30 days | `Week resolves to 2026-09-04` |
| M7 disabled ClickHouse returns empty, not unavailable | `reports clickhouse-disabled … it does NOT query` |
| M8 ask Postgres for the expensive sort on the CH path | `hydrates by id and does NOT ask Postgres for the expensive contributor ordering` |
| M9 advance the cursor by rows shown, not ids walked | `a rejected id still ADVANCES the cursor` |
| M10 drop the `entityId` tiebreak | `breaks ties on entityId so offset pagination sees one total order` |
| M11 remove the playable-sample cap | `caps the playable-sample budget at the POSTGRES over-fetch, in RANK order` |
| M12 cap without rank ordering | same guard (it asserts the *contents*, not just the length) |

**Suite.** `vitest --project unit` over `src/tests/api/v1/blocks/`, `src/server/services/blocks/__tests__/` and `src/server/services/__tests__/`:

- at `origin/main`: 8,354 tests, **12 failing**
- at HEAD: 8,418 tests, **12 failing**
- new failures introduced: **0**. Fixed: 0. (+64 new tests.)

The 12 are pre-existing on `main` — four `buildModelFlagUpsert` cases needing a real local Postgres, plus `deletePost`/`upsertUserHub`/`source suggestions`.

A 13th failure *was* introduced and is fixed: `no-direct-shared-module-mock` caught a per-file `vi.mock('~/server/logging/client')`, which has a canonical mock in `src/__tests__/setup.ts`. Removed; the file now relies on the canonical registration.

**Typecheck.** `pnpm typecheck` reports **10 errors before and 10 after** — all ten in `src/server/services/image.service.ts`, from a sibling `event-engine-common` checkout absent in a fresh worktree. **Delta 0**; neither changed file appears.

**Lint.** `eslint` on the four files: **0 errors**, 26 warnings, all `no-explicit-any` in the test double — the same rule and the same style as the sibling `collections-endpoint.test.ts` (51 warnings, 0 errors).

**Prettier.** Clean on all four files.

## Not done / not claimed

- **No live-endpoint probe.** Every behavioural claim here is from the handler-level suite plus the replica/ClickHouse measurements; nothing was exercised against a running deployment.
- **No migration, no index, no metrics-job change.** The Postgres `CollectionMetric` job is untouched and still writes `AllTime` only — the ClickHouse source is what replaced the need for it.
- **The block's UI** (the period selector) is separate and lives in the app repo.
- **`sort=newest&period=week`** does not become a popularity feed. `period` modifies popularity, so it is honoured only for the popularity sort; anything else is accepted, ignored, and reported via `sourceReason`.
