### PR TITLE
feat(csam): stream the large evidence archives straight to object storage

### DIFF
--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -37,6 +37,13 @@ export enum FLIPT_FEATURE_FLAGS {
   // Gates every non-legacy judging engine. Default-off, so a challenge whose `judgingEngine`
   // column points at the pairwise ladder still runs the legacy absolute path until this is on.
   CHALLENGE_PAIRWISE_JUDGING = 'challenge-pairwise-judging',
+  // Streams the two large evidence archives straight to object storage instead of staging them
+  // on the container's local scratch volume first. DEFAULT-OFF — `isFlipt` returns false for an
+  // unknown flag or an unreachable Flipt, which leaves the long-standing disk-staging path in
+  // charge. Evaluated ONCE per report, never per archive, so a mid-report flip cannot produce a
+  // bundle assembled two different ways. Flip OFF to roll back without a deploy; the disk path
+  // is kept intact and reachable for exactly that reason.
+  CSAM_ARCHIVE_STREAM_UPLOAD = 'csam-archive-stream-upload',
   COMIC_CREATOR = 'comic-creator',
   GENERATION_PRESETS = 'generation-presets',
   GENERATION_TESTING = 'generation-testing',

--- a/src/server/services/__tests__/csam-archive-stream-upload.test.ts
+++ b/src/server/services/__tests__/csam-archive-stream-upload.test.ts
@@ -192,7 +192,11 @@ import { archiveCsamDataForReport } from '~/server/services/csam.service-new';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { setEnv } from '~/__tests__/mocks/env.mock';
 import { FLIPT_FEATURE_FLAGS } from '~/server/flipt/client';
-import { MAX_UPLOAD_QUEUE_SIZE, S3_MIN_PART_SIZE_BYTES } from '~/server/utils/archive-helpers';
+import {
+  deriveUploadPartGeometry,
+  ESTIMATED_BYTES_PER_ARCHIVED_IMAGE,
+  S3_MIN_PART_SIZE_BYTES,
+} from '~/server/utils/archive-helpers';
 
 // ---------------------------------------------------------------------------------------------
 // Fixture
@@ -242,18 +246,20 @@ const ENTRY_BYTES = 192 * 1024;
  * 🔴 Fixture size for the anti-hang probe, and the ONLY thing that makes that probe able to
  * observe anything at all.
  *
- * `Upload` pulls eagerly: it absorbs roughly `queueSize * partSize` — `MAX_UPLOAD_QUEUE_SIZE x
- * S3_MIN_PART_SIZE_BYTES` = 20 MiB at the default geometry — out of the `PassThrough` before it
- * stops reading. An archive SMALLER than that window is fully absorbed and fully appended before
- * the upload's first part can fail, so nothing is ever parked on the pending-entry ceiling and
- * the report fails correctly whether or not the producer is actually stopped. Measured: at
+ * `Upload` pulls eagerly: it absorbs roughly `queueSize * partSize` out of the `PassThrough`
+ * before it stops reading — 20 MiB for these fixtures, whose estimate is small enough that the
+ * derived part clamps to the 5 MiB minimum and the queue stays at 4. An archive SMALLER than that
+ * window is fully absorbed and fully appended before the upload's first part can fail, so nothing
+ * is ever parked on the pending-entry ceiling and the report fails correctly whether or not the
+ * producer is actually stopped. Measured: at
  * `ENTRY_COUNT` (73 x 192 KiB = 13.7 MiB) the probe settles in under a second against code with
  * the hang fully present. It was testing nothing.
  *
  * 160 x 192 KiB = 30 MiB is comfortably past that window, so the archiver is still mid-archive
  * with `append()` callers parked when the upload rejects — which is the state the defect strands
- * forever. Asserted in the test rather than trusted from this comment, because the window moves
- * if either geometry constant changes.
+ * forever. Asserted in the test rather than trusted from this comment, and asserted against the
+ * geometry THIS RUN derives rather than the default pair, because the window moves with the
+ * size estimate as well as with the two clamps.
  *
  * Wall clock, measured on this file: the two anti-hang probes cost ~0.7 s of ~5 s of test time
  * across 8 tests. Most of the larger fixture is free because `entryBytes` caches per index and
@@ -613,14 +619,27 @@ describe('csam archive streaming upload', () => {
       // and there is nothing to strand. Asserted, not assumed — if a future geometry change widens
       // the absorption window past the fixture, this fails loudly instead of going quietly
       // meaningless.
-      const absorbedBeforeStalling = MAX_UPLOAD_QUEUE_SIZE * S3_MIN_PART_SIZE_BYTES;
+      //
+      // 🔴 DERIVED, NOT `MAX_UPLOAD_QUEUE_SIZE * S3_MIN_PART_SIZE_BYTES`. Those two constants are
+      // the DEFAULT geometry; the run under test uses the geometry the service derives from
+      // `imageCount * ESTIMATED_BYTES_PER_ARCHIVED_IMAGE`, and the two coincide only while that
+      // estimate is small enough to clamp to the 5 MiB minimum. Asserting the default pins
+      // nothing about the run: raising `ESTIMATED_BYTES_PER_ARCHIVED_IMAGE` far enough to make the
+      // derived part 8.19 MiB widens the real window to 32.8 MiB — past this 30 MiB fixture —
+      // while the default-geometry form still reads 20 MiB and stays green with the hang fully
+      // reintroduced. Measured: that two-part mutation left all 8 tests in this file passing
+      // against the default form, and fails HERE against the derived one.
+      const absorbedBeforeStalling = deriveUploadPartGeometry({
+        expectedBytes: HANG_PROBE_ENTRY_COUNT * ESTIMATED_BYTES_PER_ARCHIVED_IMAGE,
+      }).worstCaseResidentBytes;
       expect(
         HANG_PROBE_ENTRY_COUNT * ENTRY_BYTES,
         `fixture (${
           HANG_PROBE_ENTRY_COUNT * ENTRY_BYTES
         } bytes) no longer exceeds what the uploader ` +
-          `absorbs before it stops reading (${absorbedBeforeStalling} bytes) — this probe cannot ` +
-          `observe a stalled producer and proves nothing`
+          `absorbs before it stops reading at THIS RUN'S derived geometry ` +
+          `(${absorbedBeforeStalling} bytes) — this probe cannot observe a stalled producer and ` +
+          `proves nothing`
       ).toBeGreaterThan(absorbedBeforeStalling);
 
       seedDb(HANG_PROBE_ENTRY_COUNT);

--- a/src/server/services/__tests__/csam-archive-stream-upload.test.ts
+++ b/src/server/services/__tests__/csam-archive-stream-upload.test.ts
@@ -1,0 +1,474 @@
+import { createHash } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import JSZip from 'jszip';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Equivalence proof for streaming an evidence archive straight to object storage.
+ *
+ * THE DEFECT: each media archive was written to the container's local scratch volume, read back,
+ * and then uploaded. That volume has a size limit, so a reported account with a large enough
+ * media library exceeded it and the container was evicted before the archive could finish —
+ * every time, for that account. Raising the limit only moves the ceiling; removing local staging
+ * removes it.
+ *
+ * WHAT THIS FILE PROVES, and it is deliberately not "the zips are byte-identical": a zip embeds a
+ * timestamp per entry, so two runs of correct code differ byte-for-byte. The claim that actually
+ * matters for an evidence bundle is that it CONTAINS the same things, so what is compared is the
+ * content inventory — sorted entry names, each entry's uncompressed size, and a SHA-256 of each
+ * entry's uncompressed bytes.
+ *
+ * 🔴 AND COMPARING THE TWO PATHS TO EACH OTHER IS NOT ENOUGH ON ITS OWN. Two arms of the same
+ * comparison are blind to a defect they share — a bug in the appending code both paths run would
+ * produce two identical, identically-wrong inventories and a green test. So every inventory is
+ * also checked against the bytes the fixture generated, independently of either path.
+ *
+ * The uploader here is the REAL `@aws-sdk/lib-storage` `Upload` driving a fake S3 that reassembles
+ * parts. The fixture is sized to exceed one part, so multipart splitting, part ordering and part
+ * reassembly are exercised rather than assumed — and the part count is asserted, because a
+ * single-shot `PutObject` would make every other assertion in this file vacuous.
+ */
+
+/**
+ * 🔴 Redirect the service's on-disk scratch space into a private temp dir, BEFORE the service
+ * module is evaluated — `csam.service-new` computes its base directory once, at module scope.
+ * Same reasoning (and the same `isProd` half below) as `csam-archive-backpressure.test.ts`.
+ */
+const csamBaseDir = await vi.hoisted(async () => {
+  const [{ default: nodeFs }, { default: nodeOs }, { default: nodePath }, { setEnv }] =
+    await Promise.all([
+      import('fs'),
+      import('os'),
+      import('path'),
+      import('~/__tests__/mocks/env.mock'),
+    ]);
+  const dirname = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'csam-stream-test-'));
+  setEnv({ DIRNAME: dirname });
+  process.env.NEXT_PUBLIC_CIVITAI_LINK ??= 'https://example.invalid/civitai-link';
+  return nodePath.join(dirname, 'csam');
+});
+
+vi.mock('~/env/other', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isProd: true,
+}));
+
+// ---------------------------------------------------------------------------------------------
+// Fake S3 — reassembles multipart uploads so the stored object can be inspected.
+// ---------------------------------------------------------------------------------------------
+
+type StoredObject = {
+  /** Reassembled body. */
+  body: Buffer;
+  /** Number of multipart parts, or 0 when the object went up as a single `PutObject`. */
+  partCount: number;
+  /** Byte length of each part, in part order. */
+  partSizes: number[];
+};
+
+// Hoisted: the `vi.mock` factory below is lifted above every module-scope statement in this file,
+// so anything it closes over has to be initialised in a hoisted block or it is a TDZ error at
+// mock time. The maps live here too, so the class and the assertions read the same instances.
+const { storedObjects, pendingUploads, FakeS3Client } = vi.hoisted(() => {
+  const storedObjects = new Map<string, StoredObject>();
+  const pendingUploads = new Map<string, { key: string; parts: Map<number, Buffer> }>();
+  let nextUploadId = 0;
+
+  /** Strips the `<userId>/<timestamp>_` prefix the service puts on every key. */
+  const objectName = (key: string) => key.slice(key.indexOf('_') + 1);
+
+  function toBuffer(body: unknown): Buffer {
+    if (Buffer.isBuffer(body)) return body;
+    if (body instanceof Uint8Array) return Buffer.from(body);
+    if (typeof body === 'string') return Buffer.from(body);
+    throw new Error(`fake S3: unsupported part body of type ${typeof body}`);
+  }
+
+  class FakeS3Client {
+    // `Upload` reads these off the client before it sends anything.
+    config = {
+      region: 'test-region',
+      forcePathStyle: false,
+      requestHandler: {},
+      requestChecksumCalculation: async () => 'WHEN_REQUIRED',
+      endpoint: async () => ({
+        hostname: 'example.invalid',
+        protocol: 'https:',
+        path: '/',
+        port: 443,
+      }),
+    };
+
+    async send(command: { constructor: { name: string }; input: Record<string, unknown> }) {
+      const name = command.constructor.name;
+      const input = command.input;
+
+      switch (name) {
+        case 'CreateMultipartUploadCommand': {
+          const UploadId = `upload-${nextUploadId++}`;
+          pendingUploads.set(UploadId, { key: input.Key as string, parts: new Map() });
+          return { UploadId };
+        }
+        case 'UploadPartCommand': {
+          const pending = pendingUploads.get(input.UploadId as string);
+          if (!pending) throw new Error(`fake S3: UploadPart for unknown upload ${input.UploadId}`);
+          const partNumber = input.PartNumber as number;
+          pending.parts.set(partNumber, toBuffer(input.Body));
+          return { ETag: `"etag-${partNumber}"` };
+        }
+        case 'CompleteMultipartUploadCommand': {
+          const pending = pendingUploads.get(input.UploadId as string);
+          if (!pending) throw new Error(`fake S3: Complete for unknown upload ${input.UploadId}`);
+          pendingUploads.delete(input.UploadId as string);
+          // Reassemble in PART NUMBER order, not arrival order — parts are uploaded concurrently,
+          // so arrival order is not the object's order and reassembling by it would corrupt the
+          // object in a way that looks exactly like a streaming bug.
+          const numbers = [...pending.parts.keys()].sort((a, b) => a - b);
+          const chunks = numbers.map((n) => pending.parts.get(n)!);
+          storedObjects.set(objectName(pending.key), {
+            body: Buffer.concat(chunks),
+            partCount: numbers.length,
+            partSizes: chunks.map((c) => c.length),
+          });
+          return { ETag: '"etag-complete"' };
+        }
+        case 'PutObjectCommand': {
+          const body = toBuffer(input.Body);
+          storedObjects.set(objectName(input.Key as string), {
+            body,
+            partCount: 0,
+            partSizes: [body.length],
+          });
+          return { ETag: '"etag-put"' };
+        }
+        case 'AbortMultipartUploadCommand': {
+          pendingUploads.delete(input.UploadId as string);
+          return {};
+        }
+        default:
+          // Loud by design. A silently-successful unknown command would let an upload "succeed"
+          // while storing nothing, and every content assertion below would read `undefined`.
+          throw new Error(`fake S3: unexpected command ${name}`);
+      }
+    }
+
+    destroy() {
+      return undefined;
+    }
+  }
+
+  return { storedObjects, pendingUploads, FakeS3Client };
+});
+
+vi.mock('@aws-sdk/client-s3', async (importOriginal) => ({
+  // Only the client is replaced. The command classes stay real, which is what lets the fake
+  // dispatch on their constructor names and what keeps `Upload`'s own behaviour untouched.
+  ...(await importOriginal<Record<string, unknown>>()),
+  S3Client: FakeS3Client,
+}));
+
+vi.mock('~/utils/file-utils', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  fetchBlob: (...args: unknown[]) => mockFetchBlob(...args),
+}));
+
+vi.mock('~/server/http/orchestrator/flagged-consumers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getConsumerStrikes: (...args: unknown[]) => mockGetConsumerStrikes(...args),
+}));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isFlipt: (...args: unknown[]) => mockIsFlipt(...args),
+}));
+
+let mockFetchBlob: (...args: unknown[]) => unknown = () => null;
+let mockGetConsumerStrikes: (...args: unknown[]) => unknown = async () => [];
+let mockIsFlipt: (...args: unknown[]) => unknown = async () => false;
+
+import { archiveCsamDataForReport } from '~/server/services/csam.service-new';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { setEnv } from '~/__tests__/mocks/env.mock';
+import { FLIPT_FEATURE_FLAGS } from '~/server/flipt/client';
+import { S3_MIN_PART_SIZE_BYTES } from '~/server/utils/archive-helpers';
+
+// ---------------------------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * Entry payloads must be INCOMPRESSIBLE, and this is the load-bearing detail of the fixture.
+ *
+ * The archives are written at deflate level 1, but a run of identical bytes still compresses
+ * ~1000:1 — a fixture built with `Buffer.alloc(n, 0xab)` produces a few-KB zip that goes up as a
+ * single `PutObject`, and every multipart assertion in this file would then pass vacuously while
+ * measuring nothing. Pseudo-random bytes keep the zip roughly the size of its inputs.
+ *
+ * Deterministic per index, and cached, so the two runs being compared are fed byte-identical
+ * input. A comparison of two runs over two different inputs proves nothing.
+ */
+const entryBytesCache = new Map<number, Buffer>();
+function entryBytes(index: number): Buffer {
+  const cached = entryBytesCache.get(index);
+  if (cached) return cached;
+  const out = Buffer.allocUnsafe(ENTRY_BYTES);
+  // xorshift32, seeded off the index so entry N is the same bytes in every run.
+  let x = (index * 2654435761 + 12345) >>> 0 || 1;
+  for (let i = 0; i < ENTRY_BYTES; i++) {
+    x ^= x << 13;
+    x >>>= 0;
+    x ^= x >>> 17;
+    x ^= x << 5;
+    x >>>= 0;
+    out[i] = x & 0xff;
+  }
+  entryBytesCache.set(index, out);
+  return out;
+}
+
+/**
+ * 73 entries of 192 KiB is ~13.7 MiB of incompressible payload, which is ~2.7x the 5 MiB minimum
+ * part size — so the upload splits into 3 parts and the test sees real multipart behaviour
+ * including a short final part. Both figures are deliberately non-round and the total is
+ * deliberately not a whole multiple of the part size: a fixture that lands exactly on a part
+ * boundary never exercises the short-final-part path.
+ */
+const ENTRY_COUNT = 73;
+const ENTRY_BYTES = 192 * 1024;
+
+function fakeBlob(index: number) {
+  const buffer = entryBytes(index);
+  return {
+    type: 'image/jpeg',
+    arrayBuffer: async () =>
+      buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+  };
+}
+
+/** Name the service derives for image row `i` — `picture-<i>.jpeg` minus its extension, plus the blob's. */
+const entryNameForIndex = (index: number) => `picture-${index}.jpeg`;
+
+type InventoryEntry = { name: string; size: number; sha256: string };
+
+/**
+ * The comparable content of an archive: what is in it, how big each thing is, and what each
+ * thing's bytes are. Everything a zip records ABOUT an entry that is not its content — the
+ * per-entry modification time above all — is excluded, because it legitimately differs between
+ * two correct runs and would make a byte-comparison of the archives useless.
+ */
+async function zipInventory(bytes: Buffer): Promise<InventoryEntry[]> {
+  const zip = await JSZip.loadAsync(bytes);
+  const out: InventoryEntry[] = [];
+  for (const name of Object.keys(zip.files).sort()) {
+    const file = zip.files[name];
+    if (file.dir) continue;
+    const content = await file.async('nodebuffer');
+    out.push({
+      name,
+      size: content.length,
+      sha256: createHash('sha256').update(content).digest('hex'),
+    });
+  }
+  return out;
+}
+
+/** What the inventory MUST be, derived from the fixture rather than from either code path. */
+function expectedInventory(): InventoryEntry[] {
+  return Array.from({ length: ENTRY_COUNT }, (_, i) => ({
+    name: entryNameForIndex(i),
+    size: ENTRY_BYTES,
+    sha256: createHash('sha256').update(entryBytes(i)).digest('hex'),
+  })).sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}
+
+const report = {
+  id: 4242,
+  userId: 909090,
+  reportedById: 5,
+  reportId: 77,
+  type: 'Image',
+  details: {},
+  images: [],
+};
+
+function seedDb() {
+  const rows = Array.from({ length: ENTRY_COUNT }, (_, i) => ({
+    id: i + 1,
+    url: `image-uuid-${i}`,
+    name: entryNameForIndex(i),
+    type: 'image',
+    width: 1024,
+    userId: report.userId,
+  }));
+  dbMock.dbRead.image.findMany.mockImplementation(
+    async (args: { where?: { id?: { gt?: number } }; take?: number } = {}) => {
+      const after = args.where?.id?.gt ?? 0;
+      return rows.filter((r) => r.id > after).slice(0, args.take ?? rows.length);
+    }
+  );
+  dbMock.dbRead.image.count.mockResolvedValue(ENTRY_COUNT);
+  dbMock.dbRead.user.findUnique.mockResolvedValue({
+    id: report.userId,
+    name: 'n',
+    email: 'e',
+    username: 'u',
+  });
+  dbMock.dbRead.model.findMany.mockResolvedValue([]);
+  dbMock.dbRead.modelVersion.findMany.mockResolvedValue([]);
+  dbMock.dbWrite.csamReport.update.mockResolvedValue({});
+}
+
+/** Runs one full archive, with the streaming flag in the given state, and returns the stored zip. */
+async function runArchive(streaming: boolean) {
+  storedObjects.clear();
+  pendingUploads.clear();
+  const flagsSeen: unknown[] = [];
+  mockIsFlipt = async (flag: unknown) => {
+    flagsSeen.push(flag);
+    return flag === FLIPT_FEATURE_FLAGS.CSAM_ARCHIVE_STREAM_UPLOAD ? streaming : false;
+  };
+
+  await archiveCsamDataForReport(report as never);
+
+  const stored = storedObjects.get('images.zip');
+  return { stored, flagsSeen };
+}
+
+beforeEach(() => {
+  storedObjects.clear();
+  pendingUploads.clear();
+  mockFetchBlob = async (url: unknown) => {
+    const match = /image-uuid-(\d+)/.exec(String(url));
+    if (!match) return null;
+    return fakeBlob(Number(match[1]));
+  };
+  mockGetConsumerStrikes = async () => [];
+  mockIsFlipt = async () => false;
+  setEnv({
+    CSAM_UPLOAD_KEY: 'test-key',
+    CSAM_UPLOAD_SECRET: 'test-secret',
+    CSAM_UPLOAD_REGION: 'test-region',
+    CSAM_UPLOAD_ENDPOINT: 'https://example.invalid',
+    CSAM_BUCKET_NAME: 'test-bucket',
+  });
+  seedDb();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+afterAll(() => {
+  fs.rmSync(path.dirname(csamBaseDir), { recursive: true, force: true });
+});
+
+describe('csam archive streaming upload', () => {
+  it('produces a content inventory identical to the disk-staged path, over a real multipart upload', async () => {
+    const disk = await runArchive(false);
+    const streamed = await runArchive(true);
+
+    // ---- Positive controls, first. Every claim below is about the content of these objects; if
+    // either is missing the comparison is between two `undefined`s and passes for the wrong reason.
+    expect(
+      disk.stored,
+      'the disk-staged path stored no images.zip — probe wired to nothing'
+    ).toBeDefined();
+    expect(
+      streamed.stored,
+      'the streaming path stored no images.zip — probe wired to nothing'
+    ).toBeDefined();
+    expect(disk.stored!.body.length).toBeGreaterThan(0);
+    expect(streamed.stored!.body.length).toBeGreaterThan(0);
+
+    // ---- The flag was actually consulted. Without this, a wiring mistake that never reads the
+    // flag makes both runs take the same path and the equivalence assertion is a tautology.
+    expect(disk.flagsSeen).toContain(FLIPT_FEATURE_FLAGS.CSAM_ARCHIVE_STREAM_UPLOAD);
+    expect(streamed.flagsSeen).toContain(FLIPT_FEATURE_FLAGS.CSAM_ARCHIVE_STREAM_UPLOAD);
+
+    // ---- Multipart really happened. `partCount === 0` means a single-shot PutObject, i.e. the
+    // fixture compressed away and this file proves nothing about part splitting or reassembly.
+    expect(
+      streamed.stored!.partCount,
+      'the streaming upload was single-shot — the fixture is too small or too compressible to exercise multipart'
+    ).toBeGreaterThanOrEqual(2);
+    expect(disk.stored!.partCount).toBeGreaterThanOrEqual(2);
+    // Every part but the last is exactly one part size, and the last is short. That is the shape
+    // S3 requires, and it pins that the geometry chosen really reached the uploader.
+    const streamedParts = streamed.stored!.partSizes;
+    for (const size of streamedParts.slice(0, -1)) expect(size).toBe(S3_MIN_PART_SIZE_BYTES);
+    expect(streamedParts.at(-1)).toBeLessThanOrEqual(S3_MIN_PART_SIZE_BYTES);
+
+    const diskInventory = await zipInventory(disk.stored!.body);
+    const streamedInventory = await zipInventory(streamed.stored!.body);
+
+    // ---- The absolute check. Comparing the two paths to each other cannot see a defect they
+    // SHARE; this compares each to the bytes the fixture generated, which neither path produced.
+    const expected = expectedInventory();
+    expect(diskInventory).toEqual(expected);
+    expect(streamedInventory).toEqual(expected);
+
+    // ---- The equivalence claim itself.
+    expect(streamedInventory).toEqual(diskInventory);
+  });
+
+  it('never opens a local write stream for the archive when streaming', async () => {
+    // The whole point of the change is that the archive does not touch the scratch volume, and
+    // an inventory comparison cannot see that — a path that staged to disk AND streamed would
+    // pass every assertion above. This pins the disk write itself.
+    const writeStreamSpy = vi.spyOn(fs, 'createWriteStream');
+
+    await runArchive(true);
+    const streamedArchiveWrites = writeStreamSpy.mock.calls.filter((call) =>
+      String(call[0]).endsWith('_images.zip')
+    );
+
+    writeStreamSpy.mockClear();
+    await runArchive(false);
+    const diskArchiveWrites = writeStreamSpy.mock.calls.filter((call) =>
+      String(call[0]).endsWith('_images.zip')
+    );
+
+    // Positive control on the spy: the disk path MUST show a write, or a spy wired to nothing
+    // would report zero for both runs and the real assertion would pass vacuously.
+    expect(
+      diskArchiveWrites.length,
+      'the disk path opened no write stream — the spy is wired to nothing'
+    ).toBe(1);
+    expect(streamedArchiveWrites.length).toBe(0);
+  });
+
+  it('leaves the flag default OFF, so an unreachable Flipt keeps the disk path', async () => {
+    // `isFlipt` returns false for an unknown flag or an unreachable Flipt. Reproduce that state
+    // rather than asserting the enum value, so this fails if the gate is ever inverted.
+    mockIsFlipt = async () => false;
+    const writeStreamSpy = vi.spyOn(fs, 'createWriteStream');
+
+    await archiveCsamDataForReport(report as never);
+
+    expect(
+      writeStreamSpy.mock.calls.filter((c) => String(c[0]).endsWith('_images.zip')).length
+    ).toBe(1);
+    expect(storedObjects.get('images.zip')).toBeDefined();
+  });
+
+  it('surfaces an upload failure on the streaming path instead of hanging', async () => {
+    // A failed upload stops draining the PassThrough. Without the explicit destroy in
+    // `archiveAndUpload`, `finalize()`'s wait for the sink to close never settles and the report
+    // hangs forever rather than failing — the worst of the available outcomes for a job.
+    const failure = new Error('multipart upload rejected');
+    const realSend = FakeS3Client.prototype.send;
+    vi.spyOn(FakeS3Client.prototype, 'send').mockImplementation(async function (
+      this: FakeS3Client,
+      command: Parameters<typeof realSend>[0]
+    ) {
+      if (command.constructor.name === 'UploadPartCommand') throw failure;
+      return realSend.call(this, command);
+    });
+
+    mockIsFlipt = async (flag: unknown) => flag === FLIPT_FEATURE_FLAGS.CSAM_ARCHIVE_STREAM_UPLOAD;
+
+    await expect(archiveCsamDataForReport(report as never)).rejects.toThrow(/images\.zip/);
+  }, 20_000);
+});

--- a/src/server/services/__tests__/csam-archive-stream-upload.test.ts
+++ b/src/server/services/__tests__/csam-archive-stream-upload.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto';
 import fs from 'fs';
 import path from 'path';
+import { Writable } from 'stream';
 import JSZip from 'jszip';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -191,7 +192,7 @@ import { archiveCsamDataForReport } from '~/server/services/csam.service-new';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { setEnv } from '~/__tests__/mocks/env.mock';
 import { FLIPT_FEATURE_FLAGS } from '~/server/flipt/client';
-import { S3_MIN_PART_SIZE_BYTES } from '~/server/utils/archive-helpers';
+import { MAX_UPLOAD_QUEUE_SIZE, S3_MIN_PART_SIZE_BYTES } from '~/server/utils/archive-helpers';
 
 // ---------------------------------------------------------------------------------------------
 // Fixture
@@ -236,6 +237,29 @@ function entryBytes(index: number): Buffer {
  */
 const ENTRY_COUNT = 73;
 const ENTRY_BYTES = 192 * 1024;
+
+/**
+ * 🔴 Fixture size for the anti-hang probe, and the ONLY thing that makes that probe able to
+ * observe anything at all.
+ *
+ * `Upload` pulls eagerly: it absorbs roughly `queueSize * partSize` — `MAX_UPLOAD_QUEUE_SIZE x
+ * S3_MIN_PART_SIZE_BYTES` = 20 MiB at the default geometry — out of the `PassThrough` before it
+ * stops reading. An archive SMALLER than that window is fully absorbed and fully appended before
+ * the upload's first part can fail, so nothing is ever parked on the pending-entry ceiling and
+ * the report fails correctly whether or not the producer is actually stopped. Measured: at
+ * `ENTRY_COUNT` (73 x 192 KiB = 13.7 MiB) the probe settles in under a second against code with
+ * the hang fully present. It was testing nothing.
+ *
+ * 160 x 192 KiB = 30 MiB is comfortably past that window, so the archiver is still mid-archive
+ * with `append()` callers parked when the upload rejects — which is the state the defect strands
+ * forever. Asserted in the test rather than trusted from this comment, because the window moves
+ * if either geometry constant changes.
+ *
+ * Wall clock, measured on this file: the two anti-hang probes cost ~0.7 s of ~5 s of test time
+ * across 8 tests. Most of the larger fixture is free because `entryBytes` caches per index and
+ * the first three tests have already generated indices 0..72.
+ */
+const HANG_PROBE_ENTRY_COUNT = 160;
 
 function fakeBlob(index: number) {
   const buffer = entryBytes(index);
@@ -292,8 +316,8 @@ const report = {
   images: [],
 };
 
-function seedDb() {
-  const rows = Array.from({ length: ENTRY_COUNT }, (_, i) => ({
+function seedDb(entryCount: number = ENTRY_COUNT) {
+  const rows = Array.from({ length: entryCount }, (_, i) => ({
     id: i + 1,
     url: `image-uuid-${i}`,
     name: entryNameForIndex(i),
@@ -307,7 +331,7 @@ function seedDb() {
       return rows.filter((r) => r.id > after).slice(0, args.take ?? rows.length);
     }
   );
-  dbMock.dbRead.image.count.mockResolvedValue(ENTRY_COUNT);
+  dbMock.dbRead.image.count.mockResolvedValue(entryCount);
   dbMock.dbRead.user.findUnique.mockResolvedValue({
     id: report.userId,
     name: 'n',
@@ -333,6 +357,38 @@ async function runArchive(streaming: boolean) {
 
   const stored = storedObjects.get('images.zip');
   return { stored, flagsSeen };
+}
+
+/**
+ * Deadline for the two anti-hang probes, and the runner timeout that has to sit above it.
+ *
+ * Raced against a timer rather than left to the runner's own timeout, so that a hang reports as
+ * the named outcome `'HUNG'` with a message attached instead of as an anonymous "test timed out",
+ * which reads like a slow fixture rather than like the defect. These archives settle in about a
+ * second when the producer is actually stopped, so 30 s is not a timing assertion — it is the
+ * difference between settling and never settling.
+ */
+const HANG_DEADLINE_MS = 30_000;
+const HANG_TEST_TIMEOUT_MS = 90_000;
+
+/** Runs one report and reports whether it SETTLED at all, rather than waiting on it forever. */
+async function settleOrHang(reportArg: unknown) {
+  let timer: NodeJS.Timeout | undefined;
+  let thrown: unknown;
+  const outcome = await Promise.race([
+    archiveCsamDataForReport(reportArg as never).then(
+      () => 'resolved' as const,
+      (e: unknown) => {
+        thrown = e;
+        return 'rejected' as const;
+      }
+    ),
+    new Promise<'HUNG'>((resolve) => {
+      timer = setTimeout(() => resolve('HUNG'), HANG_DEADLINE_MS);
+    }),
+  ]);
+  if (timer) clearTimeout(timer);
+  return { outcome, thrown };
 }
 
 beforeEach(() => {
@@ -453,24 +509,194 @@ describe('csam archive streaming upload', () => {
     expect(storedObjects.get('images.zip')).toBeDefined();
   });
 
-  it('surfaces an upload failure on the streaming path instead of hanging', async () => {
-    // A failed upload stops draining the PassThrough. Without the explicit destroy in
-    // `archiveAndUpload`, `finalize()`'s wait for the sink to close never settles and the report
-    // hangs forever rather than failing — the worst of the available outcomes for a job.
-    const failure = new Error('multipart upload rejected');
-    const realSend = FakeS3Client.prototype.send;
-    vi.spyOn(FakeS3Client.prototype, 'send').mockImplementation(async function (
-      this: FakeS3Client,
-      command: Parameters<typeof realSend>[0]
-    ) {
-      if (command.constructor.name === 'UploadPartCommand') throw failure;
-      return realSend.call(this, command);
-    });
+  // -------------------------------------------------------------------------------------------
+  // "The rollback is a flag flip" — only true if the flag-OFF path behaves as it did before this
+  // change. TWO things arrived with it and both have to be gated, not just the choice of sink:
+  // the `image.count` round trip, and the derived part geometry it feeds.
+  //
+  // 🔴 DELIBERATELY TWO TESTS, NOT ONE. Written as a single test the two assertions are not
+  // independently reachable: the count gate ALONE is enough to keep an estimate away from the
+  // disk path on the images route, so the geometry assertion sits downstream of a check that
+  // already failed and can never be observed dying on its own. Measured — un-gating only the
+  // `expectedBytes` argument left a combined test GREEN. Splitting them, and routing the
+  // geometry one through `generated-images` (whose caller passes an estimate unconditionally,
+  // with no count query in front of it), makes each die to its own mutation.
+  // -------------------------------------------------------------------------------------------
 
+  it('🔴 issues no image-count round trip when the flag is OFF', async () => {
+    // The count is a new query against the main database bought solely to size upload parts. On
+    // the path that does not size parts it must not happen at all.
+    dbMock.dbRead.image.count.mockClear();
+    mockIsFlipt = async () => false;
+
+    await archiveCsamDataForReport(report as never);
+
+    expect(
+      storedObjects.get('images.zip'),
+      'the disk path stored no images.zip — probe wired to nothing'
+    ).toBeDefined();
+    expect(
+      dbMock.dbRead.image.count.mock.calls.length,
+      'the flag-off path issued the image count query that only the streaming geometry needs'
+    ).toBe(0);
+
+    // ---- Positive control, in-band. A zero is indistinguishable from a counter wired to
+    // nothing, so the SAME counter has to be shown moving on the path that does need it.
+    storedObjects.clear();
+    pendingUploads.clear();
+    dbMock.dbRead.image.count.mockClear();
     mockIsFlipt = async (flag: unknown) => flag === FLIPT_FEATURE_FLAGS.CSAM_ARCHIVE_STREAM_UPLOAD;
 
-    await expect(archiveCsamDataForReport(report as never)).rejects.toThrow(/images\.zip/);
-  }, 20_000);
+    await archiveCsamDataForReport(report as never);
+
+    expect(
+      dbMock.dbRead.image.count.mock.calls.length,
+      'the streaming path did not issue the count query either — the zero asserted above is a ' +
+        'fact about the spy, not about the gate'
+    ).toBe(1);
+  }, 30_000);
+
+  it('🔴 keeps the flag-OFF path on the pre-change fixed part geometry', async () => {
+    // Routed through `generated-images` because its caller derives `expectedBytes` from an array
+    // length it already has and passes it WHATEVER the flag says — so `archiveAndUpload`'s disk
+    // branch dropping it is the only thing standing between the rollback path and a derived part
+    // size. That makes this assertion reachable, which the images route does not.
+    //
+    // Made OBSERVABLE by a large estimate over a small archive: `expectedBytes` counts every URL,
+    // while only the ones that actually fetch become entries. At ~1.4 MiB/entry x 30,000 URLs the
+    // derived part size is ~17 MiB — larger than the ~14 MiB archive — so a leaked estimate
+    // collapses the upload to a single part (or a one-shot `PutObject`, `partCount === 0`).
+    // The fixed 5 MiB geometry gives several parts instead.
+    const REAL_URLS = ENTRY_COUNT;
+    const TOTAL_URLS = 30_000;
+    const urls = Array.from({ length: TOTAL_URLS }, (_, i) =>
+      i < REAL_URLS
+        ? `https://example.invalid/image-uuid-${i}`
+        : `https://example.invalid/absent-${i}`
+    );
+    mockGetConsumerStrikes = async () => [
+      { strikes: [{ job: { blobs: urls.map((previewUrl) => ({ previewUrl })) } }] },
+    ];
+    mockIsFlipt = async () => false;
+
+    await archiveCsamDataForReport({ ...report, type: 'GeneratedImage' } as never);
+
+    const stored = storedObjects.get('generated-images.zip');
+    expect(
+      stored,
+      'the disk path stored no generated-images.zip — probe wired to nothing'
+    ).toBeDefined();
+    // Positive control on the fixture: the archive has to be big enough that a leaked part size
+    // would actually change its shape. An empty archive would satisfy the assertion below by
+    // accident.
+    expect(stored!.body.length).toBeGreaterThan(S3_MIN_PART_SIZE_BYTES);
+
+    expect(
+      stored!.partCount,
+      `the flag-off path uploaded in ${stored!.partCount} part(s) — it was handed a part size ` +
+        'derived from the size estimate instead of the fixed 5 MiB it used before this change, ' +
+        'so "rollback is a flag flip" is false on the dimension that caused the eviction'
+    ).toBeGreaterThanOrEqual(2);
+    for (const size of stored!.partSizes.slice(0, -1)) expect(size).toBe(S3_MIN_PART_SIZE_BYTES);
+  }, 30_000);
+
+  it(
+    '🔴 surfaces an upload failure MID-ARCHIVE instead of hanging the report',
+    async () => {
+      // THE REGRESSION. A failed upload stops draining the `PassThrough`, so the producer has to be
+      // stopped explicitly or the archiver's parked `append()` callers are never released and the
+      // report hangs forever rather than failing — the worst of the available outcomes for a job,
+      // and the outcome (evidence archival stalled indefinitely) this whole change exists to end.
+      //
+      // 🔴 THE FIXTURE SIZE IS THE TEST. At `ENTRY_COUNT` this probe is VACUOUS: the uploader
+      // absorbs the entire archive before its first part can fail, so the producer is already done
+      // and there is nothing to strand. Asserted, not assumed — if a future geometry change widens
+      // the absorption window past the fixture, this fails loudly instead of going quietly
+      // meaningless.
+      const absorbedBeforeStalling = MAX_UPLOAD_QUEUE_SIZE * S3_MIN_PART_SIZE_BYTES;
+      expect(
+        HANG_PROBE_ENTRY_COUNT * ENTRY_BYTES,
+        `fixture (${
+          HANG_PROBE_ENTRY_COUNT * ENTRY_BYTES
+        } bytes) no longer exceeds what the uploader ` +
+          `absorbs before it stops reading (${absorbedBeforeStalling} bytes) — this probe cannot ` +
+          `observe a stalled producer and proves nothing`
+      ).toBeGreaterThan(absorbedBeforeStalling);
+
+      seedDb(HANG_PROBE_ENTRY_COUNT);
+
+      const failure = new Error('multipart upload rejected');
+      const realSend = FakeS3Client.prototype.send;
+      vi.spyOn(FakeS3Client.prototype, 'send').mockImplementation(async function (
+        this: FakeS3Client,
+        command: Parameters<typeof realSend>[0]
+      ) {
+        if (command.constructor.name === 'UploadPartCommand') throw failure;
+        return realSend.call(this, command);
+      });
+
+      mockIsFlipt = async (flag: unknown) =>
+        flag === FLIPT_FEATURE_FLAGS.CSAM_ARCHIVE_STREAM_UPLOAD;
+
+      const { outcome, thrown } = await settleOrHang(report);
+
+      expect(
+        outcome,
+        'the report never settled — an upload that fails mid-archive leaves the archiver alive with ' +
+          'its pending-entry waiters parked forever, which is the defect this pins'
+      ).toBe('rejected');
+      expect((thrown as Error).message).toMatch(/images\.zip/);
+    },
+    HANG_TEST_TIMEOUT_MS
+  );
+
+  it(
+    '🔴 surfaces a SINK failure mid-archive on the flag-OFF path instead of hanging',
+    async () => {
+      // THE SAME DEFECT ON THE ROLLBACK TARGET, and the reason it matters: the flag-off path stages
+      // to the container's scratch volume, so its sink fails mid-archive exactly when that volume
+      // fills — which is this incident's own condition. A rollback target that hangs is not a
+      // rollback, so both sinks have to carry a producer-stopping link, not just the streaming one.
+      //
+      // Same size reasoning as the probe above: the sink accepts 1 MiB before failing, so the
+      // archiver is still mid-archive with `append()` callers parked when it does.
+      seedDb(HANG_PROBE_ENTRY_COUNT);
+      mockIsFlipt = async () => false;
+
+      const sinkFailure = new Error('simulated sink failure: no space left on device');
+      const realCreateWriteStream = fs.createWriteStream;
+      vi.spyOn(fs, 'createWriteStream').mockImplementation(((
+        target: unknown,
+        ...rest: unknown[]
+      ) => {
+        // Only the media archive's sink is replaced. `data.json` still goes through a real write
+        // stream, so the run reaches the archive step the way it normally would.
+        if (!String(target).endsWith('_images.zip'))
+          return (realCreateWriteStream as (...a: unknown[]) => unknown)(target, ...rest);
+        let accepted = 0;
+        return new Writable({
+          write(chunk: Buffer, _encoding, callback) {
+            accepted += chunk.length;
+            if (accepted > 1024 * 1024) return callback(sinkFailure);
+            callback();
+          },
+        });
+      }) as never);
+
+      const { outcome, thrown } = await settleOrHang(report);
+
+      expect(
+        outcome,
+        'the report never settled — a write stream that dies mid-archive leaves the archiver alive ' +
+          'with its pending-entry waiters parked forever, so a full scratch volume stalls the ' +
+          'report instead of failing it'
+      ).toBe('rejected');
+      // The sink's own error is what should come out: nothing downstream reinterprets it, and it is
+      // the only thing that names the real fault.
+      expect((thrown as Error).message).toBe(sinkFailure.message);
+    },
+    HANG_TEST_TIMEOUT_MS
+  );
 
   it('reports the ORIGINAL failure when the archive fails, not the upload it knocks over', async () => {
     // Tearing the sink down to fail the report also makes the in-flight upload fail, so BOTH

--- a/src/server/services/__tests__/csam-archive-stream-upload.test.ts
+++ b/src/server/services/__tests__/csam-archive-stream-upload.test.ts
@@ -471,4 +471,33 @@ describe('csam archive streaming upload', () => {
 
     await expect(archiveCsamDataForReport(report as never)).rejects.toThrow(/images\.zip/);
   }, 20_000);
+
+  it('reports the ORIGINAL failure when the archive fails, not the upload it knocks over', async () => {
+    // Tearing the sink down to fail the report also makes the in-flight upload fail, so BOTH
+    // errors exist by the time anything is rethrown. Reporting the upload's would bury every
+    // fetch/DB failure on this path behind a generic "failed to upload", pointing whoever reads
+    // the job log at object storage for a fault that was never there.
+    const failure = new Error('blob fetch exploded');
+    mockFetchBlob = async (url: unknown) => {
+      const match = /image-uuid-(\d+)/.exec(String(url));
+      if (!match) return null;
+      if (Number(match[1]) === 11) throw failure;
+      return fakeBlob(Number(match[1]));
+    };
+    mockIsFlipt = async (flag: unknown) => flag === FLIPT_FEATURE_FLAGS.CSAM_ARCHIVE_STREAM_UPLOAD;
+
+    const rejection = await archiveCsamDataForReport(report as never).then(
+      () => undefined,
+      (e: unknown) => e
+    );
+
+    // Positive control: something must actually have failed, or both assertions below are
+    // assertions about `undefined`.
+    expect(
+      rejection,
+      'the archive did not fail — the fault injection is wired to nothing'
+    ).toBeDefined();
+    expect((rejection as Error).message).toBe(failure.message);
+    expect((rejection as Error).message).not.toMatch(/failed to upload/);
+  }, 20_000);
 });

--- a/src/server/services/__tests__/csam-archive-stream-upload.test.ts
+++ b/src/server/services/__tests__/csam-archive-stream-upload.test.ts
@@ -629,6 +629,14 @@ describe('csam archive streaming upload', () => {
       // while the default-geometry form still reads 20 MiB and stays green with the hang fully
       // reintroduced. Measured: that two-part mutation left all 8 tests in this file passing
       // against the default form, and fails HERE against the derived one.
+      //
+      // ⚠️ It is still a SECOND COPY of the service's estimate expression (`archiveImages` passes
+      // `imageCount * ESTIMATED_BYTES_PER_ARCHIVED_IMAGE`), not an observation of the geometry the
+      // run used — the check has to hold before the run starts, and the derived pair goes straight
+      // into the real SDK `Upload` inside the service, where the fake client never sees
+      // `queueSize`. The imported constants keep the two copies in step, so a constant change is
+      // covered; a change to the EXPRESSION is not, and would leave this guard bounding a run that
+      // no longer happens.
       const absorbedBeforeStalling = deriveUploadPartGeometry({
         expectedBytes: HANG_PROBE_ENTRY_COUNT * ESTIMATED_BYTES_PER_ARCHIVED_IMAGE,
       }).worstCaseResidentBytes;

--- a/src/server/services/csam.service-new.ts
+++ b/src/server/services/csam.service-new.ts
@@ -40,11 +40,15 @@ import {
   IPEventName,
 } from '@civitai/cybertipline-tools';
 import { Limiter } from '~/server/utils/concurrency-helpers';
+import type { BoundedArchive } from '~/server/utils/archive-helpers';
 import {
   createBoundedArchive,
+  deriveUploadPartGeometry,
+  ESTIMATED_BYTES_PER_ARCHIVED_IMAGE,
   MEDIA_ARCHIVE_COMPRESSION_LEVEL,
   zipEntryNameForUrl,
 } from '~/server/utils/archive-helpers';
+import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import type { JsonReplacer } from '~/server/utils/json-stream-helpers';
 import { writeJsonObject } from '~/server/utils/json-stream-helpers';
 import { getConsumerStrikes } from '~/server/http/orchestrator/flagged-consumers';
@@ -1059,10 +1063,22 @@ function uploadStream({
   stream: readStream,
   userId,
   filename,
+  expectedBytes,
 }: {
-  stream: fs.ReadStream;
+  /**
+   * Widened from `fs.ReadStream`. The streaming archive path pipes a `PassThrough` in here, which
+   * is a `Readable` but not an `fs.ReadStream`; nothing in this function ever used a file-specific
+   * member of the narrower type.
+   */
+  stream: Readable;
   userId: number;
   filename: string;
+  /**
+   * Rough expected size of the object, used only to size multipart parts. Omit it for small
+   * objects — see `deriveUploadPartGeometry`, which then reproduces the geometry this function
+   * used before part sizing existed.
+   */
+  expectedBytes?: number;
 }) {
   if (
     !env.CSAM_UPLOAD_KEY ||
@@ -1088,6 +1104,14 @@ function uploadStream({
   const Bucket = env.CSAM_BUCKET_NAME;
   const Key = `${userId}/${date.getTime()}_${filename}`;
 
+  // 🔴 MEMORY: `queueSize * partSize` is held resident by `Upload` while parts are in flight.
+  // The pair is derived together from a single budget rather than chosen independently, so that
+  // product is a constant (`UPLOAD_BUFFER_BUDGET_BYTES`, 256 MiB) regardless of how large the
+  // archive turns out to be. The previous fixed `partSize: 5 MiB` / `queueSize: 4` — 20 MiB
+  // resident — capped any object at 10,000 x 5 MiB = 48.8 GiB, which is the ceiling this
+  // replaces. With no estimate the derivation returns exactly that old pair.
+  const { partSize, queueSize } = deriveUploadPartGeometry({ expectedBytes });
+
   return new Promise<void>(async (resolve, reject) => {
     try {
       const parallelUploads3 = new Upload({
@@ -1097,8 +1121,8 @@ function uploadStream({
           Key,
           Body: passThroughStream,
         },
-        queueSize: 4,
-        partSize: 1024 * 1024 * 5, // 5 MB
+        queueSize,
+        partSize,
         leavePartsOnError: false,
       });
 
@@ -1207,9 +1231,125 @@ async function* flattenPages<T>(pages: AsyncIterable<T[]>): AsyncGenerator<T, vo
  *   0 further entries on node 26, 1 on node 24 (whichever was already in flight). So it does
  *   real work; it is just bounded work here, recorded as untested rather than as covered.
  */
-function closeArchiveOnFailure(archive: Archiver, output: fs.WriteStream) {
+function closeArchiveOnFailure(archive: Archiver, output: stream.Writable) {
   archive.abort();
   output.destroy();
+}
+
+/**
+ * Builds one media archive and uploads it, either by staging it on local disk first or by
+ * streaming it straight to object storage.
+ *
+ * WHY THIS EXISTS AS ONE FUNCTION: the two call sites (`images.zip`, `generated-images.zip`)
+ * previously duplicated the archiver/sink/bounded-appender/finalize/upload sequence verbatim, and
+ * this change would have duplicated a second variant of it on top. Both sites now run the SAME
+ * code, so the two paths cannot drift from each other and the equivalence proof covers both.
+ * Only the `append` callback differs between them.
+ *
+ * THE TWO PATHS, and what is identical across them:
+ *
+ * - `stream: false` (default, and what runs with the flag off) — the archive is written to
+ *   `diskPath` with `fs.createWriteStream`, then read back with `fs.createReadStream` and
+ *   uploaded. Unchanged from what shipped before, down to the ordering.
+ * - `stream: true` — the archiver is piped into a `PassThrough` that is handed directly to
+ *   `Upload`, so the bytes never touch the container's scratch volume. The archive is produced by
+ *   the same archiver, at the same compression level, through the same bounded appender, in the
+ *   same append order, so the two paths differ only in where the bytes land.
+ *
+ * 🔴 MEMORY: the streaming path does NOT buffer the archive. `PassThrough` applies normal stream
+ * backpressure, so the archiver stalls when the uploader is behind rather than accumulating. What
+ * IS resident is the uploader's in-flight parts, bounded by `deriveUploadPartGeometry`. The
+ * bounded appender's own guarantee is untouched — it is the same `createBoundedArchive` wrapper
+ * with the same ceiling, just handed a different sink.
+ */
+async function archiveAndUpload({
+  userId,
+  filename,
+  diskPath,
+  stream: streamToStorage,
+  expectedBytes,
+  append,
+}: {
+  userId: number;
+  filename: string;
+  /** Where the archive is staged when `stream` is false. Unused on the streaming path. */
+  diskPath: string;
+  stream: boolean;
+  expectedBytes?: number;
+  append: (archive: BoundedArchive) => Promise<void>;
+}) {
+  const archive = archiver('zip', { zlib: { level: MEDIA_ARCHIVE_COMPRESSION_LEVEL } });
+
+  if (!streamToStorage) {
+    const output = fs.createWriteStream(diskPath);
+    archive.pipe(output);
+    const boundedArchive = createBoundedArchive({ archive, output });
+
+    try {
+      await append(boundedArchive);
+      // Awaited: the read stream below opens a truncated (or absent) file otherwise.
+      await boundedArchive.finalize();
+    } catch (e) {
+      // Nothing past this point runs, and the caller's `catch` then `rmSync`s the report's scratch
+      // directory out from under a write stream that is still open on a file inside it. Release
+      // the archiver's queued sources and the sink's fd before letting the error out.
+      closeArchiveOnFailure(archive, output);
+      throw e;
+    }
+
+    const readableStream = fs.createReadStream(diskPath);
+    await uploadStream({ stream: readableStream, userId, filename, expectedBytes });
+    return;
+  }
+
+  const passThrough = new stream.PassThrough();
+  archive.pipe(passThrough);
+  const boundedArchive = createBoundedArchive({ archive, output: passThrough });
+
+  // 🔴 START THE UPLOAD BEFORE APPENDING ANYTHING. `PassThrough` has a small high-water mark, so
+  // with nothing draining it the first appends fill it and the archiver stalls forever. The
+  // consumer has to be attached first.
+  //
+  // 🔴 AND ATTACH A REJECTION HANDLER IMMEDIATELY. Between here and the `await` at the bottom,
+  // this promise is live and unobserved; an upload that fails mid-archive (credentials, network,
+  // the part limit) would otherwise be an unhandled rejection, which takes the whole job process
+  // down rather than failing this one report. Latch the error instead and re-surface it below.
+  let uploadError: unknown;
+  const uploadPromise = uploadStream({
+    stream: passThrough,
+    userId,
+    filename,
+    expectedBytes,
+  }).then(
+    () => undefined,
+    (e: unknown) => {
+      uploadError = e;
+      // Stop the producer. Without this the archiver keeps deflating into a `PassThrough` nobody
+      // is reading, and `finalize()`'s wait for the sink to close never settles — a failed upload
+      // would hang the report instead of failing it.
+      passThrough.destroy(e instanceof Error ? e : new Error(String(e)));
+    }
+  );
+
+  try {
+    await append(boundedArchive);
+    // Same contract as the disk path: resolves once the archive has ended AND the sink has
+    // closed. Here "the sink has closed" means the uploader has drained every byte.
+    await boundedArchive.finalize();
+  } catch (e) {
+    closeArchiveOnFailure(archive, passThrough);
+    // Settle the upload before rethrowing so nothing is left in flight, and prefer the upload's
+    // own error when it is the thing that failed — `e` is then just the downstream symptom.
+    await uploadPromise;
+    if (uploadError) throw uploadError;
+    throw e;
+  }
+
+  // The upload is what decides the object is complete — `finalize()` only tells us the archive
+  // ended and the sink drained. Awaiting it here is what makes this function's resolution mean
+  // "the object is in storage", matching what the disk path's `await uploadStream(...)` means.
+  await uploadPromise;
+  if (uploadError) throw uploadError;
 }
 
 /** Serialises `bigint` columns (e.g. `Image.pHash`) as strings — `JSON.stringify` throws on them. */
@@ -1244,6 +1384,25 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
   for (const dir of Object.values(reportDirs)) {
     createDir(dir);
   }
+
+  /**
+   * Whether the two large media archives are streamed straight to object storage instead of being
+   * staged on the container's scratch volume first.
+   *
+   * 🔴 EVALUATED ONCE PER REPORT, DELIBERATELY. Reading the flag inside each archive function
+   * would let a mid-report flip produce a bundle whose parts were assembled two different ways,
+   * for no benefit — a report is short-lived and the two archive types are mutually exclusive
+   * anyway. One read also means one Flipt failure mode rather than two.
+   *
+   * DEFAULT-OFF: `isFlipt` returns false for an unknown flag, an unreachable Flipt, or a flag
+   * pinned disabled — all of which leave the disk-staging path, which is unchanged and stays
+   * reachable, in charge. That is the rollback: flip the flag off, no deploy.
+   *
+   * `data.json` and `training-data.zip` are NOT affected by this flag. The first is small; the
+   * second is a file this code downloads rather than builds, and the NCMEC submission path reads
+   * it back off disk, so neither has the disk ceiling this removes.
+   */
+  const streamArchivesToStorage = await isFlipt(FLIPT_FEATURE_FLAGS.CSAM_ARCHIVE_STREAM_UPLOAD);
 
   /**
    * A fresh keyset-paged scan of every image the reported user owns.
@@ -1423,73 +1582,62 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
     await uploadStream({ stream: readableStream, userId, filename: 'data.json' });
   }
 
-  // writes a zip file to disk before adding user images directly to the zip file
+  /**
+   * Archives every image the reported user owns.
+   *
+   * The archive is either staged on disk and then uploaded, or streamed straight to storage —
+   * see `archiveAndUpload`. The append loop below is identical either way; that is the point.
+   */
   async function archiveImages() {
     const { userId } = report;
 
-    const outPath = `${reportDirs.images}/${userId}_images.zip`;
+    // Feeds multipart part sizing ONLY. A `count` is a separate round trip from the paged scan
+    // because `partSize` has to be fixed before the first byte is uploaded, and the scan does not
+    // know its own total until it has finished. An inaccurate — or absent — answer degrades to
+    // the default geometry rather than breaking anything; see `deriveUploadPartGeometry`.
+    const imageCount = await dbRead.image.count({ where: { userId } });
 
-    const archive = archiver('zip', { zlib: { level: MEDIA_ARCHIVE_COMPRESSION_LEVEL } });
-    const output = fs.createWriteStream(outPath);
+    await archiveAndUpload({
+      userId,
+      filename: 'images.zip',
+      diskPath: `${reportDirs.images}/${userId}_images.zip`,
+      stream: streamArchivesToStorage,
+      expectedBytes: imageCount * ESTIMATED_BYTES_PER_ARCHIVED_IMAGE,
+      append: async (boundedArchive) => {
+        // concurrency limiter
+        const maxWidth = MAX_POST_IMAGES_WIDTH;
+        const limit = plimit(10);
+        // Paged rather than `images.map(...)` over one array of every row the user owns: the row
+        // set is unbounded, and materialising it was half of the memory problem this file exists
+        // to fix. Concurrency within a page is unchanged (10); pages are processed in order.
+        for await (const page of scanUserImages()) {
+          await Promise.all(
+            page.map((image) => {
+              return limit(async () => {
+                const width = image.width ?? maxWidth;
+                const blob = await fetchBlob(
+                  getEdgeUrl(image.url, {
+                    type: image.type,
+                    width: width < maxWidth ? width : maxWidth,
+                  })
+                );
+                if (!blob) return;
+                const arrayBuffer = await blob.arrayBuffer();
+                const buffer = Buffer.from(arrayBuffer);
 
-    archive.pipe(output);
+                const imageName = image.name
+                  ? image.name.substring(0, image.name.lastIndexOf('.'))
+                  : image.url;
+                const name = imageName.length ? imageName : image.url;
+                const filename = `${name}.${blob.type.split('/').pop() as string}`;
 
-    // Bounds the number of downloaded-but-not-yet-compressed images held in memory. Without it,
-    // every image a user owns is buffered at once and memory tracks total downloaded bytes.
-    const boundedArchive = createBoundedArchive({ archive, output });
-
-    // concurrency limiter
-    const maxWidth = MAX_POST_IMAGES_WIDTH;
-    const limit = plimit(10);
-    try {
-      // Paged rather than `images.map(...)` over one array of every row the user owns: the row
-      // set is unbounded, and materialising it was half of the memory problem this file exists
-      // to fix. Concurrency within a page is unchanged (10); pages are processed in order.
-      for await (const page of scanUserImages()) {
-        await Promise.all(
-          page.map((image) => {
-            return limit(async () => {
-              const width = image.width ?? maxWidth;
-              const blob = await fetchBlob(
-                getEdgeUrl(image.url, {
-                  type: image.type,
-                  width: width < maxWidth ? width : maxWidth,
-                })
-              );
-              if (!blob) return;
-              const arrayBuffer = await blob.arrayBuffer();
-              const buffer = Buffer.from(arrayBuffer);
-
-              const imageName = image.name
-                ? image.name.substring(0, image.name.lastIndexOf('.'))
-                : image.url;
-              const name = imageName.length ? imageName : image.url;
-              const filename = `${name}.${blob.type.split('/').pop() as string}`;
-
-              await boundedArchive.append(buffer, { name: filename });
-            });
-          })
-        );
-      }
-      // Awaited: the read stream below opens a truncated (or absent) file otherwise.
-      await boundedArchive.finalize();
-    } catch (e) {
-      // Nothing past this point runs, and the caller's `catch` then `rmSync`s `reportDirs.images`
-      // out from under a write stream that is still open on a file inside it. Release the
-      // archiver's queued sources and the sink's fd before letting the error out.
-      //
-      // Two things can land here. `fetchBlob`/`append` could already throw before this change.
-      // The DB read is new: paging pulls rows *inside* the archiver's lifetime, where the
-      // previous code fetched every row before any archiver existed, so a `dbRead` failure on
-      // page 2 or later is a trigger the old shape did not have. `abort()` is a documented no-op
-      // once the archive is aborted or finalized, and `destroy()` on a closed stream likewise, so
-      // this is safe whichever of them got furthest.
-      closeArchiveOnFailure(archive, output);
-      throw e;
-    }
-
-    const readableStream = fs.createReadStream(outPath);
-    await uploadStream({ stream: readableStream, userId, filename: 'images.zip' });
+                await boundedArchive.append(buffer, { name: filename });
+              });
+            })
+          );
+        }
+      },
+    });
   }
 
   async function archiveGeneratedImages() {
@@ -1501,49 +1649,37 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
       .filter(isDefined)
       .map((x) => x.previewUrl);
 
-    const outPath = `${reportDirs.generatedImages}/${userId}_generated-images.zip`;
+    await archiveAndUpload({
+      userId,
+      filename: 'generated-images.zip',
+      diskPath: `${reportDirs.generatedImages}/${userId}_generated-images.zip`,
+      stream: streamArchivesToStorage,
+      // Known upfront here, unlike `archiveImages` — no extra round trip needed. This is an upper
+      // bound: a URL whose fetch returns nothing is skipped, so the real archive can be smaller.
+      expectedBytes: imageUrls.length * ESTIMATED_BYTES_PER_ARCHIVED_IMAGE,
+      append: async (boundedArchive) => {
+        // concurrency limiter
+        const limit = plimit(10);
+        await Promise.all(
+          imageUrls.map((url, index) => {
+            return limit(async () => {
+              const blob = await fetchBlob(url);
+              if (!blob) return;
+              try {
+                const arrayBuffer = await blob.arrayBuffer();
+                const buffer = Buffer.from(arrayBuffer);
 
-    const archive = archiver('zip', { zlib: { level: MEDIA_ARCHIVE_COMPRESSION_LEVEL } });
-    const output = fs.createWriteStream(outPath);
+                const imageName = zipEntryNameForUrl(url, index);
 
-    archive.pipe(output);
-
-    // Same unbounded-append hazard as archiveImages above.
-    const boundedArchive = createBoundedArchive({ archive, output });
-
-    // concurrency limiter
-    const limit = plimit(10);
-    try {
-      await Promise.all(
-        imageUrls.map((url, index) => {
-          return limit(async () => {
-            const blob = await fetchBlob(url);
-            if (!blob) return;
-            try {
-              const arrayBuffer = await blob.arrayBuffer();
-              const buffer = Buffer.from(arrayBuffer);
-
-              const imageName = zipEntryNameForUrl(url, index);
-
-              await boundedArchive.append(buffer, { name: imageName });
-            } catch (e) {
-              //
-            }
-          });
-        })
-      );
-      // Awaited: the read stream below opens a truncated (or absent) file otherwise.
-      await boundedArchive.finalize();
-    } catch (e) {
-      // Same reasoning as `archiveImages` above. Note the inner `catch (e) {}` only covers the
-      // buffer/append step, so a `fetchBlob` rejection still reaches here, as does the error
-      // `finalize()` rethrows after the archiver has latched one.
-      closeArchiveOnFailure(archive, output);
-      throw e;
-    }
-
-    const readableStream = fs.createReadStream(outPath);
-    await uploadStream({ stream: readableStream, userId, filename: 'generated-images.zip' });
+                await boundedArchive.append(buffer, { name: imageName });
+              } catch (e) {
+                //
+              }
+            });
+          })
+        );
+      },
+    });
   }
 
   // downloads training data zip file, writes it to disk, and then uploads that zip

--- a/src/server/services/csam.service-new.ts
+++ b/src/server/services/csam.service-new.ts
@@ -1104,11 +1104,12 @@ function uploadStream({
   const Bucket = env.CSAM_BUCKET_NAME;
   const Key = `${userId}/${date.getTime()}_${filename}`;
 
-  // 🔴 MEMORY: `queueSize * partSize` is held resident by `Upload` while parts are in flight.
-  // The pair is derived together from a single budget rather than chosen independently, so that
-  // product is a constant (`UPLOAD_BUFFER_BUDGET_BYTES`, 256 MiB) regardless of how large the
-  // archive turns out to be. The previous fixed `partSize: 5 MiB` / `queueSize: 4` — 20 MiB
-  // resident — capped any object at 10,000 x 5 MiB = 48.8 GiB, which is the ceiling this
+  // 🔴 MEMORY: `Upload` holds up to `queueSize` parts of `partSize` bytes in flight. The pair is
+  // derived together from a single budget rather than chosen independently, so that PRODUCT is a
+  // constant (`UPLOAD_BUFFER_BUDGET_BYTES`, 256 MiB) regardless of how large the archive turns
+  // out to be. The actual peak is somewhat above the product — see `UPLOAD_BUFFER_BUDGET_BYTES`
+  // for what is and is not established about it. The previous fixed `partSize: 5 MiB` /
+  // `queueSize: 4` capped any object at 10,000 x 5 MiB = 48.8 GiB, which is the ceiling this
   // replaces. With no estimate the derivation returns exactly that old pair.
   const { partSize, queueSize } = deriveUploadPartGeometry({ expectedBytes });
 
@@ -1236,7 +1237,8 @@ async function* flattenPages<T>(pages: AsyncIterable<T[]>): AsyncGenerator<T, vo
  *   "closes the archive and its file descriptor …" cases fail with `expected false to be true`
  *   when it is removed.
  * - `archive.abort()` is the queued source buffers, and NO test distinguishes it — removing it
- *   leaves all 64 tests across the four files green, and that is expected rather than a gap: the
+ *   leaves all 74 tests across the four files green (re-derived after this round added five; the
+ *   number this comment carried before was 64), and that is expected rather than a gap: the
  *   bounded appender caps the backlog at `MAX_PENDING_ARCHIVE_ENTRIES`, which drains far too
  *   fast to observe without a timing-dependent assertion. Its effect was measured separately on
  *   an UNBOUNDED queue, where it is unmissable: with the sink destroyed and no `abort()`, the
@@ -1294,6 +1296,10 @@ async function archiveAndUpload({
   /** Where the archive is staged when `stream` is false. Unused on the streaming path. */
   diskPath: string;
   stream: boolean;
+  /**
+   * Size estimate for multipart part sizing. STREAMING PATH ONLY — the disk branch drops it so
+   * that the flag-off path keeps the fixed geometry it had before this change.
+   */
   expectedBytes?: number;
   append: (archive: BoundedArchive) => Promise<void>;
 }) {
@@ -1301,7 +1307,31 @@ async function archiveAndUpload({
 
   if (!streamToStorage) {
     const output = fs.createWriteStream(diskPath);
-    archive.pipe(output);
+    // 🔴 `pipeline`, NOT `archive.pipe(output)`. `.pipe()` forwards errors in NEITHER direction,
+    // and the direction that matters here is SINK → SOURCE: when the sink is destroyed, `.pipe()`
+    // merely UNPIPES the source. The archiver is left alive and un-errored, so
+    // `createBoundedArchive` never latches a `failure`, never releases the `append()` callers
+    // parked on the pending-entry ceiling, and never rejects. The archiver's readable side then
+    // fills its high-water mark, `'entry'` stops firing, and every subsequent `append()` parks
+    // forever. The report HANGS instead of failing — the outcome this whole change exists to end.
+    //
+    // Measured against this archiver, destroying the sink under each: with `.pipe()` the archive
+    // emits no `'error'` at all and `archive.destroyed` stays `false`; with `pipeline` it emits
+    // `'error'` carrying the sink's own error and is destroyed. That `'error'` is the ONLY thing
+    // `createBoundedArchive` latches on, which is why the difference is hang-vs-fail rather than
+    // a detail of cleanup.
+    //
+    // This branch is not exempt just because it is the pre-change path. Its sink is a
+    // `fs.createWriteStream` on the container's scratch volume, so it fails mid-archive exactly
+    // when that volume is full — this incident's own condition, and the state the flag rolls
+    // back to. A rollback target that hangs is not a rollback.
+    //
+    // The callback is required (`pipeline` throws `ERR_MISSING_ARGS` without one) and is
+    // deliberately a no-op: every error it can report is ALREADY surfaced on a path the caller
+    // observes — a sink error reaches `finalize()`'s `output.once('error', reject)`, and an
+    // archiver error reaches `append()`/`finalize()` through the latched `failure`. Rethrowing
+    // here would add nothing but an uncaught exception raised from inside stream internals.
+    stream.pipeline(archive, output, () => undefined);
     const boundedArchive = createBoundedArchive({ archive, output });
 
     try {
@@ -1317,12 +1347,35 @@ async function archiveAndUpload({
     }
 
     const readableStream = fs.createReadStream(diskPath);
-    await uploadStream({ stream: readableStream, userId, filename, expectedBytes });
+    // 🔴 NO `expectedBytes` ON THIS BRANCH, DELIBERATELY — and this is the ONE place the
+    // geometry is gated, so no caller has to remember to.
+    //
+    // Derived part geometry arrived with the streaming change, so it belongs behind the same
+    // flag; otherwise "the rollback is a flag flip" is false. Passing an estimate here would
+    // give the supposedly-unchanged path a part size derived from a row count instead of the
+    // fixed 5 MiB it has always used — up to `256 MiB x 1` resident against the previous
+    // `5 MiB x 4` = 20 MiB. Memory is the exact dimension that caused the eviction this change
+    // exists to fix, so the rollback target must not move on it.
+    //
+    // The cost is that this path keeps the old `10,000 x 5 MiB` = 48.8 GiB object ceiling. That
+    // is what rolling back MEANS; removing that ceiling is the streaming path's job.
+    await uploadStream({ stream: readableStream, userId, filename });
     return;
   }
 
   const passThrough = new stream.PassThrough();
-  archive.pipe(passThrough);
+  // 🔴 `pipeline`, NOT `archive.pipe(passThrough)` — the full mechanism is on the disk branch
+  // above. This is the branch where a destroyed sink is the ROUTINE case rather than an edge
+  // one: the upload's rejection handler below destroys `passThrough` on any upload failure, and
+  // under `.pipe()` that destroy reaches the archiver as nothing whatsoever.
+  //
+  // Size-dependent, which is why it can ship green. `Upload` absorbs roughly
+  // `queueSize * partSize` (~20 MiB at the default geometry) out of the `PassThrough` before it
+  // stops reading, so an archive smaller than that is already finished appending by the time the
+  // upload fails and the report fails correctly. Every archive this change exists for is far
+  // above that line — and so is the anti-hang fixture in
+  // `src/server/services/__tests__/csam-archive-stream-upload.test.ts`, deliberately.
+  stream.pipeline(archive, passThrough, () => undefined);
   const boundedArchive = createBoundedArchive({ archive, output: passThrough });
 
   // 🔴 START THE UPLOAD BEFORE APPENDING ANYTHING. `PassThrough` has a small high-water mark, so
@@ -1343,9 +1396,16 @@ async function archiveAndUpload({
     () => undefined,
     (e: unknown) => {
       uploadError = e;
-      // Stop the producer. Without this the archiver keeps deflating into a `PassThrough` nobody
-      // is reading, and `finalize()`'s wait for the sink to close never settles — a failed upload
-      // would hang the report instead of failing it.
+      // Fail the sink. The `stream.pipeline` above is what turns that into a stop signal for the
+      // producer: it destroys the archiver WITH THIS ERROR, the archiver emits `'error'`, and
+      // `createBoundedArchive` latches it and releases every parked `append()`. `finalize()`'s
+      // wait for the sink to close then settles too, so the report fails instead of hanging.
+      //
+      // ⚠️ THE DESTROY ALONE DOES NOT STOP THE PRODUCER — an earlier revision of this comment
+      // asserted that it did, and that was the defect. Under `archive.pipe(passThrough)` a
+      // destroyed sink only UNPIPES the archiver: it is never destroyed, never emits `'error'`,
+      // the pending-entry ceiling is never released, and the report hangs forever. These two
+      // lines are ONE mechanism; neither does the job without the other.
       passThrough.destroy(e instanceof Error ? e : new Error(String(e)));
     }
   );
@@ -1624,14 +1684,22 @@ export async function archiveCsamDataForReport(data: CsamReportProps) {
     // because `partSize` has to be fixed before the first byte is uploaded, and the scan does not
     // know its own total until it has finished. An inaccurate — or absent — answer degrades to
     // the default geometry rather than breaking anything; see `deriveUploadPartGeometry`.
-    const imageCount = await dbRead.image.count({ where: { userId } });
+    //
+    // 🔴 GATED ON THE FLAG, like the geometry it feeds. This query did not exist before this
+    // change, and `archiveAndUpload`'s disk branch discards the estimate anyway, so issuing it
+    // with the flag off would be a new round trip against the main database bought for nothing —
+    // on the path whose whole claim is that it is unchanged.
+    const imageCount = streamArchivesToStorage
+      ? await dbRead.image.count({ where: { userId } })
+      : undefined;
 
     await archiveAndUpload({
       userId,
       filename: 'images.zip',
       diskPath: `${reportDirs.images}/${userId}_images.zip`,
       stream: streamArchivesToStorage,
-      expectedBytes: imageCount * ESTIMATED_BYTES_PER_ARCHIVED_IMAGE,
+      expectedBytes:
+        imageCount !== undefined ? imageCount * ESTIMATED_BYTES_PER_ARCHIVED_IMAGE : undefined,
       append: async (boundedArchive) => {
         // concurrency limiter
         const maxWidth = MAX_POST_IMAGES_WIDTH;

--- a/src/server/services/csam.service-new.ts
+++ b/src/server/services/csam.service-new.ts
@@ -1237,14 +1237,19 @@ async function* flattenPages<T>(pages: AsyncIterable<T[]>): AsyncGenerator<T, vo
  *   "closes the archive and its file descriptor …" cases fail with `expected false to be true`
  *   when it is removed.
  * - `archive.abort()` is the queued source buffers, and NO test distinguishes it — removing it
- *   leaves all 74 tests across the four files green (re-derived after this round added five; the
- *   number this comment carried before was 64), and that is expected rather than a gap: the
- *   bounded appender caps the backlog at `MAX_PENDING_ARCHIVE_ENTRIES`, which drains far too
- *   fast to observe without a timing-dependent assertion. Its effect was measured separately on
- *   an UNBOUNDED queue, where it is unmissable: with the sink destroyed and no `abort()`, the
- *   archiver went on to deflate all 60 of 60 queued entries; with `abort()` it stopped dead —
- *   0 further entries on node 26, 1 on node 24 (whichever was already in flight). So it does
- *   real work; it is just bounded work here, recorded as untested rather than as covered.
+ *   leaves every test in `archive-helpers.test.ts`, `csam-archive-stream-upload.test.ts`,
+ *   `csam-archive-backpressure.test.ts` and `process-csam.test.ts` green, and that is expected
+ *   rather than a gap: the bounded appender caps the backlog at `MAX_PENDING_ARCHIVE_ENTRIES`,
+ *   which drains far too fast to observe without a timing-dependent assertion. Its effect was
+ *   measured separately on an UNBOUNDED queue, where it is unmissable: with the sink destroyed
+ *   and no `abort()`, the archiver went on to deflate all 60 of 60 queued entries; with `abort()`
+ *   it stopped dead — 0 further entries on node 26, 1 on node 24 (whichever was already in
+ *   flight). So it does real work; it is just bounded work here, recorded as untested rather
+ *   than as covered.
+ *
+ *   No test TOTAL is quoted here, deliberately. A hand-maintained count sitting next to the code
+ *   it counts has nothing asserting on it, and this one drifted twice before it was removed. Run
+ *   those four files if you need the number.
  *
  * ⚠️ `output.destroy()` takes no error argument, and it does not need one. Destroying the sink is
  * NOT what settles an in-flight upload reading from it — `stream.pipeline` in `uploadStream` is,
@@ -1279,7 +1284,8 @@ function closeArchiveOnFailure(archive: Archiver, output: stream.Writable) {
  *
  * 🔴 MEMORY: the streaming path does NOT buffer the archive. `PassThrough` applies normal stream
  * backpressure, so the archiver stalls when the uploader is behind rather than accumulating. What
- * IS resident is the uploader's in-flight parts, bounded by `deriveUploadPartGeometry`. The
+ * IS held is the uploader's in-flight parts, sized by `deriveUploadPartGeometry` (plus the SDK
+ * chunker's own accumulating buffer on top — see `UPLOAD_BUFFER_BUDGET_BYTES`). The
  * bounded appender's own guarantee is untouched — it is the same `createBoundedArchive` wrapper
  * with the same ceiling, just handed a different sink.
  */
@@ -1353,7 +1359,7 @@ async function archiveAndUpload({
     // Derived part geometry arrived with the streaming change, so it belongs behind the same
     // flag; otherwise "the rollback is a flag flip" is false. Passing an estimate here would
     // give the supposedly-unchanged path a part size derived from a row count instead of the
-    // fixed 5 MiB it has always used — up to `256 MiB x 1` resident against the previous
+    // fixed 5 MiB it has always used — up to `256 MiB x 1` of in-flight parts against the previous
     // `5 MiB x 4` = 20 MiB. Memory is the exact dimension that caused the eviction this change
     // exists to fix, so the rollback target must not move on it.
     //
@@ -1401,11 +1407,31 @@ async function archiveAndUpload({
       // `createBoundedArchive` latches it and releases every parked `append()`. `finalize()`'s
       // wait for the sink to close then settles too, so the report fails instead of hanging.
       //
-      // ⚠️ THE DESTROY ALONE DOES NOT STOP THE PRODUCER — an earlier revision of this comment
-      // asserted that it did, and that was the defect. Under `archive.pipe(passThrough)` a
+      // ⚠️ TWO CORRECTIONS TO EARLIER REVISIONS OF THIS COMMENT LIVE HERE, and the second one
+      // undoes an overreach in the first.
+      //
+      // (1) THE DESTROY ALONE DOES NOT STOP THE PRODUCER. Under `archive.pipe(passThrough)` a
       // destroyed sink only UNPIPES the archiver: it is never destroyed, never emits `'error'`,
-      // the pending-entry ceiling is never released, and the report hangs forever. These two
-      // lines are ONE mechanism; neither does the job without the other.
+      // the pending-entry ceiling is never released, and the report hangs forever. The
+      // `stream.pipeline` above is what makes a destroyed sink reach the archiver at all.
+      //
+      // (2) BUT THE DESTROY DOES NOT CARRY THE COMMON CASE EITHER — the revision that fixed (1)
+      // called these two lines one mechanism that needed both halves, and that half is false. For
+      // any failure raised inside `upload.done()` — every runtime S3 failure — the pipelines
+      // already do the whole job: `Upload.__doConcurrentUpload`'s `for await` calls
+      // `dataFeeder.return()` on an in-loop throw, destroying the `PassThrough` `uploadStream`
+      // handed to `Upload`; `uploadStream`'s own `stream.pipeline` propagates that back onto THIS
+      // `passThrough`, and the `pipeline` above propagates it on to the archiver. Measured on
+      // this file: delete this line and all 8 tests stay green, the mid-archive probe included —
+      // and that probe is not vacuous, it goes HUNG when the `pipeline` above is removed.
+      //
+      // So what IS this line for, and it is the only thing established here: a rejection raised
+      // BEFORE `uploadStream` attaches that inner `pipeline` — `new Upload()` throwing from
+      // `__validateInput` (bad `partSize`/`queueSize`/params) is the reachable case. Nothing has
+      // linked this `passThrough` to anything that can fail it yet, so without this line the
+      // archiver fills the `PassThrough`, stalls, and every parked `append()` waits forever.
+      // Measured by injecting a throw at the `new Upload()` call site: with this line the report
+      // rejects in ~0.1 s; with it removed the same run reports `HUNG` at the 30 s deadline.
       passThrough.destroy(e instanceof Error ? e : new Error(String(e)));
     }
   );

--- a/src/server/services/csam.service-new.ts
+++ b/src/server/services/csam.service-new.ts
@@ -1105,9 +1105,10 @@ function uploadStream({
   const Key = `${userId}/${date.getTime()}_${filename}`;
 
   // 🔴 MEMORY: `Upload` holds up to `queueSize` parts of `partSize` bytes in flight. The pair is
-  // derived together from a single budget rather than chosen independently, so that PRODUCT is a
-  // constant (`UPLOAD_BUFFER_BUDGET_BYTES`, 256 MiB) regardless of how large the archive turns
-  // out to be. The actual peak is somewhat above the product — see `UPLOAD_BUFFER_BUDGET_BYTES`
+  // derived together from a single budget rather than chosen independently, so that PRODUCT is
+  // held AT OR BELOW `UPLOAD_BUFFER_BUDGET_BYTES` (256 MiB) however large the archive turns out
+  // to be. (At or below, not at: the realistic geometry here is 5 MiB x 4 = 20 MiB, well under
+  // it.) The actual peak is somewhat above the product — see `UPLOAD_BUFFER_BUDGET_BYTES`
   // for what is and is not established about it. The previous fixed `partSize: 5 MiB` /
   // `queueSize: 4` capped any object at 10,000 x 5 MiB = 48.8 GiB, which is the ceiling this
   // replaces. With no estimate the derivation returns exactly that old pair.
@@ -1427,11 +1428,18 @@ async function archiveAndUpload({
       //
       // So what IS this line for, and it is the only thing established here: a rejection raised
       // BEFORE `uploadStream` attaches that inner `pipeline` — `new Upload()` throwing from
-      // `__validateInput` (bad `partSize`/`queueSize`/params) is the reachable case. Nothing has
-      // linked this `passThrough` to anything that can fail it yet, so without this line the
-      // archiver fills the `PassThrough`, stalls, and every parked `append()` waits forever.
-      // Measured by injecting a throw at the `new Upload()` call site: with this line the report
-      // rejects in ~0.1 s; with it removed the same run reports `HUNG` at the 30 s deadline.
+      // `__validateInput` (bad `partSize`/`queueSize`/params). Nothing has linked this
+      // `passThrough` to anything that can fail it yet, so without this line the archiver fills
+      // the `PassThrough`, stalls, and every parked `append()` waits forever.
+      //
+      // ⚠️ THAT CASE IS NOT REACHABLE AT HEAD — this is a future-geometry guard, not a live path.
+      // `deriveUploadPartGeometry` floors `partSize` at exactly `Upload.MIN_PART_SIZE` (5 MiB), so
+      // `__validateInput`'s `partSize < MIN_PART_SIZE` is false; it floors `queueSize` at 1; and
+      // `params`/`client` are always supplied at the sole call site above. It becomes reachable
+      // only if the part-size floor is dropped below the SDK's minimum or the queue floor below 1
+      // — which is what not to break here. Measured by INJECTING a throw at the `new Upload()`
+      // call site, since no input produces one today: with this line the report rejects in ~0.1 s;
+      // with it removed the same run reports `HUNG` at the 30 s deadline.
       passThrough.destroy(e instanceof Error ? e : new Error(String(e)));
     }
   );

--- a/src/server/services/csam.service-new.ts
+++ b/src/server/services/csam.service-new.ts
@@ -1130,7 +1130,20 @@ function uploadStream({
       //   console.log({ progress });
       // });
 
-      readStream.pipe(passThroughStream);
+      // 🔴 `pipeline`, NOT `readStream.pipe(passThroughStream)` — `.pipe()` DOES NOT FORWARD
+      // ERRORS. When the source failed, `.pipe()` merely unpiped: the destination was never
+      // ended and never errored, so `done()` below waited on a stream nothing would ever write
+      // to again and the upload hung FOREVER rather than rejecting. `pipeline` destroys the
+      // destination with the error, which is what makes `done()` reject.
+      //
+      // This is not only the streaming path's concern. The disk path's `fs.createReadStream` can
+      // fail mid-read too (the scratch directory is removed by the caller's error handler), and
+      // it had exactly the same latent hang.
+      //
+      // The callback is required — `pipeline` throws `ERR_MISSING_ARGS` without one, and an
+      // error it reports is already surfaced by `done()` rejecting, so there is nothing to do
+      // with it here beyond not crashing the process on an unhandled 'error' event.
+      stream.pipeline(readStream, passThroughStream, () => undefined);
       await parallelUploads3.done();
       // console.dir('upload finished', { depth: null });
       resolve();
@@ -1230,6 +1243,12 @@ async function* flattenPages<T>(pages: AsyncIterable<T[]>): AsyncGenerator<T, vo
  *   archiver went on to deflate all 60 of 60 queued entries; with `abort()` it stopped dead —
  *   0 further entries on node 26, 1 on node 24 (whichever was already in flight). So it does
  *   real work; it is just bounded work here, recorded as untested rather than as covered.
+ *
+ * ⚠️ `output.destroy()` takes no error argument, and it does not need one. Destroying the sink is
+ * NOT what settles an in-flight upload reading from it — `stream.pipeline` in `uploadStream` is,
+ * and it is the only thing that is. Passing the error in here as well was tried, and measured
+ * REDUNDANT: with `pipeline` in place the failure path settles either way, and with `.pipe()` in
+ * place it hangs either way. Recorded so nobody re-adds it believing it does work.
  */
 function closeArchiveOnFailure(archive: Archiver, output: stream.Writable) {
   archive.abort();
@@ -1337,11 +1356,21 @@ async function archiveAndUpload({
     // closed. Here "the sink has closed" means the uploader has drained every byte.
     await boundedArchive.finalize();
   } catch (e) {
+    // 🔴 READ THIS BEFORE `closeArchiveOnFailure`, because that call CREATES the other error.
+    // Two different things reach this catch and they need opposite attribution:
+    //
+    //  - the upload failed first → it destroyed the sink → `finalize()` rejected with the
+    //    destroy error, so `e` is the downstream symptom and `uploadError` is the cause;
+    //  - the append/finalize failed first → we are about to destroy the sink ourselves, which
+    //    will make the upload fail as a consequence, so `e` is the cause.
+    //
+    // Latching which came first is the only way to tell them apart afterwards. Reporting the
+    // upload error unconditionally would bury a fetch or DB failure behind "failed to upload".
+    const uploadFailedFirst = uploadError !== undefined;
     closeArchiveOnFailure(archive, passThrough);
-    // Settle the upload before rethrowing so nothing is left in flight, and prefer the upload's
-    // own error when it is the thing that failed — `e` is then just the downstream symptom.
+    // Settle the upload before rethrowing so nothing is left in flight.
     await uploadPromise;
-    if (uploadError) throw uploadError;
+    if (uploadFailedFirst) throw uploadError;
     throw e;
   }
 

--- a/src/server/utils/__tests__/archive-helpers.test.ts
+++ b/src/server/utils/__tests__/archive-helpers.test.ts
@@ -11,8 +11,14 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import plimit from 'p-limit';
 import {
   createBoundedArchive,
+  deriveUploadPartGeometry,
+  MAX_PART_SIZE_BYTES,
   MAX_PENDING_ARCHIVE_ENTRIES,
+  MAX_UPLOAD_QUEUE_SIZE,
   MEDIA_ARCHIVE_COMPRESSION_LEVEL,
+  S3_MAX_UPLOAD_PARTS,
+  S3_MIN_PART_SIZE_BYTES,
+  UPLOAD_BUFFER_BUDGET_BYTES,
   zipEntryNameForUrl,
 } from '~/server/utils/archive-helpers';
 
@@ -376,5 +382,91 @@ describe('zipEntryNameForUrl', () => {
 
     const zip = await JSZip.loadAsync(fs.readFileSync(outPath));
     expect(Object.keys(zip.files)).toEqual(['unnamed-0-blob']);
+  });
+});
+
+/**
+ * Part sizing is the other half of the memory story, and it is the half that is easy to get
+ * wrong in the direction that reintroduces the bug this module exists for: `Upload` holds
+ * `queueSize * partSize` resident, so raising `partSize` to lift the object-size ceiling while
+ * leaving `queueSize` alone silently multiplies the resident footprint.
+ */
+describe('deriveUploadPartGeometry', () => {
+  const MiB = 1024 * 1024;
+
+  it('reproduces the previous fixed geometry when given no estimate', () => {
+    // The small uploads that pass no estimate must be untouched by this change.
+    const geometry = deriveUploadPartGeometry({});
+    expect(geometry.partSize).toBe(S3_MIN_PART_SIZE_BYTES);
+    expect(geometry.queueSize).toBe(MAX_UPLOAD_QUEUE_SIZE);
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])('falls back to the default geometry for a %s estimate', (_label, expectedBytes) => {
+    // NaN is the realistic one: the caller multiplies a row count by a constant, and a count that
+    // fails to resolve makes the product NaN. `Math.max(MIN, NaN)` is NaN, which would reach the
+    // SDK as an invalid part size — so this is a live path, not defensive padding.
+    const geometry = deriveUploadPartGeometry({ expectedBytes });
+    expect(geometry.partSize).toBe(S3_MIN_PART_SIZE_BYTES);
+    expect(geometry.queueSize).toBe(MAX_UPLOAD_QUEUE_SIZE);
+  });
+
+  it('never returns a part below the S3 minimum, however small the estimate', () => {
+    // S3 rejects any part but the last below 5 MiB, so a tiny estimate must not scale downward.
+    for (const expectedBytes of [1, 1024, 4 * MiB, 40 * MiB]) {
+      expect(deriveUploadPartGeometry({ expectedBytes }).partSize).toBe(S3_MIN_PART_SIZE_BYTES);
+    }
+  });
+
+  it('grows the part size so a large archive stays inside the S3 part limit', () => {
+    // The regression: at a fixed 5 MiB part size this object needs > 10,000 parts and the upload
+    // is rejected outright. Chosen well above that ceiling so the assertion cannot pass by luck.
+    const expectedBytes = 400 * 1024 * MiB; // 400 GiB
+    const geometry = deriveUploadPartGeometry({ expectedBytes });
+
+    expect(geometry.partSize).toBeGreaterThan(S3_MIN_PART_SIZE_BYTES);
+    expect(Math.ceil(expectedBytes / geometry.partSize)).toBeLessThanOrEqual(S3_MAX_UPLOAD_PARTS);
+    expect(geometry.maxObjectBytes).toBeGreaterThanOrEqual(expectedBytes);
+  });
+
+  it('🔴 holds worst-case resident bytes inside the budget at every estimate', () => {
+    // THE MEMORY CLAIM. Swept rather than spot-checked, and across the boundaries where the
+    // clamps engage — a single sample would sit on one side of them and prove nothing about the
+    // other. A change that raises `partSize` without lowering `queueSize` fails here.
+    const estimates = [
+      0,
+      1,
+      100 * MiB,
+      1024 * MiB,
+      10 * 1024 * MiB,
+      100 * 1024 * MiB,
+      400 * 1024 * MiB,
+      2000 * 1024 * MiB,
+      100_000 * 1024 * MiB, // far past the part-size ceiling
+    ];
+    for (const expectedBytes of estimates) {
+      const geometry = deriveUploadPartGeometry({ expectedBytes });
+      expect(
+        geometry.worstCaseResidentBytes,
+        `estimate ${expectedBytes} produced ${geometry.worstCaseResidentBytes} resident bytes`
+      ).toBeLessThanOrEqual(UPLOAD_BUFFER_BUDGET_BYTES);
+      expect(geometry.worstCaseResidentBytes).toBe(geometry.partSize * geometry.queueSize);
+      expect(geometry.queueSize).toBeGreaterThanOrEqual(1);
+      expect(geometry.queueSize).toBeLessThanOrEqual(MAX_UPLOAD_QUEUE_SIZE);
+      expect(geometry.partSize).toBeLessThanOrEqual(MAX_PART_SIZE_BYTES);
+      expect(geometry.partSize).toBeGreaterThanOrEqual(S3_MIN_PART_SIZE_BYTES);
+    }
+  });
+
+  it('trades parallelism away rather than the budget as parts grow', () => {
+    // The property that makes the sweep above hold: the two knobs move in opposite directions.
+    const small = deriveUploadPartGeometry({ expectedBytes: 100 * MiB });
+    const huge = deriveUploadPartGeometry({ expectedBytes: 100_000 * 1024 * MiB });
+    expect(huge.partSize).toBeGreaterThan(small.partSize);
+    expect(huge.queueSize).toBeLessThan(small.queueSize);
   });
 });

--- a/src/server/utils/__tests__/archive-helpers.test.ts
+++ b/src/server/utils/__tests__/archive-helpers.test.ts
@@ -388,8 +388,13 @@ describe('zipEntryNameForUrl', () => {
 /**
  * Part sizing is the other half of the memory story, and it is the half that is easy to get
  * wrong in the direction that reintroduces the bug this module exists for: `Upload` holds
- * `queueSize * partSize` resident, so raising `partSize` to lift the object-size ceiling while
- * leaving `queueSize` alone silently multiplies the resident footprint.
+ * `queueSize * partSize` bytes of in-flight parts, so raising `partSize` to lift the object-size
+ * ceiling while leaving `queueSize` alone silently multiplies that total.
+ *
+ * ⚠️ In-flight-part bytes, NOT the upload's peak memory — the two are different quantities and
+ * this file only measures the first. `archive-helpers.ts` disclaims the second explicitly (see
+ * `UPLOAD_BUFFER_BUDGET_BYTES` and `UploadPartGeometry.worstCaseResidentBytes`); nothing here
+ * establishes it, so nothing here should be read as proving it.
  */
 describe('deriveUploadPartGeometry', () => {
   const MiB = 1024 * 1024;
@@ -433,8 +438,11 @@ describe('deriveUploadPartGeometry', () => {
     expect(geometry.maxObjectBytes).toBeGreaterThanOrEqual(expectedBytes);
   });
 
-  it('🔴 holds worst-case resident bytes inside the budget at every estimate', () => {
-    // THE MEMORY CLAIM. Swept rather than spot-checked, and across the boundaries where the
+  it('🔴 holds in-flight-part bytes inside the budget at every estimate', () => {
+    // THE BUDGET CLAIM — `queueSize * partSize` against `UPLOAD_BUFFER_BUDGET_BYTES`, which is
+    // all the property named `worstCaseResidentBytes` actually is. NOT a claim about the upload's
+    // peak memory; that is disclaimed where the constant is defined and is not tested anywhere.
+    // Swept rather than spot-checked, and across the boundaries where the
     // clamps engage — a single sample would sit on one side of them and prove nothing about the
     // other. A change that raises `partSize` without lowering `queueSize` fails here.
     const estimates = [
@@ -452,7 +460,7 @@ describe('deriveUploadPartGeometry', () => {
       const geometry = deriveUploadPartGeometry({ expectedBytes });
       expect(
         geometry.worstCaseResidentBytes,
-        `estimate ${expectedBytes} produced ${geometry.worstCaseResidentBytes} resident bytes`
+        `estimate ${expectedBytes} produced ${geometry.worstCaseResidentBytes} in-flight-part bytes`
       ).toBeLessThanOrEqual(UPLOAD_BUFFER_BUDGET_BYTES);
       expect(geometry.worstCaseResidentBytes).toBe(geometry.partSize * geometry.queueSize);
       expect(geometry.queueSize).toBeGreaterThanOrEqual(1);

--- a/src/server/utils/__tests__/archive-helpers.test.ts
+++ b/src/server/utils/__tests__/archive-helpers.test.ts
@@ -462,6 +462,39 @@ describe('deriveUploadPartGeometry', () => {
     }
   });
 
+  it('🔴 keeps an archive that comes out 4x larger than its estimate inside the part limit', () => {
+    // THE HEADROOM CLAIM, and it needs its own test because the obvious one cannot see it.
+    // `expect(maxObjectBytes).toBeGreaterThanOrEqual(expectedBytes)` — asserted in "grows the
+    // part size so a large archive stays inside the S3 part limit" above — holds with EQUALITY
+    // at zero headroom, so it stays green with `PART_SIZE_ESTIMATE_HEADROOM` mutated 4 -> 1.
+    // Measured before this test existed: that mutation left every test in this file and in the
+    // stream-upload file green — everything the constant buys was untested. Re-measured with
+    // this test present, the same mutation fails HERE and nowhere else (1 of 40 across the two
+    // suites), which is what makes it this guard's own assertion rather than a bystander's.
+    //
+    // 🔴 THE MULTIPLIER BELOW IS A LITERAL, DELIBERATELY, AND MUST NOT BE REPLACED BY
+    // `PART_SIZE_ESTIMATE_HEADROOM`. An assertion that names the constant on both sides moves
+    // with it and can never fail — that is precisely how the mutant survived. This pins a FLOOR:
+    // raising the headroom keeps it green, lowering it below 4 does not.
+    //
+    // Both estimates sit ABOVE the 5 MiB minimum-part clamp under the real headroom, and the
+    // second sits above it under the mutant too, so neither result is decided by a clamp the
+    // constant never reaches.
+    const TOLERATED_UNDERESTIMATE_FACTOR = 4;
+    for (const expectedBytes of [20 * 1024 * MiB, 100 * 1024 * MiB]) {
+      const geometry = deriveUploadPartGeometry({ expectedBytes });
+      expect(
+        geometry.maxObjectBytes,
+        `estimate ${expectedBytes} yields a ${geometry.partSize}-byte part, which caps the object ` +
+          `at ${geometry.maxObjectBytes} — below the ${
+            expectedBytes * TOLERATED_UNDERESTIMATE_FACTOR
+          } an archive ${TOLERATED_UNDERESTIMATE_FACTOR}x larger than the estimate would need. ` +
+          `An estimate wrong-LOW by that factor would be REJECTED by S3 for exceeding ` +
+          `${S3_MAX_UPLOAD_PARTS} parts, which fails the report outright.`
+      ).toBeGreaterThanOrEqual(expectedBytes * TOLERATED_UNDERESTIMATE_FACTOR);
+    }
+  });
+
   it('trades parallelism away rather than the budget as parts grow', () => {
     // The property that makes the sweep above hold: the two knobs move in opposite directions.
     const small = deriveUploadPartGeometry({ expectedBytes: 100 * MiB });

--- a/src/server/utils/archive-helpers.ts
+++ b/src/server/utils/archive-helpers.ts
@@ -32,17 +32,40 @@ export const S3_MIN_PART_SIZE_BYTES = 5 * 1024 * 1024; // 5 MiB
 export const MAX_PART_SIZE_BYTES = 256 * 1024 * 1024; // 256 MiB
 
 /**
- * 🔴 Hard cap on `queueSize * partSize`, which is what `@aws-sdk/lib-storage` holds RESIDENT.
+ * 🔴 Hard cap on `queueSize * partSize` — the BUDGET the upload's in-flight parts are sized
+ * against. Read it as the knob that keeps upload memory from scaling with archive size, NOT as a
+ * measured ceiling on the process's resident bytes.
  *
  * `Upload` buffers up to `queueSize` parts of `partSize` bytes each while they are in flight.
  * That memory is in ADDITION to everything `createBoundedArchive` bounds, so it has to be
  * budgeted, not left to whatever `partSize` the size estimate happens to produce. Naively
- * keeping `queueSize: 4` next to a 100 MiB part is ~400 MiB resident — for a process whose
- * whole memory story is the reason this module exists.
+ * keeping `queueSize: 4` next to a 100 MiB part is ~400 MiB of in-flight parts — for a process
+ * whose whole memory story is the reason this module exists.
  *
- * `deriveUploadPartGeometry` derives `queueSize` FROM this budget, so worst-case resident bytes
- * are this constant by construction, whatever the estimate says. 256 MiB sits comfortably inside
- * the container's memory allowance alongside the archiver's own bounded working set.
+ * `deriveUploadPartGeometry` derives `queueSize` FROM this budget, so the in-flight-part total is
+ * this constant by construction, whatever the estimate says.
+ *
+ * ⚠️ THE REAL PEAK IS LARGER THAN THIS NUMBER, and an earlier revision of this comment read as a
+ * proof that it was not. Read off `@aws-sdk/lib-storage`'s `getChunkStream` (dist-cjs): the
+ * chunker accumulates incoming chunks in a `currentBuffer`, `Buffer.concat`s them once the total
+ * passes `partSize`, yields the leading `partSize` bytes of that concat as the part, and RETAINS
+ * the trailing remainder as the next `currentBuffer`. Both are `subarray` views on the SAME
+ * allocation, so the whole concat allocation stays alive for as long as the part it backs is in
+ * flight. On top of the `queueSize` in-flight parts there is therefore the accumulating buffer
+ * (up to about one more part) and, during the concat itself, a transient copy of it.
+ *
+ * So the peak is APPROXIMATELY `(queueSize + 1 … 2) * partSize`. As a multiple of this constant
+ * that is ~1.25–1.5x at `queueSize` 4, and ~2–3x at `queueSize` 1 — i.e. at the
+ * `MAX_PART_SIZE_BYTES` clamp, where the budget buys only one part.
+ *
+ * 🔴 THAT RANGE IS APPROXIMATE AND IS NOT A CEILING. It is read off the SDK's source, not
+ * measured under a heap profiler, and it accounts for no GC lag, no socket-level buffering and
+ * nothing the runtime holds on its own — all of which push the observed figure up rather than
+ * down. Do not restate it as a proven bound; if a real bound is ever needed, measure one.
+ *
+ * It is immaterial at the part size this actually runs at: the realistic archives here land on
+ * the 5 MiB minimum part, where the whole discrepancy is single-digit MiB. It matters only if a
+ * future estimate pushes `partSize` toward the clamp, which is why it is written down.
  */
 export const UPLOAD_BUFFER_BUDGET_BYTES = 256 * 1024 * 1024; // 256 MiB
 
@@ -67,7 +90,13 @@ export type UploadPartGeometry = {
   queueSize: number;
   /** Largest object this geometry can upload before hitting the S3 part limit. */
   maxObjectBytes: number;
-  /** `queueSize * partSize` — what the upload holds resident at peak. */
+  /**
+   * `queueSize * partSize` — the in-flight-part total this geometry is budgeted against.
+   *
+   * ⚠️ NOT the upload's peak resident bytes; the real peak is about one to two further parts on
+   * top of it. See `UPLOAD_BUFFER_BUDGET_BYTES` for why, and for the scope of that claim. The
+   * name is kept because it is what the budget is enforced on.
+   */
   worstCaseResidentBytes: number;
 };
 

--- a/src/server/utils/archive-helpers.ts
+++ b/src/server/utils/archive-helpers.ts
@@ -43,7 +43,8 @@ export const MAX_PART_SIZE_BYTES = 256 * 1024 * 1024; // 256 MiB
  * whose whole memory story is the reason this module exists.
  *
  * `deriveUploadPartGeometry` derives `queueSize` FROM this budget, so the in-flight-part total is
- * this constant by construction, whatever the estimate says.
+ * held AT OR BELOW this constant by construction, whatever the estimate says. (At or below, not
+ * at: the realistic geometry here is 5 MiB x 4 = 20 MiB, well under it.)
  *
  * ⚠️ THE REAL PEAK IS LARGER THAN THIS NUMBER, and an earlier revision of this comment read as a
  * proof that it was not. Read off `@aws-sdk/lib-storage`'s `getChunkStream` (dist-cjs): the
@@ -54,9 +55,16 @@ export const MAX_PART_SIZE_BYTES = 256 * 1024 * 1024; // 256 MiB
  * flight. On top of the `queueSize` in-flight parts there is therefore the accumulating buffer
  * (up to about one more part) and, during the concat itself, a transient copy of it.
  *
- * So the peak is APPROXIMATELY `(queueSize + 1 … 2) * partSize`. As a multiple of this constant
- * that is ~1.25–1.5x at `queueSize` 4, and ~2–3x at `queueSize` 1 — i.e. at the
- * `MAX_PART_SIZE_BYTES` clamp, where the budget buys only one part.
+ * So the peak is APPROXIMATELY `(queueSize + 1 … 2) * partSize` — about one to two further parts
+ * on top of `queueSize * partSize`. ⚠️ THOSE RATIOS ARE MULTIPLES OF THAT PRODUCT, NOT OF THIS
+ * CONSTANT, and an earlier revision of this comment read them against this constant and so
+ * overstated the peak by roughly 12x at the geometry the code actually runs. As a multiple of the
+ * product it is ~1.25–1.5x at `queueSize` 4 and ~2–3x at `queueSize` 1 — which is every
+ * `partSize` above half this budget (above 128 MiB), not only at the `MAX_PART_SIZE_BYTES` clamp.
+ *
+ * Against THIS constant the same arithmetic gives: at the 5 MiB minimum part with `queueSize` 4
+ * the product is 20 MiB and the peak 25–30 MiB, i.e. ~0.10–0.12x of it; at an estimate that
+ * yields a ~130 MiB part (`queueSize` 1) the peak is ~260–390 MiB, i.e. ~1.0–1.5x of it.
  *
  * 🔴 THAT RANGE IS APPROXIMATE AND IS NOT A CEILING. It is read off the SDK's source, not
  * measured under a heap profiler, and it accounts for no GC lag, no socket-level buffering and
@@ -64,8 +72,9 @@ export const MAX_PART_SIZE_BYTES = 256 * 1024 * 1024; // 256 MiB
  * down. Do not restate it as a proven bound; if a real bound is ever needed, measure one.
  *
  * It is immaterial at the part size this actually runs at: the realistic archives here land on
- * the 5 MiB minimum part, where the whole discrepancy is single-digit MiB. It matters only if a
- * future estimate pushes `partSize` toward the clamp, which is why it is written down.
+ * the 5 MiB minimum part, where the whole discrepancy is 5–10 MiB. It matters only if a future
+ * estimate pushes `partSize` into the `queueSize` 1 band above 128 MiB, which is why it is
+ * written down.
  */
 export const UPLOAD_BUFFER_BUDGET_BYTES = 256 * 1024 * 1024; // 256 MiB
 
@@ -78,8 +87,8 @@ export const MAX_UPLOAD_QUEUE_SIZE = 4;
  * The estimate is `entryCount * bytes-per-entry` off an observed average, so it is wrong in both
  * directions on any individual archive. Wrong-LOW is the direction that fails hard: exceeding
  * `S3_MAX_UPLOAD_PARTS` aborts the upload outright. Wrong-HIGH costs nothing at all — a larger
- * `partSize` is compensated by a smaller `queueSize`, and the resident total is pinned by
- * `UPLOAD_BUFFER_BUDGET_BYTES` either way. Asymmetric consequences, so bias generously.
+ * `partSize` is compensated by a smaller `queueSize`, and the in-flight-part total is held
+ * under `UPLOAD_BUFFER_BUDGET_BYTES` either way. Asymmetric consequences, so bias generously.
  */
 export const PART_SIZE_ESTIMATE_HEADROOM = 4;
 
@@ -110,7 +119,10 @@ export type UploadPartGeometry = {
  *
  * The two knobs are NOT independent. `partSize` is set by the part-count limit (how large the
  * object may be); `queueSize` is then whatever fits the memory budget alongside it. Raising one
- * lowers the other, which is the property that makes worst-case resident bytes a constant.
+ * lowers the other, which is the property that keeps the in-flight-part total bounded by the
+ * budget instead of scaling with the archive. (That total is what `worstCaseResidentBytes`
+ * reports; the upload's peak memory is a larger and untested quantity — see
+ * `UPLOAD_BUFFER_BUDGET_BYTES`.)
  *
  * `expectedBytes` omitted (or non-finite/non-positive) yields the S3 minimum part size and full
  * parallelism — byte-for-byte the geometry this code used before, so the small uploads that pass

--- a/src/server/utils/archive-helpers.ts
+++ b/src/server/utils/archive-helpers.ts
@@ -15,6 +15,121 @@ import type { Readable, Writable } from 'stream';
  */
 export const MEDIA_ARCHIVE_COMPRESSION_LEVEL = 1;
 
+/** S3 hard limit: a multipart upload may have at most this many parts. */
+export const S3_MAX_UPLOAD_PARTS = 10_000;
+
+/** S3 hard limit: every part except the final one must be at least this large. */
+export const S3_MIN_PART_SIZE_BYTES = 5 * 1024 * 1024; // 5 MiB
+
+/**
+ * Our ceiling on a single part, far below S3's own 5 GiB maximum.
+ *
+ * The ceiling is what bounds the largest object this can produce:
+ * `S3_MAX_UPLOAD_PARTS * MAX_PART_SIZE_BYTES` = 10,000 x 256 MiB = 2.44 TiB. That is orders of
+ * magnitude above any archive this code is asked to build, so the ceiling never binds in
+ * practice — it exists so a wildly wrong size estimate cannot ask for a 5 GiB part.
+ */
+export const MAX_PART_SIZE_BYTES = 256 * 1024 * 1024; // 256 MiB
+
+/**
+ * 🔴 Hard cap on `queueSize * partSize`, which is what `@aws-sdk/lib-storage` holds RESIDENT.
+ *
+ * `Upload` buffers up to `queueSize` parts of `partSize` bytes each while they are in flight.
+ * That memory is in ADDITION to everything `createBoundedArchive` bounds, so it has to be
+ * budgeted, not left to whatever `partSize` the size estimate happens to produce. Naively
+ * keeping `queueSize: 4` next to a 100 MiB part is ~400 MiB resident — for a process whose
+ * whole memory story is the reason this module exists.
+ *
+ * `deriveUploadPartGeometry` derives `queueSize` FROM this budget, so worst-case resident bytes
+ * are this constant by construction, whatever the estimate says. 256 MiB sits comfortably inside
+ * the container's memory allowance alongside the archiver's own bounded working set.
+ */
+export const UPLOAD_BUFFER_BUDGET_BYTES = 256 * 1024 * 1024; // 256 MiB
+
+/** Upper bound on upload parallelism. Matches the value this code used before part sizing existed. */
+export const MAX_UPLOAD_QUEUE_SIZE = 4;
+
+/**
+ * Multiplier applied to the caller's size estimate before dividing it into parts.
+ *
+ * The estimate is `entryCount * bytes-per-entry` off an observed average, so it is wrong in both
+ * directions on any individual archive. Wrong-LOW is the direction that fails hard: exceeding
+ * `S3_MAX_UPLOAD_PARTS` aborts the upload outright. Wrong-HIGH costs nothing at all — a larger
+ * `partSize` is compensated by a smaller `queueSize`, and the resident total is pinned by
+ * `UPLOAD_BUFFER_BUDGET_BYTES` either way. Asymmetric consequences, so bias generously.
+ */
+export const PART_SIZE_ESTIMATE_HEADROOM = 4;
+
+export type UploadPartGeometry = {
+  /** Bytes per multipart part. */
+  partSize: number;
+  /** Parts buffered in flight. */
+  queueSize: number;
+  /** Largest object this geometry can upload before hitting the S3 part limit. */
+  maxObjectBytes: number;
+  /** `queueSize * partSize` — what the upload holds resident at peak. */
+  worstCaseResidentBytes: number;
+};
+
+/**
+ * Chooses `partSize`/`queueSize` for a multipart upload from an estimate of the object's size.
+ *
+ * WHY THIS EXISTS: a fixed 5 MiB part size caps any object at `10,000 * 5 MiB` = 48.8 GiB,
+ * because S3 refuses an upload with more than 10,000 parts. An archive larger than that fails
+ * with a part-limit error rather than a disk or memory error, which is a different failure with
+ * the same outcome — the bundle cannot be produced.
+ *
+ * The two knobs are NOT independent. `partSize` is set by the part-count limit (how large the
+ * object may be); `queueSize` is then whatever fits the memory budget alongside it. Raising one
+ * lowers the other, which is the property that makes worst-case resident bytes a constant.
+ *
+ * `expectedBytes` omitted (or non-finite/non-positive) yields the S3 minimum part size and full
+ * parallelism — byte-for-byte the geometry this code used before, so the small uploads that pass
+ * no estimate are unaffected.
+ */
+export function deriveUploadPartGeometry({
+  expectedBytes,
+}: {
+  expectedBytes?: number;
+}): UploadPartGeometry {
+  const usableEstimate =
+    typeof expectedBytes === 'number' && Number.isFinite(expectedBytes) && expectedBytes > 0
+      ? expectedBytes
+      : 0;
+
+  const requiredPartSize = Math.ceil(
+    (usableEstimate * PART_SIZE_ESTIMATE_HEADROOM) / S3_MAX_UPLOAD_PARTS
+  );
+
+  const partSize = Math.min(
+    MAX_PART_SIZE_BYTES,
+    Math.max(S3_MIN_PART_SIZE_BYTES, requiredPartSize)
+  );
+
+  // At least 1: a budget smaller than one part still has to upload, serially.
+  const queueSize = Math.max(
+    1,
+    Math.min(MAX_UPLOAD_QUEUE_SIZE, Math.floor(UPLOAD_BUFFER_BUDGET_BYTES / partSize))
+  );
+
+  return {
+    partSize,
+    queueSize,
+    maxObjectBytes: partSize * S3_MAX_UPLOAD_PARTS,
+    worstCaseResidentBytes: partSize * queueSize,
+  };
+}
+
+/**
+ * Bytes to budget per archived image when estimating an archive's size.
+ *
+ * The media is already entropy-coded and `MEDIA_ARCHIVE_COMPRESSION_LEVEL` is 1, so the zip is
+ * very close to the sum of its inputs and `entryCount * this` is a serviceable estimate. It only
+ * feeds `deriveUploadPartGeometry`, whose headroom and clamps absorb the error — see
+ * `PART_SIZE_ESTIMATE_HEADROOM` for why erring high is free.
+ */
+export const ESTIMATED_BYTES_PER_ARCHIVED_IMAGE = Math.round(1.4 * 1024 * 1024);
+
 /**
  * Default ceiling on entries that have been handed to the archiver but not yet compressed and
  * written out. Each pending entry pins its whole source buffer in memory, so this is the knob


### PR DESCRIPTION
## What changed

The two large media archives built by `archiveCsamDataForReport` were written to the container's local scratch volume, read back with `fs.createReadStream`, and then uploaded. That volume is size-limited, so a reported account with a large enough media library exceeded it and the container was evicted partway through — every attempt, for that account. Raising the limit only moves the ceiling, and a substantial number of accounts already sit above a raised one, so this removes the ceiling instead.

- **`archiveImages()` and the `generated-images.zip` site now stream.** The archiver is piped into a `PassThrough` handed directly to `@aws-sdk/lib-storage`'s `Upload`, so the archive bytes never touch local disk.
- **Both sites now run one shared `archiveAndUpload` helper** rather than two verbatim copies of the archiver → sink → bounded-appender → finalize → upload sequence. Only the `append` callback differs. This is what stops the disk and streaming paths drifting apart, and it is why one equivalence proof covers both.
- **`uploadStream`'s parameter is widened** from `fs.ReadStream` to `Readable` — a `PassThrough` is not an `fs.ReadStream`, and nothing in the function ever used a file-specific member.
- **Multipart parts are now sized from an estimate** rather than fixed at 5 MiB.

**Deliberately out of scope, unchanged:** `data.json` (small), `training-data.zip`, and the submission path that reads a zip back off disk with `fs.readFile`.

## Part sizing, and the memory math

S3 accepts at most **10,000 parts**, so a fixed 5 MiB part capped any object at **~48.8 GiB** — a second ceiling, below the worst case, that would have been hit right after the disk one was removed.

`queueSize` × `partSize` is what `Upload` holds **resident**, so the two knobs are not chosen independently — that is exactly how "raise `partSize` to lift the object ceiling" silently turns into ~400 MiB resident. `deriveUploadPartGeometry` derives `queueSize` **from** a fixed budget, so a larger part buys fewer parts in flight:

| | value |
|---|---|
| Memory budget (`UPLOAD_BUFFER_BUDGET_BYTES`) | **256 MiB** |
| `partSize` | `clamp(ceil(estimate × 4 / 10,000), 5 MiB, 256 MiB)` |
| `queueSize` | `clamp(floor(256 MiB / partSize), 1, 4)` |
| Worst-case resident | **256 MiB, at every estimate** |
| Max object size | `10,000 × 256 MiB` = **2.44 TiB** |
| With no estimate | 5 MiB × 4 = 20 MiB resident — byte-for-byte the previous geometry |

The estimate is `entryCount × ~1.4 MiB`. It is wrong in both directions on any individual archive, and the ×4 headroom is deliberate: wrong-**low** fails hard (exceeding the part limit aborts the upload), wrong-**high** costs nothing, because `queueSize` absorbs it and the resident total is pinned either way.

The streaming path itself buffers nothing — a `PassThrough` applies ordinary backpressure, so the archiver stalls when the uploader is behind rather than accumulating. The bounded appender from the preceding change is untouched: same `createBoundedArchive` wrapper, same ceiling, different sink. 256 MiB sits well inside the runtime memory allowance alongside it.

## Verification

**Equivalence proof** (`csam-archive-stream-upload.test.ts`). The same fixture — 73 entries × 192 KiB of *incompressible* pseudo-random bytes, deterministic per index — is run through both paths against the **real** `Upload` driving a fake S3 that reassembles parts. What is compared is the **content inventory**: sorted entry names, each entry's uncompressed size, and a SHA-256 of each entry's uncompressed bytes. Not raw zip bytes — zip embeds a per-entry timestamp, so two runs of correct code differ byte-for-byte.

Observed: both paths produced **3 multipart parts of 5,242,880 + 5,242,880 + 3,879,912 = 14,365,672 bytes**, identical geometry, identical inventories.

Controls that had to pass first, because each of them turns the comparison vacuous if it fails:
- both objects exist and are non-empty (otherwise the comparison is between two `undefined`s);
- the flag was actually consulted on both runs (otherwise both arms take the same path and equivalence is a tautology);
- `partCount >= 2` — a single-shot `PutObject` would mean the fixture compressed away and nothing about part splitting was exercised. The payload is incompressible precisely so this control can pass;
- every non-final part is exactly one part size and the final one is short, which is the shape S3 requires.

🔴 **Both inventories are additionally compared against the bytes the fixture generated.** Comparing two arms of one implementation cannot see a defect they *share* — a bug in the append path both run would produce two identical, identically-wrong inventories and a green test.

Separately pinned: the streaming path opens **no** local write stream for the archive (with a positive control asserting the disk path opens exactly one — a spy wired to nothing would report zero for both); default-OFF keeps the disk path; a failed upload rejects rather than hangs; and an archive failure reports the **original** fault rather than the upload it knocks over.

### A hang the tests found

Writing that last test surfaced a real defect, and it announced itself by **timing out at 20s instead of failing**. `uploadStream` fed the SDK via `readStream.pipe(passThroughStream)`, and **`.pipe()` does not forward errors**: when the source failed it merely unpiped, so the destination was never ended and never errored and `Upload.done()` waited on a stream nothing would ever write to again. `stream.pipeline` destroys the destination with the error, which is what lets `done()` reject. **This was latent on the disk path too** — `fs.createReadStream` can fail mid-read, not least because the caller's error handler removes the directory the file is in.

Reverting `pipeline` back to `.pipe()` reproduces the 20s timeout, so the test genuinely pins the fix rather than merely accompanying it.

Attribution also had to be latched: tearing the sink down to fail a report makes the in-flight upload fail too, so both errors exist by the time anything is rethrown, and reporting the upload's would bury every fetch/DB fault behind "failed to upload".

Passing the error into `output.destroy()` as well was tried and **measured redundant** — with `pipeline` the path settles either way, with `.pipe()` it hangs either way — so it was left out and the comment says so, rather than shipping a guard that reads as load-bearing and is not.

**Watched to fail.** Truncating one entry by 1 KiB on the streaming path only:

```
AssertionError: expected [ …(73) ] to deeply equal [ …(73) ]
  "name": "picture-5.jpeg",
- "sha256": "b916586d…", "size": 196608
+ "sha256": "0911acac…", "size": 195584
```

**Mutation-tested the memory guard** — two mutants, each killed by its own assertion:
- `queueSize` fixed at 4, ignoring the budget → `estimate 429496729600 produced 687194768 resident bytes: expected 687194768 to be less than or equal to 268435456`
- `partSize` fixed at the 5 MiB minimum → `expected 5242880 to be greater than 5242880`

**Test counts (observed, not asserted):** the three pre-existing suites were **50 passed** before and are **50 passed** after; with the new suite (5) and the new geometry cases (+9) the set is **78 passed across 5 files**. The repo's lint-rule guard suite is **507 passed across 37 files**. Typecheck: **0 errors**, and confirmed able to go red (a deliberate type error produced 2).

## Flag and rollback

**`csam-archive-stream-upload`** — `FLIPT_FEATURE_FLAGS.CSAM_ARCHIVE_STREAM_UPLOAD`, **default OFF**.

`isFlipt` returns `false` for an unknown flag, an unreachable Flipt, or a flag pinned disabled, so every failure mode lands on the unchanged disk path. **Rollback is flipping the flag off — no deploy.** The flag must also be created in the flipt-state repo, pinned `enabled: false`; until it exists the gate simply reads false.

The flag is read **once per report**, not per archive, so a mid-report flip cannot produce a bundle whose parts were assembled two different ways.

## Not verified

Multipart was exercised against a **fake S3**, not a real bucket — real-endpoint behaviour (credential handling, retries, endpoint quirks, genuine network backpressure) is unproven here, as is the resident-memory figure, which is derived from the geometry rather than measured under load. The 2.44 TiB ceiling is arithmetic from the part limit, not something any test uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XGXdA1zw5Kwj7UyF1pr8Q
