### PR TITLE
feat(support): support button opens a menu, and bug reports go to the feedback panel

### DIFF
--- a/src/components/AppLayout/AppFooter.tsx
+++ b/src/components/AppLayout/AppFooter.tsx
@@ -5,10 +5,10 @@ import clsx from 'clsx';
 import { useRef, useState } from 'react';
 import { AssistantButton } from '~/components/Assistant/AssistantButton';
 import { ManageConsentFooterLink } from '~/components/Consent/ManageConsentFooterLink';
-import { RoutedDialogLink } from '~/components/Dialog/RoutedDialogLink';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { useScrollAreaRef } from '~/components/ScrollArea/ScrollAreaContext';
 import { SocialLinks } from '~/components/SocialLinks/SocialLinks';
+import { SupportMenu } from '~/components/Support/SupportMenu';
 import { useDomainColor } from '~/hooks/useDomainColor';
 import { useBrowsingSettingsAddons } from '~/providers/BrowsingSettingsAddonsProvider';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -249,11 +249,7 @@ export function AppFooter() {
           <SocialLinks />
         </div>
         <div className="ml-auto flex items-center gap-1">
-          <RoutedDialogLink name="support" state={{}} passHref>
-            <Button component="a" pl={4} pr="xs" color="yellow" variant="light" size="xs">
-              🛟 Support
-            </Button>
-          </RoutedDialogLink>
+          <SupportMenu />
         </div>
       </div>
     </footer>

--- a/src/components/AppLayout/AppFooter.tsx
+++ b/src/components/AppLayout/AppFooter.tsx
@@ -66,13 +66,6 @@ const footerLinks: (React.ComponentProps<typeof Button<typeof Link>> & {
     features: (features) => features.bugsPage,
   },
   {
-    key: 'education',
-    href: '/education',
-    target: '_blank',
-    rel: 'nofollow noreferrer',
-    children: 'Education',
-  },
-  {
     key: 'creator-program',
     href: '/creator-program',
     color: 'blue',

--- a/src/components/Assistant/AssistantButton.browser.test.tsx
+++ b/src/components/Assistant/AssistantButton.browser.test.tsx
@@ -1,0 +1,86 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { useAssistantPanelStore } from '~/store/assistant-panel.store';
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * 🔴 THIS FILE EXISTS BECAUSE THE STORE HAS A WRITER AND NEEDED A PROVEN READER.
+ *
+ * `AssistantButton`'s open state moved out of local `useState` into
+ * `assistant-panel.store` so the support menu could open the chat. `SupportMenu`'s
+ * tests assert the menu item WRITES the store — but until this file, nothing asserted
+ * anything READ it. Reverting this component to local `useState` would have left the
+ * whole branch green while the menu item became an inert button in production.
+ *
+ * `AssistantChat` is replaced by a marker: the real one renders an iframe from
+ * env-configured origins that the test browser does not serve, and what is under test
+ * is the wiring, not the chat.
+ */
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    assistant: { value: null as { personality: string; uuid: string } | null },
+  },
+}));
+
+vi.mock('~/components/Assistant/useAssistantAvailable', () => ({
+  useAssistantAvailable: () => mocks.assistant.value,
+}));
+
+// `IsClient` reads a context the app shell provides and this harness does not; it
+// gates on hydration, which is not what is under test here.
+vi.mock('~/components/IsClient/IsClient', () => ({
+  IsClient: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('~/components/Assistant/AssistantChat', () => ({
+  AssistantChat: () => <div data-testid="assistant-chat">chat</div>,
+  getAssistantUUID: () => 'uuid-1',
+}));
+
+const { AssistantButton } = await import('~/components/Assistant/AssistantButton');
+
+const chat = () => page.getByTestId('assistant-chat');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.assistant.value = { personality: 'civbot', uuid: 'uuid-1' };
+  useAssistantPanelStore.setState({ opened: false });
+});
+
+describe('the chat follows the shared store, not private state', () => {
+  test('🔴 opening the store from elsewhere shows the chat', async () => {
+    renderWithProviders(<AssistantButton />);
+    // The negative half, and the reason this test can fail: closed is the state the
+    // component starts in, so an assertion on the open state alone would pass against
+    // a component that always renders the chat.
+    expect(chat().elements()).toHaveLength(0);
+
+    // Exactly what the support menu's "Get help fast" item does.
+    useAssistantPanelStore.setState({ opened: true });
+
+    await expect.element(chat()).toBeInTheDocument();
+  });
+
+  /**
+   * The launcher's own click is NOT asserted here, and the reason is worth writing
+   * down rather than leaving as a gap: `AssistantButton` renders Mantine's `Button`
+   * with `component="span"`, so it exposes no `button` role and
+   * `getByRole('button')` finds nothing — it is not reachable by assistive
+   * technology either. That is how it has always been (unchanged by this branch), so
+   * fixing it is not this PR's, and reaching it through a Mantine class name would
+   * be a test about a stylesheet. The contract that changed is the one above.
+   */
+});
+
+describe('when there is no chat to show', () => {
+  test('the chat stays hidden even with the store already open', async () => {
+    mocks.assistant.value = null;
+    // The store survives unmounts, so a stale `opened: true` from a previous session
+    // must not be enough on its own — availability is the gate, not the flag.
+    useAssistantPanelStore.setState({ opened: true });
+    renderWithProviders(<AssistantButton />);
+
+    expect(chat().elements()).toHaveLength(0);
+  });
+});

--- a/src/components/Assistant/AssistantButton.browser.test.tsx
+++ b/src/components/Assistant/AssistantButton.browser.test.tsx
@@ -1,6 +1,7 @@
+import type { ButtonProps } from '@mantine/core';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { page } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 import { useAssistantPanelStore } from '~/store/assistant-panel.store';
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -9,13 +10,22 @@ import { renderWithProviders } from '../../../test/component-setup';
  *
  * `AssistantButton`'s open state moved out of local `useState` into
  * `assistant-panel.store` so the support menu could open the chat. `SupportMenu`'s
- * tests assert the menu item WRITES the store — but until this file, nothing asserted
- * anything READ it. Reverting this component to local `useState` would have left the
- * whole branch green while the menu item became an inert button in production.
+ * tests assert the menu item WRITES the store — without this file nothing asserted
+ * anything READ it, and reverting this component to local `useState` would have left
+ * the whole branch green while the menu item became an inert button in production.
  *
- * `AssistantChat` is replaced by a marker: the real one renders an iframe from
- * env-configured origins that the test browser does not serve, and what is under test
- * is the wiring, not the chat.
+ * 🔴 EVERY NEGATIVE READ HERE IS PRECEDED BY AN AWAITED MARKER, AND MUST STAY THAT
+ * WAY. `renderWithProviders` does not commit synchronously: a bare
+ * `expect(chat().elements()).toHaveLength(0)` straight after it passes because
+ * nothing has rendered YET, not because the chat is absent. Both negatives in the
+ * first version of this file were vacuous for exactly that reason — a mutation
+ * deleting the availability gate entirely still left it at 2 passed. The marker is a
+ * sibling that always renders, so awaiting it proves the commit happened before any
+ * absence is read.
+ *
+ * `AssistantChat` is replaced by a marker element: the real one renders an iframe
+ * from env-configured origins the test browser does not serve. `IsClient` is replaced
+ * because it reads a context the harness has no provider for.
  */
 const { mocks } = vi.hoisted(() => ({
   mocks: {
@@ -27,33 +37,38 @@ vi.mock('~/components/Assistant/useAssistantAvailable', () => ({
   useAssistantAvailable: () => mocks.assistant.value,
 }));
 
-// `IsClient` reads a context the app shell provides and this harness does not; it
-// gates on hydration, which is not what is under test here.
 vi.mock('~/components/IsClient/IsClient', () => ({
   IsClient: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
 vi.mock('~/components/Assistant/AssistantChat', () => ({
   AssistantChat: () => <div data-testid="assistant-chat">chat</div>,
-  getAssistantUUID: () => 'uuid-1',
 }));
 
 const { AssistantButton } = await import('~/components/Assistant/AssistantButton');
 
 const chat = () => page.getByTestId('assistant-chat');
+const launcher = () => page.getByTestId('assistant-launcher');
+
+/** Renders a sibling that always renders, and waits for it — see the file header. */
+const renderAndSettle = async () => {
+  renderWithProviders(
+    <>
+      <span data-testid="committed">committed</span>
+      <AssistantButton {...({ 'data-testid': 'assistant-launcher' } as ButtonProps)} />
+    </>
+  );
+  await expect.element(page.getByTestId('committed')).toBeInTheDocument();
+};
 
 beforeEach(() => {
-  vi.clearAllMocks();
   mocks.assistant.value = { personality: 'civbot', uuid: 'uuid-1' };
   useAssistantPanelStore.setState({ opened: false });
 });
 
 describe('the chat follows the shared store, not private state', () => {
   test('🔴 opening the store from elsewhere shows the chat', async () => {
-    renderWithProviders(<AssistantButton />);
-    // The negative half, and the reason this test can fail: closed is the state the
-    // component starts in, so an assertion on the open state alone would pass against
-    // a component that always renders the chat.
+    await renderAndSettle();
     expect(chat().elements()).toHaveLength(0);
 
     // Exactly what the support menu's "Get help fast" item does.
@@ -63,23 +78,33 @@ describe('the chat follows the shared store, not private state', () => {
   });
 
   /**
-   * The launcher's own click is NOT asserted here, and the reason is worth writing
-   * down rather than leaving as a gap: `AssistantButton` renders Mantine's `Button`
-   * with `component="span"`, so it exposes no `button` role and
-   * `getByRole('button')` finds nothing — it is not reachable by assistive
-   * technology either. That is how it has always been (unchanged by this branch), so
-   * fixing it is not this PR's, and reaching it through a Mantine class name would
-   * be a test about a stylesheet. The contract that changed is the one above.
+   * The launcher's own click, reached through the `data-testid` the component already
+   * spreads onto its Button rather than through `getByRole('button')`: it renders
+   * Mantine's `Button` with `component="span"`, so no button role exists — which also
+   * means assistive technology cannot reach it. That is how it renders today;
+   * whether the span is load-bearing is NOT established here, and changing it belongs
+   * to whoever owns that component. Reaching the element through a Mantine class name
+   * would have made this a test about a stylesheet.
    */
+  test('the launcher toggles the store both ways', async () => {
+    await renderAndSettle();
+
+    await userEvent.click(launcher());
+    await expect.element(chat()).toBeInTheDocument();
+    expect(useAssistantPanelStore.getState().opened).toBe(true);
+
+    await userEvent.click(launcher());
+    expect(useAssistantPanelStore.getState().opened).toBe(false);
+  });
 });
 
 describe('when there is no chat to show', () => {
   test('the chat stays hidden even with the store already open', async () => {
     mocks.assistant.value = null;
-    // The store survives unmounts, so a stale `opened: true` from a previous session
-    // must not be enough on its own — availability is the gate, not the flag.
+    // The store survives unmounts, so a stale `opened: true` must not be enough on its
+    // own — availability is the gate, not the flag.
     useAssistantPanelStore.setState({ opened: true });
-    renderWithProviders(<AssistantButton />);
+    await renderAndSettle();
 
     expect(chat().elements()).toHaveLength(0);
   });

--- a/src/components/Assistant/AssistantButton.tsx
+++ b/src/components/Assistant/AssistantButton.tsx
@@ -1,30 +1,22 @@
 import type { ButtonProps } from '@mantine/core';
 import { Button } from '@mantine/core';
 import { IconCat, IconMessageChatbot, IconX } from '@tabler/icons-react';
-import { useState } from 'react';
-import { AssistantChat, getAssistantUUID } from '~/components/Assistant/AssistantChat';
+import { AssistantChat } from '~/components/Assistant/AssistantChat';
+import { useAssistantAvailable } from '~/components/Assistant/useAssistantAvailable';
 import { IsClient } from '~/components/IsClient/IsClient';
-import { useCurrentUserSettings } from '~/components/UserSettings/hooks';
-import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { useAssistantPanelStore } from '~/store/assistant-panel.store';
 
 const WIDTH = 320;
 const HEIGHT = 500;
 
 export function AssistantButton({ ...props }: ButtonProps) {
-  const [open, setOpen] = useState(false);
-  const features = useFeatureFlags();
-  const currentUser = useCurrentUser();
-  const { assistantPersonality } = useCurrentUserSettings();
+  const open = useAssistantPanelStore((state) => state.opened);
+  const assistant = useAssistantAvailable();
 
-  if (!currentUser || !features.assistant) return null;
+  if (!assistant) return null;
 
-  const userPersonality = assistantPersonality ?? 'civbot';
-  const gpttUUID = getAssistantUUID(userPersonality);
-  if (!gpttUUID) return null;
-
-  const Icon = userPersonality === 'civchan' ? IconCat : IconMessageChatbot;
-  const color = userPersonality === 'civchan' ? 'pink' : 'blue';
+  const Icon = assistant.personality === 'civchan' ? IconCat : IconMessageChatbot;
+  const color = assistant.personality === 'civchan' ? 'pink' : 'blue';
 
   return (
     <IsClient>
@@ -38,7 +30,7 @@ export function AssistantButton({ ...props }: ButtonProps) {
         px="xs"
         {...props}
         color={open ? 'gray' : color}
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => useAssistantPanelStore.setState({ opened: !open })}
       >
         {open ? <IconX size={20} stroke={2.5} /> : <Icon size={20} stroke={2.5} />}
       </Button>

--- a/src/components/Assistant/useAssistantAvailable.browser.test.tsx
+++ b/src/components/Assistant/useAssistantAvailable.browser.test.tsx
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * 🔴 THE HOOK BOTH ITS CONSUMERS MOCK.
+ *
+ * `AssistantButton` and `SupportMenu` each replace `useAssistantAvailable` in their
+ * own suites — correctly, they are testing themselves — with the result that the
+ * three-condition derivation it exists to centralise executed in NO test. Dropping
+ * `|| !features.assistant` turned CivBot's footer button and its menu item on for
+ * every signed-in user regardless of the flag, and the whole branch stayed green.
+ *
+ * A feature-flag gate is the shape that fails quietly: an absent flag reads
+ * `undefined`, which is falsy on the gate's side and permissive on the query's, which
+ * is why this repo carries `no-untruthy-query-gate` as a convention guard. So every
+ * condition here is asserted in BOTH directions rather than only the deny side.
+ */
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    currentUser: { value: null as { id: number } | null },
+    assistant: { value: true },
+    personality: { value: undefined as string | undefined },
+    uuid: { value: 'uuid-1' as string | null },
+  },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mocks.currentUser.value,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ assistant: mocks.assistant.value }),
+}));
+
+vi.mock('~/components/UserSettings/hooks', () => ({
+  useCurrentUserSettings: () => ({ assistantPersonality: mocks.personality.value }),
+}));
+
+vi.mock('~/components/Assistant/AssistantChat', () => ({
+  // The uuid lookup is env-driven and the env is not set in the test browser, so the
+  // holder stands in for "this deployment has a uuid for that personality".
+  getAssistantUUID: () => mocks.uuid.value,
+}));
+
+const { useAssistantAvailable } = await import('~/components/Assistant/useAssistantAvailable');
+
+/** Renders the hook's answer so it can be read the way a consumer would see it. */
+function Probe() {
+  const assistant = useAssistantAvailable();
+  return <span data-testid="result">{assistant ? assistant.personality : 'unavailable'}</span>;
+}
+
+const result = async () => {
+  renderWithProviders(<Probe />);
+  // Awaited, not read synchronously: `renderWithProviders` does not commit before it
+  // returns, so a bare `.element()` here throws on a hook that works fine.
+  await expect.element(page.getByTestId('result')).toBeInTheDocument();
+  return page.getByTestId('result').element().textContent;
+};
+
+beforeEach(() => {
+  mocks.currentUser.value = { id: 1 };
+  mocks.assistant.value = true;
+  mocks.personality.value = undefined;
+  mocks.uuid.value = 'uuid-1';
+});
+
+describe('all three conditions have to hold', () => {
+  test('a signed-in user, the flag on, and a uuid for their personality', async () => {
+    expect(await result()).toBe('civbot');
+  });
+
+  test('🔴 the feature flag alone can turn it off', async () => {
+    mocks.assistant.value = false;
+    expect(await result()).toBe('unavailable');
+  });
+
+  test('a signed-out visitor has no chat', async () => {
+    mocks.currentUser.value = null;
+    expect(await result()).toBe('unavailable');
+  });
+
+  test('a deployment with no uuid for the personality has no chat', async () => {
+    // The case the hook's own comment says a caller deriving only the first two
+    // conditions would get wrong: it would offer a chat that then renders nothing.
+    mocks.uuid.value = null;
+    expect(await result()).toBe('unavailable');
+  });
+});
+
+describe('the personality it reports', () => {
+  test('defaults to civbot when the user has not chosen one', async () => {
+    expect(await result()).toBe('civbot');
+  });
+
+  test('is the chosen one otherwise', async () => {
+    // Pinned against the default above, so a hook that ignored the setting and always
+    // answered 'civbot' would pass one of these and fail the other.
+    mocks.personality.value = 'civchan';
+    expect(await result()).toBe('civchan');
+  });
+});

--- a/src/components/Assistant/useAssistantAvailable.browser.test.tsx
+++ b/src/components/Assistant/useAssistantAvailable.browser.test.tsx
@@ -22,6 +22,7 @@ const { mocks } = vi.hoisted(() => ({
     assistant: { value: true },
     personality: { value: undefined as string | undefined },
     uuid: { value: 'uuid-1' as string | null },
+    getAssistantUUID: vi.fn(),
   },
 }));
 
@@ -39,8 +40,13 @@ vi.mock('~/components/UserSettings/hooks', () => ({
 
 vi.mock('~/components/Assistant/AssistantChat', () => ({
   // The uuid lookup is env-driven and the env is not set in the test browser, so the
-  // holder stands in for "this deployment has a uuid for that personality".
-  getAssistantUUID: () => mocks.uuid.value,
+  // holder stands in for "this deployment has a uuid for that personality". A spy
+  // rather than a bare arrow because WHAT IT IS CALLED WITH is the load-bearing part
+  // — see the arity assertion below.
+  getAssistantUUID: (...args: unknown[]) => {
+    mocks.getAssistantUUID(...args);
+    return mocks.uuid.value;
+  },
 }));
 
 const { useAssistantAvailable } = await import('~/components/Assistant/useAssistantAvailable');
@@ -60,6 +66,7 @@ const result = async () => {
 };
 
 beforeEach(() => {
+  vi.clearAllMocks();
   mocks.currentUser.value = { id: 1 };
   mocks.assistant.value = true;
   mocks.personality.value = undefined;
@@ -94,10 +101,17 @@ describe('the personality it reports', () => {
     expect(await result()).toBe('civbot');
   });
 
-  test('is the chosen one otherwise', async () => {
+  test('is the chosen one otherwise, and is what the uuid is looked up by', async () => {
     // Pinned against the default above, so a hook that ignored the setting and always
     // answered 'civbot' would pass one of these and fail the other.
     mocks.personality.value = 'civchan';
     expect(await result()).toBe('civchan');
+
+    // 🔴 EXACT ARITY, deliberately. `AssistantChat` calls the same helper with a
+    // SECOND argument (`features.isGreen`) and this hook does not — a difference that
+    // decides which env var the footer reads on the green domain. The obvious
+    // "tidy-up" that unifies them is a behaviour change, and `toHaveBeenCalledWith`
+    // is what turns it from silent into red.
+    expect(mocks.getAssistantUUID).toHaveBeenCalledWith('civchan');
   });
 });

--- a/src/components/Assistant/useAssistantAvailable.ts
+++ b/src/components/Assistant/useAssistantAvailable.ts
@@ -4,12 +4,19 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 
 /**
- * The chat's availability, in one place because two surfaces now ask: the button
- * that renders it and the support menu item that opens it. Three conditions have to
- * hold, and a menu item deriving only the first two would offer a chat that then
- * renders nothing.
+ * The chat's availability for the two footer surfaces: the button that renders it and
+ * the support menu item that opens it. Three conditions have to hold, and a menu item
+ * deriving only the first two would offer a chat that then renders nothing.
  *
- * Returns the resolved personality alongside, since every caller needs it.
+ * 🔴 NOT the only derivation, and deliberately not unified with the other one yet.
+ * `AssistantChat` derives the same triple itself and passes `features.isGreen` to
+ * `getAssistantUUID`, which this does not — so on the green domain, a deployment with
+ * only `NEXT_PUBLIC_GPTT_UUID_GREEN` set hides the footer button while `/support`'s
+ * chat renders fine. That split predates this hook: `AssistantButton` has always
+ * called `getAssistantUUID(personality)` with no second argument, and this preserves
+ * that exactly rather than silently changing which env var the footer reads.
+ * Closing it means changing the button's behaviour on civitai.red, which is its own
+ * change with its own testing.
  */
 export function useAssistantAvailable() {
   const currentUser = useCurrentUser();

--- a/src/components/Assistant/useAssistantAvailable.ts
+++ b/src/components/Assistant/useAssistantAvailable.ts
@@ -1,0 +1,26 @@
+import { getAssistantUUID } from '~/components/Assistant/AssistantChat';
+import { useCurrentUserSettings } from '~/components/UserSettings/hooks';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+
+/**
+ * The chat's availability, in one place because two surfaces now ask: the button
+ * that renders it and the support menu item that opens it. Three conditions have to
+ * hold, and a menu item deriving only the first two would offer a chat that then
+ * renders nothing.
+ *
+ * Returns the resolved personality alongside, since every caller needs it.
+ */
+export function useAssistantAvailable() {
+  const currentUser = useCurrentUser();
+  const features = useFeatureFlags();
+  const { assistantPersonality } = useCurrentUserSettings();
+
+  if (!currentUser || !features.assistant) return null;
+
+  const personality = assistantPersonality ?? 'civbot';
+  const uuid = getAssistantUUID(personality);
+  if (!uuid) return null;
+
+  return { personality, uuid };
+}

--- a/src/components/Feedback/FeedbackAttachments.tsx
+++ b/src/components/Feedback/FeedbackAttachments.tsx
@@ -1,0 +1,141 @@
+import type { StackProps } from '@mantine/core';
+import {
+  ActionIcon,
+  Button,
+  Checkbox,
+  FileButton,
+  Group,
+  Loader,
+  Stack,
+  Text,
+} from '@mantine/core';
+import { IconPaperclip, IconX } from '@tabler/icons-react';
+import type { FeedbackSubmission } from '~/components/Feedback/useFeedbackSubmission';
+import { FEEDBACK_IMAGE_MAX_COUNT } from '~/shared/constants/feedback.constants';
+
+type FeedbackAttachmentsProps = { feedback: FeedbackSubmission } & StackProps;
+
+/**
+ * The attach / capture controls, shared by every feedback surface so the consent
+ * copy and the screenshot preview cannot differ between them. Spacing is left to
+ * the caller (`StackProps`), which is the only thing the two surfaces disagree on.
+ */
+export function FeedbackAttachments({ feedback, ...stackProps }: FeedbackAttachmentsProps) {
+  const {
+    attachments,
+    screenshot,
+    screenshotConsent,
+    capturing,
+    busy,
+    canAddMore,
+    handleFilesSelected,
+    handleRemoveAttachment,
+    handleScreenshotConsentChange,
+    handleDropScreenshot,
+  } = feedback;
+
+  return (
+    <Stack gap="xs" {...stackProps}>
+      <Group gap="xs" wrap="wrap" align="center">
+        <FileButton onChange={handleFilesSelected} accept="image/*" multiple>
+          {(props) => (
+            <Button
+              {...props}
+              size="compact-sm"
+              radius="xl"
+              variant="light"
+              leftSection={<IconPaperclip size={14} />}
+              disabled={!canAddMore || busy}
+            >
+              Attach images
+            </Button>
+          )}
+        </FileButton>
+        <Text size="xs" c="dimmed">
+          {attachments.length} of {FEEDBACK_IMAGE_MAX_COUNT} attached
+        </Text>
+      </Group>
+      {!!attachments.length && (
+        <Group gap="xs" wrap="wrap">
+          {attachments.map((attachment) => (
+            <div key={attachment.key} style={{ position: 'relative' }}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={attachment.objectUrl}
+                alt={`Attached image ${attachment.file.name}`}
+                style={{
+                  width: 64,
+                  height: 64,
+                  objectFit: 'cover',
+                  borderRadius: 8,
+                  display: 'block',
+                }}
+              />
+              <ActionIcon
+                size="xs"
+                radius="xl"
+                variant="filled"
+                color="dark"
+                style={{ position: 'absolute', top: -6, right: -6 }}
+                aria-label={`Remove attached image ${attachment.file.name}`}
+                onClick={() => handleRemoveAttachment(attachment.key)}
+              >
+                <IconX size={12} />
+              </ActionIcon>
+            </div>
+          ))}
+        </Group>
+      )}
+      <Checkbox
+        size="xs"
+        checked={screenshotConsent}
+        // `busy` subsumes `capturing` (see its definition); kept as one term so the
+        // two cannot drift apart again.
+        disabled={busy}
+        onChange={(event) => void handleScreenshotConsentChange(event.currentTarget.checked)}
+        label="Attach a screenshot of this page"
+        description="We'll show it to you before anything is sent. Only what's on screen is captured."
+      />
+      {capturing && (
+        <Group gap="xs" align="center">
+          <Loader size="xs" />
+          <Text size="xs" c="dimmed">
+            Capturing the page…
+          </Text>
+        </Group>
+      )}
+      {screenshot && (
+        <Stack gap={4} align="flex-start">
+          <Text size="xs" c="dimmed">
+            This is what will be sent:
+          </Text>
+          <div style={{ position: 'relative' }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={screenshot.objectUrl}
+              alt="Preview of the page screenshot that will be sent"
+              style={{
+                maxWidth: 240,
+                maxHeight: 160,
+                borderRadius: 8,
+                display: 'block',
+                border: '1px solid var(--mantine-color-default-border)',
+              }}
+            />
+            <ActionIcon
+              size="xs"
+              radius="xl"
+              variant="filled"
+              color="dark"
+              style={{ position: 'absolute', top: -6, right: -6 }}
+              aria-label="Remove the page screenshot"
+              onClick={handleDropScreenshot}
+            >
+              <IconX size={12} />
+            </ActionIcon>
+          </div>
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/Feedback/FeedbackDrawer.browser.test.tsx
+++ b/src/components/Feedback/FeedbackDrawer.browser.test.tsx
@@ -1,3 +1,4 @@
+import Router from 'next/router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import type * as TrpcModule from '~/utils/trpc';
@@ -7,21 +8,28 @@ import { renderWithProviders } from '../../../test/component-setup';
  * FeedbackDrawer — the panel the support menu's "Report a bug" opens.
  *
  * 🔴 WHAT IS FAKED. `trpc` (no transport in the scaffold), `useCFImageUpload` (the
- * real one PUTs to Cloudflare) and `useDialogContext` (the drawer is mounted
- * directly rather than through DialogProvider). `getFaroSessionId` is NOT faked:
- * Faro does not run in the test browser, so its real answer is `undefined` — which
- * is the ordinary dev/preview case and the one worth proving does not block a send.
+ * real one PUTs to Cloudflare), `useDialogContext` (the drawer is mounted directly
+ * rather than through DialogProvider), and `getFaroSessionId` — that last one
+ * DELIBERATELY, and through a mutable holder, because Faro never runs in the test
+ * browser. Its real answer is always `undefined`, so an unfaked "no session id" test
+ * passes on the environment rather than on the code: the whole `sessionId` read could
+ * be deleted and nothing would notice. The holder makes the present case reachable,
+ * which turns the absent case into a control instead of a coincidence.
  *
  * The attach/capture controls are NOT re-tested here; they are the same
  * `FeedbackAttachments` + `useFeedbackSubmission` the inline prompt uses, and
  * `FeedbackPrompt.browser.test.tsx` exercises the consent path against the real
- * capture module. What is only true HERE is the area slug and the reported path.
+ * capture module.
  */
 const { mocks } = vi.hoisted(() => ({
   mocks: {
     createMutate: vi.fn(),
     onClose: vi.fn(),
+    showErrorNotification: vi.fn(),
     areaEnabled: { value: true },
+    faroSessionId: { value: undefined as string | undefined },
+    /** When set, `mutate` takes the failure path instead of the success one. */
+    mutateError: { value: undefined as string | undefined },
   },
 }));
 
@@ -33,10 +41,14 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
       feedback: {
         getArea: { useQuery: () => ({ data: { enabled: mocks.areaEnabled.value } }) },
         create: {
-          useMutation: (opts?: { onSuccess?: () => void }) => ({
+          useMutation: (opts?: {
+            onSuccess?: () => void;
+            onError?: (error: { message: string }) => void;
+          }) => ({
             mutate: (input: unknown) => {
               mocks.createMutate(input);
-              opts?.onSuccess?.();
+              if (mocks.mutateError.value) opts?.onError?.({ message: mocks.mutateError.value });
+              else opts?.onSuccess?.();
             },
             isPending: false,
           }),
@@ -59,8 +71,12 @@ vi.mock('~/hooks/useCFImageUpload', () => ({
   }),
 }));
 
+vi.mock('~/utils/faro/getFaroSessionId', () => ({
+  getFaroSessionId: () => mocks.faroSessionId.value,
+}));
+
 vi.mock('~/utils/notifications', () => ({
-  showErrorNotification: vi.fn(),
+  showErrorNotification: mocks.showErrorNotification,
   showSuccessNotification: vi.fn(),
 }));
 
@@ -73,36 +89,45 @@ const openDrawer = async () => {
   await expect.element(messageBox()).toBeInTheDocument();
 };
 
-const submitted = () => mocks.createMutate.mock.calls[0][0] as Record<string, unknown>;
+const fileReport = async (text = 'the generate button does nothing') => {
+  await openDrawer();
+  await userEvent.fill(messageBox(), text);
+  await userEvent.click(page.getByRole('button', { name: 'Send report' }));
+};
+
+const sent = async () => {
+  await vi.waitFor(() => expect(mocks.createMutate).toHaveBeenCalledTimes(1));
+  return mocks.createMutate.mock.calls[0][0] as Record<string, unknown>;
+};
+
+const context = async () => (await sent()).context as Record<string, unknown>;
+
+/**
+ * The scaffold's router mock is ONE shared object and `useRouter()` returns it, so the
+ * default import is the same instance the component reads — mutated here rather than
+ * called as a hook, which is a lint error outside a component. `beforeEach` puts it
+ * back, because a route left set would leak into every later test in the file.
+ */
+const setRoute = (asPath: string) => {
+  (Router as unknown as { asPath: string }).asPath = asPath;
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.areaEnabled.value = true;
+  mocks.faroSessionId.value = undefined;
+  mocks.mutateError.value = undefined;
+  setRoute('/');
 });
 
 describe('a report from the support menu', () => {
-  test('files against the site-wide area and names the route it came from', async () => {
-    await openDrawer();
-    await userEvent.fill(messageBox(), 'the generate button does nothing');
-    await userEvent.click(page.getByRole('button', { name: 'Send report' }));
-    await vi.waitFor(() => expect(mocks.createMutate).toHaveBeenCalledTimes(1));
+  test('files against the site-wide area', async () => {
+    await fileReport();
 
     // The slug is the whole point of a site-wide entry point: a report filed under
     // `apps-marketplace` would be gated by, and triaged as, the apps store.
-    expect(submitted().area).toBe('site-bug-report');
-    expect(submitted().message).toBe('the generate button does nothing');
-    // `next/router` is mocked by the scaffold; whatever it reports is what a report
-    // has to carry, because nothing else in the payload says where the user was.
-    expect((submitted().context as { path?: string }).path).toBeTruthy();
-  });
-
-  test('sends with no Faro session rather than refusing to send', async () => {
-    await openDrawer();
-    await userEvent.fill(messageBox(), 'no faro in the test browser');
-    await userEvent.click(page.getByRole('button', { name: 'Send report' }));
-    await vi.waitFor(() => expect(mocks.createMutate).toHaveBeenCalledTimes(1));
-
-    expect((submitted().context as { sessionId?: string }).sessionId).toBeUndefined();
+    expect((await sent()).area).toBe('site-bug-report');
+    expect((await sent()).message).toBe('the generate button does nothing');
   });
 
   test('Send is unavailable until something has been typed', async () => {
@@ -110,6 +135,98 @@ describe('a report from the support menu', () => {
     await expect.element(page.getByRole('button', { name: 'Send report' })).toBeDisabled();
     await userEvent.fill(messageBox(), 'x');
     await expect.element(page.getByRole('button', { name: 'Send report' })).toBeEnabled();
+  });
+});
+
+/**
+ * 🔴 THE DECISION THIS BLOCK PINS, addressed to whoever is about to "simplify"
+ * `split(/[?#]/)[0]` back to a plain `router.asPath`: the query string must NEVER
+ * reach `Feedback.context`.
+ *
+ * This entry point is in the footer on every route, and some routes carry a secret in
+ * the URL — `/redeem-code?code=…`, `/payment/coinbase?key=…`. `context` is a JSONB
+ * column read by triage and kept indefinitely, and the reporter is never shown what
+ * the URL contained. Storing `asPath` whole writes a live redeemable code into it.
+ * `path: z.string().max(300)` in the schema is a storage bound; it filters nothing.
+ */
+describe('🔴 the reported path carries the route and not the query string', () => {
+  test('a secret in the URL is cut off, and the route survives', async () => {
+    setRoute('/redeem-code?code=SUPER-SECRET-CODE#claimed');
+    await fileReport('the code would not redeem');
+
+    expect(await context()).toMatchObject({ path: '/redeem-code' });
+    expect(JSON.stringify(await context())).not.toContain('SUPER-SECRET-CODE');
+  });
+
+  test('an ordinary route is reported in full', async () => {
+    setRoute('/models/1234/some-model');
+    await fileReport();
+
+    // The control for the test above: the clip removes the query, not the path — an
+    // implementation that reported `router.pathname` or a bare `/` would pass there
+    // and fail here.
+    expect(await context()).toMatchObject({ path: '/models/1234/some-model' });
+  });
+});
+
+/**
+ * 🔴 The Faro session id is the entire reason this panel beats a support ticket — it
+ * is what turns "it broke" into a session with the console errors in it. Both
+ * directions are asserted because Faro never runs in the test browser: an absence
+ * test alone would pass with the `getFaroSessionId()` call deleted.
+ */
+describe('🔴 the Grafana Faro session travels with the report', () => {
+  test('the session id is attached when Faro is running', async () => {
+    mocks.faroSessionId.value = 'faro-session-abc123';
+    await fileReport();
+
+    expect(await context()).toMatchObject({ sessionId: 'faro-session-abc123' });
+  });
+
+  test('and the report still sends when Faro is not running', async () => {
+    await fileReport('no faro in the test browser');
+
+    expect(await sent()).toBeTruthy();
+    expect(await context()).not.toHaveProperty('sessionId');
+  });
+});
+
+describe('when the server refuses the report', () => {
+  test('the reporter is told, and the form is not cleared', async () => {
+    mocks.mutateError.value = 'You have submitted a lot of feedback — give it a little while.';
+    await fileReport('rate limited');
+
+    await vi.waitFor(() => expect(mocks.showErrorNotification).toHaveBeenCalledTimes(1));
+    // Still the form, not the "Got it, thanks" panel — a rejected report must not
+    // read as a delivered one.
+    await expect.element(messageBox()).toBeInTheDocument();
+  });
+});
+
+/**
+ * 🔴 The drawer must not appear in the screenshot the drawer collects.
+ * `captureConsentedScreenshot` draws `document.body`, and this Drawer portals into
+ * it, so without the ignore attribute the capture is this form plus the page dimmed
+ * behind the overlay. The assertion goes through `closest()` from the rendered
+ * content rather than reading the prop, because the question is whether Mantine
+ * actually puts the attribute on an ancestor of BOTH the panel and the overlay — a
+ * prop Mantine dropped would be invisible and silently restore the bug.
+ */
+describe('🔴 the panel excludes itself from the page capture', () => {
+  test('an ancestor of the drawer content carries the html2canvas ignore attribute', async () => {
+    await openDrawer();
+
+    const ignored = messageBox().element().closest('[data-html2canvas-ignore]');
+    expect(
+      ignored,
+      'Mantine dropped the attribute — the panel would be in its own capture'
+    ).not.toBeNull();
+
+    // The overlay is the other half: it is a sibling of the panel, so an attribute
+    // that landed on the panel alone would dim the page in every capture.
+    const overlay = document.querySelector('.mantine-Drawer-overlay');
+    expect(overlay, 'no overlay rendered — this assertion would prove nothing').not.toBeNull();
+    expect(ignored?.contains(overlay!)).toBe(true);
   });
 });
 

--- a/src/components/Feedback/FeedbackDrawer.browser.test.tsx
+++ b/src/components/Feedback/FeedbackDrawer.browser.test.tsx
@@ -204,15 +204,22 @@ describe('when the server refuses the report', () => {
 });
 
 /**
- * 🔴 The drawer must not appear in the screenshot the drawer collects.
- * `captureConsentedScreenshot` draws `document.body`, and this Drawer portals into
- * it, so without the ignore attribute the capture is this form plus the page dimmed
- * behind the overlay. The assertion goes through `closest()` from the rendered
- * content rather than reading the prop, because the question is whether Mantine
- * actually puts the attribute on an ancestor of BOTH the panel and the overlay — a
- * prop Mantine dropped would be invisible and silently restore the bug.
+ * 🔴 TWO DECISIONS ABOUT WHAT THE REPORTER CAN SEE AND SEND, both easy to undo by
+ * accident, and neither visible in a passing suite without these.
+ *
+ * The panel must not appear in its own screenshot. `captureConsentedScreenshot` draws
+ * `document.body` and this Drawer portals into it, so without the ignore attribute the
+ * capture is 480px of the report form over the page. The assertion goes through
+ * `closest()` from the rendered content rather than reading the prop, because the
+ * question is whether Mantine actually puts the attribute on the DOM — a prop Mantine
+ * dropped would be invisible and would silently restore the bug.
+ *
+ * And there must be no backdrop (Justin, 2026-09-11 review): the reporter is
+ * describing the page behind this panel, so dimming it dims the subject. Mantine
+ * renders the overlay by DEFAULT, so this stays correct only while `withOverlay` is
+ * explicitly false — exactly the kind of prop a later edit drops without noticing.
  */
-describe('🔴 the panel excludes itself from the page capture', () => {
+describe('🔴 the panel excludes itself from the capture, and dims nothing', () => {
   test('an ancestor of the drawer content carries the html2canvas ignore attribute', async () => {
     await openDrawer();
 
@@ -221,12 +228,14 @@ describe('🔴 the panel excludes itself from the page capture', () => {
       ignored,
       'Mantine dropped the attribute — the panel would be in its own capture'
     ).not.toBeNull();
+  });
 
-    // The overlay is the other half: it is a sibling of the panel, so an attribute
-    // that landed on the panel alone would dim the page in every capture.
-    const overlay = document.querySelector('.mantine-Drawer-overlay');
-    expect(overlay, 'no overlay rendered — this assertion would prove nothing').not.toBeNull();
-    expect(ignored?.contains(overlay!)).toBe(true);
+  test('no overlay is rendered over the page being reported', async () => {
+    await openDrawer();
+
+    // The control for this one is Mantine's own default: `withOverlay` defaults to
+    // true, so removing the prop puts the element back and this fails.
+    expect(document.querySelector('.mantine-Drawer-overlay')).toBeNull();
   });
 });
 

--- a/src/components/Feedback/FeedbackDrawer.browser.test.tsx
+++ b/src/components/Feedback/FeedbackDrawer.browser.test.tsx
@@ -220,7 +220,7 @@ describe('when the server refuses the report', () => {
  * explicitly false — exactly the kind of prop a later edit drops without noticing.
  */
 describe('🔴 the panel excludes itself from the capture, and dims nothing', () => {
-  test('an ancestor of the drawer content carries the html2canvas ignore attribute', async () => {
+  test('the WHOLE panel is ignored, header included, not just the form', async () => {
     await openDrawer();
 
     const ignored = messageBox().element().closest('[data-html2canvas-ignore]');
@@ -228,6 +228,16 @@ describe('🔴 the panel excludes itself from the capture, and dims nothing', ()
       ignored,
       'Mantine dropped the attribute — the panel would be in its own capture'
     ).not.toBeNull();
+
+    // 🔴 WHICH element carries it is the property, not THAT one does. Moving the
+    // attribute off the Drawer root onto the inner Stack still leaves an ignored
+    // ancestor above the textarea — and captures the header, the title and the
+    // panel's background. Asserting the title is inside the ignored subtree is what
+    // separates the fix from that near-miss.
+    expect(
+      ignored?.textContent,
+      'the ignore moved inside the panel — its header is still captured'
+    ).toContain('Report a bug');
   });
 
   test('no overlay is rendered over the page being reported', async () => {
@@ -236,6 +246,20 @@ describe('🔴 the panel excludes itself from the capture, and dims nothing', ()
     // The control for this one is Mantine's own default: `withOverlay` defaults to
     // true, so removing the prop puts the element back and this fails.
     expect(document.querySelector('.mantine-Drawer-overlay')).toBeNull();
+  });
+
+  /**
+   * 🔴 The overlay was ALSO the click-outside-to-close surface — Mantine wires
+   * `closeOnClickOutside` to the overlay's own `onClick` and nowhere else, so
+   * removing it removed that affordance. Escape still works and cannot be asserted
+   * meaningfully here, so the close button is the one that has to stay: without it a
+   * reporter who opened the panel by accident has no visible way out of it.
+   */
+  test('the panel can still be dismissed without one', async () => {
+    await openDrawer();
+
+    await userEvent.click(page.getByRole('button', { name: 'Close bug report' }));
+    expect(mocks.onClose).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/components/Feedback/FeedbackDrawer.browser.test.tsx
+++ b/src/components/Feedback/FeedbackDrawer.browser.test.tsx
@@ -186,7 +186,6 @@ describe('🔴 the Grafana Faro session travels with the report', () => {
   test('and the report still sends when Faro is not running', async () => {
     await fileReport('no faro in the test browser');
 
-    expect(await sent()).toBeTruthy();
     expect(await context()).not.toHaveProperty('sessionId');
   });
 });

--- a/src/components/Feedback/FeedbackDrawer.browser.test.tsx
+++ b/src/components/Feedback/FeedbackDrawer.browser.test.tsx
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import type * as TrpcModule from '~/utils/trpc';
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * FeedbackDrawer — the panel the support menu's "Report a bug" opens.
+ *
+ * 🔴 WHAT IS FAKED. `trpc` (no transport in the scaffold), `useCFImageUpload` (the
+ * real one PUTs to Cloudflare) and `useDialogContext` (the drawer is mounted
+ * directly rather than through DialogProvider). `getFaroSessionId` is NOT faked:
+ * Faro does not run in the test browser, so its real answer is `undefined` — which
+ * is the ordinary dev/preview case and the one worth proving does not block a send.
+ *
+ * The attach/capture controls are NOT re-tested here; they are the same
+ * `FeedbackAttachments` + `useFeedbackSubmission` the inline prompt uses, and
+ * `FeedbackPrompt.browser.test.tsx` exercises the consent path against the real
+ * capture module. What is only true HERE is the area slug and the reported path.
+ */
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    createMutate: vi.fn(),
+    onClose: vi.fn(),
+    areaEnabled: { value: true },
+  },
+}));
+
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
+  return {
+    ...actual,
+    trpc: {
+      feedback: {
+        getArea: { useQuery: () => ({ data: { enabled: mocks.areaEnabled.value } }) },
+        create: {
+          useMutation: (opts?: { onSuccess?: () => void }) => ({
+            mutate: (input: unknown) => {
+              mocks.createMutate(input);
+              opts?.onSuccess?.();
+            },
+            isPending: false,
+          }),
+        },
+      },
+    },
+  };
+});
+
+vi.mock('~/components/Dialog/DialogProvider', () => ({
+  useDialogContext: () => ({ opened: true, onClose: mocks.onClose }),
+}));
+
+vi.mock('~/hooks/useCFImageUpload', () => ({
+  useCFImageUpload: () => ({
+    uploadToCF: vi.fn(),
+    files: [],
+    resetFiles: vi.fn(),
+    removeImage: vi.fn(),
+  }),
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showErrorNotification: vi.fn(),
+  showSuccessNotification: vi.fn(),
+}));
+
+const FeedbackDrawer = (await import('~/components/Feedback/FeedbackDrawer')).default;
+
+const messageBox = () => page.getByPlaceholder('What were you doing, and what happened instead?');
+
+const openDrawer = async () => {
+  renderWithProviders(<FeedbackDrawer />);
+  await expect.element(messageBox()).toBeInTheDocument();
+};
+
+const submitted = () => mocks.createMutate.mock.calls[0][0] as Record<string, unknown>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.areaEnabled.value = true;
+});
+
+describe('a report from the support menu', () => {
+  test('files against the site-wide area and names the route it came from', async () => {
+    await openDrawer();
+    await userEvent.fill(messageBox(), 'the generate button does nothing');
+    await userEvent.click(page.getByRole('button', { name: 'Send report' }));
+    await vi.waitFor(() => expect(mocks.createMutate).toHaveBeenCalledTimes(1));
+
+    // The slug is the whole point of a site-wide entry point: a report filed under
+    // `apps-marketplace` would be gated by, and triaged as, the apps store.
+    expect(submitted().area).toBe('site-bug-report');
+    expect(submitted().message).toBe('the generate button does nothing');
+    // `next/router` is mocked by the scaffold; whatever it reports is what a report
+    // has to carry, because nothing else in the payload says where the user was.
+    expect((submitted().context as { path?: string }).path).toBeTruthy();
+  });
+
+  test('sends with no Faro session rather than refusing to send', async () => {
+    await openDrawer();
+    await userEvent.fill(messageBox(), 'no faro in the test browser');
+    await userEvent.click(page.getByRole('button', { name: 'Send report' }));
+    await vi.waitFor(() => expect(mocks.createMutate).toHaveBeenCalledTimes(1));
+
+    expect((submitted().context as { sessionId?: string }).sessionId).toBeUndefined();
+  });
+
+  test('Send is unavailable until something has been typed', async () => {
+    await openDrawer();
+    await expect.element(page.getByRole('button', { name: 'Send report' })).toBeDisabled();
+    await userEvent.fill(messageBox(), 'x');
+    await expect.element(page.getByRole('button', { name: 'Send report' })).toBeEnabled();
+  });
+});
+
+describe('when the area stopped collecting between the click and the render', () => {
+  test('the form is gone and the ticket portal is offered instead', async () => {
+    mocks.areaEnabled.value = false;
+    renderWithProviders(<FeedbackDrawer />);
+
+    await expect
+      .element(page.getByRole('link', { name: 'Support Portal' }))
+      .toHaveAttribute('href', '/support-portal');
+    // Present-then-absent would be a race; this state never arrives at all, so a
+    // synchronous read after the awaited assertion above is safe.
+    expect(document.querySelector('textarea')).toBeNull();
+  });
+});

--- a/src/components/Feedback/FeedbackDrawer.tsx
+++ b/src/components/Feedback/FeedbackDrawer.tsx
@@ -1,0 +1,104 @@
+import { Anchor, Button, Drawer, Stack, Text, Textarea, Title } from '@mantine/core';
+import { IconCircleCheck } from '@tabler/icons-react';
+import { useRouter } from 'next/router';
+import { useDialogContext } from '~/components/Dialog/DialogProvider';
+import { FeedbackAttachments } from '~/components/Feedback/FeedbackAttachments';
+import { useFeedbackSubmission } from '~/components/Feedback/useFeedbackSubmission';
+import { SUPPORT_LINKS } from '~/components/Support/support.constants';
+import { useIsMobile } from '~/hooks/useIsMobile';
+import {
+  FEEDBACK_MESSAGE_MAX_LENGTH,
+  SITE_BUG_REPORT_AREA,
+} from '~/shared/constants/feedback.constants';
+
+/**
+ * "Report a bug" from the support menu.
+ *
+ * Deliberately the SAME submission path as the inline `FeedbackPrompt` — one
+ * `useFeedbackSubmission`, one `feedback.create`, one `Feedback` table — because the
+ * point of this entry point is that a report carries the Faro session id and the
+ * screenshot, which a support ticket does not.
+ */
+export default function FeedbackDrawer() {
+  const dialog = useDialogContext();
+  // `media`, not the default container query: a Drawer is positioned against the
+  // viewport, and the container one also makes this component unmountable outside a
+  // ContainerProvider — which a dialog opened from the footer has no reason to need.
+  const mobile = useIsMobile({ type: 'media' });
+  const router = useRouter();
+
+  const feedback = useFeedbackSubmission({
+    area: SITE_BUG_REPORT_AREA,
+    // The route the reporter was on when they opened the menu. `asPath` rather than
+    // `window.location.pathname` so a shallow-routed page reports where the user
+    // believes they are; clipped because `context` is a JSONB column and the schema
+    // rejects (never truncates) an over-long value.
+    context: { path: router.asPath.slice(0, 300) },
+  });
+  const { sent, message, setMessage, busy, canSubmit, handleSubmit } = feedback;
+
+  return (
+    <Drawer
+      position={mobile ? 'bottom' : 'right'}
+      size={mobile ? '100dvh' : 480}
+      shadow="lg"
+      transitionProps={{ transition: mobile ? 'slide-up' : 'slide-left' }}
+      title={
+        <Title order={4} className="font-semibold">
+          Report a bug
+        </Title>
+      }
+      {...dialog}
+    >
+      {sent ? (
+        <Stack gap="sm" align="flex-start">
+          <IconCircleCheck size={32} className="text-green-6" />
+          <Text size="sm">
+            Got it, thanks. We&apos;ll take a look — your browser session is attached, so we can see
+            what happened without having to ask.
+          </Text>
+          <Button radius="xl" onClick={dialog.onClose}>
+            Done
+          </Button>
+        </Stack>
+      ) : !feedback.areaEnabled ? (
+        // The menu already hides this entry when the area is off, so reaching here
+        // means the flag went off between the click and the render. Say so, and hand
+        // over the ticket portal rather than a dead form.
+        <Text size="sm">
+          Bug reports aren&apos;t being collected here right now. You can still reach us through the{' '}
+          <Anchor
+            href={SUPPORT_LINKS.portal}
+            target="_blank"
+            rel="nofollow noreferrer"
+            td="underline"
+          >
+            Support Portal
+          </Anchor>
+          .
+        </Text>
+      ) : (
+        <Stack gap="sm">
+          <Text size="sm" c="dimmed">
+            Tell us what went wrong. We attach your browser session automatically, so console errors
+            come with the report.
+          </Text>
+          <Textarea
+            value={message}
+            onChange={(event) => setMessage(event.currentTarget.value)}
+            placeholder="What were you doing, and what happened instead?"
+            maxLength={FEEDBACK_MESSAGE_MAX_LENGTH}
+            autosize
+            minRows={5}
+            maxRows={12}
+            autoFocus
+          />
+          <FeedbackAttachments feedback={feedback} />
+          <Button radius="xl" fullWidth disabled={!canSubmit} loading={busy} onClick={handleSubmit}>
+            Send report
+          </Button>
+        </Stack>
+      )}
+    </Drawer>
+  );
+}

--- a/src/components/Feedback/FeedbackDrawer.tsx
+++ b/src/components/Feedback/FeedbackDrawer.tsx
@@ -51,6 +51,11 @@ export default function FeedbackDrawer() {
       // attribute and its whole subtree; it sits on the Drawer ROOT so the overlay
       // goes with it. Pinned by FeedbackDrawer.browser.test.tsx.
       data-html2canvas-ignore
+      // 🔴 NO BACKDROP, deliberately (Justin, 2026-09-11 review). A reporter is
+      // describing the page behind this panel, so dimming it is dimming the subject.
+      // The capture excludes the panel either way (see above), but the reporter also
+      // has to be able to SEE what they are reporting while they type it.
+      withOverlay={false}
       position={mobile ? 'bottom' : 'right'}
       size={mobile ? '100dvh' : 480}
       shadow="lg"

--- a/src/components/Feedback/FeedbackDrawer.tsx
+++ b/src/components/Feedback/FeedbackDrawer.tsx
@@ -8,6 +8,7 @@ import { SUPPORT_LINKS } from '~/components/Support/support.constants';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import {
   FEEDBACK_MESSAGE_MAX_LENGTH,
+  FEEDBACK_PATH_MAX_LENGTH,
   SITE_BUG_REPORT_AREA,
 } from '~/shared/constants/feedback.constants';
 
@@ -29,16 +30,27 @@ export default function FeedbackDrawer() {
 
   const feedback = useFeedbackSubmission({
     area: SITE_BUG_REPORT_AREA,
-    // The route the reporter was on when they opened the menu. `asPath` rather than
-    // `window.location.pathname` so a shallow-routed page reports where the user
-    // believes they are; clipped because `context` is a JSONB column and the schema
-    // rejects (never truncates) an over-long value.
-    context: { path: router.asPath.slice(0, 300) },
+    // 🔴 THE ROUTE ONLY — the query string is cut off deliberately. This entry point
+    // is reachable from the footer on every route, including ones that carry a secret
+    // in the URL (`/redeem-code?code=…`, `/payment/coinbase?key=…`), and `context` is
+    // a JSONB column that triage reads. Storing `asPath` whole would write a live
+    // redeemable code into it, permanently, without ever telling the reporter. The
+    // inline /apps prompt already splits this way: it reports a bare pathname and
+    // sends its search term through the bounded `filters` field.
+    context: { path: router.asPath.split(/[?#]/)[0].slice(0, FEEDBACK_PATH_MAX_LENGTH) },
   });
   const { sent, message, setMessage, busy, canSubmit, handleSubmit } = feedback;
 
   return (
     <Drawer
+      // 🔴 KEEPS THE PANEL OUT OF ITS OWN SCREENSHOT. `captureConsentedScreenshot`
+      // draws `document.body`, and this Drawer portals into it — so without this the
+      // capture a reporter opts into is 480px of this form plus the page dimmed
+      // behind the overlay, which is the one artifact that makes a report better
+      // than a ticket. html2canvas-pro's cloner skips any element carrying this
+      // attribute and its whole subtree; it sits on the Drawer ROOT so the overlay
+      // goes with it. Pinned by FeedbackDrawer.browser.test.tsx.
+      data-html2canvas-ignore
       position={mobile ? 'bottom' : 'right'}
       size={mobile ? '100dvh' : 480}
       shadow="lg"

--- a/src/components/Feedback/FeedbackDrawer.tsx
+++ b/src/components/Feedback/FeedbackDrawer.tsx
@@ -44,17 +44,16 @@ export default function FeedbackDrawer() {
   return (
     <Drawer
       // 🔴 KEEPS THE PANEL OUT OF ITS OWN SCREENSHOT. `captureConsentedScreenshot`
-      // draws `document.body`, and this Drawer portals into it — so without this the
-      // capture a reporter opts into is 480px of this form plus the page dimmed
-      // behind the overlay, which is the one artifact that makes a report better
-      // than a ticket. html2canvas-pro's cloner skips any element carrying this
-      // attribute and its whole subtree; it sits on the Drawer ROOT so the overlay
-      // goes with it. Pinned by FeedbackDrawer.browser.test.tsx.
+      // draws `document.body` and this Drawer portals into it, so without this the
+      // capture a reporter opts into is 480px of this form instead of the page they
+      // are reporting — the one artifact that makes a report better than a ticket.
+      // html2canvas-pro's cloner skips any element carrying this attribute and its
+      // whole subtree. ON THE ROOT, not on the body: moved inward it still ignores
+      // the form while capturing the header and the panel's background, which the
+      // test is written to catch.
       data-html2canvas-ignore
       // 🔴 NO BACKDROP, deliberately (Justin, 2026-09-11 review). A reporter is
       // describing the page behind this panel, so dimming it is dimming the subject.
-      // The capture excludes the panel either way (see above), but the reporter also
-      // has to be able to SEE what they are reporting while they type it.
       withOverlay={false}
       position={mobile ? 'bottom' : 'right'}
       size={mobile ? '100dvh' : 480}
@@ -65,6 +64,10 @@ export default function FeedbackDrawer() {
           Report a bug
         </Title>
       }
+      // Named, because without an overlay this button is the only VISIBLE way out of
+      // the panel (Mantine wires click-outside to the overlay alone) and Mantine's
+      // close button carries no accessible name of its own.
+      closeButtonProps={{ 'aria-label': 'Close bug report' }}
       {...dialog}
     >
       {sent ? (

--- a/src/components/Feedback/FeedbackPrompt.browser.test.tsx
+++ b/src/components/Feedback/FeedbackPrompt.browser.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import type * as CaptureModule from '~/components/Feedback/captureScreenshot';
@@ -388,6 +389,44 @@ describe('🔴 Send is blocked while a capture is in flight', () => {
     await expect.element(sendButton()).toBeEnabled();
     await send();
     expect(submittedContext()).not.toHaveProperty('screenshotId');
+  });
+});
+
+/**
+ * 🔴 THE HARNESS DOES NOT USE STRICTMODE AND THE APP DOES.
+ *
+ * `next.config.mjs` sets `reactStrictMode: true`, so in development React mounts an
+ * effect, runs its cleanup, and mounts it again on the SAME component instance — refs
+ * survive that. Every other test in this file renders without StrictMode, which is why
+ * all of them passed over a guard that a cleanup had already switched off for good.
+ *
+ * The failure it catches is silent and worse than the leak the guard exists to stop: a
+ * reporter ticks the box, the checkbox shows checked, the capture runs, and the result
+ * is dropped with no preview and no error. They then send a report they believe has a
+ * screenshot attached.
+ *
+ * Keep this rendering under StrictMode. Without it the test still passes and stops
+ * being about anything.
+ */
+describe('🔴 under StrictMode, as the app runs it', () => {
+  test('a consented capture still attaches after the double-invoked effect', async () => {
+    renderWithProviders(
+      <StrictMode>
+        <FeedbackPrompt
+          area="bitdex-image-feed"
+          notice="We're testing a new system behind this feed."
+          context={{ path: '/images', reportedSource: 'bitdex' }}
+        />
+      </StrictMode>
+    );
+    await userEvent.click(page.getByRole('button', { name: 'Give feedback' }));
+    await expect.element(page.getByPlaceholder('What looked wrong?')).toBeInTheDocument();
+
+    await userEvent.click(consentCheckbox());
+
+    await expect
+      .element(page.getByAltText('Preview of the page screenshot that will be sent'))
+      .toBeInTheDocument();
   });
 });
 

--- a/src/components/Feedback/FeedbackPrompt.tsx
+++ b/src/components/Feedback/FeedbackPrompt.tsx
@@ -1,46 +1,13 @@
-import {
-  ActionIcon,
-  Button,
-  Checkbox,
-  Divider,
-  FileButton,
-  Group,
-  Loader,
-  Paper,
-  Stack,
-  Text,
-  Textarea,
-} from '@mantine/core';
-import { IconAlertTriangle, IconPaperclip, IconX } from '@tabler/icons-react';
+import { ActionIcon, Button, Divider, Group, Paper, Text, Textarea } from '@mantine/core';
+import { IconAlertTriangle, IconX } from '@tabler/icons-react';
 import type { CSSProperties } from 'react';
-import { useEffect, useRef, useState } from 'react';
-import { captureConsentedScreenshot } from '~/components/Feedback/captureScreenshot';
-import { selectAttachments } from '~/components/Feedback/selectAttachments';
-import { useCFImageUpload } from '~/hooks/useCFImageUpload';
+import { useState } from 'react';
+import { FeedbackAttachments } from '~/components/Feedback/FeedbackAttachments';
+import { useFeedbackSubmission } from '~/components/Feedback/useFeedbackSubmission';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { constants } from '~/server/common/constants';
 import type { CreateFeedbackInput } from '~/server/schema/feedback.schema';
 import type { FeedbackArea } from '~/shared/constants/feedback.constants';
-import {
-  FEEDBACK_IMAGE_MAX_COUNT,
-  FEEDBACK_MESSAGE_MAX_LENGTH,
-} from '~/shared/constants/feedback.constants';
-import { getFaroSessionId } from '~/utils/faro/getFaroSessionId';
-import { showErrorNotification } from '~/utils/notifications';
-import { formatBytes } from '~/utils/number-helpers';
-import { trpc } from '~/utils/trpc';
-
-/**
- * Ceiling on a file the USER chose, as distinct from `SCREENSHOT_MAX_BYTES`, which
- * bounds the capture this feature generates. Taken from the shared upload constant
- * that nine other upload surfaces in this repo already enforce
- * (ImageDropzone, SimpleImageUpload, ProfileImageUpload, ImageUpload, …), rather
- * than a number invented here — the point is to stop being the one picker that
- * silently accepts a 40-megapixel phone photo at full size, not to introduce a
- * different limit for feedback. Note there is NO server backstop: the presigned PUT
- * from `/api/v1/image-upload` carries no size condition, so this is the only check.
- */
-const FEEDBACK_ATTACHMENT_MAX_BYTES = constants.mediaUpload.maxImageFileSize;
+import { FEEDBACK_MESSAGE_MAX_LENGTH } from '~/shared/constants/feedback.constants';
 
 const cardStyle: CSSProperties = {
   background: 'light-dark(var(--mantine-color-white), var(--mantine-color-dark-6))',
@@ -68,25 +35,6 @@ function writeDismissed(area: FeedbackArea) {
   }
 }
 
-/**
- * A file the user has chosen (or a capture they accepted) that has NOT been
- * uploaded yet. Previews come from a local object URL, so nothing leaves the
- * browser until Send is pressed — see the upload-budget note on
- * FEEDBACK_IMAGE_MAX_COUNT.
- */
-type PendingAttachment = { key: string; file: File; objectUrl: string };
-
-let attachmentKeySeq = 0;
-const nextAttachmentKey = () => `attachment-${++attachmentKeySeq}`;
-
-const revoke = (objectUrl: string) => {
-  try {
-    URL.revokeObjectURL(objectUrl);
-  } catch {
-    // Nothing to do; the URL dies with the document either way.
-  }
-};
-
 type FeedbackPromptProps = {
   area: FeedbackArea;
   notice: string;
@@ -107,50 +55,12 @@ export function FeedbackPrompt({
   const currentUser = useCurrentUser();
   const [dismissed, setDismissed] = useState(() => readDismissed(area));
   const [open, setOpen] = useState(false);
-  const [message, setMessage] = useState('');
-  const [sent, setSent] = useState(false);
-
-  const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
-  // 🔴 The consent flag for DOM capture. Starts OFF and is only ever set by the
-  // user's own click on the checkbox below. Nothing else may set it true.
-  const [screenshotConsent, setScreenshotConsent] = useState(false);
-  const [screenshot, setScreenshot] = useState<PendingAttachment | null>(null);
-  const [capturing, setCapturing] = useState(false);
-  const [uploading, setUploading] = useState(false);
-
-  const { uploadToCF } = useCFImageUpload();
-
-  // Object URLs outlive React state unless revoked. A ref (not the state itself)
-  // because this must run on unmount with whatever was live at that moment, and a
-  // cleanup closed over `attachments` would see the value from its own render.
-  const liveObjectUrls = useRef<Set<string>>(new Set());
-  useEffect(() => {
-    const urls = liveObjectUrls.current;
-    return () => {
-      urls.forEach(revoke);
-      urls.clear();
-    };
-  }, []);
-
-  const trackObjectUrl = (objectUrl: string) => {
-    liveObjectUrls.current.add(objectUrl);
-    return objectUrl;
-  };
-  const releaseObjectUrl = (objectUrl: string) => {
-    liveObjectUrls.current.delete(objectUrl);
-    revoke(objectUrl);
-  };
 
   const enabled = active && !!currentUser && !dismissed;
-  const { data } = trpc.feedback.getArea.useQuery({ area }, { enabled });
+  const feedback = useFeedbackSubmission({ area, context, enabled });
+  const { sent, message, setMessage, busy, canSubmit, handleSubmit } = feedback;
 
-  const createFeedback = trpc.feedback.create.useMutation({
-    onSuccess: () => setSent(true),
-    onError: (error) =>
-      showErrorNotification({ title: 'Feedback not sent', error: new Error(error.message) }),
-  });
-
-  if (!enabled || !data?.enabled) return null;
+  if (!enabled || !feedback.areaEnabled) return null;
 
   const handleClose = () => {
     if (open && !sent) {
@@ -160,156 +70,6 @@ export function FeedbackPrompt({
     writeDismissed(area);
     setDismissed(true);
   };
-
-  const handleFilesSelected = (selected: File[] | null) => {
-    if (!selected?.length) return;
-    const { accepted, rejectedForSize, rejectedForCount } = selectAttachments({
-      selected,
-      alreadyAttached: attachments.length,
-      maxCount: FEEDBACK_IMAGE_MAX_COUNT,
-      maxBytes: FEEDBACK_ATTACHMENT_MAX_BYTES,
-    });
-
-    // Both rejections are said out loud, and separately. Silently dropping a file
-    // looks like the picker failed; collapsing the two reasons into one message
-    // sends the user to fix the wrong thing.
-    if (rejectedForSize.length)
-      showErrorNotification({
-        title: 'Image too large',
-        error: new Error(
-          `${rejectedForSize.map((file) => file.name).join(', ')} — images must be under ` +
-            `${formatBytes(FEEDBACK_ATTACHMENT_MAX_BYTES)}.`
-        ),
-      });
-    if (rejectedForCount.length)
-      showErrorNotification({
-        title: 'Too many images',
-        error: new Error(`You can attach up to ${FEEDBACK_IMAGE_MAX_COUNT} images.`),
-      });
-    if (!accepted.length) return;
-
-    const added = accepted.map((file) => ({
-      key: nextAttachmentKey(),
-      file,
-      objectUrl: trackObjectUrl(URL.createObjectURL(file)),
-    }));
-    setAttachments((current) => [...current, ...added]);
-  };
-
-  const handleRemoveAttachment = (key: string) => {
-    setAttachments((current) => {
-      const match = current.find((x) => x.key === key);
-      if (match) releaseObjectUrl(match.objectUrl);
-      return current.filter((x) => x.key !== key);
-    });
-  };
-
-  const clearScreenshot = () => {
-    setScreenshot((current) => {
-      if (current) releaseObjectUrl(current.objectUrl);
-      return null;
-    });
-  };
-
-  /**
-   * 🔴 The ONLY path in this component that can start a capture, and it is reached
-   * only from the checkbox's own `onChange`. `checked` IS the user's consent.
-   *
-   * Honest note on the two layers: by the time `captureConsentedScreenshot` is
-   * called, the `!checked` branch has already returned, so the argument is always
-   * `true` — the module's own guard is redundant *from this call site*. It is not
-   * redundant in general (it is the guard for every future caller, and it is what
-   * `captureScreenshot.test.ts` pins). The guarantee THIS function carries is a
-   * different one: no other code path here calls capture at all.
-   */
-  const handleScreenshotConsentChange = async (checked: boolean) => {
-    setScreenshotConsent(checked);
-    if (!checked) {
-      clearScreenshot();
-      return;
-    }
-    setCapturing(true);
-    try {
-      const file = await captureConsentedScreenshot({ consented: checked });
-      if (!file) {
-        // Defensive: `null` is the module's "no consent" answer, which this call
-        // site cannot currently produce. Handled rather than asserted away so a
-        // future refactor that loosens the argument fails visibly (the checkbox
-        // snaps back) instead of silently rendering an empty preview.
-        setScreenshotConsent(false);
-        return;
-      }
-      setScreenshot({
-        key: nextAttachmentKey(),
-        file,
-        objectUrl: trackObjectUrl(URL.createObjectURL(file)),
-      });
-    } catch (error) {
-      // A failed capture must not look like a silently attached one.
-      setScreenshotConsent(false);
-      showErrorNotification({
-        title: 'Could not capture the page',
-        error: error instanceof Error ? error : new Error('Screenshot failed'),
-      });
-    } finally {
-      setCapturing(false);
-    }
-  };
-
-  /** Drop the preview but leave the prompt usable — the user saw it and said no. */
-  const handleDropScreenshot = () => {
-    clearScreenshot();
-    setScreenshotConsent(false);
-  };
-
-  const handleSubmit = async () => {
-    setUploading(true);
-    try {
-      // Uploads happen HERE, not at attach time, so nothing is spent on a
-      // submission the user abandons.
-      const images: string[] = [];
-      for (const attachment of attachments) {
-        const { id } = await uploadToCF(attachment.file);
-        images.push(id);
-      }
-      const screenshotId = screenshot ? (await uploadToCF(screenshot.file)).id : undefined;
-
-      // Read at submit time rather than at mount: Faro may finish starting between
-      // the two. Undefined whenever Faro is not running at all — dev/test/preview,
-      // or a session that blocked it — and the field is then simply omitted, which
-      // is the ordinary case and never blocks the submission.
-      const sessionId = getFaroSessionId();
-
-      createFeedback.mutate({
-        area,
-        message: message.trim(),
-        context: {
-          ...context,
-          ...(images.length ? { images } : {}),
-          ...(screenshotId ? { screenshotId } : {}),
-          ...(sessionId ? { sessionId } : {}),
-        },
-      });
-    } catch (error) {
-      showErrorNotification({
-        title: 'Could not attach your images',
-        error: error instanceof Error ? error : new Error('Upload failed'),
-      });
-    } finally {
-      setUploading(false);
-    }
-  };
-
-  // 🔴 `capturing` belongs here, not only on the checkbox's own `disabled`. A capture
-  // is async, and `handleSubmit` reads `screenshot` — which is still null while it is
-  // in flight. Without this, a user who ticks the box, types, and presses Send before
-  // the capture resolves gets "Got it, thanks" for a submission with NO screenshot,
-  // while the capture completes onto a panel that is already hidden. They believe
-  // they attached a screenshot and did not. Blocking Send is the honest resolution:
-  // the button is briefly unavailable and says so via its spinner, rather than
-  // silently sending something other than what the user assembled.
-  const busy = uploading || capturing || createFeedback.isPending;
-  const canAddMore = attachments.length < FEEDBACK_IMAGE_MAX_COUNT;
 
   return (
     <Paper withBorder radius="md" style={cardStyle}>
@@ -360,7 +120,7 @@ export function FeedbackPrompt({
               size="sm"
               radius="xl"
               style={{ flexShrink: 0 }}
-              disabled={!message.trim() || busy}
+              disabled={!canSubmit}
               // Mantine's disabled fill is near-invisible on this card surface.
               classNames={{
                 root: 'data-[disabled]:!bg-blue-6 data-[disabled]:!text-white data-[disabled]:!opacity-50',
@@ -371,108 +131,7 @@ export function FeedbackPrompt({
               Send feedback
             </Button>
           </Group>
-          <Stack px="sm" pb="sm" gap="xs">
-            <Group gap="xs" wrap="wrap" align="center">
-              <FileButton onChange={handleFilesSelected} accept="image/*" multiple>
-                {(props) => (
-                  <Button
-                    {...props}
-                    size="compact-sm"
-                    radius="xl"
-                    variant="light"
-                    leftSection={<IconPaperclip size={14} />}
-                    disabled={!canAddMore || busy}
-                  >
-                    Attach images
-                  </Button>
-                )}
-              </FileButton>
-              <Text size="xs" c="dimmed">
-                {attachments.length} of {FEEDBACK_IMAGE_MAX_COUNT} attached
-              </Text>
-            </Group>
-            {!!attachments.length && (
-              <Group gap="xs" wrap="wrap">
-                {attachments.map((attachment) => (
-                  <div key={attachment.key} style={{ position: 'relative' }}>
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={attachment.objectUrl}
-                      alt={`Attached image ${attachment.file.name}`}
-                      style={{
-                        width: 64,
-                        height: 64,
-                        objectFit: 'cover',
-                        borderRadius: 8,
-                        display: 'block',
-                      }}
-                    />
-                    <ActionIcon
-                      size="xs"
-                      radius="xl"
-                      variant="filled"
-                      color="dark"
-                      style={{ position: 'absolute', top: -6, right: -6 }}
-                      aria-label={`Remove attached image ${attachment.file.name}`}
-                      onClick={() => handleRemoveAttachment(attachment.key)}
-                    >
-                      <IconX size={12} />
-                    </ActionIcon>
-                  </div>
-                ))}
-              </Group>
-            )}
-            <Checkbox
-              size="xs"
-              checked={screenshotConsent}
-              // `busy` now subsumes `capturing` (see its definition); kept as one
-              // term so the two cannot drift apart again.
-              disabled={busy}
-              onChange={(event) => void handleScreenshotConsentChange(event.currentTarget.checked)}
-              label="Attach a screenshot of this page"
-              description="We'll show it to you before anything is sent. Only what's on screen is captured."
-            />
-            {capturing && (
-              <Group gap="xs" align="center">
-                <Loader size="xs" />
-                <Text size="xs" c="dimmed">
-                  Capturing the page…
-                </Text>
-              </Group>
-            )}
-            {screenshot && (
-              <Stack gap={4} align="flex-start">
-                <Text size="xs" c="dimmed">
-                  This is what will be sent:
-                </Text>
-                <div style={{ position: 'relative' }}>
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={screenshot.objectUrl}
-                    alt="Preview of the page screenshot that will be sent"
-                    style={{
-                      maxWidth: 240,
-                      maxHeight: 160,
-                      borderRadius: 8,
-                      display: 'block',
-                      border: '1px solid var(--mantine-color-default-border)',
-                    }}
-                  />
-                  <ActionIcon
-                    size="xs"
-                    radius="xl"
-                    variant="filled"
-                    color="dark"
-                    style={{ position: 'absolute', top: -6, right: -6 }}
-                    aria-label="Remove the page screenshot"
-                    onClick={handleDropScreenshot}
-                  >
-                    <IconX size={12} />
-                  </ActionIcon>
-                </div>
-              </Stack>
-            )}
-          </Stack>
+          <FeedbackAttachments feedback={feedback} px="sm" pb="sm" />
         </>
       )}
     </Paper>

--- a/src/components/Feedback/useFeedbackSubmission.ts
+++ b/src/components/Feedback/useFeedbackSubmission.ts
@@ -1,0 +1,278 @@
+import { useEffect, useRef, useState } from 'react';
+import { captureConsentedScreenshot } from '~/components/Feedback/captureScreenshot';
+import { selectAttachments } from '~/components/Feedback/selectAttachments';
+import { useCFImageUpload } from '~/hooks/useCFImageUpload';
+import { constants } from '~/server/common/constants';
+import type { CreateFeedbackInput } from '~/server/schema/feedback.schema';
+import type { FeedbackArea } from '~/shared/constants/feedback.constants';
+import { FEEDBACK_IMAGE_MAX_COUNT } from '~/shared/constants/feedback.constants';
+import { getFaroSessionId } from '~/utils/faro/getFaroSessionId';
+import { showErrorNotification } from '~/utils/notifications';
+import { formatBytes } from '~/utils/number-helpers';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * Ceiling on a file the USER chose, as distinct from `SCREENSHOT_MAX_BYTES`, which
+ * bounds the capture this feature generates. Taken from the shared upload constant
+ * that nine other upload surfaces in this repo already enforce
+ * (ImageDropzone, SimpleImageUpload, ProfileImageUpload, ImageUpload, …), rather
+ * than a number invented here — the point is to stop being the one picker that
+ * silently accepts a 40-megapixel phone photo at full size, not to introduce a
+ * different limit for feedback. Note there is NO server backstop: the presigned PUT
+ * from `/api/v1/image-upload` carries no size condition, so this is the only check.
+ */
+const FEEDBACK_ATTACHMENT_MAX_BYTES = constants.mediaUpload.maxImageFileSize;
+
+/**
+ * A file the user has chosen (or a capture they accepted) that has NOT been
+ * uploaded yet. Previews come from a local object URL, so nothing leaves the
+ * browser until Send is pressed — see the upload-budget note on
+ * FEEDBACK_IMAGE_MAX_COUNT.
+ */
+export type PendingAttachment = { key: string; file: File; objectUrl: string };
+
+let attachmentKeySeq = 0;
+const nextAttachmentKey = () => `attachment-${++attachmentKeySeq}`;
+
+const revoke = (objectUrl: string) => {
+  try {
+    URL.revokeObjectURL(objectUrl);
+  } catch {
+    // Nothing to do; the URL dies with the document either way.
+  }
+};
+
+export type UseFeedbackSubmissionArgs = {
+  area: FeedbackArea;
+  /** Extra detail stored alongside the message so a one-line report is still actionable. */
+  context?: CreateFeedbackInput['context'];
+  /** The caller's own gate. False means don't ask the server whether the area is collecting. */
+  enabled?: boolean;
+};
+
+export type FeedbackSubmission = ReturnType<typeof useFeedbackSubmission>;
+
+/**
+ * Everything a feedback surface has to get right, in one place: the consent-gated
+ * page capture, the object-URL lifecycle, the deferred uploads, and the submit.
+ *
+ * It exists because there are now two surfaces (the inline `FeedbackPrompt` and the
+ * `FeedbackDrawer` behind the support menu) and only one of them can be the place
+ * the screenshot-consent rules live. Layout is deliberately NOT here — the two
+ * surfaces arrange the same controls differently.
+ */
+export function useFeedbackSubmission({
+  area,
+  context,
+  enabled = true,
+}: UseFeedbackSubmissionArgs) {
+  const [message, setMessage] = useState('');
+  const [sent, setSent] = useState(false);
+
+  const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
+  // 🔴 The consent flag for DOM capture. Starts OFF and is only ever set by the
+  // user's own click on the checkbox. Nothing else may set it true.
+  const [screenshotConsent, setScreenshotConsent] = useState(false);
+  const [screenshot, setScreenshot] = useState<PendingAttachment | null>(null);
+  const [capturing, setCapturing] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  const { uploadToCF } = useCFImageUpload();
+
+  // Object URLs outlive React state unless revoked. A ref (not the state itself)
+  // because this must run on unmount with whatever was live at that moment, and a
+  // cleanup closed over `attachments` would see the value from its own render.
+  const liveObjectUrls = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const urls = liveObjectUrls.current;
+    return () => {
+      urls.forEach(revoke);
+      urls.clear();
+    };
+  }, []);
+
+  const trackObjectUrl = (objectUrl: string) => {
+    liveObjectUrls.current.add(objectUrl);
+    return objectUrl;
+  };
+  const releaseObjectUrl = (objectUrl: string) => {
+    liveObjectUrls.current.delete(objectUrl);
+    revoke(objectUrl);
+  };
+
+  const { data } = trpc.feedback.getArea.useQuery({ area }, { enabled });
+
+  const createFeedback = trpc.feedback.create.useMutation({
+    onSuccess: () => setSent(true),
+    onError: (error) =>
+      showErrorNotification({ title: 'Feedback not sent', error: new Error(error.message) }),
+  });
+
+  const handleFilesSelected = (selected: File[] | null) => {
+    if (!selected?.length) return;
+    const { accepted, rejectedForSize, rejectedForCount } = selectAttachments({
+      selected,
+      alreadyAttached: attachments.length,
+      maxCount: FEEDBACK_IMAGE_MAX_COUNT,
+      maxBytes: FEEDBACK_ATTACHMENT_MAX_BYTES,
+    });
+
+    // Both rejections are said out loud, and separately. Silently dropping a file
+    // looks like the picker failed; collapsing the two reasons into one message
+    // sends the user to fix the wrong thing.
+    if (rejectedForSize.length)
+      showErrorNotification({
+        title: 'Image too large',
+        error: new Error(
+          `${rejectedForSize.map((file) => file.name).join(', ')} — images must be under ` +
+            `${formatBytes(FEEDBACK_ATTACHMENT_MAX_BYTES)}.`
+        ),
+      });
+    if (rejectedForCount.length)
+      showErrorNotification({
+        title: 'Too many images',
+        error: new Error(`You can attach up to ${FEEDBACK_IMAGE_MAX_COUNT} images.`),
+      });
+    if (!accepted.length) return;
+
+    const added = accepted.map((file) => ({
+      key: nextAttachmentKey(),
+      file,
+      objectUrl: trackObjectUrl(URL.createObjectURL(file)),
+    }));
+    setAttachments((current) => [...current, ...added]);
+  };
+
+  const handleRemoveAttachment = (key: string) => {
+    setAttachments((current) => {
+      const match = current.find((x) => x.key === key);
+      if (match) releaseObjectUrl(match.objectUrl);
+      return current.filter((x) => x.key !== key);
+    });
+  };
+
+  const clearScreenshot = () => {
+    setScreenshot((current) => {
+      if (current) releaseObjectUrl(current.objectUrl);
+      return null;
+    });
+  };
+
+  /**
+   * 🔴 The ONLY path here that can start a capture, and it is reached only from the
+   * consent checkbox's own `onChange`. `checked` IS the user's consent.
+   *
+   * Honest note on the two layers: by the time `captureConsentedScreenshot` is
+   * called, the `!checked` branch has already returned, so the argument is always
+   * `true` — the module's own guard is redundant *from this call site*. It is not
+   * redundant in general (it is the guard for every future caller, and it is what
+   * `captureScreenshot.test.ts` pins). The guarantee THIS function carries is a
+   * different one: no other code path here calls capture at all.
+   */
+  const handleScreenshotConsentChange = async (checked: boolean) => {
+    setScreenshotConsent(checked);
+    if (!checked) {
+      clearScreenshot();
+      return;
+    }
+    setCapturing(true);
+    try {
+      const file = await captureConsentedScreenshot({ consented: checked });
+      if (!file) {
+        // Defensive: `null` is the module's "no consent" answer, which this call
+        // site cannot currently produce. Handled rather than asserted away so a
+        // future refactor that loosens the argument fails visibly (the checkbox
+        // snaps back) instead of silently rendering an empty preview.
+        setScreenshotConsent(false);
+        return;
+      }
+      setScreenshot({
+        key: nextAttachmentKey(),
+        file,
+        objectUrl: trackObjectUrl(URL.createObjectURL(file)),
+      });
+    } catch (error) {
+      // A failed capture must not look like a silently attached one.
+      setScreenshotConsent(false);
+      showErrorNotification({
+        title: 'Could not capture the page',
+        error: error instanceof Error ? error : new Error('Screenshot failed'),
+      });
+    } finally {
+      setCapturing(false);
+    }
+  };
+
+  /** Drop the preview but leave the form usable — the user saw it and said no. */
+  const handleDropScreenshot = () => {
+    clearScreenshot();
+    setScreenshotConsent(false);
+  };
+
+  const handleSubmit = async () => {
+    setUploading(true);
+    try {
+      // Uploads happen HERE, not at attach time, so nothing is spent on a
+      // submission the user abandons.
+      const images: string[] = [];
+      for (const attachment of attachments) {
+        const { id } = await uploadToCF(attachment.file);
+        images.push(id);
+      }
+      const screenshotId = screenshot ? (await uploadToCF(screenshot.file)).id : undefined;
+
+      // Read at submit time rather than at mount: Faro may finish starting between
+      // the two. Undefined whenever Faro is not running at all — dev/test/preview,
+      // or a session that blocked it — and the field is then simply omitted, which
+      // is the ordinary case and never blocks the submission.
+      const sessionId = getFaroSessionId();
+
+      createFeedback.mutate({
+        area,
+        message: message.trim(),
+        context: {
+          ...context,
+          ...(images.length ? { images } : {}),
+          ...(screenshotId ? { screenshotId } : {}),
+          ...(sessionId ? { sessionId } : {}),
+        },
+      });
+    } catch (error) {
+      showErrorNotification({
+        title: 'Could not attach your images',
+        error: error instanceof Error ? error : new Error('Upload failed'),
+      });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  // 🔴 `capturing` belongs here, not only on the checkbox's own `disabled`. A capture
+  // is async, and `handleSubmit` reads `screenshot` — which is still null while it is
+  // in flight. Without this, a user who ticks the box, types, and presses Send before
+  // the capture resolves gets "Got it, thanks" for a submission with NO screenshot,
+  // while the capture completes onto a panel that is already hidden. They believe
+  // they attached a screenshot and did not. Blocking Send is the honest resolution:
+  // the button is briefly unavailable and says so via its spinner, rather than
+  // silently sending something other than what the user assembled.
+  const busy = uploading || capturing || createFeedback.isPending;
+
+  return {
+    areaEnabled: !!data?.enabled,
+    sent,
+    message,
+    setMessage,
+    attachments,
+    screenshot,
+    screenshotConsent,
+    capturing,
+    busy,
+    canAddMore: attachments.length < FEEDBACK_IMAGE_MAX_COUNT,
+    canSubmit: !!message.trim() && !busy,
+    handleFilesSelected,
+    handleRemoveAttachment,
+    handleScreenshotConsentChange,
+    handleDropScreenshot,
+    handleSubmit,
+  };
+}

--- a/src/components/Feedback/useFeedbackSubmission.ts
+++ b/src/components/Feedback/useFeedbackSubmission.ts
@@ -90,6 +90,12 @@ export function useFeedbackSubmission({
   // nothing. Checked before any post-await state write.
   const mounted = useRef(true);
   useEffect(() => {
+    // 🔴 SET HERE, NOT ONLY IN THE INITIALISER. `reactStrictMode` is on, so in
+    // development React runs mount -> cleanup -> mount against the SAME refs; without
+    // this line the cleanup's `false` is permanent and every consented capture is
+    // silently dropped for the life of the component. Pinned by the StrictMode test in
+    // FeedbackPrompt.browser.test.tsx, which fails without it.
+    mounted.current = true;
     const urls = liveObjectUrls.current;
     return () => {
       mounted.current = false;

--- a/src/components/Feedback/useFeedbackSubmission.ts
+++ b/src/components/Feedback/useFeedbackSubmission.ts
@@ -83,9 +83,16 @@ export function useFeedbackSubmission({
   // because this must run on unmount with whatever was live at that moment, and a
   // cleanup closed over `attachments` would see the value from its own render.
   const liveObjectUrls = useRef<Set<string>>(new Set());
+  // 🔴 A capture can resolve AFTER the surface is gone. The drawer unmounts every
+  // time it closes (the inline prompt never did), so a reporter who ticks the box and
+  // closes the panel lands here routinely: the cleanup below has already emptied the
+  // set, and a blob URL minted afterwards would be tracked by nothing and revoked by
+  // nothing. Checked before any post-await state write.
+  const mounted = useRef(true);
   useEffect(() => {
     const urls = liveObjectUrls.current;
     return () => {
+      mounted.current = false;
       urls.forEach(revoke);
       urls.clear();
     };
@@ -178,6 +185,9 @@ export function useFeedbackSubmission({
     setCapturing(true);
     try {
       const file = await captureConsentedScreenshot({ consented: checked });
+      // Closed mid-capture: mint no blob URL at all, rather than one tracked by a set
+      // the cleanup has already drained.
+      if (!mounted.current) return;
       if (!file) {
         // Defensive: `null` is the module's "no consent" answer, which this call
         // site cannot currently produce. Handled rather than asserted away so a
@@ -192,6 +202,7 @@ export function useFeedbackSubmission({
         objectUrl: trackObjectUrl(URL.createObjectURL(file)),
       });
     } catch (error) {
+      if (!mounted.current) return;
       // A failed capture must not look like a silently attached one.
       setScreenshotConsent(false);
       showErrorNotification({

--- a/src/components/Support/SupportContent.tsx
+++ b/src/components/Support/SupportContent.tsx
@@ -3,19 +3,20 @@ import type { IconProps } from '@tabler/icons-react';
 import { IconMail, IconQuestionMark } from '@tabler/icons-react';
 import { IconBook, IconBrandDiscord } from '@tabler/icons-react';
 import { AssistantChat } from '~/components/Assistant/AssistantChat';
+import { SUPPORT_LINKS } from '~/components/Support/support.constants';
 
 const SUPPORT_OPTIONS = [
   {
     title: 'Education Hub',
     description: 'Explore our Civitai and Generative AI tutorials & guides!',
     icon: (props: IconProps) => <IconBook {...props} />,
-    link: { label: 'Visit the Education Hub', href: '/education' },
+    link: { label: 'Visit the Education Hub', href: SUPPORT_LINKS.educationHub },
   },
   {
     title: 'Discord Community',
     description: 'Get assistance from our knowledgeable Community!',
     icon: (props: IconProps) => <IconBrandDiscord {...props} />,
-    link: { label: 'Join our Discord Community', href: '/discord' },
+    link: { label: 'Join our Discord Community', href: SUPPORT_LINKS.discord },
   },
   {
     title: 'Frenquently Asked Questions',
@@ -23,14 +24,14 @@ const SUPPORT_OPTIONS = [
     icon: (props: IconProps) => <IconQuestionMark {...props} />,
     link: {
       label: 'Civitai FAQ and Known Issues',
-      href: 'https://education.civitai.com/civitai-faq',
+      href: SUPPORT_LINKS.faq,
     },
   },
   {
     title: 'Report a Bug',
     description: 'Questions, bugs or errors? Reach out!',
     icon: (props: IconProps) => <IconMail {...props} />,
-    link: { label: 'Ticket portal', href: '/bugs' },
+    link: { label: 'Ticket portal', href: SUPPORT_LINKS.bugTicket },
   },
 ];
 
@@ -68,7 +69,7 @@ export function SupportContent() {
       <Grid.Col>
         <Text size="md">
           Still unsure? Contact us through our{' '}
-          <Anchor href="/support-portal" td="underline">
+          <Anchor href={SUPPORT_LINKS.portal} td="underline">
             Support Portal
           </Anchor>
         </Text>

--- a/src/components/Support/SupportMenu.browser.test.tsx
+++ b/src/components/Support/SupportMenu.browser.test.tsx
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import type * as TrpcModule from '~/utils/trpc';
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * SupportMenu — the footer support button after it stopped opening a modal.
+ *
+ * 🔴 WHAT IS FAKED. `dialogStore` is replaced so "did this open the feedback panel"
+ * is observable without mounting a Drawer; `trpc` is replaced because the scaffold
+ * wires no transport, and its `getArea` stub RECORDS the options it was handed —
+ * that is what makes "we never asked the server for a logged-out viewer" a real
+ * assertion rather than an absence nobody checked.
+ *
+ * `useCurrentUser` is replaced per-test through a mutable holder rather than a
+ * fresh `vi.mock`, because the signed-in and signed-out cases are the two halves of
+ * the same decision and belong in one file.
+ */
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    trigger: vi.fn(),
+    getAreaOptions: vi.fn(),
+    currentUser: { value: null as { id: number } | null },
+    areaEnabled: { value: true },
+  },
+}));
+
+vi.mock('~/components/Dialog/dialogStore', () => ({
+  dialogStore: { trigger: mocks.trigger, toggle: vi.fn(), closeById: vi.fn() },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mocks.currentUser.value,
+}));
+
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
+  return {
+    ...actual,
+    trpc: {
+      feedback: {
+        getArea: {
+          useQuery: (_input: unknown, options?: { enabled?: boolean }) => {
+            mocks.getAreaOptions(options);
+            // A disabled React Query resolves to `undefined`, not to a value — the
+            // stub has to reproduce that or the logged-out case would read as
+            // "enabled" and the fallback would never be exercised.
+            if (!options?.enabled) return { data: undefined };
+            return { data: { enabled: mocks.areaEnabled.value } };
+          },
+        },
+      },
+    },
+  };
+});
+
+const { SupportMenu } = await import('~/components/Support/SupportMenu');
+
+const openMenu = async () => {
+  renderWithProviders(<SupportMenu />);
+  await userEvent.click(page.getByRole('button', { name: '🛟 Support' }));
+  await expect.element(page.getByRole('menuitem', { name: 'Education Hub' })).toBeInTheDocument();
+};
+
+const bugItem = () => page.getByRole('menuitem', { name: 'Report a bug' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.currentUser.value = { id: 1 };
+  mocks.areaEnabled.value = true;
+});
+
+describe('the destinations that used to live in the support modal', () => {
+  test('all four are in the menu, plus the portal as the fallback', async () => {
+    await openMenu();
+    for (const name of [
+      'Report a bug',
+      'Education Hub',
+      'FAQ & Known Issues',
+      'Discord Community',
+      'Support Portal',
+    ])
+      await expect.element(page.getByRole('menuitem', { name })).toBeInTheDocument();
+  });
+});
+
+/**
+ * 🔴 THE DECISION THIS FILE EXISTS TO PIN, addressed to whoever is about to
+ * "simplify" it: "Report a bug" must NOT be a link to the ticket portal while the
+ * in-product panel is available.
+ *
+ * `/bugs`, `/support-portal` and `/canny/bugs` are the same `next.config.mjs`
+ * redirect to Freshdesk. Pointing this item there is a one-word change that looks
+ * tidier than a conditional and silently restores exactly the behaviour this work
+ * removed — every bug report going back to the support queue instead of arriving
+ * with the reporter's Faro session attached.
+ */
+describe('🔴 "Report a bug" reaches the feedback panel, not the ticket portal', () => {
+  test('clicking it opens the feedback drawer and navigates nowhere', async () => {
+    await openMenu();
+    const item = bugItem().element();
+    expect(item.tagName, 'the bug item became an anchor — it must not navigate').not.toBe('A');
+    expect(item.getAttribute('href')).toBeNull();
+
+    await userEvent.click(bugItem());
+    expect(mocks.trigger).toHaveBeenCalledTimes(1);
+  });
+
+  test('the fallback IS the ticket portal when the area is not collecting', async () => {
+    mocks.areaEnabled.value = false;
+    await openMenu();
+
+    const item = bugItem().element();
+    expect(item.tagName).toBe('A');
+    expect(item.getAttribute('href')).toBe('/bugs');
+    expect(mocks.trigger).not.toHaveBeenCalled();
+  });
+
+  test('a signed-out viewer gets the ticket portal, and the server is never asked', async () => {
+    mocks.currentUser.value = null;
+    await openMenu();
+
+    expect(bugItem().element().getAttribute('href')).toBe('/bugs');
+    // The positive control for that "never asked": the query IS rendered, it is
+    // rendered DISABLED. An assertion that it was simply absent would also pass if
+    // the component stopped rendering at all.
+    expect(mocks.getAreaOptions).toHaveBeenCalled();
+    for (const [options] of mocks.getAreaOptions.mock.calls) expect(options?.enabled).toBe(false);
+  });
+});

--- a/src/components/Support/SupportMenu.browser.test.tsx
+++ b/src/components/Support/SupportMenu.browser.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import type * as TrpcModule from '~/utils/trpc';
+import { useAssistantPanelStore } from '~/store/assistant-panel.store';
 import { renderWithProviders } from '../../../test/component-setup';
 
 /**
@@ -22,7 +23,12 @@ const { mocks } = vi.hoisted(() => ({
     getAreaOptions: vi.fn(),
     currentUser: { value: null as { id: number } | null },
     areaEnabled: { value: true },
+    assistant: { value: null as { personality: string; uuid: string } | null },
   },
+}));
+
+vi.mock('~/components/Assistant/useAssistantAvailable', () => ({
+  useAssistantAvailable: () => mocks.assistant.value,
 }));
 
 vi.mock('~/components/Dialog/dialogStore', () => ({
@@ -68,6 +74,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.currentUser.value = { id: 1 };
   mocks.areaEnabled.value = true;
+  mocks.assistant.value = { personality: 'civbot', uuid: 'uuid-1' };
+  useAssistantPanelStore.setState({ opened: false });
 });
 
 describe('the destinations that used to live in the support modal', () => {
@@ -76,14 +84,41 @@ describe('the destinations that used to live in the support modal', () => {
   // "Known Issues" is deliberately NOT in the FAQ label — the footer already renders a
   // "Known Issues" link to the onsite /issues two elements away, and the same words in
   // the same row pointing at two places is worse than a longer label.
+  // Every one of these leaves the app, so every one opens in a new tab — a reporter
+  // sent to the FAQ mid-report should still have the page they were reporting on.
   test.each([
     ['Education Hub', '/education'],
     ['FAQ', 'https://education.civitai.com/civitai-faq'],
     ['Discord Community', '/discord'],
     ['Support Portal', '/support-portal'],
-  ])('%s links to %s', async (name, href) => {
+  ])('%s opens %s in a new tab', async (name, href) => {
     await openMenu();
-    await expect.element(page.getByRole('menuitem', { name })).toHaveAttribute('href', href);
+    const item = page.getByRole('menuitem', { name });
+    await expect.element(item).toHaveAttribute('href', href);
+    await expect.element(item).toHaveAttribute('target', '_blank');
+  });
+});
+
+/**
+ * The chat was the right-hand column of the support modal. The modal is gone, so the
+ * menu is how it is reached from here — and it must be ABSENT rather than dead when
+ * the chat is unavailable, because `AssistantButton` renders nothing in that case and
+ * a menu item that opens an invisible panel is worse than no item.
+ */
+describe('the CivBot chat the support modal used to hold', () => {
+  test('the item opens the chat panel', async () => {
+    await openMenu();
+    expect(useAssistantPanelStore.getState().opened).toBe(false);
+
+    await userEvent.click(page.getByRole('menuitem', { name: 'Get help fast' }));
+    expect(useAssistantPanelStore.getState().opened).toBe(true);
+  });
+
+  test('and is not offered at all when the chat is unavailable', async () => {
+    mocks.assistant.value = null;
+    await openMenu();
+
+    expect(page.getByRole('menuitem', { name: 'Get help fast' }).elements()).toHaveLength(0);
   });
 });
 

--- a/src/components/Support/SupportMenu.browser.test.tsx
+++ b/src/components/Support/SupportMenu.browser.test.tsx
@@ -71,16 +71,19 @@ beforeEach(() => {
 });
 
 describe('the destinations that used to live in the support modal', () => {
-  test('all four are in the menu, plus the portal as the fallback', async () => {
+  // Labels AND hrefs: the four cards all pointed somewhere specific, and a menu that
+  // lists the right words against the wrong destinations is the failure this replaces.
+  // "Known Issues" is deliberately NOT in the FAQ label — the footer already renders a
+  // "Known Issues" link to the onsite /issues two elements away, and the same words in
+  // the same row pointing at two places is worse than a longer label.
+  test.each([
+    ['Education Hub', '/education'],
+    ['FAQ', 'https://education.civitai.com/civitai-faq'],
+    ['Discord Community', '/discord'],
+    ['Support Portal', '/support-portal'],
+  ])('%s links to %s', async (name, href) => {
     await openMenu();
-    for (const name of [
-      'Report a bug',
-      'Education Hub',
-      'FAQ & Known Issues',
-      'Discord Community',
-      'Support Portal',
-    ])
-      await expect.element(page.getByRole('menuitem', { name })).toBeInTheDocument();
+    await expect.element(page.getByRole('menuitem', { name })).toHaveAttribute('href', href);
   });
 });
 

--- a/src/components/Support/SupportMenu.tsx
+++ b/src/components/Support/SupportMenu.tsx
@@ -96,7 +96,7 @@ export function SupportMenu() {
           rel="nofollow noreferrer"
           leftSection={<IconQuestionMark size={ICON_SIZE} />}
         >
-          FAQ &amp; Known Issues
+          FAQ
         </Menu.Item>
         <Menu.Item
           component="a"

--- a/src/components/Support/SupportMenu.tsx
+++ b/src/components/Support/SupportMenu.tsx
@@ -1,0 +1,123 @@
+import { Button, Menu } from '@mantine/core';
+import {
+  IconBook,
+  IconBrandDiscord,
+  IconBug,
+  IconLifebuoy,
+  IconQuestionMark,
+} from '@tabler/icons-react';
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+import { dialogStore } from '~/components/Dialog/dialogStore';
+import { NextLink as Link } from '~/components/NextLink/NextLink';
+import { SUPPORT_LINKS } from '~/components/Support/support.constants';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { SITE_BUG_REPORT_AREA } from '~/shared/constants/feedback.constants';
+import { trpc } from '~/utils/trpc';
+
+const FeedbackDrawer = dynamic(() => import('~/components/Feedback/FeedbackDrawer'), {
+  ssr: false,
+});
+
+const ICON_SIZE = 16;
+
+/**
+ * The footer support button.
+ *
+ * It used to open a modal whose four cards all ended at the ticket portal or an
+ * external site; the menu is the same set of destinations minus that interstitial,
+ * with "Report a bug" rewired to the in-product feedback panel so a report arrives
+ * with the reporter's Faro session attached instead of as a ticket someone has to
+ * chase. The modal itself is untouched and still serves `/support`.
+ */
+export function SupportMenu() {
+  const currentUser = useCurrentUser();
+  const [opened, setOpened] = useState(false);
+
+  // Asked only once the menu is open, and only for a signed-in viewer: the panel
+  // cannot accept a submission without a session, so an anonymous viewer's answer
+  // could not change what this renders.
+  const { data: bugReportArea } = trpc.feedback.getArea.useQuery(
+    { area: SITE_BUG_REPORT_AREA },
+    { enabled: opened && !!currentUser }
+  );
+  const canReportInProduct = !!currentUser && !!bugReportArea?.enabled;
+
+  return (
+    <Menu
+      opened={opened}
+      onChange={setOpened}
+      position="top-end"
+      width={230}
+      shadow="md"
+      // The footer is a sticky, overflow-scrolling bar; the app theme turns
+      // `withinPortal` OFF for Popover by default, which Menu builds on, so this is
+      // the difference between a dropdown and a clipped one.
+      withinPortal
+    >
+      <Menu.Target>
+        <Button pl={4} pr="xs" color="yellow" variant="light" size="xs">
+          🛟 Support
+        </Button>
+      </Menu.Target>
+      <Menu.Dropdown>
+        {canReportInProduct ? (
+          <Menu.Item
+            leftSection={<IconBug size={ICON_SIZE} />}
+            onClick={() => dialogStore.trigger({ component: FeedbackDrawer })}
+          >
+            Report a bug
+          </Menu.Item>
+        ) : (
+          // No session, or the area is not collecting: the ticket portal is the only
+          // honest destination left. Shown rather than hidden so the menu never
+          // silently loses its bug path.
+          <Menu.Item
+            component="a"
+            href={SUPPORT_LINKS.bugTicket}
+            target="_blank"
+            rel="nofollow noreferrer"
+            leftSection={<IconBug size={ICON_SIZE} />}
+          >
+            Report a bug
+          </Menu.Item>
+        )}
+        <Menu.Item
+          component={Link}
+          href={SUPPORT_LINKS.educationHub}
+          leftSection={<IconBook size={ICON_SIZE} />}
+        >
+          Education Hub
+        </Menu.Item>
+        <Menu.Item
+          component="a"
+          href={SUPPORT_LINKS.faq}
+          target="_blank"
+          rel="nofollow noreferrer"
+          leftSection={<IconQuestionMark size={ICON_SIZE} />}
+        >
+          FAQ &amp; Known Issues
+        </Menu.Item>
+        <Menu.Item
+          component="a"
+          href={SUPPORT_LINKS.discord}
+          target="_blank"
+          rel="nofollow noreferrer"
+          leftSection={<IconBrandDiscord size={ICON_SIZE} />}
+        >
+          Discord Community
+        </Menu.Item>
+        <Menu.Divider />
+        <Menu.Item
+          component="a"
+          href={SUPPORT_LINKS.portal}
+          target="_blank"
+          rel="nofollow noreferrer"
+          leftSection={<IconLifebuoy size={ICON_SIZE} />}
+        >
+          Support Portal
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/src/components/Support/SupportMenu.tsx
+++ b/src/components/Support/SupportMenu.tsx
@@ -4,15 +4,17 @@ import {
   IconBrandDiscord,
   IconBug,
   IconLifebuoy,
+  IconMessageChatbot,
   IconQuestionMark,
 } from '@tabler/icons-react';
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
+import { useAssistantAvailable } from '~/components/Assistant/useAssistantAvailable';
 import { dialogStore } from '~/components/Dialog/dialogStore';
-import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { SUPPORT_LINKS } from '~/components/Support/support.constants';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { SITE_BUG_REPORT_AREA } from '~/shared/constants/feedback.constants';
+import { useAssistantPanelStore } from '~/store/assistant-panel.store';
 import { trpc } from '~/utils/trpc';
 
 const FeedbackDrawer = dynamic(() => import('~/components/Feedback/FeedbackDrawer'), {
@@ -42,6 +44,9 @@ export function SupportMenu() {
     { enabled: opened && !!currentUser }
   );
   const canReportInProduct = !!currentUser && !!bugReportArea?.enabled;
+  // The chat used to be the right-hand column of the support modal. It has its own
+  // launcher beside this button, but the modal is gone, so the menu keeps a way in.
+  const assistant = useAssistantAvailable();
 
   return (
     <Menu
@@ -83,8 +88,10 @@ export function SupportMenu() {
           </Menu.Item>
         )}
         <Menu.Item
-          component={Link}
+          component="a"
           href={SUPPORT_LINKS.educationHub}
+          target="_blank"
+          rel="nofollow noreferrer"
           leftSection={<IconBook size={ICON_SIZE} />}
         >
           Education Hub
@@ -107,6 +114,14 @@ export function SupportMenu() {
         >
           Discord Community
         </Menu.Item>
+        {assistant && (
+          <Menu.Item
+            leftSection={<IconMessageChatbot size={ICON_SIZE} />}
+            onClick={() => useAssistantPanelStore.setState({ opened: true })}
+          >
+            Get help fast
+          </Menu.Item>
+        )}
         <Menu.Divider />
         <Menu.Item
           component="a"

--- a/src/components/Support/support.constants.ts
+++ b/src/components/Support/support.constants.ts
@@ -1,0 +1,18 @@
+/**
+ * The support destinations, in one place because the footer menu and the `/support`
+ * page now both offer them and a divergence between the two is invisible until a
+ * user lands on the wrong one.
+ *
+ * 🔴 `/bugs`, `/support-portal` and `/canny/bugs` are the SAME redirect in
+ * `next.config.mjs` — all three land on the Freshdesk ticket portal. That is why the
+ * support menu's "Report a bug" is NOT one of these: routing it here is the exact
+ * behaviour the in-product feedback panel exists to replace.
+ */
+export const SUPPORT_LINKS = {
+  educationHub: '/education',
+  discord: '/discord',
+  faq: 'https://education.civitai.com/civitai-faq',
+  portal: '/support-portal',
+  /** The ticket portal, reached only when the feedback panel is unavailable. */
+  bugTicket: '/bugs',
+} as const;

--- a/src/server/schema/__tests__/feedback.schema.test.ts
+++ b/src/server/schema/__tests__/feedback.schema.test.ts
@@ -184,11 +184,11 @@ describe('feedback schema — context bounds', () => {
  * report bounced.
  */
 describe('feedback areas', () => {
-  const areas = ['bitdex-image-feed', 'apps-marketplace'];
+  const areas = ['bitdex-image-feed', 'apps-marketplace', 'site-bug-report'];
 
   // Both halves hand-typed. Reading the expectation out of FEEDBACK_AREAS would make
   // this test follow any future edit instead of pinning the set.
-  it('are exactly the two declared surfaces', () => {
+  it('are exactly the three declared surfaces', () => {
     expect([...FEEDBACK_AREAS]).toEqual(areas);
   });
 
@@ -217,6 +217,7 @@ describe('feedback areas', () => {
   it('derive their Flipt flag keys from the slug', () => {
     expect(feedbackAreaFlagKey('bitdex-image-feed')).toBe('feedback-area-bitdex-image-feed');
     expect(feedbackAreaFlagKey('apps-marketplace')).toBe('feedback-area-apps-marketplace');
+    expect(feedbackAreaFlagKey('site-bug-report')).toBe('feedback-area-site-bug-report');
   });
 });
 

--- a/src/server/schema/__tests__/feedback.schema.test.ts
+++ b/src/server/schema/__tests__/feedback.schema.test.ts
@@ -5,6 +5,7 @@ import {
   FEEDBACK_FILTER_VALUE_MAX_LENGTH,
   FEEDBACK_IMAGE_ID_MAX_LENGTH,
   FEEDBACK_IMAGE_MAX_COUNT,
+  FEEDBACK_PATH_MAX_LENGTH,
   FEEDBACK_SESSION_ID_MAX_LENGTH,
   feedbackAreaFlagKey,
 } from '~/shared/constants/feedback.constants';
@@ -218,6 +219,33 @@ describe('feedback areas', () => {
     expect(feedbackAreaFlagKey('bitdex-image-feed')).toBe('feedback-area-bitdex-image-feed');
     expect(feedbackAreaFlagKey('apps-marketplace')).toBe('feedback-area-apps-marketplace');
     expect(feedbackAreaFlagKey('site-bug-report')).toBe('feedback-area-site-bug-report');
+  });
+});
+
+/**
+ * `context.path` — the route a report came from, and the one context field a caller
+ * has to clip to by hand (`FeedbackDrawer`). The bound is exported for that reason:
+ * a `max()` REJECTS rather than truncating, so a drifted copy does not produce a
+ * shortened path, it 400s the whole submission on the surface that exists to collect
+ * reports. These two assertions are the contract between the clip and the schema.
+ */
+describe('context.path', () => {
+  const parsePath = (path: string) =>
+    createFeedbackSchema.parse({
+      area: 'site-bug-report' as const,
+      message: 'something broke',
+      context: { path },
+    });
+
+  it('is a 300-character ceiling', () => {
+    expect(FEEDBACK_PATH_MAX_LENGTH).toBe(300);
+  });
+
+  it('accepts a path of exactly the bound, and rejects one character more', () => {
+    expect(parsePath('/'.padEnd(FEEDBACK_PATH_MAX_LENGTH, 'a')).context?.path).toHaveLength(
+      FEEDBACK_PATH_MAX_LENGTH
+    );
+    expect(() => parsePath('/'.padEnd(FEEDBACK_PATH_MAX_LENGTH + 1, 'a'))).toThrow();
   });
 });
 

--- a/src/server/schema/feedback.schema.ts
+++ b/src/server/schema/feedback.schema.ts
@@ -5,6 +5,7 @@ import {
   FEEDBACK_IMAGE_ID_MAX_LENGTH,
   FEEDBACK_IMAGE_MAX_COUNT,
   FEEDBACK_MESSAGE_MAX_LENGTH,
+  FEEDBACK_PATH_MAX_LENGTH,
   FEEDBACK_SESSION_ID_MAX_LENGTH,
 } from '~/shared/constants/feedback.constants';
 
@@ -23,7 +24,7 @@ export const feedbackAreaSchema = z.enum(FEEDBACK_AREAS);
 // ordinary case, not an error. Every one of them is bounded because a JSONB
 // column will store exactly what it is handed.
 const feedbackContextSchema = z.object({
-  path: z.string().max(300).optional(),
+  path: z.string().max(FEEDBACK_PATH_MAX_LENGTH).optional(),
   reportedSource: z.string().max(50).optional(),
   reportedPageSources: z.array(z.string().max(50)).max(500).optional(),
   pagesLoaded: z.number().int().min(0).max(10_000).optional(),

--- a/src/shared/constants/feedback.constants.ts
+++ b/src/shared/constants/feedback.constants.ts
@@ -8,7 +8,14 @@
 // prompt that writes it and its area flag is off, so it cannot grow.
 // Enforced: `feedback.schema.test.ts` compares a hand-typed list against this one,
 // so removing the slug fails there with an array diff rather than silently.
-export const FEEDBACK_AREAS = ['bitdex-image-feed', 'apps-marketplace'] as const;
+export const FEEDBACK_AREAS = ['bitdex-image-feed', 'apps-marketplace', 'site-bug-report'] as const;
+
+/**
+ * The area behind the support menu's "Report a bug", and the only one that is not
+ * tied to a single page — it is reachable from the footer on every route, so its
+ * `context.path` is the only thing that says where the report came from.
+ */
+export const SITE_BUG_REPORT_AREA: FeedbackArea = 'site-bug-report';
 
 export type FeedbackArea = (typeof FEEDBACK_AREAS)[number];
 

--- a/src/shared/constants/feedback.constants.ts
+++ b/src/shared/constants/feedback.constants.ts
@@ -46,6 +46,16 @@ export const FEEDBACK_IMAGE_MAX_COUNT = 3;
 /** Cloudflare image ids written here are `randomUUID()` (36 chars); this is headroom, not a fit. */
 export const FEEDBACK_IMAGE_ID_MAX_LENGTH = 100;
 
+/**
+ * Length ceiling on `context.path`.
+ *
+ * Exported for the same reason as FEEDBACK_FILTER_VALUE_MAX_LENGTH below: a caller
+ * has to clip to it, and `feedbackContextSchema` REJECTS an over-long value rather
+ * than clipping, so a drifted copy fails the whole submission on the surface that
+ * exists to collect reports.
+ */
+export const FEEDBACK_PATH_MAX_LENGTH = 300;
+
 /** Faro session ids are short opaque strings; bounded because it is still client-supplied. */
 export const FEEDBACK_SESSION_ID_MAX_LENGTH = 64;
 

--- a/src/store/assistant-panel.store.ts
+++ b/src/store/assistant-panel.store.ts
@@ -1,0 +1,10 @@
+import { create } from 'zustand';
+
+/**
+ * Whether the CivBot chat is showing. Lifted out of `AssistantButton`'s local state
+ * so the support menu can open it — the chat used to live inside the support modal,
+ * and the menu that replaced it needs a way back to it.
+ */
+type State = { opened: boolean };
+
+export const useAssistantPanelStore = create<State>(() => ({ opened: false }));


### PR DESCRIPTION
Closes the loop on bug reports: the footer support button opens a **menu** instead of a modal, and "Report a bug" opens the existing feedback system as a **side panel** instead of sending the reporter to the Freshdesk ticket portal.

From the lab breakout, 2026-09-11. The problem was not the modal — it was that bug reports arrived as support tickets someone had to chase, and a ticket is usually not resolvable. A report through the feedback system carries the Grafana Faro session id, an opt-in page capture and the reporter's own images, so it is.

## 🔴 Merging this ships nothing a user can see

The new area is gated on the Flipt flag `feedback-area-site-bug-report`, **which does not exist**. Flag state lives in a GitOps repo, not here, and an unknown flag evaluates false — so on merge every user still gets the ticket portal from "Report a bug". **That flag PR is owed, is not in this diff, and this ticket does not close on the merge.**

What *is* live on merge: the menu itself, the new-tab fix, the footer change, and "Get help fast".

## What changed

- `SupportMenu` replaces the `RoutedDialogLink` in `AppFooter`. Five destinations: Report a bug, Education Hub, FAQ, Discord Community, and Support Portal under a divider.
- `FeedbackDrawer` — the feedback system promoted out of the inline alert box it lives in on `/apps` into a real right-hand panel (bottom sheet on mobile).
- **Same endpoints.** One `useFeedbackSubmission` hook now backs both the inline prompt and the drawer, so there is a single `feedback.create` and a single `Feedback` table. The rules that are easy to get wrong — consent-gated capture, object-URL lifecycle, uploads deferred to submit, Send blocked while a capture is in flight — live in one place rather than per surface.
- `AssistantButton`'s open state moved into a small store so the menu can open CivBot, which used to be the modal's right-hand column.
- The footer's own "Education" link is gone; the menu carries it.

The `/support` page and its modal are **untouched** and still serve the old content.

## Two defects the review lanes caught, both mine

**The panel stored the full URL, query string included.** A report filed from `/redeem-code?code=<live code>` wrote that code verbatim into the `Feedback.context` JSONB column — permanently, read by triage, never shown to the reporter. Now cut at `?`/`#`. The inline `/apps` prompt already avoided this; the drawer dropped the distinction and became reachable from every route.

**The panel appeared in its own screenshot.** `captureConsentedScreenshot` draws `document.body` and a Mantine Drawer portals into it, so the capture a reporter opted into was the report form over a dimmed page — and on mobile, no page at all. That capture is the entire reason this beats a ticket. Fixed with `data-html2canvas-ignore` on the Drawer root.

And one defect a *fix* introduced, caught by the next round: the `mounted` ref added to stop a post-unmount capture was never reset in the effect body, so `reactStrictMode`'s dev double-invoke left it permanently false and **silently dropped every consented screenshot in development**. Nothing could have caught it — the browser harness renders without `StrictMode`, so 20 prompt tests and six controls passed over it. The test added with the fix renders under `StrictMode` deliberately and fails without it.

## Verification

`pnpm run typecheck` 0 errors. `pnpm run lint` clean on every changed file. Unit and component suites green except two failures proven byte-identical on clean `main` (filed separately, not from this branch).

Every guard in this PR has a control that was run, mutated, and watched fail with an assertion naming the wrong value — including the near-miss ones: moving the html2canvas attribute *inward* rather than deleting it, and reverting `AssistantButton` to local state while leaving the menu's write in place.

Five review lanes (reuse, safety, perf, tests, intent) read the diff twice, and safety and tests read it a third time after the fixes.

## Known and deliberately not done

- The `/support` modal still routes its "Report a Bug" card to Freshdesk. Raised with the product owner; no answer yet.
- Signed-out visitors get the ticket portal rather than a login prompt.
- `useAssistantAvailable` and `AssistantChat` derive assistant availability separately and disagree on `isGreen`. **That split predates this PR** — `AssistantButton` has always called `getAssistantUUID` without it — and closing it changes which assistant a civitai.red user gets, so it is its own change. Recorded in the hook and filed as a follow-up.
- Dropping the backdrop also dropped click-outside-to-close (Mantine wires it to the overlay alone). Escape and the close button remain; the close button had **no accessible name** and now has one.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeyudzEkdDbmeXY75RZsHC
