### PR TITLE
fix(blocks): a dropped keep-alive socket must not cost a period request its ranking

### DIFF
--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -24,6 +24,7 @@ import {
   getWindowedCollectionRanking,
   isWindowedPeriod,
 } from '~/server/services/blocks/block-collection-popularity.service';
+import { recordBlockCollectionRankingSource } from '~/server/prom/block-collection-ranking.metrics';
 import { resolveCatalogBrowsingLevel } from '~/server/utils/block-catalog-maturity';
 import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
@@ -351,6 +352,17 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
         sourceReason = 'period-ignored-for-non-popularity-sort';
       }
     }
+
+    // 🔴 ONE INCREMENT PER WINDOWED REQUEST, SUCCESS INCLUDED — AND THAT IS THE POINT.
+    // Four of the five fallback reasons above emit no log line at all (only
+    // `clickhouse-error` does, inside the ranking service), so before this counter a
+    // silent log stream and a healthy feed were the same observation from outside.
+    // Counting every period-bearing request, not only the degraded ones, is what makes
+    // `source="clickhouse"` a readable positive rather than an absence. It sits here
+    // rather than in the ranking service because this is the only place where the FULL
+    // reason space exists — the service never learns about `empty-window` or either
+    // `period-ignored-*` outcome. See `~/server/prom/block-collection-ranking.metrics`.
+    if (period) recordBlockCollectionRankingSource({ period, source, reason: sourceReason });
 
     // 🔴 EMITTED ONLY WHEN A `period` WAS SUPPLIED. This empty-object-spread is the
     // whole backward-compatibility mechanism: a caller that never sends `period`

--- a/src/server/prom/block-collection-ranking.metrics.ts
+++ b/src/server/prom/block-collection-ranking.metrics.ts
@@ -1,0 +1,103 @@
+import client from 'prom-client';
+import { PROM_PREFIX } from '@civitai/telemetry/client';
+
+/**
+ * WHICH SOURCE ACTUALLY SERVED A WINDOWED App-Blocks COLLECTION REQUEST.
+ *
+ * ## Why this exists
+ *
+ * `GET /api/v1/blocks/collections?period=…` answers 200 with a full grid of
+ * collections whether ClickHouse ranked them or the request quietly fell back to the
+ * all-time Postgres ordering. From outside the service those two responses differ by
+ * ONE optional string in a body that needs a block JWT to fetch at all — so "the
+ * popular-this-month tab is serving all-time" was, for the whole of 2026-09-11,
+ * answerable only by reading a user's browser network tab.
+ *
+ * 🔴 AND FOUR OF THE FIVE FALLBACK REASONS EMITTED NO SERVER-SIDE SIGNAL WHATSOEVER.
+ * Only `clickhouse-error` logged (`block-collection-ranking-degraded`, in
+ * `~/server/services/blocks/block-collection-popularity.service`). `empty-window`,
+ * `clickhouse-disabled` and the two period-ignored reasons wrote nothing anywhere, so
+ * a flat absence of degrade logs was indistinguishable from a healthy feed — which is
+ * exactly the inference that cost an hour of the investigation that produced this
+ * file. A counter that increments on EVERY windowed request, success included, cannot
+ * be read that way: a zero in the `clickhouse` series is a positive statement.
+ *
+ * ## The signal
+ *
+ * `civitai_app_block_collection_ranking_total{period, source, reason}` — one
+ * increment per request that SUPPLIED a `period`, labelled with what served it.
+ *
+ *   - `source` is `clickhouse` (the windowed ranking was used) or `postgres`
+ *     (the pre-existing all-time ordering was used instead).
+ *   - `reason` is `none` on the ClickHouse path, and otherwise names WHY Postgres
+ *     served it: `clickhouse-disabled`, `clickhouse-error`, `empty-window`,
+ *     `all-time-served-from-postgres`, `period-ignored-outside-public-discovery`,
+ *     `period-ignored-for-non-popularity-sort`.
+ *
+ * Bounded by construction: `period` is a validated `MetricTimeframe` (5 values) and
+ * `reason` comes from a closed set, so the series count cannot grow with traffic.
+ *
+ * 🔴 TWO OF THE `reason` VALUES ARE NOT FAULTS AND MUST NOT BE ALERTED ON.
+ * `all-time-served-from-postgres` is the designed answer for `period=AllTime` (the
+ * ClickHouse history begins 2025-11-06, so it has no all-time to give), and the two
+ * `period-ignored-*` values are a caller sending a period where it cannot apply. The
+ * fault signature is `reason` in {`clickhouse-error`, `clickhouse-disabled`,
+ * `empty-window`} against a WINDOWED `period` — i.e. anything but `AllTime`.
+ *
+ * ## What it cannot see
+ *
+ * A request that never supplied a `period` at all. That is deliberate: such a request
+ * takes the code path that existed before the parameter did, and counting it here
+ * would put the endpoint's whole legacy traffic into a denominator that is not about
+ * ranking.
+ *
+ * Pinned on globalThis so an HMR re-eval / a second request-graph eval reuse the one
+ * instance instead of throwing prom-client's duplicate-registration error (the same
+ * trap documented on the store-scope and http-error counters).
+ */
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __civitaiBlockCollectionRankingMetrics: { ranking: client.Counter<string> } | undefined;
+}
+
+const metrics =
+  globalThis.__civitaiBlockCollectionRankingMetrics ??
+  (globalThis.__civitaiBlockCollectionRankingMetrics = {
+    ranking: new client.Counter({
+      name: PROM_PREFIX + 'block_collection_ranking_total',
+      help:
+        'Cumulative App-Blocks collection-discovery requests that supplied a `period`, by the ' +
+        'requested period, the source that actually served them (clickhouse|postgres) and, for ' +
+        'a Postgres answer, the reason. `reason="none"` is the ClickHouse path. Monotonic; use ' +
+        'rate(). A windowed period (anything but AllTime) served from postgres with reason ' +
+        'clickhouse-error / clickhouse-disabled / empty-window is the degraded state the app ' +
+        'renders as "ranking isn\'t available right now".',
+      labelNames: ['period', 'source', 'reason'],
+    }),
+  });
+
+/**
+ * Record which source served one windowed-discovery request.
+ *
+ * `reason` is recorded as the literal `none` when absent, never omitted: a label that
+ * sometimes disappears splits one series in two and makes `sum by (source)` disagree
+ * with itself across a deploy.
+ *
+ * Never throws — telemetry must not be able to fail the read it observes.
+ */
+export function recordBlockCollectionRankingSource({
+  period,
+  source,
+  reason,
+}: {
+  period: string;
+  source: 'clickhouse' | 'postgres';
+  reason?: string;
+}): void {
+  try {
+    metrics.ranking.inc({ period, source, reason: reason ?? 'none' });
+  } catch {
+    /* never throw from telemetry */
+  }
+}

