### PR TITLE
test(account): the early-adopter suite's trpc mock went stale when SettingsCard grew a feature-flags query

### DIFF
--- a/src/components/Account/SettingsCard.earlyAdopter.browser.test.tsx
+++ b/src/components/Account/SettingsCard.earlyAdopter.browser.test.tsx
@@ -57,6 +57,15 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
     }),
     user: {
       getSettings: { useQuery: () => ({ data: settings.value }) },
+      // `ToggleableFeatures` (SettingsCard.tsx) reads this during render, so its
+      // absence is not a missing assertion — it is a TypeError that fails the whole
+      // component tree and every test in this file with it. The `useUtils()` double
+      // below already defines `user.getFeatureFlags`, which is exactly what made the
+      // gap read as wired. `{}` mirrors that double's `getData: () => ({})`, and is
+      // safe for this file because the key under test (`earlyAdopter`) is not in
+      // `fliptGatedToggleableKeys` — that set needs `toggleable`, which it lacks — so
+      // an empty overlay does not filter the switch out of the list.
+      getFeatureFlags: { useQuery: () => ({ data: {} }) },
       setSettings: {
         useMutation: (options?: Record<string, unknown>) => {
           capturedMutationOptions.value = options;


### PR DESCRIPTION
test(account): the early-adopter suite's trpc mock went stale when SettingsCard grew a feature-flags query

`preview / component-tests` has been red on `main` since #4701 merged. All six tests in
SettingsCard.earlyAdopter.browser.test.tsx fail with the same error:

  TypeError: Cannot read properties of undefined (reading 'useQuery')
  at ToggleableFeatures (src/components/Account/SettingsCard.tsx:330:59)

79912901a5 ("make trainingStudioUi a Flipt-gated opt-in toggle", in #4701) added

  const { data: userFeatures } = trpc.user.getFeatureFlags.useQuery(undefined, {...})

to ToggleableFeatures. This file's partial `vi.mock('~/utils/trpc')` defines `trpc.user` as
{ getSettings, setSettings, update, toggleFeature } - no getFeatureFlags - so the property
is undefined and reading `.useQuery` off it throws during render. That kills the whole
component tree, which is why all six fail rather than one: none of them asserts on feature
flags at all.

🔴 The near-miss that makes this read as already-wired: the `useUtils()` double in the SAME
mock DOES define `user.getFeatureFlags` (getData/setData/invalidate/cancel), because the
mutation's onMutate needs it. Only the query side was missing.

One line, and `{}` rather than a populated overlay on purpose: the switch under test
(`earlyAdopter`) is NOT in `fliptGatedToggleableKeys` - that set requires `toggleable`,
which earlyAdopter's definition lacks - so an empty overlay cannot filter the switch out of
the list. It also mirrors the `useUtils` double's `getData: () => ({})` right above it.

RED/GREEN, watched on one machine with one harness, differing only in this line:

  without the line : Test Files 1 failed, Tests 6 failed (6), exit 1, TypeError as above
  with the line    : Test Files 1 passed, Tests 6 passed (6), exit 0

NOT a fix to #4701's feature, and no production code is touched - only this test's mock
catches up to what the component now reads.

Closing condition: `preview / component-tests` green on a branch cut from current main.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NuvKwyx3mq9yuPzuGBSsLv
