### PR TITLE
test(apps): make the permissions-copy pin exact, and its tripwire reachable

### DIFF
--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -679,6 +679,24 @@ describe('Apps & permissions — the per-app daily Buzz limit', () => {
  * left the literal untouched and the whole file passed **26/26** — i.e. the exact
  * instruction this block exists to retract could be put back, as a second sentence, with
  * every test green. With `exact: true` that same append fails 2 of 26 on this locator.
+ *
+ * 🔴 BUT `exact: true` ALONE CLOSES ONLY THE SAME-ELEMENT APPEND — it is geometry, not
+ * string semantics, and an audit walked it: the locator matches the deepest element whose
+ * whole normalised subtree text equals the string, so moving the same sentence into a
+ * SIBLING `<Text>` in the same `<Stack>` leaves the pinned `<p>` byte-identical and the
+ * pin matches again. MEASURED: that sibling walk passed 26/26 with `exact: true` in place.
+ * Adding a line of copy as a new `<Text>` is at least as natural as extending an existing
+ * one, so this was the likely shape, not an exotic one. What closes it is the PAGE-WIDE
+ * absence check in the tripwire below — which is why that assertion is a phrase class
+ * rather than a literal, and why it reads `document.body.textContent` rather than this
+ * element. The two guards cover different geometry ON PURPOSE: this one pins the exact
+ * sentence, that one bans the instruction anywhere on the page.
+ *
+ * ⚠️ CONTAINMENT NOTE for the tripwire's wait: its anchor comes from the ACTIVITY panel,
+ * which is ungated, while the permissions panel is gated on `appBlocks`. So in a state
+ * where the permissions panel is absent entirely, the tripwire passes vacuously — the
+ * coverage for that state lives in the two tests that DO wait on the copy itself, which
+ * fail loudly in the same run. Do not read the tripwire alone as proof the panel exists.
  */
 describe('🔴 the revoke instruction is retracted, not reworded', () => {
   // 🔴 WIDENED WITH THE DATA SOURCE, NOT REWORDED FOR STYLE. `listMyScopeGrants` now also
@@ -727,12 +745,26 @@ describe('🔴 the revoke instruction is retracted, not reworded', () => {
     // under test. That proves the page rendered without coupling the wait to the thing
     // being asserted about.
     await expect.element(page.getByText(ACTIVITY_PANEL_ANCHOR)).toBeInTheDocument();
-    // Lower-cased on both sides: the retracted sentence began a sentence in the copy it
-    // came from, so a capitalised re-add slips past a lower-case `toContain`.
+    // 🔴 A PHRASE CLASS, NOT A LITERAL — and for an ABSENCE check that is the STRONGER
+    // choice, which is the exact inverse of the presence pin above. There, prose is
+    // walkable by rewording, so the whole string is pinned. Here, rewording IS the attack:
+    // a literal `toContain('to revoke access, remove the install')` is walked by
+    // "remove your install", "to withdraw a permission, remove the install", or any other
+    // spelling of the same false instruction.
+    //
+    // 🔴 PURPOSIVE, NOT MERELY CO-OCCURRING, because the honest copy legitimately mentions
+    // BOTH halves in one sentence in order to CONTRAST them ("Removing an install … does
+    // not withdraw a permission"). MEASURED against a looser co-occurrence pattern: it
+    // false-positives on an imperative rewrite of the HONEST copy ("Remove an install …
+    // but it does not withdraw a permission"). Requiring the infinitive-of-purpose
+    // ("to revoke/withdraw … remove … install", or the reverse order) rejects all three
+    // honest variants tried and catches all four dishonest ones.
+    const REVOKE_BY_UNINSTALL =
+      /\bto\s+(revoke|withdraw)\b[\s\S]{0,60}\bremov\w*\b[\s\S]{0,25}\binstall|\bremov\w*\b[\s\S]{0,25}\binstall[\s\S]{0,60}\bto\s+(revoke|withdraw)\b/i;
     expect(
-      (document.body.textContent ?? '').toLowerCase(),
+      document.body.textContent ?? '',
       'the copy instructs an uninstall as a way to revoke access, which it is not'
-    ).not.toContain('to revoke access, remove the install');
+    ).not.toMatch(REVOKE_BY_UNINSTALL);
   });
 
   test('🔴 POSITIVE CONTROL: the body text really is readable from here', async () => {
@@ -742,6 +774,6 @@ describe('🔴 the revoke instruction is retracted, not reworded', () => {
     mocks.flags = { appBlocks: true, appBlocksPages: true, appListings: true };
     renderWithProviders(<AppActivityPage />);
     await expect.element(page.getByText(PERMISSIONS_TAB_COPY, { exact: true })).toBeInTheDocument();
-    expect(document.body.textContent ?? '').toContain('Recent actions apps have taken');
+    expect(document.body.textContent ?? '').toContain(ACTIVITY_PANEL_ANCHOR);
   });
 });

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -663,13 +663,22 @@ describe('Apps & permissions — the per-app daily Buzz limit', () => {
  * setting `revokedAt: null`. Nothing writes a non-null `revoked_at`; nothing deletes a row.
  * So the scopes survive the uninstall and the next mint carries them with no fresh prompt.
  *
- * 🔴 PINNED AS THE WHOLE NORMALISED STRING, DELIBERATELY. The artifact under test is
- * PROSE, so a guard on keywords is walkable by rewording — a future edit could reintroduce
- * "remove the install to revoke" without tripping any `/revoke/`-shaped matcher, because
- * the honest copy contains that word too. Pinning the whole sentence means a cosmetic
- * reword fails this test; that cost is the price of a machine-readable claim about what
- * the page tells users. If you are here because you reworded it, re-read the paragraph
- * above and confirm your new wording is still TRUE before updating the literal.
+ * 🔴 PINNED AS THE WHOLE NORMALISED STRING, AND MATCHED **EXACTLY**. The artifact under
+ * test is PROSE, so a guard on keywords is walkable by rewording — a future edit could
+ * reintroduce "remove the install to revoke" without tripping any `/revoke/`-shaped
+ * matcher, because the honest copy contains that word too. Pinning the whole sentence
+ * means a cosmetic reword fails this test; that cost is the price of a machine-readable
+ * claim about what the page tells users. If you are here because you reworded it, re-read
+ * the paragraph above and confirm your new wording is still TRUE before updating it.
+ *
+ * 🔴 `{ exact: true }` IS LOAD-BEARING, NOT TIDINESS — without it this guard was WALKABLE
+ * and the paragraph above was false. `page.getByText(str)` is SUBSTRING matching, so the
+ * pin caught a reword (which changes the string) and NOT an append (which leaves it
+ * byte-intact). MEASURED at the parent of this commit: appending
+ * "To withdraw a permission, remove the install on the Installs tab." to the same `<Text>`
+ * left the literal untouched and the whole file passed **26/26** — i.e. the exact
+ * instruction this block exists to retract could be put back, as a second sentence, with
+ * every test green. With `exact: true` that same append fails 2 of 26 on this locator.
  */
 describe('🔴 the revoke instruction is retracted, not reworded', () => {
   // 🔴 WIDENED WITH THE DATA SOURCE, NOT REWORDED FOR STYLE. `listMyScopeGrants` now also
@@ -684,12 +693,19 @@ describe('🔴 the revoke instruction is retracted, not reworded', () => {
     'granted — withdrawing one is not possible yet. Recent activity is the full record of ' +
     'what apps have actually done on your account.';
 
+  /**
+   * A string from the ACTIVITY panel, deliberately not from the copy under test. Used as
+   * the render-wait for the absence check below — see the comment there for why the wait
+   * and the assertion must not be the same string.
+   */
+  const ACTIVITY_PANEL_ANCHOR = 'Recent actions apps have taken';
+
   test('the panel states plainly that withdrawing a permission is not possible', async () => {
     // `Tabs.Panel` is `keepMounted` by default, so the permissions panel's copy is in the
     // DOM without a click — the same property the marketplace-anchor count above relies on.
     mocks.flags = { appBlocks: true, appBlocksPages: true, appListings: true };
     renderWithProviders(<AppActivityPage />);
-    await expect.element(page.getByText(PERMISSIONS_TAB_COPY)).toBeInTheDocument();
+    await expect.element(page.getByText(PERMISSIONS_TAB_COPY, { exact: true })).toBeInTheDocument();
   });
 
   test('🔴 …and the retracted sentence is nowhere on the page', async () => {
@@ -698,9 +714,23 @@ describe('🔴 the revoke instruction is retracted, not reworded', () => {
     // because the two fail with very different messages, and this one names the defect.
     mocks.flags = { appBlocks: true, appBlocksPages: true, appListings: true };
     renderWithProviders(<AppActivityPage />);
-    await expect.element(page.getByText(PERMISSIONS_TAB_COPY)).toBeInTheDocument();
+    // 🔴 WAIT ON A STABLE ANCHOR, NOT ON THE COPY UNDER TEST — and the distinction is the
+    // whole fix here. `renderWithProviders` is async and is not awaited, so an absence
+    // check placed first runs against an EMPTY body and passes vacuously. This tripwire
+    // previously waited on `PERMISSIONS_TAB_COPY` itself, which supplied the await but made
+    // the check unreachable in the one scenario it names: on a literal revert that copy is
+    // gone, so the wait failed first and this assertion never ran — measured, all three
+    // tests died with the same locator error and this message never appeared. Reordering
+    // alone does NOT fix it; it just trades unreachable for vacuous (also measured).
+    //
+    // So: wait on a string from a DIFFERENT panel, which survives any rewrite of the copy
+    // under test. That proves the page rendered without coupling the wait to the thing
+    // being asserted about.
+    await expect.element(page.getByText(ACTIVITY_PANEL_ANCHOR)).toBeInTheDocument();
+    // Lower-cased on both sides: the retracted sentence began a sentence in the copy it
+    // came from, so a capitalised re-add slips past a lower-case `toContain`.
     expect(
-      document.body.textContent ?? '',
+      (document.body.textContent ?? '').toLowerCase(),
       'the copy instructs an uninstall as a way to revoke access, which it is not'
     ).not.toContain('to revoke access, remove the install');
   });
@@ -711,7 +741,7 @@ describe('🔴 the revoke instruction is retracted, not reworded', () => {
     // different panel so it cannot be satisfied by the copy under test.
     mocks.flags = { appBlocks: true, appBlocksPages: true, appListings: true };
     renderWithProviders(<AppActivityPage />);
-    await expect.element(page.getByText(PERMISSIONS_TAB_COPY)).toBeInTheDocument();
+    await expect.element(page.getByText(PERMISSIONS_TAB_COPY, { exact: true })).toBeInTheDocument();
     expect(document.body.textContent ?? '').toContain('Recent actions apps have taken');
   });
 });


### PR DESCRIPTION
Follow-up to #4722, from a retrospective audit of it (I merged that one without a round, so the audit ran afterwards). Test-only, one file.

**The shipped copy is correct. Both defects are in the guard that protects it** — and the guard's own docblock claimed properties it did not have.

## 1. The whole-string pin was walkable

`page.getByText(str)` is **substring** matching. So the pin caught a **reword** (which changes the string) and not an **append** (which leaves it byte-intact).

Measured at `origin/main`, appending this to the same `<Text>` while leaving the pinned literal untouched:

> To withdraw a permission, remove the install on the Installs tab.

→ **26/26 pass.** The exact instruction this block exists to retract could be put back, as a second sentence, with every test green. `{ exact: true }` at the locator sites; the same append now fails 2 of 26.

🔴 **Correction:** this said "all three call sites". There are **two** — the third was replaced by the anchor locator, not made exact. The "2 of 26" figure was the consistent one and reproduced exactly.

🔴 **And `exact: true` alone was NOT enough** — an audit walked it by moving the same sentence into a sibling `<Text>` (26/26 pass). Closed in `3d258e63b0` with a page-wide purposive phrase class; see the round-1 comment for the full mutation battery.

This matters because #4760's comment — reasonably — reads *"The whole-string pin is doing exactly its job here."* That is true for the reword case it hit, and was false for an append.

## 2. The literal-revert tripwire was unreachable in the scenario its comment names

It asserted the new copy **present** before checking the old copy **absent**. On a literal revert the new copy is gone, so the presence assert failed first and all three tests died with the same locator error — the tripwire's own message never appeared, contradicting its *"the two fail with very different messages"* comment.

**The fix is not simply reordering, and I'm recording that because I tried it and measured it wrong.** `renderWithProviders` is async and is not awaited, so an absence check placed first runs against an **empty body** and passes vacuously — reordering alone trades *unreachable* for *vacuous*. The old presence assert had been serving, accidentally, as the render-wait.

It now waits on a **stable anchor from a different panel**, which survives any rewrite of the copy under test, then asserts absence. Also lower-cased on both sides: the retracted sentence began a sentence in the copy it came from, so a capitalised re-add slipped past a lower-case `toContain`.

## Matrix — all measured, page and test at their real content

| scenario | `origin/main` | this change |
|---|---|---|
| clean tree | 26/26 pass | 26/26 pass |
| append the revoke instruction, pin byte-intact | **26/26 pass — walked** | 2 failed, on the exact locator |
| literal revert, **capitalised** | locator error only; tripwire never ran | tripwire fires with **its own** `AssertionError` |

The capitalised variant is deliberate — it exercises the case fix as well as the ordering fix.

## Scope

Test-only; no production file touched. Green path unaffected (26/26, ~2 s of test time).

Not included: the stale `block_user_subscriptions ONLY` comments the same audit flagged — **#4760 already corrected them**, so there is nothing left to do there.

