### PR TITLE
feat(image-scan): stuck-scan alert signal and a moderator rescan for stranded images

### DIFF
--- a/apps/moderator/src/lib/format.ts
+++ b/apps/moderator/src/lib/format.ts
@@ -67,6 +67,15 @@ export const relativeTime = (value: Date | string | null): string => {
   return fmt.format(seconds, 'second');
 };
 
+/** "12m" / "5h" / "3d": for a badge or caption, where `relativeTime`'s phrasing is too long. */
+export const shortAge = (value: Date | string, now = Date.now()): string => {
+  const minutes = Math.max(0, Math.floor((now - new Date(value).getTime()) / 60_000));
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+};
+
 /**
  * User-authored rich text (review `details`, comment bodies) is stored as HTML. Svelte escapes it, so
  * rendering it raw shows a moderator the markup — and any filter matching on it matches the tags, which

--- a/apps/moderator/src/lib/queue-thresholds.ts
+++ b/apps/moderator/src/lib/queue-thresholds.ts
@@ -45,6 +45,8 @@ const THRESHOLDS: Record<string, readonly number[]> = {
   urgent: [5, 4, 1, 1, 0],
   errors: [30, 20, 10, 5, 0],
   articleReviews: [30, 20, 10, 5, 0],
+  // Ours, not Retool's: a healthy pipeline holds 0.
+  stuckIngestion: [200, 50, 10, 1, 0],
 };
 
 /** Retool's five-step scale, worst first. Tailwind rather than its hex, so the palette stays ours. */

--- a/apps/moderator/src/lib/server/__tests__/rescan-stuck-images.sql.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/rescan-stuck-images.sql.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The SQL `rescanStuckImages` compiles to, asserted without a database. The UPDATE's WHERE is the
+ * whole safety story — it is what stops a rescan from resetting a verdict that already landed or a
+ * moderator's locked rating — so it is pinned clause by clause, with the values bound to it.
+ */
+
+const h = vi.hoisted(() => ({
+  sql: [] as string[],
+  params: [] as unknown[][],
+  rows: [] as unknown[],
+  recordModActivity: vi.fn(),
+}));
+
+vi.mock('../db', async () => {
+  const { capturingDb } = await import('../../../test/capture-sql');
+  const db = capturingDb(h.sql, h.rows, h.params);
+  return { dbRead: db, dbWrite: db };
+});
+vi.mock('../mod-activity', () => ({ recordModActivity: h.recordModActivity }));
+vi.mock('../search-index', () => ({ syncSearchIndex: vi.fn() }));
+vi.mock('../cache', () => ({ bustCachedObject: vi.fn() }));
+vi.mock('../storage', () => ({ getStorage: vi.fn(), getMediaProbeStorage: vi.fn() }));
+
+const { rescanStuckImages, MAX_RESCAN_PER_REQUEST } = await import('../ingestion.service');
+
+const NOW = new Date('2026-09-11T12:00:00.000Z');
+const STUCK_CUTOFF = new Date(NOW.getTime() - 15 * 60_000);
+const flat = (i: number) => h.sql[i].replace(/\s+/g, ' ').trim();
+const cannedRows = (...ids: number[]) => {
+  h.rows.length = 0;
+  h.rows.push(...ids.map((id) => ({ id })));
+};
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(NOW);
+  h.sql.length = 0;
+  h.params.length = 0;
+  h.recordModActivity.mockReset();
+  cannedRows();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('rescanStuckImages', () => {
+  it('moves only still-stuck, unlocked rows from the selection to Rescan', async () => {
+    cannedRows(11, 12);
+
+    const result = await rescanStuckImages({ imageIds: [11, 12, 12], userId: 7 });
+
+    expect(h.sql).toHaveLength(1);
+    const update = flat(0);
+    expect(update).toMatch(/^update "Image" set "ingestion" = \$1 where "id" in \(\$2, \$3\) and /);
+    expect(update).toContain(`ingestion = 'Pending'::"ImageIngestionStatus" AND "createdAt" < $4`);
+    expect(update).toContain(`"nsfwLevelLocked" = $5`);
+    expect(update).toMatch(/returning "id"$/);
+    expect(h.params[0]).toEqual(['Rescan', 11, 12, STUCK_CUTOFF, false]);
+    expect(result).toEqual({ ok: true, count: 2 });
+  });
+
+  it('records one mod-activity row per image it actually moved', async () => {
+    cannedRows(11);
+
+    await rescanStuckImages({ imageIds: [11, 12], userId: 7 });
+
+    expect(h.recordModActivity).toHaveBeenCalledTimes(1);
+    expect(h.recordModActivity).toHaveBeenCalledWith({
+      userId: 7,
+      entityType: 'image',
+      entityId: 11,
+      activity: 'rescanStuck',
+    });
+  });
+
+  it('without ids, picks the oldest stuck unlocked images up to the cap, then updates those', async () => {
+    cannedRows(21, 22);
+
+    const result = await rescanStuckImages({ userId: 7 });
+
+    expect(h.sql).toHaveLength(2);
+    const pick = flat(0);
+    expect(pick).toMatch(/^select "id" from "Image" where /);
+    expect(pick).toContain(`ingestion = 'Pending'::"ImageIngestionStatus" AND "createdAt" < $1`);
+    expect(pick).toContain(`"nsfwLevelLocked" = $2`);
+    expect(pick).toMatch(/order by "id" limit \$3$/);
+    expect(h.params[0]).toEqual([STUCK_CUTOFF, false, MAX_RESCAN_PER_REQUEST]);
+    expect(h.params[1]).toEqual(['Rescan', 21, 22, STUCK_CUTOFF, false]);
+    expect(result).toEqual({ ok: true, count: 2 });
+  });
+
+  it('with nothing stuck, stops after the pick and records nothing', async () => {
+    const result = await rescanStuckImages({ userId: 7 });
+
+    expect(h.sql).toHaveLength(1);
+    expect(result).toEqual({ ok: true, count: 0 });
+    expect(h.recordModActivity).not.toHaveBeenCalled();
+  });
+
+  it('refuses an empty or oversized selection without touching the database', async () => {
+    const tooMany = Array.from({ length: MAX_RESCAN_PER_REQUEST + 1 }, (_, i) => i + 1);
+
+    expect(await rescanStuckImages({ imageIds: [], userId: 7 })).toEqual({
+      ok: false,
+      error: 'Select at least one image.',
+    });
+    expect(await rescanStuckImages({ imageIds: tooMany, userId: 7 })).toMatchObject({ ok: false });
+    expect(h.sql).toHaveLength(0);
+  });
+});

