### PR TITLE
feat(models): reciprocal Suggested Resources, derived once

### DIFF
--- a/src/components/AssociatedModels/AssociateModels.tsx
+++ b/src/components/AssociatedModels/AssociateModels.tsx
@@ -2,19 +2,7 @@ import type { DragEndEvent, UniqueIdentifier } from '@dnd-kit/core';
 import { closestCenter, DndContext, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type { ComboboxItem } from '@mantine/core';
-import {
-  Stack,
-  Text,
-  Card,
-  Group,
-  Button,
-  Center,
-  Loader,
-  Alert,
-  Badge,
-  Box,
-  Chip,
-} from '@mantine/core';
+import { Stack, Text, Card, Group, Button, Center, Loader, Badge, Box, Chip } from '@mantine/core';
 import type { AssociationType } from '~/shared/utils/prisma/enums';
 import { IconGripVertical, IconTrash, IconUser } from '@tabler/icons-react';
 import { isEqual } from 'lodash-es';
@@ -35,6 +23,7 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
 import { constants } from '~/server/common/constants';
 import { selectNewlyAddedModelIds } from '~/server/services/model-association.utils';
 import { showWarningNotification } from '~/utils/notifications';
+import { getDisplayName } from '~/utils/string-helpers';
 
 type State = Array<Omit<ModelGetAssociatedResourcesSimple[number], 'id'> & { id?: number }>;
 
@@ -206,103 +195,107 @@ export function AssociateModels({
         <Center p="xl">
           <Loader />
         </Center>
+      ) : !associatedResources.length ? (
+        <Text align="center" c="dimmed" size="sm" py="lg">
+          No {type.toLowerCase()} resources yet — search above to add one
+        </Text>
       ) : (
-        <Stack gap={0}>
-          <Text align="right" c="dimmed" size="xs">
-            You can select {limit - associatedResources.length} more resources
+        <Stack gap="xs">
+          <Text c="dimmed" size="xs">
+            {associatedResources.length} of {limit} selected
           </Text>
-          {!!associatedResources.length ? (
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={associatedResources.map(({ item }) => item.id)}
+              strategy={verticalListSortingStrategy}
             >
-              <SortableContext
-                items={associatedResources.map(({ item }) => item.id)}
-                strategy={verticalListSortingStrategy}
-              >
-                <Stack gap={4}>
-                  {associatedResources.map((association) => (
-                    <SortableItem key={association.item.id} id={association.item.id}>
-                      <Card
-                        withBorder
-                        pl={4}
-                        pr={6}
-                        pt={4}
-                        pb={6}
-                        className={
-                          newlyAddedIds.has(association.item.id)
-                            ? 'border-blue-5 dark:border-blue-5'
-                            : undefined
-                        }
-                      >
-                        <Group justify="space-between" wrap="nowrap">
-                          <Group align="center" gap="xs" wrap="nowrap">
-                            <IconGripVertical />
-                            <Stack gap={4}>
-                              <Text size="md" lineClamp={2}>
-                                {'name' in association.item
-                                  ? association.item.name
-                                  : association.item.title}
-                              </Text>
-                              <Group gap={4}>
-                                <Badge size="md" radius="xl">
-                                  {'type' in association.item ? association.item.type : 'Article'}
+              <Stack gap={4}>
+                {associatedResources.map((association) => (
+                  <SortableItem key={association.item.id} id={association.item.id} cursor="grab">
+                    <Card
+                      withBorder
+                      pl={4}
+                      pr={6}
+                      pt={4}
+                      pb={6}
+                      className={
+                        newlyAddedIds.has(association.item.id)
+                          ? 'border-blue-5 dark:border-blue-5'
+                          : undefined
+                      }
+                    >
+                      <Group justify="space-between" wrap="nowrap">
+                        <Group align="center" gap="xs" wrap="nowrap">
+                          <IconGripVertical
+                            size={20}
+                            className="shrink-0 text-gray-6 dark:text-dark-2"
+                          />
+                          <Stack gap={4}>
+                            <Text size="md" lineClamp={2}>
+                              {'name' in association.item
+                                ? association.item.name
+                                : association.item.title}
+                            </Text>
+                            <Group gap={4}>
+                              <Badge size="md" radius="xl">
+                                {'type' in association.item
+                                  ? getDisplayName(association.item.type)
+                                  : 'Article'}
+                              </Badge>
+                              {!reciprocalEligible.has(association.item.id) && (
+                                <Badge size="md" radius="xl" pl={4} color="gray" variant="light">
+                                  <Group gap={2}>
+                                    <IconUser size={12} strokeWidth={2.5} />
+                                    {association.item.user.username}
+                                  </Group>
                                 </Badge>
-                                {!reciprocalEligible.has(association.item.id) && (
-                                  <Badge size="md" radius="xl" pl={4}>
-                                    <Group gap={2}>
-                                      <IconUser size={12} strokeWidth={2.5} />
-                                      {association.item.user.username}
-                                    </Group>
-                                  </Badge>
-                                )}
-                                {!getIsSafeBrowsingLevel(association.item.nsfwLevel) && (
-                                  <Badge color="red" size="md" radius="xl">
-                                    NSFW
-                                  </Badge>
-                                )}
-                                {reciprocalEligible.has(association.item.id) && (
-                                  <Chip
-                                    size="xs"
-                                    checked={linkBack.includes(association.item.id)}
-                                    onChange={() => toggleLinkBack(association.item.id)}
-                                  >
-                                    Link back
-                                  </Chip>
-                                )}
-                              </Group>
-                            </Stack>
-                          </Group>
-                          <LegacyActionIcon
-                            variant="outline"
-                            color="red"
-                            onClick={() => handleRemove(association.item.id)}
-                          >
-                            <IconTrash size={20} />
-                          </LegacyActionIcon>
+                              )}
+                              {!getIsSafeBrowsingLevel(association.item.nsfwLevel) && (
+                                <Badge color="red" size="md" radius="xl">
+                                  NSFW
+                                </Badge>
+                              )}
+                              {reciprocalEligible.has(association.item.id) && (
+                                <Chip
+                                  size="xs"
+                                  checked={linkBack.includes(association.item.id)}
+                                  onChange={() => toggleLinkBack(association.item.id)}
+                                >
+                                  Link back
+                                </Chip>
+                              )}
+                            </Group>
+                          </Stack>
                         </Group>
-                      </Card>
-                    </SortableItem>
-                  ))}
-                </Stack>
-              </SortableContext>
-            </DndContext>
-          ) : (
-            <Alert>There are no {type.toLowerCase()} resources associated with this model</Alert>
-          )}
+                        <LegacyActionIcon
+                          variant="subtle"
+                          color="red"
+                          aria-label="Remove resource"
+                          onClick={() => handleRemove(association.item.id)}
+                        >
+                          <IconTrash size={20} />
+                        </LegacyActionIcon>
+                      </Group>
+                    </Card>
+                  </SortableItem>
+                ))}
+              </Stack>
+            </SortableContext>
+          </DndContext>
         </Stack>
       )}
-      {changed && (
-        <Group justify="flex-end">
-          <Button variant="default" onClick={handleReset}>
-            Reset
-          </Button>
-          <Button onClick={handleSave} loading={isSaving}>
-            Save Changes
-          </Button>
-        </Group>
-      )}
+      <Group justify="flex-end">
+        <Button variant="default" onClick={handleReset} disabled={!changed || isSaving}>
+          Reset
+        </Button>
+        <Button onClick={handleSave} loading={isSaving} disabled={!changed}>
+          Save Changes
+        </Button>
+      </Group>
     </Stack>
   );
 }