--- a/src/server/services/blocks/__tests__/block-collection-popularity.test.ts
+++ b/src/server/services/blocks/__tests__/block-collection-popularity.test.ts
@@ -35,6 +35,8 @@ vi.mock('~/server/clickhouse/client', () => ({
 
 import {
   CH_RANKING_DEPTH,
+  CH_RANKING_MAX_ATTEMPTS,
+  CH_RANKING_RETRY_BUDGET_MS,
   PERIOD_WINDOW_DAYS,
   getWindowedCollectionRanking,
   isWindowedPeriod,
@@ -162,8 +164,13 @@ describe('getWindowedCollectionRanking', () => {
     expect(mockQuery).not.toHaveBeenCalled();
   });
 
-  it('reports `clickhouse-error` when the query throws, rather than propagating', async () => {
-    mockQuery.mockRejectedValueOnce(new Error('connection reset'));
+  // 🔴 `mockRejectedValue`, NOT `mockRejectedValueOnce`, in every test below that means
+  // "the query throws". A single-shot rejection no longer degrades — the retry catches
+  // it — so a `…Once` here would silently become a test of the SECOND call's default
+  // resolution. Both of these were `…Once` until the retry shipped, and one of them then
+  // passed for the wrong reason (`{ ids: [] }` is also `!==` the disabled result).
+  it('reports `clickhouse-error` when EVERY attempt throws, rather than propagating', async () => {
+    mockQuery.mockRejectedValue(new Error('connection reset'));
     const result = await getWindowedCollectionRanking({ period: MetricTimeframe.Year, now: NOW });
     expect(result).toEqual({ ids: null, source: 'unavailable', reason: 'clickhouse-error' });
   });
@@ -172,9 +179,83 @@ describe('getWindowedCollectionRanking', () => {
     clickhouseBox.client = undefined;
     const disabled = await getWindowedCollectionRanking({ period: MetricTimeframe.Day, now: NOW });
     clickhouseBox.client = { $query: mockQuery };
-    mockQuery.mockRejectedValueOnce(new Error('boom'));
+    mockQuery.mockRejectedValue(new Error('boom'));
     const errored = await getWindowedCollectionRanking({ period: MetricTimeframe.Day, now: NOW });
     expect(disabled).not.toEqual(errored);
+    expect(errored).toEqual({ ids: null, source: 'unavailable', reason: 'clickhouse-error' });
+  });
+
+  /**
+   * THE RETRY, at the level the transport actually fails.
+   *
+   * `@clickhouse/client` 0.2.10 throws `Socket hang up after 3 retries` the moment every
+   * pooled keep-alive socket it tries is past `keep_alive.socket_ttl` — ~341 times an
+   * hour against the production deployment on 2026-09-11, and once on the single live
+   * `period=Month` request in that day's ingress access log. Nothing is sent, so
+   * the failure is instantaneous; a second ask opens a fresh connection.
+   */
+  describe('the retry', () => {
+    it('re-asks once after a Socket-hang-up and serves the ranking', async () => {
+      mockQuery
+        .mockRejectedValueOnce(new Error('ClickHouse query failed: Socket hang up after 3 retries'))
+        .mockResolvedValueOnce([{ id: 5 }, { id: 8 }]);
+      const result = await getWindowedCollectionRanking({
+        period: MetricTimeframe.Month,
+        now: NOW,
+      });
+      expect(result).toEqual({ ids: [5, 8], source: 'clickhouse' });
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('costs nothing on the happy path — one success is one ask', async () => {
+      mockQuery.mockResolvedValueOnce([{ id: 1 }]);
+      await getWindowedCollectionRanking({ period: MetricTimeframe.Month, now: NOW });
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it('is BOUNDED at CH_RANKING_MAX_ATTEMPTS — it is a retry, not a spin', async () => {
+      mockQuery.mockRejectedValue(
+        new Error('ClickHouse query failed: Socket hang up after 3 retries')
+      );
+      await getWindowedCollectionRanking({ period: MetricTimeframe.Month, now: NOW });
+      expect(mockQuery).toHaveBeenCalledTimes(CH_RANKING_MAX_ATTEMPTS);
+    });
+
+    /**
+     * 🔴 THE BUDGET IS THE HALF THAT MATTERS, because it is what stops the retry
+     * doubling the failure mode it is NOT for: a 30 s `request_timeout` against a
+     * saturated server. The clock, not an attempt counter, separates the two — so
+     * this test makes the first attempt SLOW and asserts there is no second one.
+     */
+    it('does not retry a failure that already spent the whole budget', async () => {
+      mockQuery.mockImplementation(async () => {
+        vi.advanceTimersByTime(CH_RANKING_RETRY_BUDGET_MS + 1);
+        throw new Error('ClickHouse query failed: Timeout error');
+      });
+      const result = await getWindowedCollectionRanking({
+        period: MetricTimeframe.Month,
+        now: NOW,
+      });
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ ids: null, source: 'unavailable', reason: 'clickhouse-error' });
+    });
+
+    it('still retries a failure that spent only PART of the budget', async () => {
+      // The boundary from the other side: same shape, one millisecond under. Without
+      // this, a mutant that never retries would survive the test above.
+      mockQuery
+        .mockImplementationOnce(async () => {
+          vi.advanceTimersByTime(CH_RANKING_RETRY_BUDGET_MS - 1);
+          throw new Error('ClickHouse query failed: Socket hang up after 3 retries');
+        })
+        .mockResolvedValueOnce([{ id: 42 }]);
+      const result = await getWindowedCollectionRanking({
+        period: MetricTimeframe.Month,
+        now: NOW,
+      });
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ ids: [42], source: 'clickhouse' });
+    });
   });
 
   it('an empty window is an EMPTY LIST, not an unavailability — the caller decides', async () => {

--- a/src/server/services/blocks/block-collection-popularity.service.ts
+++ b/src/server/services/blocks/block-collection-popularity.service.ts
@@ -83,6 +83,55 @@ export type WindowedPeriod = keyof typeof PERIOD_WINDOW_DAYS;
 export const CH_RANKING_DEPTH = 10_000;
 
 /**
+ * How many times one request may ASK ClickHouse for its ranking.
+ *
+ * 🔴 MORE THAN ONE, BECAUSE THE TRANSPORT UNDER THIS QUERY DROPS REQUESTS AT A RATE A
+ * ONE-SHOT READ CANNOT ABSORB, AND A DROP HERE IS USER-VISIBLE. `@clickhouse/client`
+ * 0.2.10 pools keep-alive sockets and proactively destroys any it hands out that has
+ * been idle longer than `keep_alive.socket_ttl` (2500 ms, set in
+ * `packages/civitai-clickhouse/src/client.ts`). When the socket it is handed is stale
+ * it destroys that socket and asks the agent for another — four times — and then
+ * throws `Socket hang up after 3 retries`, instantly, before a byte reaches
+ * ClickHouse. Measured against the production deployment on 2026-09-11: **~341 such
+ * throws per hour** app-wide, and the single live `period=Month` request in that
+ * day's ingress access log (21:58:27Z) is one of them — it degraded to the all-time Postgres
+ * ordering and rendered the app's "ranking isn't available right now" note.
+ *
+ * 🔴 THE CLIENT'S OWN FOUR ATTEMPTS ARE NOT A SUBSTITUTE, AND AN ATTEMPT HERE IS BEST
+ * READ AS "DRAIN UP TO FOUR MORE STALE SOCKETS". No `max_open_connections` is
+ * configured, so Node's agent pools without bound and a burst can leave more than four
+ * idle sockets behind; each failed `$query` retires the four it touched, so a further
+ * ask is materially more likely to reach a live or brand-new connection than the one
+ * before it. THREE is therefore a probability improvement, not a guarantee — the
+ * durable fix is at the shared client (bound the pool, or stop handing out sockets
+ * this close to their TTL), which is an app-wide change and deliberately not made from
+ * this feature.
+ *
+ * 🔴 IT IS A RETRY OF A `SELECT`, AND NOTHING ELSE MAY EVER BE RETRIED HERE. This
+ * query reads; it has no side effect to duplicate. A future writer on this path must
+ * not inherit the loop.
+ */
+export const CH_RANKING_MAX_ATTEMPTS = 3;
+
+/**
+ * How long a FAILED attempt may have taken and still earn a retry.
+ *
+ * 🔴 THE BUDGET IS WHAT KEEPS THE RETRY FROM DOUBLING A HANG — it is the reason this
+ * is a budget and not a plain attempt count. The failure mode above is instantaneous
+ * (the socket is destroyed locally, nothing is sent), so every attempt it allows fits
+ * inside the budget many times over. The failure mode that must NOT be retried is a
+ * slow one — `@clickhouse/client`'s own 30 s `request_timeout` against a saturated or
+ * unreachable server — because retrying that parks a user-facing discovery request for
+ * a further 30 s to reach the same answer it already had. Elapsed time is the signal
+ * that separates them, so elapsed time is what is measured.
+ *
+ * 1500 ms sits an order of magnitude above the whole healthy query (Month ranks
+ * 10,000 ids in ~33 ms server-side) and two orders below the hang it excludes, so
+ * neither boundary is near it.
+ */
+export const CH_RANKING_RETRY_BUDGET_MS = 1_500;
+
+/**
  * Is this period one ClickHouse can serve?
  *
  * `AllTime` and an absent period are BOTH false — the caller must take its
@@ -156,20 +205,42 @@ export async function getWindowedCollectionRanking({
     LIMIT ${Math.trunc(depth)}
   `;
 
-  try {
-    const rows = await clickhouse.$query<{ id: number }>(query);
-    return { ids: rows.map((r) => Number(r.id)), source: 'clickhouse' };
-  } catch (error) {
-    // Swallowed on purpose: discovery must keep serving. The caller degrades to
-    // its Postgres ordering and SAYS SO in the response, so the degradation is
-    // observable from the outside rather than only in this log line.
-    logToAxiom({
-      name: 'block-collection-ranking-degraded',
-      type: 'error',
-      message: error instanceof Error ? error.message : String(error),
-      period,
-      since,
-    }).catch(() => null);
-    return { ids: null, source: 'unavailable', reason: 'clickhouse-error' };
+  // ATTEMPT LOOP — see CH_RANKING_MAX_ATTEMPTS / CH_RANKING_RETRY_BUDGET_MS. The
+  // budget is measured from the START of the first attempt, not per attempt, so the
+  // whole loop costs at most CH_RANKING_RETRY_BUDGET_MS plus one final attempt —
+  // never CH_RANKING_MAX_ATTEMPTS × the client's own 30 s request_timeout.
+  const startedAt = Date.now();
+  let lastError: unknown;
+  let attempts = 0;
+  for (let attempt = 1; attempt <= CH_RANKING_MAX_ATTEMPTS; attempt++) {
+    attempts = attempt;
+    try {
+      const rows = await clickhouse.$query<{ id: number }>(query);
+      return { ids: rows.map((r) => Number(r.id)), source: 'clickhouse' };
+    } catch (error) {
+      lastError = error;
+      if (Date.now() - startedAt >= CH_RANKING_RETRY_BUDGET_MS) break;
+    }
   }
+
+  // Swallowed on purpose: discovery must keep serving. The caller degrades to
+  // its Postgres ordering and SAYS SO in the response, so the degradation is
+  // observable from the outside rather than only in this log line.
+  //
+  // `attempts` and `elapsedMs` are carried because together they are the one thing that
+  // separates the two faults this degrade can be. `attempts: 1` means the FIRST failure
+  // spent the whole retry budget — a slow fault (a hang, a saturated server), and the
+  // budget correctly declined to double it. `attempts: CH_RANKING_MAX_ATTEMPTS` with a
+  // small `elapsedMs` means every ask was refused instantly — the socket-pool fault, and
+  // a sign the retry is no longer enough on its own.
+  logToAxiom({
+    name: 'block-collection-ranking-degraded',
+    type: 'error',
+    message: lastError instanceof Error ? lastError.message : String(lastError),
+    period,
+    since,
+    attempts,
+    elapsedMs: Date.now() - startedAt,
+  }).catch(() => null);
+  return { ids: null, source: 'unavailable', reason: 'clickhouse-error' };
 }

--- a/src/tests/api/v1/blocks/collections-period-transport.test.ts
+++ b/src/tests/api/v1/blocks/collections-period-transport.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+
+/**
+ * THE TRANSPORT SEAM of GET /api/v1/blocks/collections?period=…
+ *
+ * `collections-period.test.ts` doubles `getWindowedCollectionRanking` itself, so every
+ * assertion in it is about what the ENDPOINT does with a ranking result. That left the
+ * step between the endpoint and ClickHouse — the only step that actually failed in
+ * production — with no coverage at all: the whole suite was green while every live
+ * `period=Month` request rendered the app's "ranking isn't available right now" note.
+ *
+ * 🔴 SO THE DOUBLE HERE IS ONE LEVEL DEEPER, AND THAT IS THE POINT. The REAL
+ * `getWindowedCollectionRanking` runs; only the ClickHouse CLIENT is doubled, with the
+ * exact error production threw:
+ *
+ *     ClickHouse query failed: Socket hang up after 3 retries
+ *
+ * `@clickhouse/client` 0.2.10 raises that when every pooled keep-alive socket it tries
+ * has been idle past `keep_alive.socket_ttl` — measured at ~341 throws per hour against
+ * the production deployment on 2026-09-11, and the single live `period=Month` request
+ * in that day's ingress access log (21:58:27Z) is one of them.
+ *
+ * 🔴 AND THE REQUEST IS THE LITERAL PRODUCTION QUERY STRING, parsed the way the server
+ * parses it, rather than a hand-built object. The whole defect class here is "the state
+ * a test constructs is not the state a request produces", so the shape is taken from
+ * the wire: `sort=Most+Followers` (the raw enum spelling the app sends) rather than the
+ * `sort=popular` alias every other test in this directory uses.
+ */
+
+const PRODUCTION_QUERY_STRING = 'mode=public&sort=Most+Followers&period=Month&limit=24';
+
+/** The verbatim message `@clickhouse/client` 0.2.10 throws on an exhausted socket pool. */
+const SOCKET_HANG_UP = 'ClickHouse query failed: Socket hang up after 3 retries';
+
+function createMocks(query: Record<string, unknown>) {
+  const req = {
+    method: 'GET',
+    query,
+    headers: {},
+    socket: { remoteAddress: '203.0.113.7' },
+  } as unknown as Record<string, unknown>;
+  let statusCode = 200;
+  let payload: unknown;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader() {
+      /* not asserted here */
+    },
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+  parseSubjectUserId: (sub: string): number | null => (sub === 'anon' ? null : 42),
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const {
+  mockGetAll,
+  mockItemCount,
+  mockHydrate,
+  mockFollowed,
+  mockRate,
+  mockMaturity,
+  mockFallbackCovers,
+  mockPlayableSample,
+  mockChQuery,
+  mockRecordSource,
+} = vi.hoisted(() => ({
+  mockGetAll: vi.fn(),
+  mockItemCount: vi.fn(),
+  mockHydrate: vi.fn(),
+  mockFollowed: vi.fn(),
+  mockRate: vi.fn(),
+  mockMaturity: vi.fn(),
+  mockFallbackCovers: vi.fn(),
+  mockPlayableSample: vi.fn(),
+  mockChQuery: vi.fn(),
+  mockRecordSource: vi.fn(),
+}));
+
+vi.mock('~/server/services/collection.service', () => ({
+  getAllCollections: mockGetAll,
+  getCollectionItemCount: mockItemCount,
+  getUserCollectionsWithPermissions: vi.fn(),
+}));
+vi.mock('~/server/services/blocks/block-collections.service', () => ({
+  hydrateBlockSubject: mockHydrate,
+  getFollowedCollectionIds: mockFollowed,
+  getFallbackCoverImages: mockFallbackCovers,
+  getCollectionPlayableSample: mockPlayableSample,
+  toCoverFields: () => ({ coverImageUrl: null }),
+  collectionWithinCeiling: () => true,
+}));
+/**
+ * 🔴 THE ONLY DOUBLE ON THE RANKING PATH. `block-collection-popularity.service` is NOT
+ * mocked — its retry loop, its window arithmetic and its degrade reason are the code
+ * under test. Stubbing it is what made the shipped suite blind to this.
+ */
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: { $query: mockChQuery } }));
+vi.mock('~/server/prom/block-collection-ranking.metrics', () => ({
+  recordBlockCollectionRankingSource: mockRecordSource,
+}));
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: mockRate,
+}));
+vi.mock('~/server/utils/block-catalog-maturity', () => ({
+  resolveCatalogBrowsingLevel: mockMaturity,
+}));
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: () => ({}),
+  isRegionRestricted: () => false,
+}));
+
+import handler from '~/pages/api/v1/blocks/collections/index';
+import {
+  CH_RANKING_MAX_ATTEMPTS,
+  CH_RANKING_RETRY_BUDGET_MS,
+} from '~/server/services/blocks/block-collection-popularity.service';
+
+/**
+ * Ranked ids ClickHouse would return, in rank order.
+ *
+ * Deliberately NOT id-ascending and NOT id-descending: the `getAllCollections` double
+ * below returns rows in id-DESC order, so an endpoint that served Postgres' order
+ * instead of the rank order would produce a visibly different list rather than the same
+ * one by coincidence.
+ */
+const RANKED = [903, 901, 902];
+
+async function run(queryString = PRODUCTION_QUERY_STRING) {
+  const query = Object.fromEntries(new URLSearchParams(queryString));
+  const { req, res } = createMocks(query);
+  await handler(req as never, res as never);
+  return { status: res._status(), body: res._json() as any };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // 🔴 `mockReset`, not `clearAllMocks`, for the ClickHouse double — and the difference
+  // is not hygiene, it is correctness. `clearAllMocks` empties `mock.calls` but leaves
+  // the `…Once` QUEUE intact, so a test whose subject stops asking before the queue is
+  // drained leaks its unconsumed entries into the next test. Measured at the pre-change
+  // base, where exactly that happens (one ask instead of two): the leftover
+  // `mockResolvedValueOnce` fired in a LATER test and made a degraded path report
+  // `source: 'clickhouse'`. Every test here queues its own asks from empty.
+  mockChQuery.mockReset();
+  claimsBox.claims = {
+    sub: 'user:42',
+    scopes: ['collections:read:self'],
+    blockInstanceId: 'bki_test',
+    maxBrowsingLevel: 31,
+    ctx: {},
+  } as unknown as BlockTokenClaims;
+  mockRate.mockResolvedValue({ allowed: true });
+  mockMaturity.mockReturnValue({ browsingLevel: 31, isSfwCeiling: false });
+  mockHydrate.mockResolvedValue({ id: 42, username: 'mod' });
+  mockFollowed.mockResolvedValue(new Set<number>());
+  mockFallbackCovers.mockResolvedValue(new Map());
+  mockPlayableSample.mockResolvedValue(new Map());
+  mockItemCount.mockResolvedValue([]);
+  mockGetAll.mockImplementation(async ({ input }: any) => {
+    const rows = [901, 902, 903]
+      .map((id) => ({
+        id,
+        name: `C${id}`,
+        description: null,
+        read: 'Public',
+        nsfwLevel: 1,
+        userId: 1,
+        user: { id: 1, username: 'a' },
+        image: null,
+      }))
+      .sort((a, b) => b.id - a.id);
+    const filtered =
+      input.ids && input.ids.length > 0 ? rows.filter((c) => input.ids.includes(c.id)) : rows;
+    return filtered.slice(0, input.limit);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('a keep-alive socket drop must not cost the request its ranking', () => {
+  it('serves the ClickHouse ranking after one Socket-hang-up, for the real production request', async () => {
+    mockChQuery
+      .mockRejectedValueOnce(new Error(SOCKET_HANG_UP))
+      .mockResolvedValueOnce(RANKED.map((id) => ({ id })));
+
+    const { status, body } = await run();
+
+    expect(status).toBe(200);
+    // The three claims that separate a served ranking from the degraded grid the app
+    // renders its "ranking isn't available right now" note over.
+    expect(body.source).toBe('clickhouse');
+    expect(body.sourceReason).toBeUndefined();
+    expect(body.items.map((i: any) => i.id)).toEqual(RANKED);
+    // And it cost exactly one extra ask — not a loop.
+    expect(mockChQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('records the ClickHouse source on the metric, with no reason', async () => {
+    mockChQuery
+      .mockRejectedValueOnce(new Error(SOCKET_HANG_UP))
+      .mockResolvedValueOnce(RANKED.map((id) => ({ id })));
+
+    await run();
+
+    expect(mockRecordSource).toHaveBeenCalledWith({
+      period: 'Month',
+      source: 'clickhouse',
+      reason: undefined,
+    });
+  });
+
+  it('still degrades — and says why — when the retry fails too', async () => {
+    mockChQuery.mockRejectedValue(new Error(SOCKET_HANG_UP));
+
+    const { body } = await run();
+
+    expect(body.source).toBe('postgres');
+    expect(body.sourceReason).toBe('clickhouse-error');
+    // Bounded: the loop is a retry, not a spin.
+    expect(mockChQuery).toHaveBeenCalledTimes(CH_RANKING_MAX_ATTEMPTS);
+    expect(mockRecordSource).toHaveBeenCalledWith({
+      period: 'Month',
+      source: 'postgres',
+      reason: 'clickhouse-error',
+    });
+  });
+
+  it('does NOT retry a failure that already spent the budget — a hang must not be doubled', async () => {
+    // 🔴 The clock, not an attempt counter, is what separates the two failure modes.
+    // `Date.now` is stubbed rather than the timers faked so that `windowStartDate`'s
+    // `new Date()` keeps producing a real window literal — the retry decision is the
+    // only thing under this stub.
+    //
+    // The service reads the clock once before the first attempt and once after each
+    // failure; the second reading overshoots the budget, so the loop must stop with one
+    // attempt spent.
+    const realNow = Date.now();
+    vi.spyOn(Date, 'now').mockImplementation(
+      (() => {
+        let call = 0;
+        return () => (call++ === 0 ? realNow : realNow + CH_RANKING_RETRY_BUDGET_MS + 1);
+      })()
+    );
+    mockChQuery.mockRejectedValue(new Error('ClickHouse query failed: Timeout error'));
+
+    const { body } = await run();
+
+    expect(mockChQuery).toHaveBeenCalledTimes(1);
+    expect(body.source).toBe('postgres');
+    expect(body.sourceReason).toBe('clickhouse-error');
+  });
+});


### PR DESCRIPTION
## The symptom

`playable-collections` renders the period selector, Month is selected by default, and the grid comes back with the all-time ordering plus the app's note:

> Ranking for this month isn't available right now — showing all-time popularity instead.

## Root cause — it is the transport, not the route

The lead I was handed was that a branch condition between the route and the service is false for the real request. **It is not.** I reproduced the literal production query string end-to-end through the handler and it reaches ClickHouse correctly: `sort=Most+Followers` (the raw enum spelling the app sends) parses to exactly the same value as the `sort=popular` alias every existing test uses, and `period=Month` clears `isWindowedPeriod`. That half of the hypothesis is refuted, and the refutation is now pinned by a test.

What actually failed is the ranking **query**:

```
ClickHouse query failed: Socket hang up after 3 retries
Query:
    SELECT entityId AS id
    FROM entityMetricDailyAgg_history_v2
    …
```

`@civitai/clickhouse` builds the client with `keep_alive: { socket_ttl: 2500, retry_on_expired_socket: true }`. `@clickhouse/client` 0.2.10 destroys any pooled socket it is handed that has been idle past that TTL and asks the agent for another — four times — then throws, **instantly, before a byte reaches ClickHouse**. Measured against the production deployment on 2026-09-11: **~341 such throws per hour** app-wide. The single live `period=Month` request in that day's ingress access log — 21:58:27Z, `200` in 9655 ms — carries a matching `block-collection-ranking-degraded` line at the same second.

`getWindowedCollectionRanking` asked **once** and degraded on the first failure, so one transport blip cost a user-facing request its entire ranking. Ruled out by measurement, not assumption: the client is constructed (`clickhouse-disabled` impossible), and the query itself returns **10,000 rows in ~200 ms** from inside a production pod (`empty-window` impossible).

## The fix

Ask up to `CH_RANKING_MAX_ATTEMPTS` (3) times, gated on a wall-clock budget measured from the start of the *first* attempt.

**The budget is the load-bearing half.** The socket fault is instantaneous, so it always earns its retries. The fault that must *not* be retried is a slow one — the client's own 30 s `request_timeout` against a saturated server — and retrying that would park a user-facing request for another 30 s to reach the answer it already had. Elapsed time is the only signal that separates the two, so elapsed time is what is measured. The query is a `SELECT`; there is no side effect to duplicate.

**Stated plainly: this is a probability improvement, not a guarantee.** No `max_open_connections` is configured, so the agent pools without bound and more than four sockets can be stale at once; each failed `$query` retires the four it touched, so each further ask is likelier to land on a live or brand-new connection. The durable fix belongs at the shared client (bound the pool, or stop handing out sockets this close to their TTL) — an app-wide change, deliberately not made from this feature.

## The observability gap

This took an hour from the outside for a reason worth fixing separately: **four of the five fallback reasons emitted no server-side signal at all.** Only `clickhouse-error` logged. `empty-window`, `clickhouse-disabled` and the two `period-ignored-*` reasons wrote nothing anywhere, so a silent log stream and a healthy feed were the same observation.

New counter, `civitai_app_block_collection_ranking_total{period, source, reason}`, incremented on **every** request that supplied a `period` — success included, which is what makes `source="clickhouse"` a readable positive rather than an absence. Bounded by construction (5 periods × 2 sources × a closed reason set). It lives at the route because that is the only place the full reason space exists; the service never learns about `empty-window` or either `period-ignored-*`.

**What I chose not to do:** nothing is added to the response body. `sourceReason` already tells the *caller* what served it; the missing half was a signal a diagnostician can read **without a block token**, and a Prometheus series is that without widening the public surface. The degrade log now also carries `attempts` and `elapsedMs`, which is what distinguishes a slow fault (`attempts: 1`, the budget correctly declining to double it) from the socket-pool one (all attempts, tiny elapsed).

## Test — red at base, green at HEAD

`src/tests/api/v1/blocks/collections-period-transport.test.ts` runs the **real** popularity service and doubles only the ClickHouse client, with the verbatim production error, against the **literal production query string** parsed the way the server parses it.

The shipped suite could not have caught this: `collections-period.test.ts` doubles `getWindowedCollectionRanking` itself, so the step that actually failed had no coverage, and every test in it uses the `sort=popular` alias rather than the spelling the app sends.

| | base `41837fc6be` | HEAD |
|---|---|---|
| serves the ranking after one Socket-hang-up | ❌ `expected 'postgres' to be 'clickhouse'` | ✅ |
| records the ClickHouse source on the metric | ❌ `Number of calls: 0` | ✅ |
| still degrades when the retry fails too | ❌ `expected 3 calls, got 1` | ✅ |
| does not retry a failure that spent the budget | ✅ (vacuous at base — base never retries; an invariant guard there, a live boundary guard at HEAD) | ✅ |

(The base run used the same file with its two HEAD-only imports removed and the constants inlined; nothing else differed.)

Plus service-level coverage for the retry, the happy path costing one ask, the bound, and both sides of the budget boundary. Two existing tests used `mockRejectedValueOnce` to mean "the query throws" — now `mockRejectedValue`, since a single-shot rejection no longer degrades and one of them had started passing for the wrong reason.

## Gates

- `pnpm typecheck`: **0 errors** (delta 0). Note: a fresh worktree reports 10 phantom `TS2307`s until `git submodule update --init event-engine-common`.
- `vitest --project unit*` over `src/server/services/blocks/__tests__/` + `src/tests/api/v1/blocks/`: **4417 passed / 188 files**.
- `eslint`: 0 errors (7 `no-explicit-any` warnings, matching the sibling test file). `prettier --check`: clean.

## Not verified

**Production.** This repo deploys from `release`, so merging to `main` does not make this live and I cannot claim the symptom is gone. I also could **not** reproduce the transport failure in an isolated probe (0 failures in 30 asks from a production pod, 6-wide waves with 5 s idles between them), so the retry's real-world recovery rate is unmeasured — the argument for it is mechanical, not observed.

**The live check that closes this**, after a release: a `period=Month` request served with `source: "clickhouse"`, or equivalently

```
sum by (source, reason) (increase(civitai_app_block_collection_ranking_total{period="Month"}[1h]))
```

showing `source="clickhouse"` non-zero and `reason="clickhouse-error"` at or near zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uua8uQHGNWnfzRHgLEkZyM