--- a/apps/moderator/src/lib/server/access.ts
+++ b/apps/moderator/src/lib/server/access.ts
@@ -29,8 +29,8 @@ export type NavLink = {
   path?: string;
   countKey?: string;
   external?: boolean;
-  // Count is informational only — the dashboard keeps it out of "needs attention". For backlogs nobody
-  // works through, like articles unpublished for spam.
+  // Count is informational only — kept out of the dashboard's "needs attention" total and the sidebar
+  // group badge. For counts nobody works through: spam-unpublished articles, stuck scans.
   informational?: boolean;
   // The section is granted as one page and its children are neither granted nor checked individually. Making
   // these children grantable would drop the grants already stored against the parent path.
@@ -81,12 +81,12 @@ export const NAVIGATION: NavLink[] = [
       { path: '/images/tags', label: 'Image Tags', countKey: 'imageTags' },
       { path: '/images/ratings', label: 'Image Ratings', countKey: 'imageRatings' },
       { path: '/images/downleveled', label: 'Downleveled' },
-      // `informational`: the page has no actions — the count is upload throughput, and the whole
-      // backlog whenever the scanner stalls. Summed into the group badge it reads as a review backlog.
+      // `informational`: stuck scans are a pipeline fault with no moderator action; summed into
+      // the group badge they would read as a review backlog.
       {
         path: '/images/to-ingest',
         label: 'Images to Ingest',
-        countKey: 'toIngest',
+        countKey: 'stuckIngestion',
         informational: true,
       },
       { path: '/images/ingestion-errors', label: 'Ingestion Errors', countKey: 'ingestionErrors' },

--- a/apps/moderator/src/lib/server/ingestion.service.ts
+++ b/apps/moderator/src/lib/server/ingestion.service.ts
@@ -1,6 +1,7 @@
 import { sql } from '@civitai/db/kysely';
 import { REDIS_KEYS } from '@civitai/redis';
 import { assertMediaPresentForPublish, MediaPresence, summarizeProbeError } from '@civitai/shared';
+import { STUCK_PENDING_MINUTES } from '@civitai/shared/image-ingestion';
 import { dbRead, dbWrite } from './db';
 import { bustCachedObject } from './cache';
 import { syncSearchIndex } from './search-index';
@@ -17,24 +18,36 @@ export type PendingIngestionImage = {
   metadata: unknown;
 };
 
-const pendingCutoff = () => {
-  const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() - 5);
-  return cutoff;
-};
+export const RECENT_PENDING_DAYS = 5;
+
+const recentWhere = () => sql<boolean>`
+  ingestion = 'Pending'::"ImageIngestionStatus"
+  AND "createdAt" > ${new Date(Date.now() - RECENT_PENDING_DAYS * 86_400_000)}
+`;
+
+/** One predicate for the stuck view and its badge, or the badge never reaches zero. Deliberately
+ *  uncapped, unlike the main app's 24h gauge: the months-old rows are the point. */
+const stuckWhere = () => sql<boolean>`
+  ingestion = 'Pending'::"ImageIngestionStatus"
+  AND "createdAt" < ${new Date(Date.now() - STUCK_PENDING_MINUTES * 60_000)}
+`;
+
+export type PendingIngestionView = 'recent' | 'stuck';
 
 export async function getImagesPendingIngestion({
   cursor,
   limit,
+  view,
 }: {
   cursor?: number;
   limit: number;
+  view: PendingIngestionView;
 }): Promise<{ items: PendingIngestionImage[]; nextCursor?: number }> {
   const rows = await dbRead
     .selectFrom('Image')
     .select(['id', 'name', 'url', 'type', 'createdAt', 'metadata'])
-    .where('ingestion', '=', 'Pending')
-    .where('createdAt', '>', pendingCutoff())
+    .$if(view === 'stuck', (qb) => qb.where(stuckWhere()))
+    .$if(view === 'recent', (qb) => qb.where(recentWhere()))
     .$if(cursor != null, (qb) => qb.where('id', '<', cursor!))
     .orderBy('id', 'desc')
     .limit(limit + 1)
@@ -49,10 +62,123 @@ export async function countImagesPendingIngestion(): Promise<number> {
   const row = await dbRead
     .selectFrom('Image')
     .select((eb) => eb.fn.countAll<number>().as('count'))
-    .where('ingestion', '=', 'Pending')
-    .where('createdAt', '>', pendingCutoff())
+    .where(recentWhere())
     .executeTakeFirst();
   return Number(row?.count ?? 0);
+}
+
+export async function countStuckIngestion(): Promise<number> {
+  const row = await dbRead
+    .selectFrom('Image')
+    .select((eb) => eb.fn.countAll<number>().as('count'))
+    .where(stuckWhere())
+    .executeTakeFirst();
+  return Number(row?.count ?? 0);
+}
+
+export type IngestionHealth = {
+  stuck: number;
+  stuckImages: number;
+  stuckVideos: number;
+  stuckAudio: number;
+  stuckOffQueue: number;
+  queueDepth: number;
+  queueOldestAt: Date | null;
+};
+
+export async function getIngestionHealth(): Promise<IngestionHealth> {
+  const [stuck, queue] = await Promise.all([
+    dbRead
+      .selectFrom('Image')
+      .select((eb) => [
+        eb.fn.countAll<string>().as('total'),
+        eb.fn.countAll<string>().filterWhere('type', '=', 'image').as('images'),
+        eb.fn.countAll<string>().filterWhere('type', '=', 'video').as('videos'),
+        eb.fn
+          .countAll<string>()
+          .filterWhere(sql<boolean>`type::text = 'audio'`)
+          .as('audio'),
+        eb.fn
+          .countAll<string>()
+          .filterWhere(
+            sql<boolean>`NOT EXISTS (
+              SELECT 1 FROM "JobQueue" jq
+              WHERE jq.type = 'ImageScan' AND jq."entityType" = 'Image' AND jq."entityId" = "Image".id
+            )`
+          )
+          .as('offQueue'),
+      ])
+      .where(stuckWhere())
+      .executeTakeFirst(),
+    dbRead
+      .selectFrom('JobQueue')
+      .select((eb) => [eb.fn.countAll<string>().as('depth'), eb.fn.min('createdAt').as('oldest')])
+      .where('type', '=', 'ImageScan')
+      .executeTakeFirst(),
+  ]);
+
+  return {
+    stuck: Number(stuck?.total ?? 0),
+    stuckImages: Number(stuck?.images ?? 0),
+    stuckVideos: Number(stuck?.videos ?? 0),
+    stuckAudio: Number(stuck?.audio ?? 0),
+    stuckOffQueue: Number(stuck?.offQueue ?? 0),
+    queueDepth: Number(queue?.depth ?? 0),
+    queueOldestAt: queue?.oldest ?? null,
+  };
+}
+
+export const MAX_RESCAN_PER_REQUEST = 500;
+
+export type RescanResult = { ok: true; count: number } | { ok: false; error: string };
+
+/**
+ * Hands stuck images to the ingest-images cron by moving them to `Rescan`: the ingestion trigger
+ * queues each one, and the cron's Rescan lane sends it at low priority behind its cooldown and retry
+ * cap. Nothing is sent from here. Without `imageIds`, takes the oldest stuck images, up to the cap.
+ */
+export async function rescanStuckImages({
+  imageIds,
+  userId,
+}: {
+  imageIds?: number[];
+  userId: number;
+}): Promise<RescanResult> {
+  let ids = imageIds ? [...new Set(imageIds)] : undefined;
+  if (ids && !ids.length) return { ok: false, error: 'Select at least one image.' };
+  if (ids && ids.length > MAX_RESCAN_PER_REQUEST)
+    return { ok: false, error: `Select at most ${MAX_RESCAN_PER_REQUEST} images at a time.` };
+
+  ids ??= (
+    await dbWrite
+      .selectFrom('Image')
+      .select('id')
+      .where(stuckWhere())
+      .where('nsfwLevelLocked', '=', false)
+      .orderBy('id')
+      .limit(MAX_RESCAN_PER_REQUEST)
+      .execute()
+  ).map((row) => row.id);
+  if (!ids.length) return { ok: true, count: 0 };
+
+  // Re-checked rather than trusted from the page: a verdict that landed since it rendered must not be
+  // reset, and a moderator's locked rating must not be rescanned away.
+  const rescanned = await dbWrite
+    .updateTable('Image')
+    .set({ ingestion: 'Rescan' })
+    .where('id', 'in', ids)
+    .where(stuckWhere())
+    .where('nsfwLevelLocked', '=', false)
+    .returning('id')
+    .execute();
+
+  // One row per image, as `bulkRemove` does: ModActivity keys on the content id.
+  await Promise.all(
+    rescanned.map(({ id }) =>
+      recordModActivity({ userId, entityType: 'image', entityId: id, activity: 'rescanStuck' })
+    )
+  );
+  return { ok: true, count: rescanned.length };
 }
 
 /** Shared by the queue and its badge: a divergence here is a count that never reaches zero. */

--- a/apps/moderator/src/lib/server/sidebar-counts.service.ts
+++ b/apps/moderator/src/lib/server/sidebar-counts.service.ts
@@ -4,7 +4,7 @@ import { createCache } from './cache';
 import { dbRead } from './db';
 import { bounded } from './bounded';
 import { getImageReviewCounts } from './image-review.service';
-import { countImagesPendingIngestion, countIngestionErrorImages } from './ingestion.service';
+import { countStuckIngestion, countIngestionErrorImages } from './ingestion.service';
 import { getImageRatingReviewCount } from './image-rating-review.service';
 import { countModeratorArticles } from './articles.service';
 import { getArticleRatingReviewCounts } from './article-rating-reviews.service';
@@ -28,7 +28,7 @@ async function fetchCounts(): Promise<SidebarCounts> {
     articles,
     articleRatings,
     reports,
-    toIngest,
+    stuckIngestion,
     ingestionErrors,
   ] = await Promise.all([
     getImageReviewCounts(),
@@ -59,9 +59,8 @@ async function fetchCounts(): Promise<SidebarCounts> {
     countModeratorArticles(),
     getArticleRatingReviewCounts(),
     getReportCounts(),
-    // Both queues were populated and badgeless — the counts simply had no key. Bounded because
-    // neither predicate has an index of its own; see `bounded`.
-    bounded(countImagesPendingIngestion),
+    // Bounded: neither count is served by an index alone; see `bounded`.
+    bounded(countStuckIngestion),
     bounded(countIngestionErrorImages),
   ]);
   return {
@@ -73,7 +72,7 @@ async function fetchCounts(): Promise<SidebarCounts> {
     reported: Number(reported?.count ?? 0),
     articles,
     articleRatings: articleRatings.Pending,
-    ...(toIngest != null ? { toIngest } : {}),
+    ...(stuckIngestion != null ? { stuckIngestion } : {}),
     ...(ingestionErrors != null ? { ingestionErrors } : {}),
   };
 }

--- a/apps/moderator/src/routes/+layout.svelte
+++ b/apps/moderator/src/routes/+layout.svelte
@@ -72,7 +72,12 @@
   const countFor = (key: string | undefined) =>
     key && counts.value ? (counts.value[key] ?? null) : null;
   const rollupFor = (item: NavLink) =>
-    item.children ? (item.children.reduce((sum, c) => sum + (countFor(c.countKey) ?? 0), 0) || null) : null;
+    item.children
+      ? item.children.reduce(
+          (sum, c) => sum + (c.informational ? 0 : (countFor(c.countKey) ?? 0)),
+          0
+        ) || null
+      : null;
 
   const isActive = (href: string, path: string) =>
     href === '/' ? path === '/' : path === href || path.startsWith(href + '/');

--- a/apps/moderator/src/routes/images/__tests__/to-ingest-rescan-action.test.ts
+++ b/apps/moderator/src/routes/images/__tests__/to-ingest-rescan-action.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const rescanStuckImages = vi.fn();
+
+vi.mock('$lib/server/ingestion.service', () => ({
+  rescanStuckImages,
+  getImagesPendingIngestion: vi.fn(),
+  countImagesPendingIngestion: vi.fn(),
+  getIngestionHealth: vi.fn(),
+  MAX_RESCAN_PER_REQUEST: 500,
+  RECENT_PENDING_DAYS: 5,
+}));
+
+// `$lib/server/query` reaches `db.ts` through users.service, which throws at import without a URL.
+vi.mock('$lib/server/db', () => ({ dbRead: {}, dbWrite: {} }));
+
+const { actions } = await import('../to-ingest/+page.server');
+
+const request = (fields: Record<string, string>) =>
+  ({
+    formData: async () => {
+      const form = new FormData();
+      for (const [k, v] of Object.entries(fields)) form.set(k, v);
+      return form;
+    },
+  } as never);
+
+const locals = { user: { id: 7 } } as never;
+const rescan = (fields: Record<string, string>) =>
+  actions.rescan({ request: request(fields), locals } as never);
+
+beforeEach(() => {
+  // reset, not clear: a `mockResolvedValue` from one case must not answer the next.
+  vi.resetAllMocks();
+});
+
+describe('to-ingest rescan action', () => {
+  it('passes the selected ids and the acting moderator', async () => {
+    rescanStuckImages.mockResolvedValue({ ok: true, count: 2 });
+
+    const result = await rescan({ imageIds: '11,12' });
+
+    expect(rescanStuckImages).toHaveBeenCalledWith({ imageIds: [11, 12], userId: 7 });
+    expect(result).toEqual({ success: true, count: 2 });
+  });
+
+  it('"all" passes no ids, so the service picks the oldest stuck images itself', async () => {
+    rescanStuckImages.mockResolvedValue({ ok: true, count: 242 });
+
+    await rescan({ all: 'true', imageIds: '11' });
+
+    expect(rescanStuckImages).toHaveBeenCalledWith({ imageIds: undefined, userId: 7 });
+  });
+
+  it("returns the service's refusal to the moderator as a 400", async () => {
+    rescanStuckImages.mockResolvedValue({ ok: false, error: 'Select at least one image.' });
+
+    const result = (await rescan({ imageIds: '' })) as { status: number; data: { error: string } };
+
+    expect(result.status).toBe(400);
+    expect(result.data.error).toBe('Select at least one image.');
+  });
+});

--- a/apps/moderator/src/routes/images/to-ingest/+page.server.ts
+++ b/apps/moderator/src/routes/images/to-ingest/+page.server.ts
@@ -1,21 +1,52 @@
+import { fail } from '@sveltejs/kit';
 import { z } from 'zod';
-import type { PageServerLoad } from './$types';
-import { parseQuery } from '$lib/server/query';
+import { STUCK_PENDING_MINUTES } from '@civitai/shared/image-ingestion';
+import type { Actions, PageServerLoad } from './$types';
+import { parseIdList, parseQuery } from '$lib/server/query';
 import {
   getImagesPendingIngestion,
   countImagesPendingIngestion,
+  getIngestionHealth,
+  rescanStuckImages,
+  MAX_RESCAN_PER_REQUEST,
+  RECENT_PENDING_DAYS,
 } from '$lib/server/ingestion.service';
 
 const querySchema = z.object({
   cursor: z.coerce.number().int().positive().optional().catch(undefined),
   limit: z.coerce.number().int().min(10).max(200).catch(100),
+  view: z.enum(['recent', 'stuck']).catch('recent'),
 });
 
 export const load: PageServerLoad = async ({ url }) => {
-  const { cursor, limit } = parseQuery(url, querySchema);
-  const [{ items, nextCursor }, total] = await Promise.all([
-    getImagesPendingIngestion({ cursor, limit }),
-    countImagesPendingIngestion(),
+  const { cursor, limit, view } = parseQuery(url, querySchema);
+  const [{ items, nextCursor }, total, health] = await Promise.all([
+    getImagesPendingIngestion({ cursor, limit, view }),
+    view === 'recent' ? countImagesPendingIngestion() : null,
+    getIngestionHealth().catch(() => null),
   ]);
-  return { wide: true, images: items, nextCursor, total };
+  return {
+    wide: true,
+    images: items,
+    nextCursor,
+    total,
+    health,
+    view,
+    recentDays: RECENT_PENDING_DAYS,
+    stuckMinutes: STUCK_PENDING_MINUTES,
+    maxRescan: MAX_RESCAN_PER_REQUEST,
+  };
+};
+
+// Access is enforced globally (hooks.server.ts), as on the sibling ingestion queues.
+export const actions: Actions = {
+  rescan: async ({ request, locals }) => {
+    const form = await request.formData();
+    const imageIds =
+      form.get('all') === 'true' ? undefined : parseIdList(String(form.get('imageIds') ?? ''));
+
+    const result = await rescanStuckImages({ imageIds, userId: locals.user.id });
+    if (!result.ok) return fail(400, { error: result.error });
+    return { success: true, count: result.count };
+  },
 };

--- a/apps/moderator/src/routes/images/to-ingest/+page.svelte
+++ b/apps/moderator/src/routes/images/to-ingest/+page.svelte
@@ -1,26 +1,96 @@
 <script lang="ts">
+  import { enhance } from '$app/forms';
+  import { page } from '$app/state';
+  import { SvelteSet } from 'svelte/reactivity';
+  import type { SubmitFunction } from '@sveltejs/kit';
   import { Badge } from '@civitai/ui/components/ui/badge/index.js';
+  import { Button } from '@civitai/ui/components/ui/button/index.js';
+  import ErrorAlert from '$lib/components/ErrorAlert.svelte';
   import ImageQueueGrid from '$lib/components/ImageQueueGrid.svelte';
-  import type { PageData } from './$types';
+  import { LINK_CLASS, num, shortAge } from '$lib/format';
+  import { clearPaging } from '$lib/paging';
+  import IngestionHealthPanel from './IngestionHealthPanel.svelte';
+  import type { ActionData, PageData } from './$types';
 
-  let { data }: { data: PageData } = $props();
+  let { data, form }: { data: PageData; form: ActionData } = $props();
   type Item = PageData['images'][number];
 
-  const daysAgo = (d: Date) => {
-    const days = Math.floor((Date.now() - new Date(d).getTime()) / 86_400_000);
-    return days <= 0 ? 'today' : days === 1 ? '1 day ago' : `${days} days ago`;
+  const selected = new SvelteSet<string | number>();
+  $effect(() => {
+    data.images;
+    selected.clear();
+  });
+  const selectedIds = $derived([...selected].join(','));
+  const stuckView = $derived(data.view === 'stuck');
+
+  let submitting = $state(false);
+  const submitRescan: SubmitFunction = () => {
+    submitting = true;
+    return async ({ update }) => {
+      await update();
+      submitting = false;
+    };
   };
+
+  // Links rather than `Tabs`, as on users/newest: a tab control cannot be middle-clicked.
+  const viewHref = (view: PageData['view']) => {
+    const url = new URL(page.url);
+    clearPaging(url.searchParams);
+    if (view === 'recent') url.searchParams.delete('view');
+    else url.searchParams.set('view', view);
+    return url.pathname + url.search;
+  };
+  const viewClass = (active: boolean) => (active ? 'text-white underline' : LINK_CLASS);
 </script>
 
 <header class="page-header">
   <h1>Images to Ingest</h1>
-  <p>{data.total} images pending ingestion</p>
+  {#if stuckView}
+    <p>
+      {data.health ? `${num(data.health.stuck)} scans` : 'Scans'} with no verdict after
+      {data.stuckMinutes} minutes, no age limit
+    </p>
+  {:else}
+    <p>{num(data.total ?? 0)} images pending ingestion in the last {data.recentDays} days</p>
+  {/if}
+
+  <nav class="mt-3 flex gap-3 text-sm">
+    <a
+      href={viewHref('recent')}
+      aria-current={data.view === 'recent' ? 'page' : undefined}
+      class={viewClass(data.view === 'recent')}>Last {data.recentDays} days</a
+    >
+    <a
+      href={viewHref('stuck')}
+      aria-current={stuckView ? 'page' : undefined}
+      class={viewClass(stuckView)}>Stuck past {data.stuckMinutes} min</a
+    >
+  </nav>
 </header>
+
+<IngestionHealthPanel health={data.health} stuckMinutes={data.stuckMinutes} />
+
+{#if form?.error}
+  <ErrorAlert class="mb-4" message={form.error} />
+{:else if form?.success}
+  <p class="mb-4 text-sm text-teal-400">
+    Queued {num(form.count)} images for rescan. The ingest job sends them within a few minutes.
+  </p>
+{/if}
+
+{#if stuckView && data.images.length > 0}
+  <form method="POST" action="?/rescan" use:enhance={submitRescan} class="mb-4">
+    <input type="hidden" name="all" value="true" />
+    <Button type="submit" size="sm" variant="outline" disabled={submitting}>
+      Rescan all stuck (oldest {num(data.maxRescan)})
+    </Button>
+  </form>
+{/if}
 
 {#snippet card(image: Item)}
   <div class="flex items-center justify-between text-xs text-muted-foreground">
     <span class="tabular-nums">#{image.id}</span>
-    <Badge variant="secondary">{daysAgo(image.createdAt)}</Badge>
+    <Badge variant="secondary">{shortAge(image.createdAt)}</Badge>
   </div>
 {/snippet}
 
@@ -29,5 +99,28 @@
   civitaiUrl={data.civitaiUrl}
   nextCursor={data.nextCursor}
   {card}
-  empty="No images pending ingestion."
+  selected={stuckView ? selected : undefined}
+  empty={stuckView
+    ? `Nothing stuck. Every pending scan is under ${data.stuckMinutes} minutes old.`
+    : 'No images pending ingestion.'}
 />
+
+{#if stuckView && selected.size > 0}
+  <!-- spacer so the fixed bar can't cover the last row / Next button -->
+  <div class="h-20"></div>
+  <div
+    class="fixed inset-x-0 bottom-0 z-20 border-t border-border bg-background/95 px-4 py-3 backdrop-blur"
+  >
+    <div class="mx-auto flex max-w-6xl flex-wrap items-center gap-3">
+      <span class="text-sm font-semibold">{selected.size} selected</span>
+      <button
+        onclick={() => selected.clear()}
+        class="text-xs text-muted-foreground hover:text-foreground">Clear</button
+      >
+      <form method="POST" action="?/rescan" use:enhance={submitRescan} class="ml-auto">
+        <input type="hidden" name="imageIds" value={selectedIds} />
+        <Button type="submit" size="sm" disabled={submitting}>Rescan selected</Button>
+      </form>
+    </div>
+  </div>
+{/if}

--- a/apps/moderator/src/routes/images/to-ingest/IngestionHealthPanel.svelte
+++ b/apps/moderator/src/routes/images/to-ingest/IngestionHealthPanel.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { num, shortAge } from '$lib/format';
+  import { queueSeverityClass } from '$lib/queue-thresholds';
+  import type { PageData } from './$types';
+
+  let { health, stuckMinutes }: { health: PageData['health']; stuckMinutes: number } = $props();
+
+  const breakdown = $derived.by(() => {
+    if (!health) return '';
+    const parts = [`${num(health.stuckImages)} images`, `${num(health.stuckVideos)} videos`];
+    if (health.stuckAudio) parts.push(`${num(health.stuckAudio)} audio`);
+    return parts.join(' · ');
+  });
+</script>
+
+{#snippet tile(value: number, label: string, caption: string, valueClass: string)}
+  <div>
+    <div class="text-xl font-semibold tabular-nums {valueClass}">{num(value)}</div>
+    <div class="text-xs text-dark-2">{label}</div>
+    <div class="mt-1 text-xs text-dark-2">{caption}</div>
+  </div>
+{/snippet}
+
+<section class="mb-4 rounded-xl border border-dark-4 bg-dark-6 p-5">
+  <h3 class="mb-3 text-sm font-semibold text-white">Scan pipeline</h3>
+  {#if !health}
+    <p class="text-sm text-red-300">Could not load scan pipeline health.</p>
+  {:else}
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      {@render tile(
+        health.stuck,
+        `Stuck past ${stuckMinutes} min`,
+        breakdown,
+        queueSeverityClass('stuckIngestion', health.stuck) ?? 'text-white'
+      )}
+      {@render tile(
+        health.stuckOffQueue,
+        'Stuck and off the scan queue',
+        'No automatic retry reaches these',
+        'text-white'
+      )}
+      {@render tile(
+        health.queueDepth,
+        'In the scan queue',
+        health.queueOldestAt
+          ? `Oldest ${shortAge(health.queueOldestAt)} · retries wait here for hours`
+          : 'Empty',
+        'text-white'
+      )}
+    </div>
+  {/if}
+</section>

--- a/docs/moderator-app/mod-studio-feedback-2026-08-17.md
+++ b/docs/moderator-app/mod-studio-feedback-2026-08-17.md
@@ -63,6 +63,9 @@ new code. Recorded because two are repeats of things this file already documents
 - [x] **`Images to Ingest` is `informational`** — the page has no actions and the count is upload
       throughput, so summing it into the Images badge reads as a review backlog whenever the scanner
       stalls.
+      - The flag reached the dashboard total only; the sidebar's `rollupFor` kept summing it until the
+        stuck-scan change (`feat/image-scan-stuck-alert`), which also switched the badge to count stuck
+        scans (`stuckIngestion`) instead of every pending upload from the last 5 days.
 - [x] **The Most reported rewrite evaluated its seventeen subplans below the sort**, i.e. for every
       qualifying report rather than the twenty kept — Postgres cannot project through a `Sort`, and the
       comment claimed the opposite. The LIMIT is taken in a CTE and the ids resolved outside it.

--- a/packages/civitai-shared/package.json
+++ b/packages/civitai-shared/package.json
@@ -13,7 +13,8 @@
     "./lazy": "./src/lazy.ts",
     "./type-guards": "./src/type-guards.ts",
     "./moderator-paths": "./src/moderator-paths.ts",
-    "./missing-media": "./src/missing-media.ts"
+    "./missing-media": "./src/missing-media.ts",
+    "./image-ingestion": "./src/image-ingestion.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/civitai-shared/src/image-ingestion.ts
+++ b/packages/civitai-shared/src/image-ingestion.ts
@@ -1,0 +1,3 @@
+/** A scan with no verdict after this long has stalled. The stuck-scan alert and the moderator page
+ *  that triages it must agree. */
+export const STUCK_PENDING_MINUTES = 15;

--- a/src/server/prom/__tests__/image-ingestion-gauges.behavior.test.ts
+++ b/src/server/prom/__tests__/image-ingestion-gauges.behavior.test.ts
@@ -1,0 +1,144 @@
+import { PGlite } from '@electric-sql/pglite';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Booting PGlite can exceed the default hook timeout on a contended runner.
+vi.setConfig({ hookTimeout: 60_000, testTimeout: 60_000 });
+
+const holder = vi.hoisted(() => ({
+  db: null as unknown as PGlite,
+  failImageQuery: false,
+  releases: [] as (Error | undefined)[],
+}));
+
+// src/__tests__/setup.ts stubs this module globally.
+vi.unmock('~/server/prom/client');
+
+// Hands the refresh's SQL to PGlite unmodified; canned rows could not catch a wrong WHERE.
+vi.mock('~/server/db/pgDb', () => ({
+  pgDbReadLong: {},
+  pgDbWrite: {},
+  pgDbRead: {
+    connect: async () => ({
+      query: async (sql: string) => {
+        if (holder.failImageQuery && sql.includes('"Image"'))
+          throw new Error('canceling statement due to statement timeout');
+        return holder.db.query(sql);
+      },
+      release: (error?: Error) => {
+        holder.releases.push(error);
+      },
+    }),
+  },
+}));
+vi.mock('~/server/db/datapacketDb', () => ({ datapacketDbRead: {} }));
+
+import { __refreshIngestionGaugesForTest, instrumentationRegistry } from '~/server/prom/client';
+
+type MetricJSON = { values: { value: number; labels: Record<string, string> }[] };
+
+async function series(name: string): Promise<[string, number][]> {
+  const metric = instrumentationRegistry.getSingleMetric(`civitai_app_${name}`) as unknown as {
+    get: () => Promise<MetricJSON>;
+  };
+  const { values } = await metric.get();
+  return values
+    .map((v) => [v.labels.type ?? v.labels.status ?? '', v.value] as [string, number])
+    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+}
+
+const value = async (name: string) => (await series(name))[0]?.[1];
+
+beforeAll(async () => {
+  holder.db = new PGlite();
+  await holder.db.exec(`
+    CREATE TABLE "Image" (
+      id serial PRIMARY KEY,
+      ingestion text NOT NULL,
+      type text NOT NULL,
+      "createdAt" timestamp(3) NOT NULL
+    );
+    CREATE TABLE "JobQueue" (
+      type text NOT NULL,
+      "entityType" text NOT NULL,
+      "entityId" int NOT NULL,
+      "createdAt" timestamp(3) NOT NULL
+    );
+  `);
+});
+
+beforeEach(async () => {
+  holder.failImageQuery = false;
+  holder.releases = [];
+  // Different stuck counts per type, so a swapped image/video mapping cannot pass.
+  await holder.db.exec(`
+    TRUNCATE "Image", "JobQueue";
+    INSERT INTO "Image" (ingestion, type, "createdAt") VALUES
+      ('Pending', 'image', now() - interval '30 minutes'),
+      ('Pending', 'image', now() - interval '40 minutes'),
+      ('Pending', 'image', now() - interval '2 minutes'),
+      ('Pending', 'image', now() - interval '3 days'),
+      ('Pending', 'video', now() - interval '1 hour'),
+      ('Scanned', 'image', now() - interval '30 minutes');
+    INSERT INTO "JobQueue" (type, "entityType", "entityId", "createdAt") VALUES
+      ('ImageScan', 'Image', 1, now() - interval '2 hours'),
+      ('ImageScan', 'Image', 2, now()),
+      ('BlockedImageDelete', 'Image', 3, now() - interval '9 days');
+  `);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('image-ingestion gauges', () => {
+  it('counts only Pending rows 15m-24h old, and reports every media type even at zero', async () => {
+    await __refreshIngestionGaugesForTest();
+
+    // Whole list, not a lookup: a missing `audio` series is the regression, and a `?? 0` lookup
+    // would read it as a healthy zero.
+    expect(await series('image_ingestion_stuck_pending')).toEqual([
+      ['audio', 0],
+      ['image', 2],
+      ['video', 1],
+    ]);
+    expect(await series('image_ingestion_backlog')).toContainEqual(['Pending', 5]);
+  });
+
+  it('counts the whole ImageScan queue and ages it by its oldest row', async () => {
+    await __refreshIngestionGaugesForTest();
+
+    expect(await value('image_scan_queue_depth')).toBe(2);
+    const oldest = await value('image_scan_queue_oldest_age_seconds');
+    expect(oldest).toBeGreaterThanOrEqual(7200);
+    expect(oldest).toBeLessThan(7300);
+  });
+
+  it('a failed refresh keeps the last values, leaves the timestamp stale, and discards the client', async () => {
+    // Frozen at the real current second, not a fixed date: PGlite's now() follows the faked clock,
+    // and the seeded rows are relative to the real one.
+    const start = new Date(Math.floor(Date.now() / 1000) * 1000);
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(start);
+
+    await __refreshIngestionGaugesForTest();
+    expect(await value('image_ingestion_gauges_refreshed_timestamp_seconds')).toBe(
+      start.getTime() / 1000
+    );
+    expect(holder.releases).toEqual([undefined]);
+
+    await holder.db.exec(`
+      INSERT INTO "Image" (ingestion, type, "createdAt")
+      VALUES ('Pending', 'image', now() - interval '20 minutes')
+    `);
+    holder.failImageQuery = true;
+    // Well inside the 45s cache window, so reading the gauges below cannot start a refresh.
+    vi.setSystemTime(new Date(start.getTime() + 10_000));
+    await __refreshIngestionGaugesForTest();
+
+    expect(await value('image_ingestion_gauges_refreshed_timestamp_seconds')).toBe(
+      start.getTime() / 1000
+    );
+    expect(await series('image_ingestion_stuck_pending')).toContainEqual(['image', 2]);
+    expect(holder.releases[1]).toBeInstanceOf(Error);
+  });
+});

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -20,6 +20,7 @@ import {
 import type { RedisMetricsBridge } from '@civitai/redis';
 import { datapacketDbRead } from '~/server/db/datapacketDb';
 import { pgDbRead, pgDbReadLong, pgDbWrite } from '~/server/db/pgDb';
+import { STUCK_PENDING_MINUTES } from '@civitai/shared/image-ingestion';
 // request-bulkhead is a pure leaf module (no imports), so this edge cannot form a cycle.
 import { bulkheadSnapshot } from '~/server/utils/request-bulkhead';
 
@@ -82,34 +83,59 @@ declare global {
 }
 
 // Image-ingestion working-state backlog + oldest-age gauges. These are DB-derived,
-// so they must NOT hit Postgres on every /metrics scrape (~15s). The query is served
+// so they must NOT hit Postgres on every /metrics scrape (~15s). The queries are served
 // from an in-process cache with a short TTL and refreshed lazily off the scrape path
 // (fire-and-forget) — a scrape only ever kicks a background refresh, never blocks on
 // it, and reads the last-known values.
 //
-// DB SAFETY: the Image table is enormous and Scanned dominates it, so an unfiltered
-// GROUP BY over `ingestion` would seq-scan the whole table. Instead each working state
-// is counted independently and UNION ALL'd, which lets Postgres serve every branch
-// index-only from the existing per-state indexes (~1s). A defensive statement_timeout
-// caps the rare replica cold-cache spike; on timeout we keep the last-known values.
+// DB SAFETY (backlog query): the Image table is enormous and Scanned dominates it, so an unfiltered
+// GROUP BY over `ingestion` would seq-scan the whole table. Instead each working state is counted
+// independently and UNION ALL'd, so each branch walks only its own state's index (~1s). A defensive
+// statement_timeout caps the rare replica cold-cache spike; on timeout we keep the last-known values.
 const INGESTION_GAUGE_TTL_MS = 45_000;
 const INGESTION_GAUGE_STATEMENT_TIMEOUT_MS = 10_000;
 
+// Capped at 24h: months-old stranded rows would hold the count above zero, so the alert could
+// never resolve.
+const STUCK_WINDOW = `"createdAt" < now() - interval '${STUCK_PENDING_MINUTES} minutes'
+  AND "createdAt" > now() - interval '24 hours'`;
+
+// The stuck counts ride the Pending walk rather than a query of their own: `createdAt` only filters
+// that index scan, so a separate query repeats the whole walk (~200k buffers on the replica).
 const INGESTION_BACKLOG_SQL = `
-  SELECT 'Pending' AS status, count(*) AS backlog, min("createdAt") AS oldest
+  SELECT 'Pending' AS status, count(*) AS backlog, min("createdAt") AS oldest,
+         count(*) FILTER (WHERE type::text = 'image' AND ${STUCK_WINDOW}) AS stuck_image,
+         count(*) FILTER (WHERE type::text = 'video' AND ${STUCK_WINDOW}) AS stuck_video,
+         count(*) FILTER (WHERE type::text = 'audio' AND ${STUCK_WINDOW}) AS stuck_audio
     FROM "Image" WHERE ingestion='Pending'
   UNION ALL
-  SELECT 'Error', count(*), min("createdAt")
+  SELECT 'Error', count(*), min("createdAt"), NULL, NULL, NULL
     FROM "Image" WHERE ingestion='Error'
   UNION ALL
-  SELECT 'Rescan', count(*), min("createdAt")
+  SELECT 'Rescan', count(*), min("createdAt"), NULL, NULL, NULL
     FROM "Image" WHERE ingestion='Rescan'
   UNION ALL
-  SELECT 'PendingManualAssignment', count(*), min("createdAt")
+  SELECT 'PendingManualAssignment', count(*), min("createdAt"), NULL, NULL, NULL
     FROM "Image" WHERE ingestion='PendingManualAssignment'`;
+
+// Uncapped, unlike image_ingest_cron_queue_depth, which is the length of a `take`-limited read.
+const SCAN_QUEUE_SQL = `
+  SELECT count(*) AS depth, EXTRACT(EPOCH FROM now() - min("createdAt"))::float8 AS oldest_age
+    FROM "JobQueue" WHERE type='ImageScan'`;
+
+type IngestionBacklogQueryRow = {
+  status: string;
+  backlog: string;
+  oldest: Date | null;
+  stuck_image: string | null;
+  stuck_video: string | null;
+  stuck_audio: string | null;
+};
 
 type IngestionBacklogRow = { status: string; backlog: number; oldestAgeSeconds: number };
 let ingestionBacklogCache: IngestionBacklogRow[] = [];
+let stuckPendingCache: Record<string, number> = {};
+let scanQueueCache: { depth: number; oldestAgeSeconds: number } | null = null;
 let ingestionBacklogFetchedAt = 0;
 let ingestionBacklogInflight: Promise<void> | null = null;
 
@@ -117,31 +143,45 @@ async function queryIngestionBacklog() {
   // SET LOCAL binds the statement_timeout to this backend for the txn only, so the
   // pool's default policy is untouched. Checkout is required for it to apply.
   const dbClient = await pgDbRead.connect();
+  let failure: Error | undefined;
   try {
     await dbClient.query('BEGIN');
     await dbClient.query(`SET LOCAL statement_timeout = ${INGESTION_GAUGE_STATEMENT_TIMEOUT_MS}`);
-    const res = await dbClient.query<{ status: string; backlog: string; oldest: Date | null }>(
-      INGESTION_BACKLOG_SQL
+    const backlog = await dbClient.query<IngestionBacklogQueryRow>(INGESTION_BACKLOG_SQL);
+    const queue = await dbClient.query<{ depth: string; oldest_age: number | null }>(
+      SCAN_QUEUE_SQL
     );
     await dbClient.query('COMMIT');
-    return res.rows;
+    return { backlog: backlog.rows, queue: queue.rows[0] };
   } catch (e) {
+    failure = e as Error;
     await dbClient.query('ROLLBACK').catch(() => undefined);
     throw e;
   } finally {
-    dbClient.release();
+    // Passing the error discards the client instead of pooling a possibly-dead connection.
+    dbClient.release(failure);
   }
 }
 
 function refreshIngestionBacklog() {
   if (ingestionBacklogInflight) return ingestionBacklogInflight;
   ingestionBacklogInflight = queryIngestionBacklog()
-    .then((rows) => {
-      ingestionBacklogCache = rows.map((r) => ({
+    .then(({ backlog, queue }) => {
+      ingestionBacklogCache = backlog.map((r) => ({
         status: r.status,
         backlog: Number(r.backlog),
         oldestAgeSeconds: r.oldest != null ? (Date.now() - new Date(r.oldest).getTime()) / 1000 : 0,
       }));
+      const pending = backlog.find((r) => r.status === 'Pending');
+      stuckPendingCache = {
+        image: Number(pending?.stuck_image ?? 0),
+        video: Number(pending?.stuck_video ?? 0),
+        audio: Number(pending?.stuck_audio ?? 0),
+      };
+      scanQueueCache = {
+        depth: Number(queue?.depth ?? 0),
+        oldestAgeSeconds: Number(queue?.oldest_age ?? 0),
+      };
       ingestionBacklogFetchedAt = Date.now();
     })
     .catch(() => {
@@ -154,41 +194,82 @@ function refreshIngestionBacklog() {
   return ingestionBacklogInflight;
 }
 
+export const __refreshIngestionGaugesForTest = () => refreshIngestionBacklog();
+
 function maybeRefreshIngestionBacklog() {
   if (Date.now() - ingestionBacklogFetchedAt > INGESTION_GAUGE_TTL_MS)
     void refreshIngestionBacklog();
 }
 
-registerInstrumentationMetric(
-  PROM_PREFIX + 'image_ingestion_backlog',
-  () =>
-    new client.Gauge({
-      name: PROM_PREFIX + 'image_ingestion_backlog',
-      help: 'Images in a non-terminal working ingestion state (Pending/Error/Rescan/PendingManualAssignment)',
-      labelNames: ['status'],
-      registers: [instrumentationRegistry],
-      collect() {
-        maybeRefreshIngestionBacklog();
-        this.reset();
-        for (const row of ingestionBacklogCache) this.set({ status: row.status }, row.backlog);
-      },
-    })
+function registerIngestionGauge(
+  name: string,
+  help: string,
+  labelNames: string[],
+  fill: (gauge: client.Gauge<string>) => void
+) {
+  registerInstrumentationMetric(
+    PROM_PREFIX + name,
+    () =>
+      new client.Gauge({
+        name: PROM_PREFIX + name,
+        help,
+        labelNames,
+        registers: [instrumentationRegistry],
+        collect() {
+          maybeRefreshIngestionBacklog();
+          this.reset();
+          fill(this);
+        },
+      })
+  );
+}
+
+registerIngestionGauge(
+  'image_ingestion_backlog',
+  'Images in a non-terminal working ingestion state (Pending/Error/Rescan/PendingManualAssignment)',
+  ['status'],
+  (gauge) => {
+    for (const row of ingestionBacklogCache) gauge.set({ status: row.status }, row.backlog);
+  }
 );
-registerInstrumentationMetric(
-  PROM_PREFIX + 'image_ingestion_oldest_age_seconds',
-  () =>
-    new client.Gauge({
-      name: PROM_PREFIX + 'image_ingestion_oldest_age_seconds',
-      help: 'Age in seconds of the oldest image (now - min(createdAt)) per non-terminal ingestion state',
-      labelNames: ['status'],
-      registers: [instrumentationRegistry],
-      collect() {
-        maybeRefreshIngestionBacklog();
-        this.reset();
-        for (const row of ingestionBacklogCache)
-          this.set({ status: row.status }, row.oldestAgeSeconds);
-      },
-    })
+registerIngestionGauge(
+  'image_ingestion_oldest_age_seconds',
+  'Age in seconds of the oldest image (now - min(createdAt)) per non-terminal ingestion state',
+  ['status'],
+  (gauge) => {
+    for (const row of ingestionBacklogCache)
+      gauge.set({ status: row.status }, row.oldestAgeSeconds);
+  }
+);
+registerIngestionGauge(
+  'image_ingestion_stuck_pending',
+  `Images created ${STUCK_PENDING_MINUTES}m-24h ago still in ingestion=Pending: scans that should have returned and did not. The stuck-scan alert signal`,
+  ['type'],
+  (gauge) => {
+    for (const [type, stuck] of Object.entries(stuckPendingCache)) gauge.set({ type }, stuck);
+  }
+);
+registerIngestionGauge(
+  'image_scan_queue_depth',
+  'Rows in the ImageScan JobQueue, uncapped',
+  [],
+  (gauge) => {
+    if (scanQueueCache) gauge.set(scanQueueCache.depth);
+  }
+);
+registerIngestionGauge(
+  'image_scan_queue_oldest_age_seconds',
+  'Age in seconds of the oldest ImageScan JobQueue row. Error rows legitimately sit here for hours across retries, so this is context, not an alert signal',
+  [],
+  (gauge) => {
+    if (scanQueueCache) gauge.set(scanQueueCache.oldestAgeSeconds);
+  }
+);
+registerIngestionGauge(
+  'image_ingestion_gauges_refreshed_timestamp_seconds',
+  'Unix time the image-ingestion gauges last refreshed. A failing refresh freezes every other ingestion gauge at its last value; alert on this going stale',
+  [],
+  (gauge) => gauge.set(ingestionBacklogFetchedAt / 1000)
 );
 
 // 🔴 WHY THE BULKHEAD GAUGES USE registerInstrumentationMetric, AND WHY A globalThis


### PR DESCRIPTION
An image whose content scan never returns stays at ingestion = 'Pending' indefinitely: invisible to everyone else, with no error, no metric and nothing to alert on. A write-back defect in early September stranded tens of thousands this way and was found from support tickets, not monitoring.

Main app (src/server/prom/client.ts):
- image_ingestion_stuck_pending{type}: Pending images created 15m-24h ago, per media type and zero-filled. The alert signal. The existing Pending oldest-age gauge is pinned flat by rows stranded months ago, so it could never have fired.
- image_scan_queue_depth / image_scan_queue_oldest_age_seconds: the ImageScan JobQueue, uncapped (the cron's own depth gauge is the length of a take-limited read).
- image_ingestion_gauges_refreshed_timestamp_seconds: a failing refresh freezes every gauge at its last value, so the refresh's own freshness is published. The stuck counts ride the existing Pending walk rather than a second query (+47 buffers measured on the replica). A failed refresh now discards its pg client instead of pooling it.

Moderator app (/images/to-ingest):
- A stuck view with no age limit and a scan-pipeline panel; the sidebar badge counts stuck scans.
- A Rescan action, for selected images or the oldest 500. It moves still-stuck, unlocked images from Pending to Rescan and records mod activity per image; the ingestion trigger queues them and the ingest cron's Rescan lane sends them at low priority behind its cooldown and retry cap.
- The sidebar group badge now leaves out informational children, as the dashboard already did.

@civitai/shared/image-ingestion carries the 15-minute threshold, so the alert and the page that triages it cannot disagree.