--- a/src/components/AssociatedModels/AssociateModels.tsx
+++ b/src/components/AssociatedModels/AssociateModels.tsx
@@ -244,7 +244,7 @@ export function AssociateModels({
                                 : association.item.title}
                             </Text>
                             <Group gap={4}>
-                              <Badge size="md" radius="xl" variant="light">
+                              <Badge size="md" radius="xl">
                                 {'type' in association.item
                                   ? getDisplayName(association.item.type)
                                   : 'Article'}

--- a/src/components/AssociatedModels/AssociateModels.tsx
+++ b/src/components/AssociatedModels/AssociateModels.tsx
@@ -159,19 +159,17 @@ export function AssociateModels({
     savedTargetIds
   );
   const newlyAddedIds = new Set(newlyAdded);
-  // Ownership is the model owner's, never the viewer's — a moderator editing someone else's
-  // model links that creator's resources. Derived once here and read by both the chip gate
-  // and the author badge, so the two can never disagree.
-  const creatorOwnedIds = new Set(
-    associatedResources.filter(({ item }) => item.user.id === ownerId).map(({ item }) => item.id)
-  );
-  const viewerIsCreator = currentUser?.id === ownerId;
   // A row can be linked back only if it is newly added AND the creator owns it. The first half
   // comes from the shared derivation the server also uses; the second is the same ownership
   // rule the server re-derives from the database, which remains the authority.
+  //
+  // This asks whether the MODEL OWNER owns the row. The author badge below asks whether the
+  // VIEWER does. They are different questions and they disagree for a moderator, so do not
+  // merge them into one derivation — an earlier revision did, and the shared set mixed model
+  // ids with article ids because only this half is model-only.
   const reciprocalEligible = new Set(
     associatedResources
-      .filter(({ item }) => newlyAddedIds.has(item.id) && creatorOwnedIds.has(item.id))
+      .filter(({ item }) => newlyAddedIds.has(item.id) && item.user.id === ownerId)
       .map(({ item }) => item.id)
   );
   const toggleLinkBack = (modelId: number) => {
@@ -216,7 +214,11 @@ export function AssociateModels({
               Drag to reorder
             </Text>
             <Text c="dimmed" size="xs">
-              {associatedResources.length} of {limit} selected
+              {/* The list is seeded from the saved set, which predates the cap — 9 models hold
+                  11-12 — so it can exceed `limit` and "12 of 10" would be nonsense. */}
+              {associatedResources.length > limit
+                ? `${associatedResources.length} selected`
+                : `${associatedResources.length} of ${limit} selected`}
             </Text>
           </Group>
           <DndContext
@@ -264,7 +266,7 @@ export function AssociateModels({
                               <Badge size="md" radius="xl" pl={4} color="gray">
                                 <Group gap={2}>
                                   <IconUser size={12} strokeWidth={2.5} />
-                                  {creatorOwnedIds.has(association.item.id) && viewerIsCreator
+                                  {association.item.user.id === currentUser?.id
                                     ? 'You'
                                     : association.item.user.username}
                                 </Group>
@@ -279,13 +281,7 @@ export function AssociateModels({
                                   size="xs"
                                   checked={linkBack.includes(association.item.id)}
                                   onChange={() => toggleLinkBack(association.item.id)}
-                                  styles={{
-                                    label: {
-                                      textTransform: 'uppercase',
-                                      fontWeight: 700,
-                                      letterSpacing: '0.25px',
-                                    },
-                                  }}
+                                  classNames={{ label: 'uppercase font-bold tracking-[0.25px]' }}
                                 >
                                   Link back
                                 </Chip>

--- a/src/components/AssociatedModels/AssociateModels.tsx
+++ b/src/components/AssociatedModels/AssociateModels.tsx
@@ -2,7 +2,19 @@ import type { DragEndEvent, UniqueIdentifier } from '@dnd-kit/core';
 import { closestCenter, DndContext, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type { ComboboxItem } from '@mantine/core';
-import { Stack, Text, Card, Group, Button, Center, Loader, Alert, Badge, Box } from '@mantine/core';
+import {
+  Stack,
+  Text,
+  Card,
+  Group,
+  Button,
+  Center,
+  Loader,
+  Alert,
+  Badge,
+  Box,
+  Checkbox,
+} from '@mantine/core';
 import type { AssociationType } from '~/shared/utils/prisma/enums';
 import { IconGripVertical, IconTrash, IconUser } from '@tabler/icons-react';
 import { isEqual } from 'lodash-es';
@@ -20,20 +32,24 @@ import {
 } from '~/shared/constants/browsingLevel.constants';
 import type { SearchIndexDataMap } from '~/components/Search/search.utils2';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { constants } from '~/server/common/constants';
+import { selectNewlyAddedModelIds } from '~/server/services/model-association.utils';
+import { showWarningNotification } from '~/utils/notifications';
 
 type State = Array<Omit<ModelGetAssociatedResourcesSimple[number], 'id'> & { id?: number }>;
 
 export function AssociateModels({
   fromId,
   type,
+  ownerId,
   onSave,
-  limit = 10,
 }: {
   fromId: number;
   type: AssociationType;
+  ownerId: number;
   onSave?: () => void;
-  limit?: number;
 }) {
+  const limit = constants.modelAssociations.limit;
   const currentUser = useCurrentUser();
   const queryUtils = trpc.useUtils();
   const [changed, setChanged] = useState(false);
@@ -45,16 +61,31 @@ export function AssociateModels({
     browsingLevel: allBrowsingLevelsFlag,
   });
   const [associatedResources, setAssociatedResources] = useState<State>(data);
+  const [reciprocal, setReciprocal] = useState(false);
   const [searchMode, setSearchMode] = useState<'me' | 'all'>('all');
 
   const { mutate, isPending: isSaving } = trpc.model.setAssociatedResources.useMutation({
-    onSuccess: async () => {
-      queryUtils.model.getAssociatedResourcesSimple.setData(
-        { fromId, type, browsingLevel: allBrowsingLevelsFlag },
-        () => associatedResources as ModelGetAssociatedResourcesSimple
-      );
-      await queryUtils.model.getAssociatedResourcesCardData.invalidate({ fromId, type });
+    onSuccess: async (result) => {
+      const declined = result.reciprocal.skipped.filter((x) => x.reason !== 'alreadyLinked');
+      if (declined.length)
+        showWarningNotification({
+          title: 'Some links back were not added',
+          message: `${declined.length} of the resources you added could not be linked back — either they belong to someone else, or their own suggested resources are already full.`,
+        });
+
+      // Refetch instead of seeding the cache with the local rows. They carry no association
+      // ids, and staleTime is Infinity, so writing them back leaves the next open of this
+      // modal unable to tell a saved resource from a newly added one.
+      await Promise.all([
+        queryUtils.model.getAssociatedResourcesSimple.invalidate({
+          fromId,
+          type,
+          browsingLevel: allBrowsingLevelsFlag,
+        }),
+        queryUtils.model.getAssociatedResourcesCardData.invalidate({ fromId, type }),
+      ]);
       setChanged(false);
+      setReciprocal(false);
       onSave?.();
     },
   });
@@ -98,6 +129,7 @@ export function AssociateModels({
 
   const handleReset = () => {
     setChanged(false);
+    setReciprocal(false);
     setAssociatedResources(data);
   };
 
@@ -110,6 +142,7 @@ export function AssociateModels({
         resourceType,
         resourceId: item.id,
       })),
+      reciprocal: reciprocal && newlyAdded.length > 0,
     });
   };
 
@@ -123,6 +156,20 @@ export function AssociateModels({
   }, [data]);
 
   const onlyMe = searchMode === 'me';
+
+  // The model ids this model already points at, taken from the saved list rather than from
+  // whether a row carries an association id. Same question the server asks, same answer.
+  const savedTargetIds = new Set(
+    data.filter(({ resourceType }) => resourceType === 'model').map(({ item }) => item.id)
+  );
+  const newlyAdded = selectNewlyAddedModelIds(
+    associatedResources.map(({ resourceType, item }) => ({ resourceType, resourceId: item.id })),
+    savedTargetIds
+  );
+  const newlyAddedIds = new Set(newlyAdded);
+  const ownedNewCount = associatedResources.filter(
+    ({ item }) => newlyAddedIds.has(item.id) && item.user.id === ownerId
+  ).length;
 
   return (
     <Stack>
@@ -180,6 +227,11 @@ export function AssociateModels({
                                 <Badge size="xs">
                                   {'type' in association.item ? association.item.type : 'Article'}
                                 </Badge>
+                                {newlyAddedIds.has(association.item.id) && (
+                                  <Badge size="xs" color="green">
+                                    New
+                                  </Badge>
+                                )}
                                 <Badge size="xs" pl={4}>
                                   <Group gap={2}>
                                     <IconUser size={12} strokeWidth={2.5} />
@@ -213,6 +265,26 @@ export function AssociateModels({
           )}
         </Stack>
       )}
+      {newlyAdded.length > 0 && (
+        <Checkbox
+          checked={reciprocal}
+          onChange={(event) => {
+            setReciprocal(event.currentTarget.checked);
+            setChanged(true);
+          }}
+          label="Link both ways"
+          description={`Also adds this model to the suggested resources of ${
+            ownedNewCount === newlyAdded.length
+              ? newlyAdded.length === 1
+                ? 'the model marked New'
+                : `the ${newlyAdded.length} models marked New`
+              : `the ${ownedNewCount} of ${newlyAdded.length} models marked New that ${
+                  currentUser?.id === ownerId ? 'you own' : 'this creator owns'
+                }`
+          }. Resources already on the list are untouched, and a link added this way stays on the other model until it is removed there.`}
+        />
+      )}
+
       {changed && (
         <Group justify="flex-end">
           <Button variant="default" onClick={handleReset}>

--- a/src/components/AssociatedModels/AssociateModels.tsx
+++ b/src/components/AssociatedModels/AssociateModels.tsx
@@ -246,19 +246,11 @@ export function AssociateModels({
                                   : association.item.title}
                               </Text>
                               <Group gap={4}>
-                                <Badge size="xs">
+                                <Badge size="md" radius="xl">
                                   {'type' in association.item ? association.item.type : 'Article'}
                                 </Badge>
-                                {reciprocalEligible.has(association.item.id) ? (
-                                  <Chip
-                                    size="xs"
-                                    checked={linkBack.includes(association.item.id)}
-                                    onChange={() => toggleLinkBack(association.item.id)}
-                                  >
-                                    Link back
-                                  </Chip>
-                                ) : (
-                                  <Badge size="xs" pl={4}>
+                                {!reciprocalEligible.has(association.item.id) && (
+                                  <Badge size="md" radius="xl" pl={4}>
                                     <Group gap={2}>
                                       <IconUser size={12} strokeWidth={2.5} />
                                       {association.item.user.username}
@@ -266,9 +258,18 @@ export function AssociateModels({
                                   </Badge>
                                 )}
                                 {!getIsSafeBrowsingLevel(association.item.nsfwLevel) && (
-                                  <Badge color="red" size="xs">
+                                  <Badge color="red" size="md" radius="xl">
                                     NSFW
                                   </Badge>
+                                )}
+                                {reciprocalEligible.has(association.item.id) && (
+                                  <Chip
+                                    size="xs"
+                                    checked={linkBack.includes(association.item.id)}
+                                    onChange={() => toggleLinkBack(association.item.id)}
+                                  >
+                                    Link back
+                                  </Chip>
                                 )}
                               </Group>
                             </Stack>

--- a/src/components/AssociatedModels/AssociateModels.tsx
+++ b/src/components/AssociatedModels/AssociateModels.tsx
@@ -159,12 +159,19 @@ export function AssociateModels({
     savedTargetIds
   );
   const newlyAddedIds = new Set(newlyAdded);
+  // Ownership is the model owner's, never the viewer's — a moderator editing someone else's
+  // model links that creator's resources. Derived once here and read by both the chip gate
+  // and the author badge, so the two can never disagree.
+  const creatorOwnedIds = new Set(
+    associatedResources.filter(({ item }) => item.user.id === ownerId).map(({ item }) => item.id)
+  );
+  const viewerIsCreator = currentUser?.id === ownerId;
   // A row can be linked back only if it is newly added AND the creator owns it. The first half
   // comes from the shared derivation the server also uses; the second is the same ownership
   // rule the server re-derives from the database, which remains the authority.
   const reciprocalEligible = new Set(
     associatedResources
-      .filter(({ item }) => newlyAddedIds.has(item.id) && item.user.id === ownerId)
+      .filter(({ item }) => newlyAddedIds.has(item.id) && creatorOwnedIds.has(item.id))
       .map(({ item }) => item.id)
   );
   const toggleLinkBack = (modelId: number) => {
@@ -204,9 +211,14 @@ export function AssociateModels({
         </Text>
       ) : (
         <Stack gap="xs">
-          <Text c="dimmed" size="xs">
-            {associatedResources.length} of {limit} selected
-          </Text>
+          <Group justify="space-between" gap="xs" wrap="nowrap">
+            <Text c="dimmed" size="xs">
+              Drag to reorder
+            </Text>
+            <Text c="dimmed" size="xs">
+              {associatedResources.length} of {limit} selected
+            </Text>
+          </Group>
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}
@@ -249,14 +261,14 @@ export function AssociateModels({
                                   ? getDisplayName(association.item.type)
                                   : 'Article'}
                               </Badge>
-                              {!reciprocalEligible.has(association.item.id) && (
-                                <Badge size="md" radius="xl" pl={4} color="gray" variant="light">
-                                  <Group gap={2}>
-                                    <IconUser size={12} strokeWidth={2.5} />
-                                    {association.item.user.username}
-                                  </Group>
-                                </Badge>
-                              )}
+                              <Badge size="md" radius="xl" pl={4} color="gray">
+                                <Group gap={2}>
+                                  <IconUser size={12} strokeWidth={2.5} />
+                                  {creatorOwnedIds.has(association.item.id) && viewerIsCreator
+                                    ? 'You'
+                                    : association.item.user.username}
+                                </Group>
+                              </Badge>
                               {!getIsSafeBrowsingLevel(association.item.nsfwLevel) && (
                                 <Badge color="red" size="md" radius="xl">
                                   NSFW
@@ -267,6 +279,13 @@ export function AssociateModels({
                                   size="xs"
                                   checked={linkBack.includes(association.item.id)}
                                   onChange={() => toggleLinkBack(association.item.id)}
+                                  styles={{
+                                    label: {
+                                      textTransform: 'uppercase',
+                                      fontWeight: 700,
+                                      letterSpacing: '0.25px',
+                                    },
+                                  }}
                                 >
                                   Link back
                                 </Chip>

--- a/src/components/AssociatedModels/AssociateModels.tsx
+++ b/src/components/AssociatedModels/AssociateModels.tsx
@@ -113,6 +113,9 @@ export function AssociateModels({
   const handleRemove = (id: number) => {
     const models = [...associatedResources.filter(({ item }) => item.id !== id)];
     setAssociatedResources(models);
+    // Drop the tick too: re-adding the row in the same edit would otherwise arrive
+    // pre-ticked and write a back-link the user never asked for in this composition.
+    setLinkBack((current) => current.filter((modelId) => modelId !== id));
     setChanged(!isEqual(data, models));
   };
 
@@ -241,7 +244,7 @@ export function AssociateModels({
                                 : association.item.title}
                             </Text>
                             <Group gap={4}>
-                              <Badge size="md" radius="xl">
+                              <Badge size="md" radius="xl" variant="light">
                                 {'type' in association.item
                                   ? getDisplayName(association.item.type)
                                   : 'Article'}

--- a/src/components/AssociatedModels/AssociateModels.tsx
+++ b/src/components/AssociatedModels/AssociateModels.tsx
@@ -13,7 +13,7 @@ import {
   Alert,
   Badge,
   Box,
-  Checkbox,
+  Chip,
 } from '@mantine/core';
 import type { AssociationType } from '~/shared/utils/prisma/enums';
 import { IconGripVertical, IconTrash, IconUser } from '@tabler/icons-react';
@@ -61,7 +61,7 @@ export function AssociateModels({
     browsingLevel: allBrowsingLevelsFlag,
   });
   const [associatedResources, setAssociatedResources] = useState<State>(data);
-  const [reciprocal, setReciprocal] = useState(false);
+  const [linkBack, setLinkBack] = useState<number[]>([]);
   const [searchMode, setSearchMode] = useState<'me' | 'all'>('all');
 
   const { mutate, isPending: isSaving } = trpc.model.setAssociatedResources.useMutation({
@@ -85,7 +85,7 @@ export function AssociateModels({
         queryUtils.model.getAssociatedResourcesCardData.invalidate({ fromId, type }),
       ]);
       setChanged(false);
-      setReciprocal(false);
+      setLinkBack([]);
       onSave?.();
     },
   });
@@ -129,7 +129,7 @@ export function AssociateModels({
 
   const handleReset = () => {
     setChanged(false);
-    setReciprocal(false);
+    setLinkBack([]);
     setAssociatedResources(data);
   };
 
@@ -142,7 +142,7 @@ export function AssociateModels({
         resourceType,
         resourceId: item.id,
       })),
-      reciprocal: reciprocal && newlyAdded.length > 0,
+      reciprocal: linkBack.filter((id) => reciprocalEligible.has(id)),
     });
   };
 
@@ -167,9 +167,20 @@ export function AssociateModels({
     savedTargetIds
   );
   const newlyAddedIds = new Set(newlyAdded);
-  const ownedNewCount = associatedResources.filter(
-    ({ item }) => newlyAddedIds.has(item.id) && item.user.id === ownerId
-  ).length;
+  // A row can be linked back only if it is newly added AND the creator owns it. The first half
+  // comes from the shared derivation the server also uses; the second is the same ownership
+  // rule the server re-derives from the database, which remains the authority.
+  const reciprocalEligible = new Set(
+    associatedResources
+      .filter(({ item }) => newlyAddedIds.has(item.id) && item.user.id === ownerId)
+      .map(({ item }) => item.id)
+  );
+  const toggleLinkBack = (modelId: number) => {
+    setChanged(true);
+    setLinkBack((current) =>
+      current.includes(modelId) ? current.filter((id) => id !== modelId) : [...current, modelId]
+    );
+  };
 
   return (
     <Stack>
@@ -213,7 +224,18 @@ export function AssociateModels({
                 <Stack gap={4}>
                   {associatedResources.map((association) => (
                     <SortableItem key={association.item.id} id={association.item.id}>
-                      <Card withBorder pl={4} pr={6} pt={4} pb={6}>
+                      <Card
+                        withBorder
+                        pl={4}
+                        pr={6}
+                        pt={4}
+                        pb={6}
+                        className={
+                          newlyAddedIds.has(association.item.id)
+                            ? 'border-blue-5 dark:border-blue-5'
+                            : undefined
+                        }
+                      >
                         <Group justify="space-between" wrap="nowrap">
                           <Group align="center" gap="xs" wrap="nowrap">
                             <IconGripVertical />
@@ -227,17 +249,22 @@ export function AssociateModels({
                                 <Badge size="xs">
                                   {'type' in association.item ? association.item.type : 'Article'}
                                 </Badge>
-                                {newlyAddedIds.has(association.item.id) && (
-                                  <Badge size="xs" color="green">
-                                    New
+                                {reciprocalEligible.has(association.item.id) ? (
+                                  <Chip
+                                    size="xs"
+                                    checked={linkBack.includes(association.item.id)}
+                                    onChange={() => toggleLinkBack(association.item.id)}
+                                  >
+                                    Link back
+                                  </Chip>
+                                ) : (
+                                  <Badge size="xs" pl={4}>
+                                    <Group gap={2}>
+                                      <IconUser size={12} strokeWidth={2.5} />
+                                      {association.item.user.username}
+                                    </Group>
                                   </Badge>
                                 )}
-                                <Badge size="xs" pl={4}>
-                                  <Group gap={2}>
-                                    <IconUser size={12} strokeWidth={2.5} />
-                                    {association.item.user.username}
-                                  </Group>
-                                </Badge>
                                 {!getIsSafeBrowsingLevel(association.item.nsfwLevel) && (
                                   <Badge color="red" size="xs">
                                     NSFW
@@ -265,26 +292,6 @@ export function AssociateModels({
           )}
         </Stack>
       )}
-      {newlyAdded.length > 0 && (
-        <Checkbox
-          checked={reciprocal}
-          onChange={(event) => {
-            setReciprocal(event.currentTarget.checked);
-            setChanged(true);
-          }}
-          label="Link both ways"
-          description={`Also adds this model to the suggested resources of ${
-            ownedNewCount === newlyAdded.length
-              ? newlyAdded.length === 1
-                ? 'the model marked New'
-                : `the ${newlyAdded.length} models marked New`
-              : `the ${ownedNewCount} of ${newlyAdded.length} models marked New that ${
-                  currentUser?.id === ownerId ? 'you own' : 'this creator owns'
-                }`
-          }. Resources already on the list are untouched, and a link added this way stays on the other model until it is removed there.`}
-        />
-      )}
-
       {changed && (
         <Group justify="flex-end">
           <Button variant="default" onClick={handleReset}>

--- a/src/components/AssociatedModels/AssociatedModels.tsx
+++ b/src/components/AssociatedModels/AssociatedModels.tsx
@@ -38,7 +38,7 @@ export function AssociatedModels({
   });
 
   const handleManageClick = () => {
-    openAssociateModelsModal({ props: { fromId, type } });
+    openAssociateModelsModal({ props: { fromId, type, ownerId } });
   };
 
   if (!isOwnerOrModerator && !recommendedResources.length) return null;

--- a/src/components/ImageUpload/SortableItem.tsx
+++ b/src/components/ImageUpload/SortableItem.tsx
@@ -9,10 +9,12 @@ export function SortableItem({
   disabled,
   children,
   id,
+  cursor = 'pointer',
 }: {
   disabled?: boolean;
   children: React.ReactElement<React.ComponentPropsWithRef<'div'>>;
   id: UniqueIdentifier;
+  cursor?: CSSProperties['cursor'];
 }) {
   const sortable = useSortable({ id });
 
@@ -21,7 +23,7 @@ export function SortableItem({
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
-    cursor: isDragging ? 'grabbing' : !disabled ? 'pointer' : 'auto',
+    cursor: isDragging ? 'grabbing' : !disabled ? cursor : 'auto',
     zIndex: isDragging ? 1 : undefined,
     touchAction: 'none',
   };

--- a/src/components/Modals/AssociateModelsModal.tsx
+++ b/src/components/Modals/AssociateModelsModal.tsx
@@ -1,4 +1,4 @@
-import { Stack, Text, Title, Modal } from '@mantine/core';
+import { Title, Modal } from '@mantine/core';
 import type { AssociationType } from '~/shared/utils/prisma/enums';
 import { AssociateModels } from '~/components/AssociatedModels/AssociateModels';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
@@ -18,15 +18,7 @@ export default function AssociateModelsModal({
   return (
     <Modal
       {...dialog}
-      title={
-        <Stack gap={2}>
-          <Title order={3}>{`Manage ${getDisplayName(type)} Resources`}</Title>
-          <Text size="sm" c="dimmed">
-            Drag to reorder
-          </Text>
-        </Stack>
-      }
-      styles={{ header: { alignItems: 'flex-start' } }}
+      title={<Title order={3}>{`Manage ${getDisplayName(type)} Resources`}</Title>}
       centered
     >
       <AssociateModels fromId={fromId} type={type} ownerId={ownerId} onSave={dialog.onClose} />

--- a/src/components/Modals/AssociateModelsModal.tsx
+++ b/src/components/Modals/AssociateModelsModal.tsx
@@ -1,7 +1,8 @@
-import { CloseButton, Stack, Text, Group, Modal } from '@mantine/core';
+import { Stack, Text, Title, Modal } from '@mantine/core';
 import type { AssociationType } from '~/shared/utils/prisma/enums';
 import { AssociateModels } from '~/components/AssociatedModels/AssociateModels';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
+import { getDisplayName } from '~/utils/string-helpers';
 
 export default function AssociateModelsModal({
   fromId,
@@ -15,14 +16,20 @@ export default function AssociateModelsModal({
   const dialog = useDialogContext();
 
   return (
-    <Modal {...dialog} withCloseButton={false}>
-      <Stack>
-        <Group wrap="nowrap" justify="space-between">
-          <Text>{`Manage ${type} Resources`}</Text>
-          <CloseButton onClick={dialog.onClose} />
-        </Group>
-        <AssociateModels fromId={fromId} type={type} ownerId={ownerId} onSave={dialog.onClose} />
-      </Stack>
+    <Modal
+      {...dialog}
+      title={
+        <Stack gap={2}>
+          <Title order={3}>{`Manage ${getDisplayName(type)} Resources`}</Title>
+          <Text size="sm" c="dimmed">
+            Drag to reorder — visitors see them in this order
+          </Text>
+        </Stack>
+      }
+      styles={{ header: { alignItems: 'flex-start' } }}
+      centered
+    >
+      <AssociateModels fromId={fromId} type={type} ownerId={ownerId} onSave={dialog.onClose} />
     </Modal>
   );
 }

--- a/src/components/Modals/AssociateModelsModal.tsx
+++ b/src/components/Modals/AssociateModelsModal.tsx
@@ -6,9 +6,11 @@ import { useDialogContext } from '~/components/Dialog/DialogProvider';
 export default function AssociateModelsModal({
   fromId,
   type,
+  ownerId,
 }: {
   fromId: number;
   type: AssociationType;
+  ownerId: number;
 }) {
   const dialog = useDialogContext();
 
@@ -19,7 +21,7 @@ export default function AssociateModelsModal({
           <Text>{`Manage ${type} Resources`}</Text>
           <CloseButton onClick={dialog.onClose} />
         </Group>
-        <AssociateModels fromId={fromId} type={type} onSave={dialog.onClose} />
+        <AssociateModels fromId={fromId} type={type} ownerId={ownerId} onSave={dialog.onClose} />
       </Stack>
     </Modal>
   );

--- a/src/components/Modals/AssociateModelsModal.tsx
+++ b/src/components/Modals/AssociateModelsModal.tsx
@@ -22,7 +22,7 @@ export default function AssociateModelsModal({
         <Stack gap={2}>
           <Title order={3}>{`Manage ${getDisplayName(type)} Resources`}</Title>
           <Text size="sm" c="dimmed">
-            Drag to reorder — visitors see them in this order
+            Drag to reorder
           </Text>
         </Stack>
       }

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -197,6 +197,12 @@ export const constants = {
     'Enhancement LoRA': 14,
     Other: 15,
   },
+  modelAssociations: {
+    limit: 10,
+    // Server ceiling, deliberately above the UI limit: 9 models already hold 11-12
+    // associations, and rejecting their saves would strand them.
+    maxPerSave: 20,
+  },
   cardSizes: {
     model: 320,
     image: 320,

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -411,7 +411,10 @@ export const setAssociatedResourcesSchema = z.object({
       resourceId: z.number(),
       resourceType: z.enum(['model', 'article']),
     })
-    .array(),
+    .array()
+    .max(constants.modelAssociations.maxPerSave),
+  // Also add this model to the list of every associated model the same owner holds.
+  reciprocal: z.boolean().optional(),
 });
 // #endregion
 

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -413,8 +413,10 @@ export const setAssociatedResourcesSchema = z.object({
     })
     .array()
     .max(constants.modelAssociations.maxPerSave),
-  // Also add this model to the list of every associated model the same owner holds.
-  reciprocal: z.boolean().optional(),
+  // Model ids the caller asked to link back. A request, not an instruction: the server keeps
+  // its own answer for which of them were added in this edit and which the owner owns, and
+  // narrows this list to that. Bounded by the same cap as the array above.
+  reciprocal: z.array(z.number()).max(constants.modelAssociations.maxPerSave).optional(),
 });
 // #endregion
 

--- a/src/server/services/__tests__/model-association-reciprocal.test.ts
+++ b/src/server/services/__tests__/model-association-reciprocal.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { planReciprocalAssociations } from '~/server/services/model-association.utils';
+
+const OWNER = 100;
+const STRANGER = 200;
+const SOURCE = 1;
+
+const plan = (
+  candidates: Array<{ modelId: number; ownerId: number }>,
+  {
+    existingCounts = new Map<number, number>(),
+    alreadyLinked = new Set<number>(),
+    limit = 10,
+  }: {
+    existingCounts?: Map<number, number>;
+    alreadyLinked?: Set<number>;
+    limit?: number;
+  } = {}
+) =>
+  planReciprocalAssociations({
+    sourceModelId: SOURCE,
+    ownerId: OWNER,
+    candidates,
+    existingCounts,
+    alreadyLinked,
+    limit,
+  });
+
+describe('planReciprocalAssociations', () => {
+  it('writes a back-link on a model the owner owns', () => {
+    const { create, skipped } = plan([{ modelId: 2, ownerId: OWNER }]);
+
+    expect(create).toEqual([{ fromModelId: 2, toModelId: SOURCE, index: 0 }]);
+    expect(skipped).toEqual([]);
+  });
+
+  // The safety boundary this whole feature turns on. Before it, nothing in the codebase
+  // could write an association row into a model the acting user does not own; reciprocal
+  // insertion is the first path that addresses another model at all. If you are here to
+  // relax this, the ask that produced it was explicitly "only ones that are theirs".
+  it('never writes a back-link on a model owned by someone else', () => {
+    const { create, skipped } = plan([
+      { modelId: 2, ownerId: OWNER },
+      { modelId: 3, ownerId: STRANGER },
+    ]);
+
+    expect(create.map((x) => x.fromModelId)).toEqual([2]);
+    expect(skipped).toEqual([{ modelId: 3, reason: 'notOwned' }]);
+  });
+
+  it('does not link a model to itself', () => {
+    const { create, skipped } = plan([{ modelId: SOURCE, ownerId: OWNER }]);
+
+    expect(create).toEqual([]);
+    expect(skipped).toEqual([]);
+  });
+
+  it('skips a target that already carries the back-link', () => {
+    const { create, skipped } = plan([{ modelId: 2, ownerId: OWNER }], {
+      alreadyLinked: new Set([2]),
+      existingCounts: new Map([[2, 3]]),
+    });
+
+    expect(create).toEqual([]);
+    expect(skipped).toEqual([{ modelId: 2, reason: 'alreadyLinked' }]);
+  });
+
+  it('skips a target whose own list is already at the limit', () => {
+    const { create, skipped } = plan([{ modelId: 2, ownerId: OWNER }], {
+      existingCounts: new Map([[2, 10]]),
+      limit: 10,
+    });
+
+    expect(create).toEqual([]);
+    expect(skipped).toEqual([{ modelId: 2, reason: 'atLimit' }]);
+  });
+
+  it('indexes the back-link at the size of the target list, not at 0', () => {
+    const { create } = plan([{ modelId: 2, ownerId: OWNER }], {
+      existingCounts: new Map([[2, 4]]),
+    });
+
+    expect(create).toEqual([{ fromModelId: 2, toModelId: SOURCE, index: 4 }]);
+  });
+
+  // The only control against a cap that is one too STRICT. Without it, `count >= limit - 1`
+  // ships green and silently refuses the last slot on every list.
+  it('still links a target sitting one below the limit', () => {
+    const { create, skipped } = plan([{ modelId: 2, ownerId: OWNER }], {
+      existingCounts: new Map([[2, 9]]),
+      limit: 10,
+    });
+
+    expect(create).toEqual([{ fromModelId: 2, toModelId: SOURCE, index: 9 }]);
+    expect(skipped).toEqual([]);
+  });
+
+  it('writes one back-link when the same target is listed twice', () => {
+    const { create, skipped } = plan([
+      { modelId: 2, ownerId: OWNER },
+      { modelId: 2, ownerId: OWNER },
+    ]);
+
+    expect(create).toEqual([{ fromModelId: 2, toModelId: SOURCE, index: 0 }]);
+    expect(skipped).toEqual([]);
+  });
+
+  it('saves the owned links even when the selection is mixed', () => {
+    const { create, skipped } = plan([
+      { modelId: 2, ownerId: STRANGER },
+      { modelId: 3, ownerId: OWNER },
+      { modelId: 4, ownerId: STRANGER },
+      { modelId: 5, ownerId: OWNER },
+    ]);
+
+    expect(create.map((x) => x.fromModelId)).toEqual([3, 5]);
+    expect(skipped.map((x) => x.modelId)).toEqual([2, 4]);
+  });
+});

--- a/src/server/services/__tests__/set-associated-resources.wiring.test.ts
+++ b/src/server/services/__tests__/set-associated-resources.wiring.test.ts
@@ -151,9 +151,6 @@ beforeEach(() => {
 });
 
 describe('setAssociatedResources — reciprocal wiring', () => {
-  // The opt-in itself. Deleting the `reciprocal` ternary in model.service.ts makes every
-  // Suggested-Resources save on the site rewrite other models' lists; before this test, that
-  // mutation turned nothing red. If you are removing the flag, you are removing the opt-in.
   // The request is a request, not an instruction. A caller naming a model that was already on
   // the list, or one the owner does not own, gets nothing for it — the shared derivation and
   // the ownership check both still run and the list only narrows them.
@@ -175,6 +172,12 @@ describe('setAssociatedResources — reciprocal wiring', () => {
     expect(createdRows().map((row) => row.fromModelId)).toEqual([3]);
   });
 
+  // This is the opt-in, and the line that carries it is the
+  // `.filter((id) => reciprocalRequested.has(id))` — NOT the `reciprocalRequested.size` ternary
+  // above it, which is a pure short-circuit: deleting the ternary changes no behaviour, because
+  // an empty request set already yields an empty target list. Delete the filter and every save
+  // links back everything newly added, whether the caller asked or not. That mutation turned
+  // nothing red before this test.
   it('links back only the rows the caller asked for', async () => {
     givenTargets([
       { id: 2, userId: OWNER },

--- a/src/server/services/__tests__/set-associated-resources.wiring.test.ts
+++ b/src/server/services/__tests__/set-associated-resources.wiring.test.ts
@@ -132,7 +132,7 @@ function givenTargetLists(rows: Array<{ fromModelId: number; toModelId: number |
 
 const save = (
   associations: Array<{ resourceId: number; resourceType: 'model' | 'article'; id?: number }>,
-  { reciprocal, user = owner }: { reciprocal?: boolean; user?: SessionUser } = {}
+  { reciprocal, user = owner }: { reciprocal?: number[]; user?: SessionUser } = {}
 ) => setAssociatedResources({ fromId: SOURCE, type: 'Suggested', associations, reciprocal }, user);
 
 const createdRows = () =>

--- a/src/server/services/__tests__/set-associated-resources.wiring.test.ts
+++ b/src/server/services/__tests__/set-associated-resources.wiring.test.ts
@@ -154,7 +154,45 @@ describe('setAssociatedResources — reciprocal wiring', () => {
   // The opt-in itself. Deleting the `reciprocal` ternary in model.service.ts makes every
   // Suggested-Resources save on the site rewrite other models' lists; before this test, that
   // mutation turned nothing red. If you are removing the flag, you are removing the opt-in.
-  it('writes no back-link at all when the checkbox was not ticked', async () => {
+  // The request is a request, not an instruction. A caller naming a model that was already on
+  // the list, or one the owner does not own, gets nothing for it — the shared derivation and
+  // the ownership check both still run and the list only narrows them.
+  it('ignores a requested model that was not added in this edit', async () => {
+    givenSourceModel([[11, 2]]);
+    givenTargets([
+      { id: 2, userId: OWNER },
+      { id: 3, userId: OWNER },
+    ]);
+
+    await save(
+      [
+        { resourceId: 2, resourceType: 'model', id: 11 },
+        { resourceId: 3, resourceType: 'model' },
+      ],
+      { reciprocal: [2, 3] }
+    );
+
+    expect(createdRows().map((row) => row.fromModelId)).toEqual([3]);
+  });
+
+  it('links back only the rows the caller asked for', async () => {
+    givenTargets([
+      { id: 2, userId: OWNER },
+      { id: 3, userId: OWNER },
+    ]);
+
+    await save(
+      [
+        { resourceId: 2, resourceType: 'model' },
+        { resourceId: 3, resourceType: 'model' },
+      ],
+      { reciprocal: [3] }
+    );
+
+    expect(createdRows().map((row) => row.fromModelId)).toEqual([3]);
+  });
+
+  it('writes no back-link at all when nothing was asked for', async () => {
     givenTargets([{ id: 2, userId: OWNER }]);
 
     await save([{ resourceId: 2, resourceType: 'model' }]);
@@ -165,7 +203,7 @@ describe('setAssociatedResources — reciprocal wiring', () => {
   it('writes the back-link when it was ticked', async () => {
     givenTargets([{ id: 2, userId: OWNER }]);
 
-    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: [2, 3, 5] });
 
     expect(dbMock.dbWrite.modelAssociations.createMany).toHaveBeenCalledTimes(1);
     expect(createdRows()).toEqual([
@@ -188,7 +226,7 @@ describe('setAssociatedResources — reciprocal wiring', () => {
         { resourceId: 2, resourceType: 'model' },
         { resourceId: 3, resourceType: 'model' },
       ],
-      { reciprocal: true, user: moderator }
+      { reciprocal: [2, 3], user: moderator }
     );
 
     expect(createdRows()).toEqual([
@@ -199,7 +237,7 @@ describe('setAssociatedResources — reciprocal wiring', () => {
   it('asks the database for each target owner', async () => {
     givenTargets([{ id: 2, userId: 555 }]);
 
-    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: [2, 3, 5] });
 
     expect(dbMock.dbWrite.model.findMany).toHaveBeenCalledWith(
       expect.objectContaining({ select: { id: true, userId: true } })
@@ -213,7 +251,7 @@ describe('setAssociatedResources — reciprocal wiring', () => {
   it('reads ownership from the writer, never the replica', async () => {
     givenTargets([{ id: 2, userId: OWNER }]);
 
-    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: [2, 3, 5] });
 
     expect(dbMock.dbRead.model.findMany).not.toHaveBeenCalled();
     expect(dbMock.dbRead.modelAssociations.findMany).not.toHaveBeenCalled();
@@ -227,7 +265,7 @@ describe('setAssociatedResources — reciprocal wiring', () => {
     givenTargets([{ id: 2, userId: OWNER }]);
     givenTargetLists([{ fromModelId: 2, toModelId: SOURCE }]);
 
-    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: [2, 3, 5] });
 
     expect(dbMock.dbWrite.modelAssociations.createMany).not.toHaveBeenCalled();
   });
@@ -241,7 +279,7 @@ describe('setAssociatedResources — reciprocal wiring', () => {
       { fromModelId: 99, toModelId: 73 },
     ]);
 
-    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: [2, 3, 5] });
 
     expect(createdRows()).toEqual([
       { fromModelId: 2, toModelId: SOURCE, index: 3, type: 'Suggested', associatedById: OWNER },
@@ -270,7 +308,7 @@ describe('setAssociatedResources — reciprocal wiring', () => {
         { resourceId: 2, resourceType: 'model' },
         { resourceId: 3, resourceType: 'model' },
       ],
-      { reciprocal: true }
+      { reciprocal: [2, 3, 5] }
     );
 
     expect(createdRows().map((row) => [row.fromModelId, row.index])).toEqual([
@@ -291,7 +329,9 @@ describe('setAssociatedResources — reciprocal wiring', () => {
       }))
     );
 
-    const result = await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+    const result = await save([{ resourceId: 2, resourceType: 'model' }], {
+      reciprocal: [2, 3, 5],
+    });
 
     expect(dbMock.dbWrite.modelAssociations.createMany).not.toHaveBeenCalled();
     expect(result.reciprocal).toEqual({
@@ -306,7 +346,7 @@ describe('setAssociatedResources — reciprocal wiring', () => {
   it('asks Postgres to swallow a duplicate rather than fail the save', async () => {
     givenTargets([{ id: 2, userId: OWNER }]);
 
-    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: [2, 3, 5] });
 
     expect(dbMock.dbWrite.modelAssociations.createMany).toHaveBeenCalledWith(
       expect.objectContaining({ skipDuplicates: true })
@@ -330,7 +370,7 @@ describe('setAssociatedResources — reciprocal wiring', () => {
         { resourceId: 2, resourceType: 'model', id: 11 },
         { resourceId: 3, resourceType: 'model' },
       ],
-      { reciprocal: true }
+      { reciprocal: [2, 3, 5] }
     );
 
     expect(createdRows().map((row) => row.fromModelId)).toEqual([3]);
@@ -345,7 +385,7 @@ describe('setAssociatedResources — reciprocal wiring', () => {
     givenSourceModel([[11, 2]]);
     givenTargets([{ id: 2, userId: OWNER }]);
 
-    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: [2, 3, 5] });
 
     expect(dbMock.dbWrite.modelAssociations.createMany).not.toHaveBeenCalled();
   });
@@ -358,7 +398,7 @@ describe('setAssociatedResources — reciprocal wiring', () => {
         { resourceId: 2, resourceType: 'model' },
         { resourceId: 7, resourceType: 'article' },
       ],
-      { reciprocal: true }
+      { reciprocal: [2, 3, 5] }
     );
 
     expect(dbMock.dbWrite.model.findMany).toHaveBeenCalledWith(
@@ -379,7 +419,7 @@ describe('setAssociatedResources — reciprocal wiring', () => {
     ]);
     givenTargets([{ id: 2, userId: OWNER }]);
 
-    await save([{ resourceId: 2, resourceType: 'model', id: 11 }], { reciprocal: true });
+    await save([{ resourceId: 2, resourceType: 'model', id: 11 }], { reciprocal: [2, 3, 5] });
 
     expect(dbMock.dbWrite.modelAssociations.deleteMany).toHaveBeenCalledTimes(1);
     expect(dbMock.dbWrite.modelAssociations.deleteMany).toHaveBeenCalledWith({

--- a/src/server/services/__tests__/set-associated-resources.wiring.test.ts
+++ b/src/server/services/__tests__/set-associated-resources.wiring.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Wiring tests for setAssociatedResources — specifically the reciprocal ("link both ways")
+// write, whose safety property lives in how its inputs are DERIVED, not in the planner that
+// consumes them. planReciprocalAssociations is tested separately and thoroughly; every one of
+// its callers could still be wrong without a single assertion moving, which is what this file
+// closes. model.service.ts has a very large import graph, so its transitive service/search
+// dependencies are stubbed below to keep this a unit test.
+
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  preventReplicationLag: vi.fn(),
+  getDbWithoutLag: vi.fn(async () => dbMock.dbRead),
+  preventModelVersionLagBatch: vi.fn(),
+}));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {}, pgDbReadLong: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null, Tracker: class {} }));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(() => false), FLIPT_FEATURE_FLAGS: {} }));
+vi.mock('~/server/metrics', () => ({ modelMetrics: {} }));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: {},
+  modelTagCache: { refresh: vi.fn() },
+  modelVotableTagsCache: { bust: vi.fn() },
+  userBasicCache: {},
+  userModelCountCache: { refresh: vi.fn() },
+}));
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+  imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+  modelsSearchIndex: { queueUpdate: vi.fn() },
+}));
+vi.mock('~/server/services/auction.service', () => ({
+  deleteBidsForModel: vi.fn(),
+  getLastAuctionReset: vi.fn(),
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getMultiAccountTransactionsByPrefix: vi.fn(),
+  getUserBuzzAccountByAccountTypes: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+}));
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTagsForModels: vi.fn(),
+}));
+vi.mock('~/server/services/blocklist.service', () => ({
+  throwOnBlockedLinkDomain: vi.fn(),
+  throwOnBlockedUserContent: vi.fn(),
+}));
+vi.mock('~/server/services/collection.service', () => ({
+  getAvailableCollectionItemsFilterForUser: vi.fn(),
+  getUserCollectionPermissionsById: vi.fn(),
+  saveItemInCollections: vi.fn(),
+}));
+vi.mock('~/server/services/cosmetic.service', () => ({ getCosmeticsForEntity: vi.fn() }));
+vi.mock('~/server/services/creator-program.service', () => ({
+  getValidCreatorMembershipMap: vi.fn(),
+}));
+vi.mock('~/server/services/generation/generation.service', () => ({
+  getUnavailableResources: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(),
+  getImagesForModelVersionCache: {},
+  queueImageSearchIndexUpdate: vi.fn(),
+}));
+vi.mock('~/server/services/model-file.service', () => ({ getFilesForModelVersionCache: {} }));
+vi.mock('~/server/services/model-version.service', () => ({
+  bustMvCache: vi.fn(),
+  bustPublicModelResponseCache: vi.fn(),
+  createModelVersionPostFromTraining: vi.fn(),
+  publishModelVersionsWithEarlyAccess: vi.fn(),
+}));
+vi.mock('~/server/services/subscriptions.service', () => ({ getHighestTierSubscription: vi.fn() }));
+vi.mock('~/server/services/system-cache', () => ({ getCategoryTags: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({
+  deleteBasicDataForUser: vi.fn(),
+  getCosmeticsForUsers: vi.fn(),
+  getProfilePicturesForUsers: vi.fn(),
+}));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  bustFetchThroughCache: vi.fn(),
+  fetchThroughCache: vi.fn(),
+}));
+vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
+vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));
+
+import { setAssociatedResources } from '~/server/services/model.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { constants } from '~/server/common/constants';
+import type { SessionUser } from '~/types/session';
+
+const SOURCE = 1;
+const OWNER = 100;
+const MODERATOR = 900;
+
+const owner = { id: OWNER, isModerator: false } as SessionUser;
+const moderator = { id: MODERATOR, isModerator: true } as SessionUser;
+
+/**
+ * The model being edited, and what it currently points at: `[associationRowId, toModelId]`
+ * pairs, matching the shape the service selects.
+ */
+function givenSourceModel(associations: Array<[number, number | null]> = []) {
+  dbMock.dbWrite.model.findUnique.mockResolvedValue({
+    userId: OWNER,
+    associations: associations.map(([id, toModelId]) => ({ id, toModelId })),
+  });
+}
+
+/**
+ * What the writer reports for the reciprocal targets and their current lists.
+ *
+ * Honours the `where.id.in` the service passes. A fake that returns every row regardless of
+ * the query would let a test pass while the service asked for the wrong ids — which is the
+ * decision these tests exist to check.
+ */
+function givenTargets(targets: Array<{ id: number; userId: number }>) {
+  dbMock.dbWrite.model.findMany.mockImplementation(async (args: unknown) => {
+    const ids = (args as { where?: { id?: { in?: number[] } } })?.where?.id?.in;
+    if (!ids) throw new Error('model.findMany called without where.id.in');
+    return targets.filter((target) => ids.includes(target.id));
+  });
+}
+
+/** Rows the targets' own suggested-resource lists already hold. */
+function givenTargetLists(rows: Array<{ fromModelId: number; toModelId: number | null }>) {
+  dbMock.dbWrite.modelAssociations.findMany.mockImplementation(async (args: unknown) => {
+    const ids = (args as { where?: { fromModelId?: { in?: number[] } } })?.where?.fromModelId?.in;
+    if (!ids) throw new Error('modelAssociations.findMany called without where.fromModelId.in');
+    return rows.filter((row) => ids.includes(row.fromModelId));
+  });
+}
+
+const save = (
+  associations: Array<{ resourceId: number; resourceType: 'model' | 'article'; id?: number }>,
+  { reciprocal, user = owner }: { reciprocal?: boolean; user?: SessionUser } = {}
+) => setAssociatedResources({ fromId: SOURCE, type: 'Suggested', associations, reciprocal }, user);
+
+const createdRows = () =>
+  (dbMock.dbWrite.modelAssociations.createMany.mock.calls[0]?.[0]?.data ?? []) as Array<{
+    fromModelId: number;
+  }>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  givenSourceModel();
+  givenTargets([]);
+  // Armed here rather than inside givenTargets, so the scoped-where guard is live in EVERY
+  // test. On the retired branch givenTargets reset this to an unconditional empty resolve,
+  // which left the guard live in 2 of 11 tests while reading as though it covered all of them.
+  givenTargetLists([]);
+});
+
+describe('setAssociatedResources — reciprocal wiring', () => {
+  // The opt-in itself. Deleting the `reciprocal` ternary in model.service.ts makes every
+  // Suggested-Resources save on the site rewrite other models' lists; before this test, that
+  // mutation turned nothing red. If you are removing the flag, you are removing the opt-in.
+  it('writes no back-link at all when the checkbox was not ticked', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }]);
+
+    expect(dbMock.dbWrite.modelAssociations.createMany).not.toHaveBeenCalled();
+  });
+
+  it('writes the back-link when it was ticked', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(dbMock.dbWrite.modelAssociations.createMany).toHaveBeenCalledTimes(1);
+    expect(createdRows()).toEqual([
+      { fromModelId: 2, toModelId: SOURCE, index: 0, type: 'Suggested', associatedById: OWNER },
+    ]);
+  });
+
+  // Ownership is scoped to the OWNER of the edited model, never to whoever is clicking. A
+  // moderator may edit someone else's model; the back-links belong to that creator's models,
+  // not to the moderator's. Swapping `fromModel.userId` for `user?.id` at the call site is a
+  // one-identifier change that this is the only assertion standing in front of.
+  it('scopes ownership to the model owner, not the acting moderator', async () => {
+    givenTargets([
+      { id: 2, userId: OWNER },
+      { id: 3, userId: MODERATOR },
+    ]);
+
+    await save(
+      [
+        { resourceId: 2, resourceType: 'model' },
+        { resourceId: 3, resourceType: 'model' },
+      ],
+      { reciprocal: true, user: moderator }
+    );
+
+    expect(createdRows()).toEqual([
+      { fromModelId: 2, toModelId: SOURCE, index: 0, type: 'Suggested', associatedById: MODERATOR },
+    ]);
+  });
+
+  it('asks the database for each target owner', async () => {
+    givenTargets([{ id: 2, userId: 555 }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(dbMock.dbWrite.model.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ select: { id: true, userId: true } })
+    );
+    expect(dbMock.dbWrite.modelAssociations.createMany).not.toHaveBeenCalled();
+  });
+
+  // Ownership and existing-link reads must not go to a replica: a model that just changed
+  // hands would report its previous owner, and a back-link committed moments earlier would be
+  // invisible and written twice.
+  it('reads ownership from the writer, never the replica', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(dbMock.dbRead.model.findMany).not.toHaveBeenCalled();
+    expect(dbMock.dbRead.modelAssociations.findMany).not.toHaveBeenCalled();
+  });
+
+  // The target's OWN list is what decides both of these, and both were previously derived
+  // from a read the suite never populated — every test ran with it empty, so a mutation that
+  // counted the wrong column, or inverted the already-linked check, shipped green and wrote a
+  // second back-link into someone else's model on every repeat save.
+  it('does not write a back-link the target already holds', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+    givenTargetLists([{ fromModelId: 2, toModelId: SOURCE }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(dbMock.dbWrite.modelAssociations.createMany).not.toHaveBeenCalled();
+  });
+
+  it('appends after the rows the target already holds', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+    givenTargetLists([
+      { fromModelId: 2, toModelId: 71 },
+      { fromModelId: 2, toModelId: 72 },
+      { fromModelId: 2, toModelId: null },
+      { fromModelId: 99, toModelId: 73 },
+    ]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(createdRows()).toEqual([
+      { fromModelId: 2, toModelId: SOURCE, index: 3, type: 'Suggested', associatedById: OWNER },
+    ]);
+  });
+
+  // The per-target keying of the counts. Collapsing the loop to `existing.length` — every
+  // target given the TOTAL row count — passed 20 of 20 on the retired branch, because no test
+  // ever had two targets holding lists of different lengths. Both back-links then land on the
+  // same index, and the at-limit skip fires for the wrong model. Two REAL targets in one call
+  // is what exercises it; asserting a fake filters another model's rows out tests the fake.
+  it('indexes each target against its own list, not against the total', async () => {
+    givenTargets([
+      { id: 2, userId: OWNER },
+      { id: 3, userId: OWNER },
+    ]);
+    givenTargetLists([
+      { fromModelId: 2, toModelId: 71 },
+      { fromModelId: 3, toModelId: 81 },
+      { fromModelId: 3, toModelId: 82 },
+      { fromModelId: 3, toModelId: 83 },
+    ]);
+
+    await save(
+      [
+        { resourceId: 2, resourceType: 'model' },
+        { resourceId: 3, resourceType: 'model' },
+      ],
+      { reciprocal: true }
+    );
+
+    expect(createdRows().map((row) => [row.fromModelId, row.index])).toEqual([
+      [2, 1],
+      [3, 3],
+    ]);
+  });
+
+  // The limit is read from constants at the call site, and nothing pinned that. Swapping it for
+  // Infinity was invisible: no fixture went near 10. This also covers the only path that
+  // produces an atLimit skip, which is the input to the warning the modal shows.
+  it('refuses a back-link when the target list is already at the limit', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+    givenTargetLists(
+      Array.from({ length: constants.modelAssociations.limit }, (_, i) => ({
+        fromModelId: 2,
+        toModelId: 900 + i,
+      }))
+    );
+
+    const result = await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(dbMock.dbWrite.modelAssociations.createMany).not.toHaveBeenCalled();
+    expect(result.reciprocal).toEqual({
+      linked: 0,
+      skipped: [{ modelId: 2, reason: 'atLimit' }],
+    });
+  });
+
+  // skipDuplicates is the backstop for the race the already-linked read cannot close: two
+  // concurrent saves both reading "not linked". Deleting it was 0-red, and once the unique
+  // index is applied its absence turns a silent dedupe into a 500 on the whole save.
+  it('asks Postgres to swallow a duplicate rather than fail the save', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(dbMock.dbWrite.modelAssociations.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skipDuplicates: true })
+    );
+  });
+
+  // Scope decided by Justin on 2026-09-11: the checkbox acts on what you just added, not on
+  // the whole saved list. Our modal saves the entire list, so without this a user who ticks
+  // the box while changing something unrelated retroactively back-links resources they linked
+  // months ago and never touched this session. If you widen this to every association, that is
+  // the behaviour you are bringing back.
+  it('back-links only resources added in this edit, never ones already on the list', async () => {
+    givenSourceModel([[11, 2]]);
+    givenTargets([
+      { id: 2, userId: OWNER },
+      { id: 3, userId: OWNER },
+    ]);
+
+    await save(
+      [
+        { resourceId: 2, resourceType: 'model', id: 11 },
+        { resourceId: 3, resourceType: 'model' },
+      ],
+      { reciprocal: true }
+    );
+
+    expect(createdRows().map((row) => row.fromModelId)).toEqual([3]);
+  });
+
+  // The reachable version of the same bug, and the reason the rule is derived from model ids
+  // rather than from association ids. The component used to write its own id-less rows into a
+  // query cache with staleTime Infinity, so on a second open every saved row presented itself
+  // as new. The client is fixed, but the server must not depend on the client being right:
+  // an association id is a claim, and the model ids the database holds are not.
+  it('ignores a claim of newness when the model is already on the list', async () => {
+    givenSourceModel([[11, 2]]);
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save([{ resourceId: 2, resourceType: 'model' }], { reciprocal: true });
+
+    expect(dbMock.dbWrite.modelAssociations.createMany).not.toHaveBeenCalled();
+  });
+
+  it('ignores articles when choosing reciprocal targets', async () => {
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save(
+      [
+        { resourceId: 2, resourceType: 'model' },
+        { resourceId: 7, resourceType: 'article' },
+      ],
+      { reciprocal: true }
+    );
+
+    expect(dbMock.dbWrite.model.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: { in: [2] } } })
+    );
+  });
+
+  // Removal is deliberately NOT symmetric: once written, a back-link is an entry in the other
+  // model's own list and is removed from there. Justin decided this on 2026-09-11 rather than
+  // match MNeMiC's RelatedContentBidirectionalTest, because symmetric removal means a delete
+  // that reaches into a model the request never named — the one thing this feature keeps shut.
+  // If you are here to add symmetric removal, that is the tradeoff you are re-opening, and it
+  // needs a marker column to tell which rows were safe to delete.
+  it('deletes only from the edited model, never from a model it links to', async () => {
+    givenSourceModel([
+      [11, 2],
+      [12, 5],
+    ]);
+    givenTargets([{ id: 2, userId: OWNER }]);
+
+    await save([{ resourceId: 2, resourceType: 'model', id: 11 }], { reciprocal: true });
+
+    expect(dbMock.dbWrite.modelAssociations.deleteMany).toHaveBeenCalledTimes(1);
+    expect(dbMock.dbWrite.modelAssociations.deleteMany).toHaveBeenCalledWith({
+      where: { fromModelId: SOURCE, type: 'Suggested', id: { in: [12] } },
+    });
+  });
+});

--- a/src/server/services/model-association.utils.ts
+++ b/src/server/services/model-association.utils.ts
@@ -1,0 +1,77 @@
+export type ReciprocalSkipReason = 'notOwned' | 'alreadyLinked' | 'atLimit';
+
+/**
+ * THE definition of "added during this edit", and the only one. The server decides what to
+ * write with it and the checkbox describes what will happen with it; if you are about to write
+ * a second predicate that answers this question, that is the bug this module exists to prevent.
+ * Three defects on the retired branch came from client and server each holding their own copy.
+ *
+ * It asks which MODEL ids are new, never which association rows are, because an association id
+ * is a claim the client makes and a model id is a fact both sides can check. `alreadyLinked` is
+ * the set of model ids the edited model already points at: read from the writer on the server,
+ * from the fetched association list on the client.
+ */
+export function selectNewlyAddedModelIds(
+  selection: ReadonlyArray<{ resourceType: 'model' | 'article'; resourceId: number }>,
+  alreadyLinked: ReadonlySet<number>
+): number[] {
+  return selection
+    .filter((item) => item.resourceType === 'model' && !alreadyLinked.has(item.resourceId))
+    .map((item) => item.resourceId);
+}
+
+export type ReciprocalCandidate = { modelId: number; ownerId: number };
+
+export type ReciprocalPlan = {
+  create: Array<{ fromModelId: number; toModelId: number; index: number }>;
+  skipped: Array<{ modelId: number; reason: ReciprocalSkipReason }>;
+};
+
+/**
+ * Decides which back-links a "link both ways" save may write.
+ *
+ * `ownerId` is the owner of the model being edited, not the acting user — a moderator
+ * editing someone else's model still links that owner's models together, never their own.
+ */
+export function planReciprocalAssociations({
+  sourceModelId,
+  ownerId,
+  candidates,
+  existingCounts,
+  alreadyLinked,
+  limit,
+}: {
+  sourceModelId: number;
+  ownerId: number;
+  candidates: ReciprocalCandidate[];
+  existingCounts: Map<number, number>;
+  alreadyLinked: Set<number>;
+  limit: number;
+}): ReciprocalPlan {
+  const plan: ReciprocalPlan = { create: [], skipped: [] };
+  const seen = new Set<number>();
+
+  for (const { modelId, ownerId: candidateOwnerId } of candidates) {
+    if (modelId === sourceModelId || seen.has(modelId)) continue;
+    seen.add(modelId);
+
+    if (candidateOwnerId !== ownerId) {
+      plan.skipped.push({ modelId, reason: 'notOwned' });
+      continue;
+    }
+    if (alreadyLinked.has(modelId)) {
+      plan.skipped.push({ modelId, reason: 'alreadyLinked' });
+      continue;
+    }
+
+    const count = existingCounts.get(modelId) ?? 0;
+    if (count >= limit) {
+      plan.skipped.push({ modelId, reason: 'atLimit' });
+      continue;
+    }
+
+    plan.create.push({ fromModelId: modelId, toModelId: sourceModelId, index: count });
+  }
+
+  return plan;
+}

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -21,6 +21,11 @@ import { toApiModelFile } from '~/server/common/model-helpers';
 import type { Context } from '~/server/createContext';
 import { dbRead, dbWrite } from '~/server/db/client';
 import {
+  planReciprocalAssociations,
+  selectNewlyAddedModelIds,
+} from '~/server/services/model-association.utils';
+import type { AssociationType } from '~/shared/utils/prisma/enums';
+import {
   getDbWithoutLag,
   preventModelVersionLagBatch,
   preventReplicationLag,
@@ -4067,7 +4072,7 @@ export const getAssociatedResourcesSimple = async ({
 };
 
 export const setAssociatedResources = async (
-  { fromId, type, associations }: SetAssociatedResourcesInput,
+  { fromId, type, associations, reciprocal }: SetAssociatedResourcesInput,
   user?: SessionUser
 ) => {
   const fromModel = await dbWrite.model.findUnique({
@@ -4076,7 +4081,7 @@ export const setAssociatedResources = async (
       userId: true,
       associations: {
         where: { type },
-        select: { id: true },
+        select: { id: true, toModelId: true },
         orderBy: { index: 'asc' },
       },
     },
@@ -4087,11 +4092,14 @@ export const setAssociatedResources = async (
   if (!user?.isModerator && fromModel.userId !== user?.id) throw throwAuthorizationError();
 
   const existingAssociations = fromModel.associations.map((x) => x.id);
+  const existingModelTargets = new Set(
+    fromModel.associations.map((x) => x.toModelId).filter(isDefined)
+  );
   const associationsToRemove = existingAssociations.filter(
     (existingToId) => !associations.find((item) => item.id === existingToId)
   );
 
-  return await dbWrite.$transaction([
+  const result = await dbWrite.$transaction([
     // remove associated resources not included in payload
     dbWrite.modelAssociations.deleteMany({
       where: {
@@ -4114,6 +4122,95 @@ export const setAssociatedResources = async (
       });
     }),
   ]);
+
+  const reciprocalResult = reciprocal
+    ? await addReciprocalAssociations({
+        fromId,
+        ownerId: fromModel.userId,
+        type,
+        // Only resources added during this edit, never the ones already on the list. An
+        // association the model already held is one the creator linked at some earlier point
+        // and chose not to link back then; a later save of an unrelated change must not
+        // retroactively reach into those models.
+        //
+        // This is the whole enforcement of that rule, and it deliberately asks the database
+        // which models are already linked rather than trusting the payload's association ids.
+        // Those ids are absent for a row the client believes is new, and the client is wrong
+        // about that more often than it looks: it writes its own id-less array into the query
+        // cache after a save, so a second save in the same page session presents every row as
+        // new. Comparing model ids is immune to that, and to a caller omitting an id on purpose.
+        targetIds: selectNewlyAddedModelIds(associations, existingModelTargets),
+        actorId: user?.id,
+      })
+    : { linked: 0, skipped: [] };
+
+  return { associations: result, reciprocal: reciprocalResult };
+};
+
+/**
+ * Writes the "link both ways" back-links: adds `fromId` to the suggested-resource list of
+ * every target that `ownerId` also owns. Targets owned by anyone else are skipped, not
+ * rejected, so a mixed selection still saves its forward links.
+ *
+ * This is the only path that writes an association whose `fromModelId` is a model the
+ * request did not name, so ownership is re-derived here from the database rather than
+ * trusted from the caller.
+ */
+const addReciprocalAssociations = async ({
+  fromId,
+  ownerId,
+  type,
+  targetIds,
+  actorId,
+}: {
+  fromId: number;
+  ownerId: number;
+  type: AssociationType;
+  targetIds: number[];
+  actorId?: number;
+}) => {
+  const ids = [...new Set(targetIds)].filter((id) => id !== fromId);
+  if (!ids.length) return { linked: 0, skipped: [] };
+
+  // Both reads go to the writer. Ownership decides whether a row may be written into a model
+  // the request never named, and a replica within its lag window can report the previous owner
+  // of a model that just changed hands. The same lag would hide a back-link committed moments
+  // earlier, which is what stops a second save duplicating it.
+  const [targets, existing] = await Promise.all([
+    dbWrite.model.findMany({ where: { id: { in: ids } }, select: { id: true, userId: true } }),
+    dbWrite.modelAssociations.findMany({
+      where: { fromModelId: { in: ids }, type },
+      select: { fromModelId: true, toModelId: true },
+    }),
+  ]);
+
+  const existingCounts = new Map<number, number>();
+  const alreadyLinked = new Set<number>();
+  for (const association of existing) {
+    existingCounts.set(
+      association.fromModelId,
+      (existingCounts.get(association.fromModelId) ?? 0) + 1
+    );
+    if (association.toModelId === fromId) alreadyLinked.add(association.fromModelId);
+  }
+
+  const { create, skipped } = planReciprocalAssociations({
+    sourceModelId: fromId,
+    ownerId,
+    candidates: targets.map((target) => ({ modelId: target.id, ownerId: target.userId })),
+    existingCounts,
+    alreadyLinked,
+    limit: constants.modelAssociations.limit,
+  });
+
+  if (create.length) {
+    await dbWrite.modelAssociations.createMany({
+      data: create.map((row) => ({ ...row, type, associatedById: actorId })),
+      skipDuplicates: true,
+    });
+  }
+
+  return { linked: create.length, skipped };
 };
 // #endregion
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -4123,7 +4123,8 @@ export const setAssociatedResources = async (
     }),
   ]);
 
-  const reciprocalResult = reciprocal
+  const reciprocalRequested = new Set(reciprocal ?? []);
+  const reciprocalResult = reciprocalRequested.size
     ? await addReciprocalAssociations({
         fromId,
         ownerId: fromModel.userId,
@@ -4139,7 +4140,11 @@ export const setAssociatedResources = async (
         // about that more often than it looks: it writes its own id-less array into the query
         // cache after a save, so a second save in the same page session presents every row as
         // new. Comparing model ids is immune to that, and to a caller omitting an id on purpose.
-        targetIds: selectNewlyAddedModelIds(associations, existingModelTargets),
+        // The shared derivation decides what is eligible; the request only narrows it. A caller
+        // naming a model that was already on the list, or one it does not own, gets nothing.
+        targetIds: selectNewlyAddedModelIds(associations, existingModelTargets).filter((id) =>
+          reciprocalRequested.has(id)
+        ),
         actorId: user?.id,
       })
     : { linked: 0, skipped: [] };


### PR DESCRIPTION
## What this does

Ticking a per-row **Link back** chip when adding resources to a model's Suggested Resources also adds *that* model to the suggested list of each resource added **in the same edit**, limited to models owned by the **same creator who owns the model being edited**. Resources owned by anyone else are skipped silently, never rejected, so a mixed selection still saves every forward link.

This replaces the retired PR #4762 (`4c39b20dda`), which was cut rather than fixed. It is based directly on `main` — not stacked on anything.

## The one property that matters

**The "is this newly added" rule is derived exactly once.** `selectNewlyAddedModelIds` in `src/server/services/model-association.utils.ts:14` is the single definition. The server reads it at `src/server/services/model.service.ts:4145` to decide what to write; the component reads the same function at `src/components/AssociatedModels/AssociateModels.tsx:157` to decide what to offer.

This is the whole reason the previous attempt was re-cut. The same rule written twice produced a defect three times on that branch — ownership, then the scope rule, then "added this edit" — and each fix moved one copy and not the other. Three independent review lanes converged on the third.

**Please do not add a second predicate answering that question.** If you need it in a third place, call the function.

The rule answers which *model ids* are new, not which *association rows* are. An association id is a claim the client makes; a model id is a fact both sides can check. Two of the three defects turned on that difference.

## Product decisions already made (not open for re-decision)

- **Independent removal.** Once written, a back-link belongs to the other model's list and is removed from there. Not symmetric — symmetric removal means a delete reaching into a model the request never named.
- **Scope is this edit only**, not the whole saved list. This modal saves the entire list, so without the scoping a user ticking the control while changing something unrelated would retroactively reach into models they linked months ago.
- **Filename auto-search is out of scope.** Model file names are not in the Meilisearch index at all — the indexer drops `files` — so it needs a new indexed field plus a full reindex.
- The per-row chip replaced an earlier bottom-of-modal checkbox, which acted on a subset of what was on screen with nothing on screen delimiting it.

## Safety shape

- `reciprocal` in the tRPC input is the **list of model ids the caller asked to link back** — a request, not an instruction. The server derives eligibility itself and then narrows by the request, so the request can only ever narrow. Both directions are pinned: trusting the request alone turns four tests red, ignoring it turns one red.
- Ownership is re-derived from the database and scoped to `fromModel.userId`, never the acting user, so a moderator editing someone else's model links *that creator's* models. `associatedById` still records the actor.
- Both reads in the reciprocal path go to `dbWrite`, deliberately: a replica inside its lag window reports the previous owner of a model that just changed hands, and hides a back-link committed moments earlier so a second save duplicates it.
- The per-target association cap is keyed per target model, not collapsed to a total.
- `associations` in the input schema gains `.max(20)`; it was previously unbounded.

## Dependency: the unique index is committed but NOT applied

The migration for the unique index on `("fromModelId", "toModelId", type)` landed as a **file** in #4767 (`88daa07e8d`). Migrations in this repo are applied by hand, so **nothing about the database has changed yet**. `createMany({ skipDuplicates: true })` emits `ON CONFLICT DO NOTHING`, which is valid with or without the index but conflicts with nothing until it exists — so duplicate suppression is not live until someone runs that SQL.

Declaring `@@unique` in `schema.full.prisma` is blocked by construction until then (the drift gate treats a constraint declared on live columns as enforced drift) and is tracked separately.

## UI pass

The modal was described as dated, so this also brings it up to standard. Presentation only:

- The type badge went through `getDisplayName`, so an embedding reads `Embedding` rather than `TextualInversion`.
- The sortable rows showed `pointer`. `src/components/ImageUpload/SortableItem.tsx` is shared by **9 consumers**, 3 of which are `rectSortingStrategy` grids, so its cursor was **not** changed globally — it takes an optional `cursor` whose default is the exact literal it replaced, and only this modal passes `grab`. The other 8 render an identical style object.
- A real modal title; the ordering hint and the selection count share one line, hint left and count right; the footer is always present and disabled until something changes, rather than popping in and out; a dimmed line replaces an `Alert` in the empty state; the remove control is subtle instead of a red outlined box.
- The "Link back" chip's label matches the badges beside it (uppercase, bold).
- The author badge is now always shown, and asks whether the resource belongs to **the person reading the screen**. Previously it was hidden only on chip-eligible rows, which requires the row to be newly added, so a resource the creator owned showed their own name back at them the moment it had been saved once. It reads "You" whenever the row's author is the viewer — including a moderator who finds their own model inside someone else's list; the creator's own rows show the creator's username.

  This is deliberately a different question from the one the chip asks. The chip asks whether the **model owner** owns the row, and the server is the authority for it; the badge asks whether the **viewer** does. They disagree for a moderator, so they are two inline per-row terms rather than one shared derivation. An earlier revision of this PR merged them and got the moderator case wrong in exactly the way the badge was meant to fix.

## Deliberately not done, so the absence is not read as oversight

- **No `notFound` skip reason** for target ids the database does not return. Filtering the reciprocal read on `deletedAt`/`status` would put a filter on one side of a pair whose forward path has none, so a resource you can still add to your own list could not receive a back-link, for reasons nothing in the UI explains. Fix both paths together or neither.
- **The reciprocal write's throw is not caught.** It runs outside the main transaction, so a failure rejects the mutation while the forward links are already committed. Wrapping it would swallow a real database error on a write path, which is worse. State self-heals on retry.
- **Back-link provenance is invisible to the recipient.** `associatedById` is stored and surfaced nowhere. The only unasked-for back-link comes from a moderator save, which is rare enough to wait for a complaint.
- The public carousel re-merges its result as `[...models, ...articles]` (`src/components/AssociatedModels/recommender.utils.ts:58`), so a mixed list does not render in the creator's drag order even though the server preserves it end to end. Restoring that changes a public render path, so this PR drops the UI's ordering claim rather than the behaviour.

## Verification

- `pnpm run typecheck` — 0 errors.
- `pnpm exec eslint` on every file this PR changes — 0 errors, 0 warnings on changed lines. (`pnpm run lint` exits 1 repo-wide on ~358 pre-existing errors.)
- Covering suites: `Test Files 2 passed (2)` / `Tests 25 passed (25)`, exit 0.
- Full unit suite: `Test Files 1 failed | 1763 passed | 3 skipped (1767)`, `Tests 1 failed | 40233 passed | 35 skipped (40269)`. The single failure is `src/server/integrations/__tests__/moderation-cache-probe.test.ts`, a `vi.waitFor` against Redis — pre-existing and separately tracked. It passes in isolation (`Test Files 2 passed (2)` / `Tests 35 passed (35)`, exit 0), the file is untouched by this branch, and there is no import path from it to any file this PR changes.
- `blocks.router.workflow.test.ts` collected a nonzero count (`Tests 380 passed (380)`), confirming the submodule was initialised and the suite was real.
- Every safety-critical path has a control that was **run and watched go red**, not asserted: trusting the client's request alone, ignoring it, swapping actor for owner, collapsing per-target counts, dropping `skipDuplicates`, moving reads to the replica, bypassing the shared derivation.
- The consent fix (a tick surviving row removal) was verified by deliberately removing the fix and observing the chip return pre-ticked, then restoring it — fixed `checked: [false]`, broken `checked: [true]`, same sequence both times.

Prod query plans: ownership read 0.086 ms, existing-associations read 1.400 ms at the 12 heaviest `fromModelId`s in the table. The reciprocal path adds a flat +3 statements regardless of N, and zero when no chip is ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVht5SW2FH1BBo1Koeg9Pt


## Corrections to this PR's own record

Recorded here because two of them live in pushed commit messages that cannot be amended, and a wrong reason is worse than no reason — it is a trap with a comment on it.

- **`be99b8854a`'s message is wrong about why its fix is safe.** It says removing an article cannot clear a model's link-back tick "because `handleSelect` dedupes on id across both resource types, so the two can never be in the list together." `handleSelect` guards **additions only**; the list is also seeded from the server's saved list, which applies no cross-type dedupe, so the pair can arrive from the server. The fix is still correct, for a different reason: a colliding id is in `savedTargetIds`, so it is never newly added, so no chip renders for it, so `linkBack` can never hold it.
- **`deabbb24c4`'s message overstates one property.** It says the restored per-row ownership term is "immune by construction" to the model/article id-namespace crossing. The eligibility `Set` is still keyed on a bare `item.id`, so that is not quite true — what actually closes it is `handleSelect`'s cross-namespace dedupe, plus the fact that a saved model/article pair puts the id in `savedTargetIds` and therefore out of the newly-added set. Both directions are closed, so there is no reachable defect, but the property rests on a dedupe elsewhere in the file rather than on the term itself. Narrowing that dedupe to per-`resourceType` would reopen it.
- **Two separate review lanes independently claimed a `Badge` in this diff renders "Mantine's default filled" and diverges visually from `ModelTypeBadge`.** Both were wrong for the same reason: `src/providers/ThemeProvider.tsx:52` sets `Badge` `defaultProps: { radius: 'sm', variant: 'light' }` app-wide, so every `Badge` is already light and `ModelTypeBadge`'s own explicit `variant="light"` is itself redundant. Measured, before and after: background identical at `rgba(34, 139, 230, 0.15)`. Commit `a526e8de93` exists only to revert the no-op prop that claim produced. Two lanes making the same mistake is a pattern rather than two accidents, so it is written down here to stop it becoming three.
- **A load-bearing test comment credited the wrong line** and is retargeted in `deabbb24c4`. It named the `reciprocalRequested.size` ternary as the opt-in; deleting that ternary changes no behaviour, because an empty request set already yields an empty target list and `addReciprocalAssociations` returns at its own length check. The opt-in is the `.filter((id) => reciprocalRequested.has(id))` below it.

## Known follow-ups this PR does not take

- `src/components/SortableGrid/SortableGrid.tsx` holds a second, module-private `SortableItem` whose cursor line was byte-identical to the shared one before this PR parameterised it, so the two have now diverged. Not merged here because that copy passes `disabled` into `useSortable` while the shared component does not, so unifying them changes drag behaviour at one of the two call-site families — a behaviour change dressed as a de-dup. Closing condition: `SortableGrid.tsx` imports `SortableItem` from `~/components/ImageUpload/SortableItem` and its local `function SortableItem` is gone, with the shared component forwarding `disabled` into `useSortable` first.
- `constants.modelAssociations.maxPerSave` has no test pinning it above `limit`, and the at-limit test builds its fixture from `limit` itself, so the value of both constants is unpinned. The reachable mutation is a tidy-up that collapses the two, which would strand the nine models already holding 11-12 associations.
- The reciprocal write runs after the forward transaction commits, so its failure leaves a save that partly landed and opens a retry path that can mint duplicate forward rows. Behaviour is deliberate and documented above; the retry path is untested.
- `User.username` is nullable, so a row owned by a username-less account renders the author badge as a bare icon. Pre-existing for every non-chip-eligible row; this PR makes the badge unconditional, so it is now reachable on all of them.
