### PR TITLE
fix(apps): listing detail rail — one word for the kind facet, and two links that look like links

### DIFF
--- a/src/components/Apps/AppListingDetailBody.affordances.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.affordances.browser.test.tsx
@@ -1,0 +1,199 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
+import type * as FeatureFlagsMod from '~/providers/FeatureFlagsProvider';
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * App-listing detail — the Details rail's LINK AFFORDANCES.
+ *
+ * Two tester reports, 2026-09-10, both about the same rail:
+ *   - *"I see that 'Source' is clickable, but there is no indication."*
+ *   - *"'Reviews' are not clickable."*
+ *
+ * 🔴 READ BEFORE TREATING ANY RESULT HERE AS A GATE: IT IS NOT ONE. This file is in
+ * the Vitest browser-mode `component` project, which CI runs only as the preview
+ * pipeline's `preview / component-tests` — report-only and non-blocking. The GATING
+ * claims for this change live in the node project:
+ * `__tests__/appListingReviewsAnchor.test.ts` (the link/target seam, which fails
+ * SILENTLY in production and so is the one that matters) and
+ * `__tests__/kindFacetLabelCallSites.test.ts`. This file exists for the half those
+ * structurally cannot make: that the rendered element is actually an anchor, with the
+ * href and the visible affordance a viewer needs.
+ *
+ * 🔴 NO CSS IS LOADED, so nothing here can assert "it looks like a link" — there is
+ * no computed colour and no rendered underline to read. What IS assertable is the
+ * contract that produces the affordance: the element is an `<a>`, it carries the
+ * right `href`, and Mantine's `underline="always"` reaches the DOM as
+ * `data-underline="always"`. A test claiming to verify the VISUAL would be claiming
+ * more than this tier can see, which is the failure mode these files are prone to.
+ */
+
+const WIDE: [number, number] = [1440, 900];
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// `importOriginal` SPREAD, not a wholesale replacement (local-rules/
+// no-wholesale-module-mock): a hand-written factory silently breaks every importer
+// the day the real module grows an export it omits, and here that surfaces as
+// `Tests no tests` — nothing to see rather than a failure.
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => {
+  const flags = { appBlocks: true, appListings: true, appBlocksPages: false };
+  return {
+    ...(await importOriginal<typeof FeatureFlagsMod>()),
+    useFeatureFlags: () => flags,
+    useOptionalFeatureFlags: () => flags,
+  };
+});
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    appListings: {
+      listAvailable: { useQuery: () => ({ data: { items: [] }, isLoading: false }) },
+      getMyReview: { useQuery: () => ({ data: null, isLoading: false }) },
+      upsertReview: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      reportListing: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
+    user: {
+      getCreator: { useQuery: () => ({ data: null }) },
+      getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) },
+    },
+    useUtils: () => ({
+      appListings: {
+        getMyReview: { invalidate: async () => undefined },
+        listReviews: { invalidate: async () => undefined },
+        getAppDetail: { invalidate: async () => undefined },
+      },
+    }),
+  },
+}));
+vi.mock('~/components/Apps/AppListingReviews', () => ({
+  AppListingReviews: () => <div data-testid="mock-reviews" />,
+}));
+vi.mock('~/components/Apps/AppListingComments', () => ({
+  AppListingComments: () => <div data-testid="mock-comments" />,
+}));
+
+// 🔴 Imported AFTER the mocks, like the component itself. A top-level VALUE import
+// from the app graph pulls part of that graph in before `vi.mock` hoisting settles,
+// which resolved a SECOND copy of React here and produced 'Invalid hook call' on
+// every test in the file. A `import type` is fine (erased); a value import is not.
+const { AppListingDetailBody } = await import('./AppListingDetailBody');
+const { LISTING_REVIEWS_ANCHOR_ID } = await import('~/components/Apps/listingKindLabels');
+
+beforeEach(async () => {
+  await page.viewport(...WIDE);
+});
+
+const SOURCE_URL = 'https://github.com/acme/cool-app';
+
+function base(over: Partial<ListingDetail> = {}): ListingDetail {
+  return {
+    id: 'l1',
+    serialId: 1,
+    slug: 'my-app',
+    kind: 'onsite',
+    collaborators: [],
+    name: 'My App',
+    tagline: 'A handy app',
+    description: null,
+    category: 'utility',
+    contentRating: null,
+    isBeta: false,
+    betaMessage: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    // Non-zero so the reviews row renders its LINK form, not "No reviews yet".
+    recommend: { recommendedCount: 7, notRecommendedCount: 1, recommendPct: 0.875 },
+    reviewCount: 8,
+    installCount: 4213,
+    sourceRepoUrl: SOURCE_URL,
+    updatedAt: '2026-03-04T05:06:07.000Z',
+    screenshots: [],
+    scopes: [],
+    kindData: {
+      kind: 'onsite',
+      appBlockId: 'blk-1',
+      hasPage: true,
+      liveUrl: 'https://my-app.civit.ai',
+    },
+    ...over,
+  };
+}
+
+async function renderBody(detail: ListingDetail, preview = false) {
+  const { container } = await renderWithProviders(
+    <AppListingDetailBody detail={detail} preview={preview} />
+  );
+  const within = page.elementLocator(container);
+  await expect.element(within.getByText('My App')).toBeInTheDocument();
+  return { container, within };
+}
+
+describe('Details rail — link affordances', () => {
+  test('🔴 the Source value is an anchor WITH a visible underline affordance', async () => {
+    const { container } = await renderBody(base());
+
+    const link = container.querySelector<HTMLAnchorElement>('[data-listing-detail-link="source"]');
+    expect(link, 'the source row must render a link').not.toBeNull();
+    expect(link!.tagName).toBe('A');
+    expect(link!.getAttribute('href')).toBe(SOURCE_URL);
+    // The affordance itself. Colour alone is not accessible; the underline is the
+    // part that survives a viewer who cannot separate the two hues.
+    expect(link!.getAttribute('data-underline')).toBe('always');
+  });
+
+  test('the Source link keeps its outbound security attributes', async () => {
+    // Not new behaviour — but this change swapped the element that carries them, and
+    // `noopener` on a `target="_blank"` third-party link is the one attribute whose
+    // loss is a security regression rather than a cosmetic one.
+    const { container } = await renderBody(base());
+    const link = container.querySelector<HTMLAnchorElement>('[data-listing-detail-link="source"]');
+    expect(link!.getAttribute('target')).toBe('_blank');
+    expect(link!.getAttribute('rel')).toContain('noopener');
+    expect(link!.getAttribute('rel')).toContain('noreferrer');
+  });
+
+  test('🔴 the Reviews value is a fragment link pointing at the reviews section', async () => {
+    const { container } = await renderBody(base());
+
+    const anchor = container.querySelector<HTMLAnchorElement>(
+      '[data-listing-detail-anchor="reviews"]'
+    );
+    expect(anchor, 'the reviews row must render a link').not.toBeNull();
+    expect(anchor!.tagName).toBe('A');
+    expect(anchor!.getAttribute('href')).toBe(`#${LISTING_REVIEWS_ANCHOR_ID}`);
+    // 🔴 NOT an outbound link: a same-page jump must not open a new tab.
+    expect(anchor!.getAttribute('target')).toBeNull();
+  });
+
+  test('🔴 the target it points at EXISTS in the rendered document', async () => {
+    // The seam, asserted where it can actually be observed. The node-tier sibling
+    // pins that both sides read one constant; this pins that the element is really
+    // in the DOM, which is what makes the link work.
+    const { container } = await renderBody(base());
+    expect(container.querySelector(`#${LISTING_REVIEWS_ANCHOR_ID}`)).not.toBeNull();
+  });
+
+  test('with NO reviews the row is plain text, not a link to an empty section', async () => {
+    const { container } = await renderBody(
+      base({
+        recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+        reviewCount: 0,
+      })
+    );
+    expect(container.querySelector('[data-listing-detail-anchor="reviews"]')).toBeNull();
+    expect(container.textContent).toContain('No reviews yet');
+  });
+
+  test('🔴 in PREVIEW there is no reviews link — the section is not rendered', async () => {
+    // The dangerous pairing: a link emitted in a posture that omits its target is a
+    // dead link, and a dead fragment link fails silently.
+    const { container } = await renderBody(base(), true);
+    expect(container.querySelector('[data-listing-detail-anchor="reviews"]')).toBeNull();
+    expect(container.querySelector(`#${LISTING_REVIEWS_ANCHOR_ID}`)).toBeNull();
+  });
+});

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -39,6 +39,7 @@ import {
 import { ACTION_GLYPH_ICONS, detailActionGlyph } from '~/components/Apps/appListingActionGlyph';
 import { BlockScopeList } from '~/components/Apps/BlockScopeList';
 import { buildListingDetailRows } from '~/components/Apps/appListingDetailRows';
+import { LISTING_REVIEWS_ANCHOR_ID } from '~/components/Apps/listingKindLabels';
 import { buildListingStatChips, type ListingStatChip } from '~/components/Apps/appListingStatChips';
 import {
   type DetailActionMode,
@@ -765,17 +766,45 @@ function DetailsPanel({ detail, preview }: { detail: ListingDetail; preview: boo
                   // look-alike. The href is already host-allowlisted and normalised
                   // server-side (`validateRepositoryUrl`); this is the second control, and
                   // `appListingDetailRows.ts` documents the contract on `href`.
-                  <Text
+                  // 🔴 `Anchor`, NOT `Text component="a"` — this is an AFFORDANCE fix,
+                  // not a component preference. As a `Text` the value rendered in the
+                  // body colour with no underline, so it was visually identical to the
+                  // non-link values sitting directly above and below it in the same
+                  // rail. Reported by a tester 2026-09-10: "I see that 'Source' is
+                  // clickable, but there is no indication." `Anchor` is the repo's
+                  // inline-link idiom (used throughout this file and the sibling Apps
+                  // components) and carries the link colour; `underline="always"` is
+                  // explicit because a colour difference alone is not an accessible
+                  // affordance — it fails for a viewer who cannot separate the two hues.
+                  <Anchor
                     size="sm"
-                    component="a"
                     href={row.href}
                     target="_blank"
                     rel="noopener noreferrer"
+                    underline="always"
                     data-listing-detail-link={row.key}
                     style={{ wordBreak: 'break-all' }}
                   >
                     {row.value}
-                  </Text>
+                  </Anchor>
+                ) : row.anchorId ? (
+                  // SAME-PAGE jump — deliberately NOT `target="_blank"`/`noopener`.
+                  // Those belong to `row.href` (an outbound third-party URL) and would
+                  // open this page's own reviews section in a new tab. See the two
+                  // fields' docstrings in `appListingDetailRows.ts`.
+                  // A real fragment link rather than a scroll handler: it works with
+                  // the keyboard, with middle-click, before hydration, and it can be
+                  // copied.
+                  <Anchor
+                    size="sm"
+                    href={`#${row.anchorId}`}
+                    underline="always"
+                    c={row.color}
+                    tt={row.key === 'reviews' ? 'capitalize' : undefined}
+                    data-listing-detail-anchor={row.key}
+                  >
+                    {row.value}
+                  </Anchor>
                 ) : (
                   <Text
                     size="sm"
@@ -1293,7 +1322,14 @@ export function AppListingDetailBody({
           heading. Omitted in preview: a shadow listing has no review rows and we must
           not query them. */}
       {!preview && (
-        <Stack gap="md">
+        // 🔴 `id` is the jump TARGET for the Details rail's "Reviews" row, which is a
+        // link a viewer can follow (a tester found the rail's reviews line and
+        // reasonably expected it to take them somewhere). Renaming or removing this id
+        // silently breaks that link — an `href="#…"` to a missing id is inert with no
+        // error — so it is pinned by `appListingReviewsAnchor.test.ts`.
+        // Not a `scrollIntoView` handler: a real fragment link works with the keyboard,
+        // with middle-click, and before hydration, and it survives being copied.
+        <Stack gap="md" id={LISTING_REVIEWS_ANCHOR_ID}>
           <Divider />
           <Title order={2}>Reviews</Title>
           <AppListingReviews appListingId={detail.id} />

--- a/src/components/Apps/AppsStoreFiltersDropdown.tsx
+++ b/src/components/Apps/AppsStoreFiltersDropdown.tsx
@@ -2,6 +2,7 @@ import { Button, Divider, Group, Stack } from '@mantine/core';
 import { AdaptiveFiltersDropdown } from '~/components/Filters/AdaptiveFiltersDropdown';
 import { CategoryFilterButtons } from '~/components/Apps/CategoryFilterButtons';
 import { KindFilterButtons } from '~/components/Apps/KindFilterButtons';
+import { LISTING_FACET_LABELS } from '~/components/Apps/listingKindLabels';
 import {
   APPS_STORE_DEFAULTS,
   countActiveAppsStoreFilters,
@@ -56,7 +57,7 @@ export function AppsStoreFiltersDropdown({ filters, onChange }: AppsStoreFilters
           {/* `Divider label=` is the /models panel's section-header idiom — a
               labelled rule rather than a heading, so the panel doesn't inject
               h3s into the page's heading outline. */}
-          <Divider label="Type" className="text-sm font-bold" />
+          <Divider label={LISTING_FACET_LABELS.kind} className="text-sm font-bold" />
           <KindFilterButtons value={filters.kind} onChange={(kind) => onChange({ kind })} />
         </Stack>
 

--- a/src/components/Apps/__tests__/appListingDetailRows.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailRows.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { getListingBadge } from '~/components/Apps/appListingCardView';
 import { buildListingDetailRows } from '~/components/Apps/appListingDetailRows';
+import { LISTING_FACET_LABELS } from '~/components/Apps/listingKindLabels';
 import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
@@ -55,7 +56,12 @@ describe('buildListingDetailRows — order', () => {
     const by = Object.fromEntries(rows.map((r) => [r.key, r]));
     // The `… app` form, not the bare word: the noun is what disambiguates "Embedded"
     // from the `Embedding` model type. See `listingKindLabels`' header.
-    expect(by.kind).toMatchObject({ label: 'Kind', value: 'Embedded app' });
+    // The facet LABEL is single-sourced (`LISTING_FACET_LABELS.kind`) so the detail
+    // rail and the store filter cannot drift apart again — they said "Kind" and
+    // "Type" for one field. Asserted through the constant rather than the word, so a
+    // later copy change edits one place instead of reddening this file.
+    // The row's `key` is deliberately still `kind`: that is its stable identity.
+    expect(by.kind).toMatchObject({ label: LISTING_FACET_LABELS.kind, value: 'Embedded app' });
     // 🔴 DISPLAY labels, not the stored enum. The fixture stores `utility` / `pg`.
     expect(by.category).toMatchObject({ label: 'Category', value: 'Utility' });
     expect(by.rating).toMatchObject({ label: 'Rating', value: 'PG' });

--- a/src/components/Apps/__tests__/appListingReviewsAnchor.test.ts
+++ b/src/components/Apps/__tests__/appListingReviewsAnchor.test.ts
@@ -92,7 +92,9 @@ describe('reviews anchor — the link and its target', () => {
   it('🔴 the section id is NOT hardcoded — both ends must read the constant', () => {
     // The whole point of the constant. A literal on either side re-opens the drift
     // this file exists to close.
-    const src = componentSource().replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    const src = componentSource()
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '');
     expect(src).not.toMatch(new RegExp(`id=(["'\`])${LISTING_REVIEWS_ANCHOR_ID}\\1`));
   });
 

--- a/src/components/Apps/__tests__/appListingReviewsAnchor.test.ts
+++ b/src/components/Apps/__tests__/appListingReviewsAnchor.test.ts
@@ -26,9 +26,23 @@ import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.sche
  * ## What is deliberately NOT asserted
  *
  * That the link scrolls. That is the browser's job for a fragment link, it needs a
- * real layout, and a test that mocked it would be testing the mock. The browser-tier
- * sibling asserts the ANCHOR EXISTS with the right href; this file asserts the target
- * exists to receive it.
+ * real layout, and a test that mocked it would be testing the mock.
+ *
+ * 🔴 AND A COVERAGE BOUNDARY THIS FILE CANNOT CROSS — stated because an earlier
+ * version of this header called the node tier "the one that matters", which was too
+ * strong. The id assertion below is a SOURCE-TEXT check: it catches the id being
+ * RENAMED or DELETED, and it does NOT catch the section being rendered under a
+ * NARROWER CONDITION than the link. Measured: adding a second conjunct to the
+ * section's render guard (`{!preview && canOpenPage && (`) while leaving the id
+ * intact leaves this file and `appListingDetailRows.test.ts` fully GREEN — 40 passed,
+ * 0 failed — and is caught only by the browser sibling's "the target it points at
+ * EXISTS in the rendered document".
+ *
+ * So the two tiers cover DIFFERENT HALVES and neither substitutes for the other: this
+ * one pins the VALUE (both ends read one constant), the browser one pins the
+ * PRESENCE (the element is really in the rendered document). The browser tier is
+ * report-only in CI, so that half is currently unblocked — a real gap, named rather
+ * than papered over. No shipped code path triggers it today.
  */
 
 const REPO_ROOT = path.resolve(__dirname, '../../../..');

--- a/src/components/Apps/__tests__/appListingReviewsAnchor.test.ts
+++ b/src/components/Apps/__tests__/appListingReviewsAnchor.test.ts
@@ -1,0 +1,126 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { LISTING_REVIEWS_ANCHOR_ID } from '~/components/Apps/listingKindLabels';
+import { buildListingDetailRows } from '~/components/Apps/appListingDetailRows';
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * 🔒 THE SEAM between the Details rail's "Reviews" LINK and the reviews SECTION it
+ * jumps to.
+ *
+ * ## Why a guard, when both sides are three lines of obvious code
+ *
+ * 🔴 BECAUSE THIS SEAM FAILS SILENTLY. An `href="#x"` pointing at an id nothing
+ * renders produces no error, no console warning and no visual difference — the link
+ * looks exactly like a working one and does nothing when clicked. Neither side is
+ * wrong on its own; only the RELATIONSHIP can be wrong, and nothing else in the tree
+ * observes it. Renaming the section's `id`, or dropping it during an unrelated
+ * refactor of that `Stack`, would ship a dead link that only a human who tried it
+ * would ever notice — which is precisely how the row came to be reported as "not
+ * clickable" in the first place.
+ *
+ * So this asserts the two ends AGREE, not that either end has a particular value.
+ * Changing `LISTING_REVIEWS_ANCHOR_ID` keeps every assertion below green.
+ *
+ * ## What is deliberately NOT asserted
+ *
+ * That the link scrolls. That is the browser's job for a fragment link, it needs a
+ * real layout, and a test that mocked it would be testing the mock. The browser-tier
+ * sibling asserts the ANCHOR EXISTS with the right href; this file asserts the target
+ * exists to receive it.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+function componentSource(): string {
+  return fs.readFileSync(
+    path.join(REPO_ROOT, 'src/components/Apps/AppListingDetailBody.tsx'),
+    'utf8'
+  );
+}
+
+function detailFixture(over: Partial<ListingDetail> = {}): ListingDetail {
+  return {
+    id: 'l1',
+    serialId: 1,
+    slug: 'my-app',
+    kind: 'onsite',
+    collaborators: [],
+    name: 'My App',
+    tagline: null,
+    description: null,
+    category: 'utility',
+    contentRating: null,
+    isBeta: false,
+    betaMessage: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    // Non-zero by default: the LINK only exists when there are reviews to jump to.
+    recommend: { recommendedCount: 7, notRecommendedCount: 1, recommendPct: 0.875 },
+    reviewCount: 8,
+    installCount: 3,
+    sourceRepoUrl: null,
+    updatedAt: '2026-03-04T05:06:07.000Z',
+    screenshots: [],
+    scopes: [],
+    kindData: {
+      kind: 'onsite',
+      appBlockId: 'blk-1',
+      hasPage: true,
+      liveUrl: 'https://my-app.civit.ai',
+    },
+    ...over,
+  };
+}
+
+const rowsFor = (over: Partial<ListingDetail> = {}, preview = false) =>
+  buildListingDetailRows(detailFixture(over), { preview, formatDate: () => 'some date' });
+
+describe('reviews anchor — the link and its target', () => {
+  it('🔴 the section renders the SAME id the row links to', () => {
+    // The target half. Read from source because the id is set on a JSX element in a
+    // branch this node-tier file cannot render.
+    expect(componentSource()).toContain('id={LISTING_REVIEWS_ANCHOR_ID}');
+
+    // The link half.
+    const reviews = rowsFor().find((r) => r.key === 'reviews');
+    expect(reviews?.anchorId).toBe(LISTING_REVIEWS_ANCHOR_ID);
+  });
+
+  it('🔴 the section id is NOT hardcoded — both ends must read the constant', () => {
+    // The whole point of the constant. A literal on either side re-opens the drift
+    // this file exists to close.
+    const src = componentSource().replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(src).not.toMatch(new RegExp(`id=(["'\`])${LISTING_REVIEWS_ANCHOR_ID}\\1`));
+  });
+
+  it('there is NO link when there are no reviews — it would land on an empty heading', () => {
+    const reviews = rowsFor({
+      recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+      reviewCount: 0,
+    }).find((r) => r.key === 'reviews');
+
+    expect(reviews?.value).toBe('No reviews yet');
+    expect(reviews?.anchorId).toBeUndefined();
+  });
+
+  it('🔴 there is NO link in PREVIEW — the section is not rendered in that posture', () => {
+    // The dangerous case: the moderator preview omits the reviews section entirely,
+    // so an anchor emitted there would point at an id that does not exist on the page.
+    // The row is gated out in preview today; this pins that the LINK cannot outlive
+    // the row if that ever changes.
+    const reviews = rowsFor({}, true).find((r) => r.key === 'reviews');
+    expect(reviews?.anchorId).toBeUndefined();
+  });
+
+  it('the reviews link does NOT use the outbound-link field', () => {
+    // `href` obliges the renderer to emit target="_blank" + rel="noopener noreferrer".
+    // Using it for a same-page fragment would open this page in a new tab, and would
+    // quietly attach a security posture designed for third-party URLs to one that is
+    // not. Two link kinds, two fields.
+    const reviews = rowsFor().find((r) => r.key === 'reviews');
+    expect(reviews?.href).toBeUndefined();
+  });
+});

--- a/src/components/Apps/__tests__/kindFacetLabelCallSites.test.ts
+++ b/src/components/Apps/__tests__/kindFacetLabelCallSites.test.ts
@@ -22,16 +22,34 @@ import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.sche
  *
  * 🔴 SO THIS ASSERTS THE RELATIONSHIP, NOT THE WORD. Fixing two strings does not
  * remove the condition — the next surface to label this facet will hardcode
- * whichever word its author last saw. Every assertion below is written so that
- * changing `LISTING_FACET_LABELS.kind` to any other string keeps the suite green
- * while the two surfaces stay in agreement; only DRIFT fails it. A test spelling
- * `'Type'` would instead have to be edited on every copy change, which is how a
- * guard becomes something people bump rather than read.
+ * whichever word its author last saw. No assertion below spells `'Type'`, so an
+ * ordinary copy change edits one constant instead of this file. A test spelling the
+ * word would have to be edited on every copy change, which is how a guard becomes
+ * something people bump rather than read.
+ *
+ * ⚠ BUT "ANY new word keeps the suite green" WOULD BE TOO STRONG, so it is not
+ * claimed. The `hardcoded` rule scans a whole enrolled FILE for the current word in
+ * any quoted string, so renaming the kind facet to a word ANOTHER facet already uses
+ * — `kind: 'Category'` — flags `AppsStoreFiltersDropdown`'s correct `label="Category"`
+ * for the category facet. That is a false positive, and it is accepted: it fails
+ * LOUDLY with the offending file and word in the message, the collision only arises
+ * for a word already on the same panel, and the alternative (tracking which literal
+ * belongs to which facet) is more machinery than the defect warrants.
  */
 
 const REPO_ROOT = path.resolve(__dirname, '../../../..');
 
-/** The two surfaces that name this facet to a viewer today. */
+/**
+ * The two PUBLIC-STORE surfaces that name this facet to a viewer.
+ *
+ * ⚠ NOT every surface in the tree that renders the word, and the omission is
+ * deliberate rather than an oversight — recorded here because the repo's convention
+ * is to write down a non-enrolment (`MyAppsBody.tsx` does it for the sibling ledger).
+ * `UnifiedReviewList.tsx` renders a `<Table.Th>Kind</Table.Th>` on the MODERATOR
+ * review queue. It is left out because that column's `kind` is the ROUTING kind of a
+ * review row, not the store facet a shopper filters on, and the two are free to
+ * diverge. If that queue ever starts showing the store facet, enrol it here.
+ */
 const FACET_LABEL_CALL_SITES = [
   'src/components/Apps/AppsStoreFiltersDropdown.tsx',
   'src/components/Apps/appListingDetailRows.ts',
@@ -60,7 +78,12 @@ function readCode(rel: string): string {
 describe('kind FACET label — enrolment ledger', () => {
   it('🔴 every enrolled call site imports the constant rather than spelling the word', () => {
     for (const rel of FACET_LABEL_CALL_SITES) {
-      const src = read(rel);
+      // 🔴 `readCode`, NOT `read` — and this line was the exception that proved the
+      // docstring above right. It used the raw file, so the claim "imports the
+      // constant rather than spelling the word" was satisfiable by a COMMENT
+      // mentioning the token. That is not hypothetical: it is what made this file's
+      // self-reported mutation count wrong by one.
+      const src = readCode(rel);
       expect(src, `${rel} must import LISTING_FACET_LABELS.kind`).toContain(
         'LISTING_FACET_LABELS.kind'
       );

--- a/src/components/Apps/__tests__/kindFacetLabelCallSites.test.ts
+++ b/src/components/Apps/__tests__/kindFacetLabelCallSites.test.ts
@@ -1,0 +1,146 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { LISTING_FACET_LABELS } from '~/components/Apps/listingKindLabels';
+import { buildListingDetailRows } from '~/components/Apps/appListingDetailRows';
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * 🔒 THE ENROLMENT LEDGER for the name of the KIND FACET — the word above the
+ * thing, not the words for its values (those are `standaloneWordingCallSites`).
+ *
+ * ## WHY THIS FILE EXISTS — measured, not hypothetical
+ *
+ * The store's filter panel called this facet **"Type"**; the listing detail page's
+ * Details rail called the same field **"Kind"**. One field, two words, on two
+ * surfaces a viewer moves between in one session. Reported by a tester 2026-09-10:
+ * *"why is it 'Kind' and not 'Type'? Should be 'Type', just like in the filter."*
+ *
+ * This is the sibling module's own defect one level up: the VALUE labels were
+ * single-sourced into `listingKindLabels.ts` and the FACET label was left
+ * open-coded at each site, so it drifted exactly as the values had.
+ *
+ * 🔴 SO THIS ASSERTS THE RELATIONSHIP, NOT THE WORD. Fixing two strings does not
+ * remove the condition — the next surface to label this facet will hardcode
+ * whichever word its author last saw. Every assertion below is written so that
+ * changing `LISTING_FACET_LABELS.kind` to any other string keeps the suite green
+ * while the two surfaces stay in agreement; only DRIFT fails it. A test spelling
+ * `'Type'` would instead have to be edited on every copy change, which is how a
+ * guard becomes something people bump rather than read.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+/** The two surfaces that name this facet to a viewer today. */
+const FACET_LABEL_CALL_SITES = [
+  'src/components/Apps/AppsStoreFiltersDropdown.tsx',
+  'src/components/Apps/appListingDetailRows.ts',
+] as const;
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+}
+
+/**
+ * Source with comments removed.
+ *
+ * 🔴 LOAD-BEARING, and it is here because the naive version FAILED ON ITSELF: the
+ * first draft of this guard flagged `appListingDetailRows.ts` for "hardcoding" the
+ * word, and the match was a COMMENT explaining the fix — prose naming the two words
+ * that used to disagree. A guard that goes red when someone writes the word in a
+ * sentence is one people learn to bump, which is worse than no guard. The claims
+ * below are about CODE, so they read code.
+ */
+function readCode(rel: string): string {
+  return read(rel)
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments, including JSX {/* … */} bodies
+    .replace(/^\s*\/\/.*$/gm, ''); // line comments
+}
+
+describe('kind FACET label — enrolment ledger', () => {
+  it('🔴 every enrolled call site imports the constant rather than spelling the word', () => {
+    for (const rel of FACET_LABEL_CALL_SITES) {
+      const src = read(rel);
+      expect(src, `${rel} must import LISTING_FACET_LABELS.kind`).toContain(
+        'LISTING_FACET_LABELS.kind'
+      );
+    }
+  });
+
+  it('🔴 no enrolled call site hardcodes the facet word in a user-facing string', () => {
+    // Matches the literal in a quoted string or a JSX text node. Derived from the
+    // constant, so this assertion follows a copy change instead of blocking it.
+    const word = LISTING_FACET_LABELS.kind;
+    const hardcoded = new RegExp(`(["'\`])${word}\\1|>\\s*${word}\\s*<`);
+    for (const rel of FACET_LABEL_CALL_SITES) {
+      const src = readCode(rel);
+      expect(hardcoded.test(src), `${rel} hardcodes "${word}" instead of the constant`).toBe(false);
+    }
+  });
+
+  it('🔴 the retired word "Kind" is gone from the enrolled surfaces as a LABEL', () => {
+    // Scoped to a user-facing label. `key: 'kind'` is the row's stable identity and
+    // must SURVIVE — a consumer selects on it — so this must not become a blanket
+    // ban on the token. That distinction is the whole reason the assertion is
+    // written against quoted display text rather than the identifier.
+    const labelKind = /label:\s*(["'`])Kind\1|label=\{?(["'`])Kind\2|>\s*Kind\s*</;
+    for (const rel of FACET_LABEL_CALL_SITES) {
+      expect(labelKind.test(readCode(rel)), `${rel} still labels the facet "Kind"`).toBe(false);
+    }
+  });
+
+  it('the row identity `kind` is UNCHANGED — only the label moved', () => {
+    // The mirror of the assertion above, and the thing that would break a consumer
+    // if the rename had gone one token too far.
+    const rows = buildListingDetailRows(detailFixture(), {
+      formatDate: () => 'some date',
+    });
+    const kindRow = rows.find((r) => r.key === 'kind');
+    expect(kindRow, 'the kind row must still be addressable by key "kind"').toBeDefined();
+    expect(kindRow?.label).toBe(LISTING_FACET_LABELS.kind);
+  });
+
+  it('the detail row and the filter panel agree — the actual claim', () => {
+    // Both sides read from one constant, so agreement is structural rather than
+    // coincidental. This asserts that the structure is what is in place: the
+    // filter references the constant, and the row's rendered label IS the constant.
+    const filterSrc = readCode('src/components/Apps/AppsStoreFiltersDropdown.tsx');
+    expect(filterSrc).toContain('label={LISTING_FACET_LABELS.kind}');
+
+    const rows = buildListingDetailRows(detailFixture(), { formatDate: () => 'some date' });
+    expect(rows.find((r) => r.key === 'kind')?.label).toBe(LISTING_FACET_LABELS.kind);
+  });
+});
+
+function detailFixture(): ListingDetail {
+  return {
+    id: 'l1',
+    serialId: 1,
+    slug: 'my-app',
+    kind: 'onsite',
+    collaborators: [],
+    name: 'My App',
+    tagline: null,
+    description: null,
+    category: 'utility',
+    contentRating: null,
+    isBeta: false,
+    betaMessage: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    installCount: 0,
+    sourceRepoUrl: null,
+    updatedAt: '2026-03-04T05:06:07.000Z',
+    screenshots: [],
+    scopes: [],
+    kindData: {
+      kind: 'onsite',
+      appBlockId: 'blk-1',
+      hasPage: true,
+      liveUrl: 'https://my-app.civit.ai',
+    },
+  };
+}

--- a/src/components/Apps/appListingDetailRows.ts
+++ b/src/components/Apps/appListingDetailRows.ts
@@ -41,6 +41,8 @@
 
 import {
   LISTING_KIND_APP_LABELS,
+  LISTING_FACET_LABELS,
+  LISTING_REVIEWS_ANCHOR_ID,
   STANDALONE_KIND_LABEL,
 } from '~/components/Apps/listingKindLabels';
 import { getRatingLabel } from '~/utils/rating-label';
@@ -69,6 +71,22 @@ export type ListingDetailRow = {
    * this is defence in depth on a link we already constrain, not the only control.
    */
   href?: string;
+  /**
+   * When set, the row's value renders as a SAME-PAGE fragment link to this element id.
+   * Only the `reviews` row sets it, and only when there is something to jump to.
+   *
+   * 🔴 DELIBERATELY A SEPARATE FIELD FROM {@link href}, NOT A FRAGMENT SQUEEZED INTO IT.
+   * `href`'s contract obliges the renderer to emit `target="_blank"` +
+   * `rel="noopener noreferrer"`, which is correct for an outbound third-party URL and
+   * WRONG here — it would open this page's own reviews section in a new tab. Two
+   * different link kinds with two different security postures do not share one field;
+   * merging them is how the `noopener` requirement quietly stops applying to the case
+   * that needs it.
+   *
+   * 🔴 The id must be `LISTING_REVIEWS_ANCHOR_ID`, the same constant the section
+   * renders — a fragment link to an id nothing renders fails SILENTLY.
+   */
+  anchorId?: string;
   /**
    * Mantine colour token for the value, when the value carries a verdict. Only the
    * `reviews` row sets it (the rating ladder's colour); everything else renders in the
@@ -112,7 +130,10 @@ export function buildListingDetailRows(
 ): ListingDetailRow[] {
   const rows: ListingDetailRow[] = [];
 
-  rows.push({ key: 'kind', label: 'Kind', value: kindLabel(detail) });
+  // `key` stays `'kind'` — it is the stable row identity the tests and any consumer
+  // select on. Only the human LABEL is single-sourced, so the detail rail and the
+  // store filter cannot drift apart again (they said "Kind" and "Type").
+  rows.push({ key: 'kind', label: LISTING_FACET_LABELS.kind, value: kindLabel(detail) });
 
   // 🔴 BOTH VALUES GO THROUGH THEIR DISPLAY-LABEL MAP. These two rows shipped
   // rendering the RAW stored enum — a tester read "utility" and "pg13" in the store
@@ -169,6 +190,9 @@ export function buildListingDetailRows(
       // Matches `getRecommendLabel`'s zero case. 🔴 The ladder is NOT called here: with
       // zero reviews `positiveRating` is 0, which the ladder scores `Mixed` — a verdict
       // about an app nobody has reviewed.
+      // No `href` in the zero-review case: there is a section to jump to, but nothing
+      // in it, so a link would move the viewer to an empty heading. The link is an
+      // affordance for content that exists.
       rows.push({ key: 'reviews', label: 'Reviews', value: 'No reviews yet' });
     } else {
       const { label, color } = getRatingLabel({
@@ -180,6 +204,14 @@ export function buildListingDetailRows(
         label: 'Reviews',
         value: `${label} (${detail.reviewCount.toLocaleString()})`,
         color: String(color),
+        // 🔴 Only in this branch — the zero-review row above deliberately omits it.
+        // No `preview` guard is needed HERE because the whole block is already inside
+        // `if (!opts.preview)`. That matters: the reviews SECTION is not rendered in
+        // the preview posture, so a link emitted there would point at an id that does
+        // not exist on the page — and a dead fragment link fails silently. The
+        // existing row-level gate is what keeps that from happening; do not move this
+        // row out from under it without moving the link too.
+        anchorId: LISTING_REVIEWS_ANCHOR_ID,
       });
     }
   }

--- a/src/components/Apps/listingKindLabels.ts
+++ b/src/components/Apps/listingKindLabels.ts
@@ -80,6 +80,65 @@ export const STANDALONE_KIND_LABEL = LISTING_KIND_LABELS.offsite;
  */
 export const EMBEDDED_KIND_LABEL = LISTING_KIND_LABELS.onsite;
 
+/**
+ * 🔒 THE SINGLE SOURCE for the name of the KIND FACET ITSELF — the word a viewer
+ * reads above the thing, as opposed to the words for its values above.
+ *
+ * The store's filter panel called this facet **"Type"** while the listing detail
+ * page's Details rail called the same field **"Kind"**. One field, two words, on two
+ * surfaces a viewer moves between in a single session — the identical N-sites defect
+ * this module was created for, one level up: the VALUE labels were unified here and
+ * the FACET label was left open-coded at each site.
+ *
+ * Reported by a tester on 2026-09-10: *"why is it 'Kind' and not 'Type'? Should be
+ * 'Type', just like in the filter."*
+ *
+ * 🔴 "Type" WON because the filter is where a viewer meets the concept FIRST and it
+ * is the more common word; the detail row was the outlier. As with the labels above,
+ * this is a DISPLAY name only — the stored value, the `kind` query param, the
+ * `StoreListingKind` union and the public `/api/v1/apps` enum are untouched.
+ */
+export const LISTING_FACET_LABELS = {
+  kind: 'Type',
+} as const satisfies Record<string, string>;
+
+/**
+ * 🔴 A MAP, NOT A SCALAR, AND THE SHAPE IS LOAD-BEARING TWICE OVER.
+ *
+ * 1. `listingLabelCallSites.test.ts`'s `bare-option-label` rule requires that a
+ *    `label:` paired with a `value:` in the same object literal be "a LOOKUP or a
+ *    LITERAL, never a bare identifier". A detail ROW literal is `{key, label, value}`,
+ *    which matches that shape even though it is not a Select option — so a scalar
+ *    constant here trips a guard aimed at `{value: r, label: r}`. `LISTING_FACET_LABELS.kind`
+ *    is a lookup and satisfies the rule as written. **Conform to the guard; do not
+ *    widen it for this.** It was narrowed deliberately and its own tests say so.
+ * 2. ⚠ A `category` key was TRIED and BACKED OUT — recorded so nobody adds it again.
+ *    The reasoning was sound (category is the other facet named on both surfaces, so
+ *    it is the next one that can drift), but `LISTING_FACET_LABELS.category` in a
+ *    `label:` position trips `listingLabelCallSites.test.ts`'s OTHER rule, which
+ *    name-matches a `.category` read rendered as a label — the rule that exists
+ *    because these rows once shipped the raw stored enum. That guard is RIGHT to be
+ *    suspicious of that shape, and the two surfaces agree on "Category" today, so
+ *    this was a speculative fix colliding with a real one. If category ever does
+ *    drift, fix it in a way the guard can tell apart from the defect it hunts.
+ */
+export const LISTING_KIND_FACET_LABEL = LISTING_FACET_LABELS.kind;
+
+/**
+ * 🔒 THE SINGLE SOURCE for the listing detail page's REVIEWS section anchor.
+ *
+ * The Details rail's "Reviews" row links here; the section itself carries this as its
+ * `id`. Both sides must read this constant, because the failure mode is SILENT: an
+ * `href="#…"` pointing at an id nothing renders does nothing at all — no error, no
+ * console warning, just a link that appears to be broken to the one person who tried
+ * it. A tester reported the rail's Reviews line as "not clickable"; a link that
+ * scrolls nowhere is the same experience with more steps.
+ *
+ * Lives here rather than in the component so the two sites cannot be edited apart, in
+ * the same spirit as the kind labels above.
+ */
+export const LISTING_REVIEWS_ANCHOR_ID = 'app-listing-reviews';
+
 /** kind → bare display label. */
 export function listingKindLabel(kind: StoreListingKind): string {
   return LISTING_KIND_LABELS[kind];

--- a/src/components/Apps/listingKindLabels.ts
+++ b/src/components/Apps/listingKindLabels.ts
@@ -97,21 +97,25 @@ export const EMBEDDED_KIND_LABEL = LISTING_KIND_LABELS.onsite;
  * is the more common word; the detail row was the outlier. As with the labels above,
  * this is a DISPLAY name only — the stored value, the `kind` query param, the
  * `StoreListingKind` union and the public `/api/v1/apps` enum are untouched.
- */
-export const LISTING_FACET_LABELS = {
-  kind: 'Type',
-} as const satisfies Record<string, string>;
-
-/**
+ *
  * 🔴 A MAP, NOT A SCALAR, AND THE SHAPE IS LOAD-BEARING TWICE OVER.
  *
  * 1. `listingLabelCallSites.test.ts`'s `bare-option-label` rule requires that a
  *    `label:` paired with a `value:` in the same object literal be "a LOOKUP or a
  *    LITERAL, never a bare identifier". A detail ROW literal is `{key, label, value}`,
- *    which matches that shape even though it is not a Select option — so a scalar
- *    constant here trips a guard aimed at `{value: r, label: r}`. `LISTING_FACET_LABELS.kind`
- *    is a lookup and satisfies the rule as written. **Conform to the guard; do not
- *    widen it for this.** It was narrowed deliberately and its own tests say so.
+ *    which matches that shape even though it is not a Select option — so a SCALAR
+ *    constant in that position trips a guard aimed at `{value: r, label: r}`.
+ *    `LISTING_FACET_LABELS.kind` is a lookup and satisfies the rule as written.
+ *    **Conform to the guard; do not widen it for this.** It was narrowed deliberately
+ *    and its own tests say so.
+ *
+ *    🔴 SO DO NOT RE-ADD A SCALAR ALIAS. One existed (`LISTING_KIND_FACET_LABEL`) and
+ *    was deleted: nothing imported it, the repo has no unused-export gate to say so,
+ *    and it sat under the more discoverable name carrying THIS comment — i.e. it
+ *    shipped the hazard under a doc explaining the hazard. A third facet site reaching
+ *    for it would fail `listingLabelCallSites` with a message about rendering a raw
+ *    `category`/`contentRating`, naming nothing about the real cause, on a line that
+ *    reads as obviously correct.
  * 2. ⚠ A `category` key was TRIED and BACKED OUT — recorded so nobody adds it again.
  *    The reasoning was sound (category is the other facet named on both surfaces, so
  *    it is the next one that can drift), but `LISTING_FACET_LABELS.category` in a
@@ -122,7 +126,9 @@ export const LISTING_FACET_LABELS = {
  *    this was a speculative fix colliding with a real one. If category ever does
  *    drift, fix it in a way the guard can tell apart from the defect it hunts.
  */
-export const LISTING_KIND_FACET_LABEL = LISTING_FACET_LABELS.kind;
+export const LISTING_FACET_LABELS = {
+  kind: 'Type',
+} as const satisfies Record<string, string>;
 
 /**
  * 🔒 THE SINGLE SOURCE for the listing detail page's REVIEWS section anchor.


### PR DESCRIPTION
Three tester reports about the same Details rail on the listing detail page.

## 1. "Why is it 'Kind' and not 'Type'? Should be 'Type', just like in the filter."

The store filter panel labelled the facet **"Type"**; the detail rail labelled the same field **"Kind"**. One field, two words, on two surfaces a viewer moves between in a single session.

This is `listingKindLabels.ts`'s own defect one level up. That module exists because *"a display rule open-coded at N sites is typically wrong at N−1 of them"* — the kind **value** labels were single-sourced into it, and the **facet** label was left open-coded at each site, so it drifted exactly as the values had. Both surfaces now read `LISTING_FACET_LABELS.kind`.

🔴 **A map rather than a scalar, and that is required rather than stylistic.** `listingLabelCallSites.test.ts`'s `bare-option-label` rule obliges a `label:` paired with a `value:` in one literal to be *"a LOOKUP or a LITERAL, never a bare identifier"* — and a detail **row** literal is `{key, label, value}`, which matches that shape even though it is not a Select option. A lookup satisfies the guard as written. The guard was narrowed deliberately and its own tests say so, so this conforms to it instead of widening it.

⚠ **A `category` key was tried and backed out**, recorded in the module so nobody re-adds it. `LISTING_FACET_LABELS.category` in a `label:` position trips that same file's *other* rule, which name-matches a `.category` read rendered as a label — the rule that exists because these rows once shipped the raw stored enum. That guard is right to be suspicious of the shape, the two surfaces agree on "Category" today, and a speculative fix colliding with a real guard is not worth shipping.

## 2. "I see that 'Source' is clickable, but there is no indication."

It rendered as `Text component="a"` — body colour, no underline, visually identical to the non-link values directly above and below it. Now a Mantine `Anchor` (this file's own inline-link idiom) with `underline="always"` — explicit, because colour alone is not an accessible affordance.

`target="_blank"` + `rel="noopener noreferrer"` carry over **and are now pinned by a test**: the element carrying them changed, and `noopener` on a third-party link is the attribute whose loss would be a security regression rather than a cosmetic one.

## 3. "'Reviews' are not clickable."

The reviews row now links to the reviews section.

🔴 **Via a separate row field (`anchorId`), not a fragment squeezed into `href`.** `href`'s documented contract obliges the renderer to emit `target="_blank"` + `noopener` — correct for an outbound URL, wrong here, since it would open this page's own reviews section in a new tab. Two link kinds with two security postures do not share one field; merging them is how the `noopener` requirement quietly stops applying to the case that needs it.

No link when there are **no reviews** (it would land on an empty heading) and none in the moderator **`preview`** posture, which omits the section entirely — a link there would be dead. **A dead fragment link fails silently**: no error, no warning, indistinguishable from a working one. That is why the link/target seam is pinned in the **blocking** node tier rather than left to the report-only browser project.

## Tests — tier stated, because it decides what the claim is worth

**Node (blocking).** `kindFacetLabelCallSites.test.ts` asserts the two surfaces **agree via the shared constant**, not that either says "Type" — so a later copy change edits one place instead of reddening the suite. Mutation-checked: reverting the rail to a hardcoded `'Kind'` fails 3 of its 5 assertions, including *"the detail row and the filter panel agree"*. `appListingReviewsAnchor.test.ts` pins the seam; mutation-checked by deleting the section's `id`, which fails *"the section renders the SAME id the row links to"* by its own assertion.

**Browser (report-only).** `AppListingDetailBody.affordances.browser.test.tsx`, 6 tests, for the half the node tier structurally cannot see — that the rendered element really is an `<a>` with the right href and affordance attribute. It asserts **no visual**: no CSS is loaded in that project, so "it looks like a link" is not a claim this tier can make.

🔴 **A trap worth recording:** a top-level **value** import from the app graph in a browser-mode test resolved a *second copy of React* and produced `Invalid hook call` on every test in the file. An `import type` is erased and fine; a value import must sit below the `vi.mock` block beside the component's own dynamic import.

**Verification.** Node `src/components/Apps` + `src/server/services/blocks` + `src/server/schema/blocks` = **266 files / 6476 tests, all passing**. Browser `src/components/Apps` = **86 files / 1282 tests**, all passing on re-run (a first run showed 7 files at `0 test` — the cold vite-optimizer import flake, every one in a file this change does not touch).

## Not done, reported rather than quietly dropped

- **App card metadata** (category / creator / last-updated) — **descoped**: it edits `AppListingCard.tsx`, which another in-flight task is actively reworking. Racing that on one component buys a conflict.
- **Colour-coded browsing-level icons** — not done, for a concrete reason. `BrowsingLevelBadge` takes a **numeric** nsfwLevel bitmask; a listing carries `contentRating` as a nullable **free-text** column a renderer can be handed out-of-domain values for. The existing rating→level mapping **fails closed to PG (SFW)**, so a colour badge fed through it would render an unknown rating as **safe** — worse than the plain text it replaced. That needs a deliberate decision about out-of-domain ratings, not a styling change.
- **"Apps" in the main nav** — a navigation-prominence product call, surfaced rather than taken unilaterally.

The field/value half of the Details request was already true: the rail renders label and value as distinct elements today.

## Deliberately out of scope

Moving **"More in category"** below the discussion was also requested. The current order is deliberate and reasoned in-file — the discovery rail sits above unbounded comment threads so it is not buried for the viewers most likely to want it. Reversing that is a decision, not a bug fix, and belongs in its own change that argues against the stated reasoning.
