### PR TITLE
feat(moderator): a /feedback triage surface for the Feedback table

### DIFF
--- a/apps/moderator/.env.example
+++ b/apps/moderator/.env.example
@@ -136,6 +136,20 @@ NCMEC_PASSWORD=
 # NEXT_PUBLIC_IMAGE_LOCATION (prod value below; point at your dev cacher for local testing).
 PUBLIC_IMAGE_LOCATION=https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA
 
+# --- Grafana (the /feedback queue's Faro session deep link) ---
+# Origin of the Grafana that holds the browser-RUM logs, e.g. https://grafana.example.internal.
+# PUBLIC_ prefix because the link is built for the browser ($env/dynamic/public).
+#
+# 🔴 DELIBERATELY BLANK HERE, AND DO NOT COMMIT THE REAL VALUE. This repository is PUBLIC and that
+# origin is internal infrastructure. Take it from the deployment config when wiring the moderator
+# app; it does not belong in the tree.
+#
+# 🔴 Unset is a SUPPORTED state and the link simply does not render — `faroSessionLink` returns null
+# rather than building `undefined/explore`, which would look live and be broken. So a deployment
+# that forgets this variable loses the link SILENTLY: the panel says the link is unconfigured, but
+# only to whoever opens a row.
+PUBLIC_GRAFANA_URL=
+
 # --- Observability (Axiom / Loki via @civitai/axiom) ---
 # Unhandled load/action/endpoint errors (hooks.server.ts), the blocklist duplicate-row anomaly and the
 # training-gate audit trail log through $lib/server/axiom. In prod @civitai/axiom ALWAYS emits a structured

--- a/apps/moderator/src/lib/__tests__/feedback.test.ts
+++ b/apps/moderator/src/lib/__tests__/feedback.test.ts
@@ -67,9 +67,12 @@ describe('reconstructFeedbackUrl', () => {
     expect(reconstructFeedbackUrl(null)).toBeNull();
   });
 
-  it('refuses a `path` that is not a path — it is client-supplied', () => {
+  it('refuses a `path` that is not a same-origin path — it is client-supplied', () => {
     expect(reconstructFeedbackUrl('https://evil.example/x')).toBeNull();
     expect(reconstructFeedbackUrl('apps')).toBeNull();
+    // 🔴 `//host` passes a naive `startsWith('/')` and becomes a HOST SWAP once concatenated onto
+    // the civitai base.
+    expect(reconstructFeedbackUrl('//evil.example/x')).toBeNull();
   });
 });
 
@@ -99,19 +102,24 @@ describe('feedbackAreaOptions', () => {
 
 describe('splitContext', () => {
   it('names the five keys the panel renders', () => {
+    // Realistic ids: the producer writes `randomUUID()`, and `splitContext` refuses anything that
+    // is not shaped like a Cloudflare key — a short stand-in would be rejected here for a reason
+    // that has nothing to do with what this case is about.
+    const images = ['2f0b6a1e-0f7a-4f2e-9c3e-1a2b3c4d5e6f', '7c9a1d2b-3e4f-4a5b-8c9d-0e1f2a3b4c5d'];
+    const screenshotId = 'b1c2d3e4-f5a6-4b7c-8d9e-0f1a2b3c4d5e';
     const ctx = splitContext({
       path: '/apps',
       filters: { kind: 'onsite' },
-      images: ['img-1', 'img-2'],
-      screenshotId: 'shot-1',
+      images,
+      screenshotId,
       sessionId: 'v913JNcgDs',
     });
 
     expect(ctx).toEqual({
       path: '/apps',
       filters: { kind: 'onsite' },
-      images: ['img-1', 'img-2'],
-      screenshotId: 'shot-1',
+      images,
+      screenshotId,
       sessionId: 'v913JNcgDs',
       other: null,
     });
@@ -145,8 +153,50 @@ describe('splitContext', () => {
     }
   });
 
+  /**
+   * 🔴 A SECURITY GUARD, not tidiness. `getEdgeUrl` returns its argument VERBATIM when it starts
+   * with `http` or `blob`, and the producer bounds these ids by LENGTH ONLY — so an unfiltered
+   * value renders `<img src="https://attacker.example/…">` in a moderator's browser and hands the
+   * reporter a read receipt naming who opened their report and when.
+   */
+  it('refuses an attachment id that is a URL, and still shows it as text', () => {
+    const ctx = splitContext({ images: ['https://attacker.example/x.png', 'real-image-key-1'] });
+
+    expect(ctx.images).toEqual(['real-image-key-1']);
+    expect(ctx.other).toEqual({ images: ['https://attacker.example/x.png', 'real-image-key-1'] });
+  });
+
+  /**
+   * `getEdgeUrl` takes its verbatim branch on ANY value starting with `http`/`blob`, so an id
+   * spelled like one renders as a broken same-origin relative src instead of a CDN URL.
+   */
+  it('refuses an id spelled like a URL scheme even though it cannot BE a URL', () => {
+    expect(splitContext({ images: ['httpabcdefgh', 'blobabcdefgh'] }).images).toEqual([]);
+  });
+
+  it('refuses a screenshot id that is a URL', () => {
+    const ctx = splitContext({ screenshotId: 'https://attacker.example/x.png' });
+
+    expect(ctx.screenshotId).toBeNull();
+    expect(ctx.other).toEqual({ screenshotId: 'https://attacker.example/x.png' });
+  });
+
+  /**
+   * 🔴 `{#each … (id)}` THROWS on a duplicate key in production as well as dev, so one repeated id
+   * in a client-supplied array makes that report permanently unopenable.
+   */
+  it('deduplicates attachment ids', () => {
+    expect(splitContext({ images: ['same-image-key', 'same-image-key'] }).images).toEqual([
+      'same-image-key',
+    ]);
+  });
+
   it('counts the opt-in capture as an attachment alongside the reporter’s own files', () => {
-    expect(feedbackAttachmentCount(splitContext({ images: ['a', 'b'], screenshotId: 's' }))).toBe(3);
+    expect(
+      feedbackAttachmentCount(
+        splitContext({ images: ['image-key-a', 'image-key-b'], screenshotId: 'shot-key-1' })
+      )
+    ).toBe(3);
     expect(feedbackAttachmentCount(splitContext({}))).toBe(0);
   });
 });
@@ -217,9 +267,7 @@ describe('faroSessionLink', () => {
   });
 
   it('is null past the retention window — the caller renders the expiry note instead', () => {
-    expect(
-      link({ now: CREATED.getTime() + (FARO_LOKI_RETENTION_HOURS + 1) * HOUR })
-    ).toBeNull();
+    expect(link({ now: CREATED.getTime() + (FARO_LOKI_RETENTION_HOURS + 1) * HOUR })).toBeNull();
   });
 
   /**

--- a/apps/moderator/src/lib/__tests__/feedback.test.ts
+++ b/apps/moderator/src/lib/__tests__/feedback.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FARO_LOKI_RETENTION_HOURS,
+  faroSessionLink,
+  feedbackAreaOptions,
+  feedbackAttachmentCount,
+  reconstructFeedbackUrl,
+  splitContext,
+} from '$lib/feedback';
+
+/**
+ * The pure decisions behind `/feedback`. Every one of them fails SILENTLY when wrong — a link to a
+ * page the report is not about, an area whose rows nobody can reach, a Grafana query that returns
+ * some rows, a context key that vanishes.
+ */
+
+const HOUR = 60 * 60 * 1000;
+
+describe('reconstructFeedbackUrl', () => {
+  it('omits every value that equals the store default, so the link is the one the reporter had', () => {
+    expect(
+      reconstructFeedbackUrl('/apps', {
+        kind: 'all',
+        category: 'none',
+        sort: 'top-rated',
+        query: '',
+      })
+    ).toBe('/apps');
+  });
+
+  it('round-trips a non-default combination', () => {
+    expect(
+      reconstructFeedbackUrl('/apps', {
+        kind: 'onsite',
+        category: 'none',
+        sort: 'newest',
+        query: '',
+      })
+    ).toBe('/apps?kind=onsite&sort=newest');
+  });
+
+  it('carries a real category and a real search term', () => {
+    expect(
+      reconstructFeedbackUrl('/apps', {
+        kind: 'all',
+        category: 'generation',
+        sort: 'top-rated',
+        query: 'upscale',
+      })
+    ).toBe('/apps?category=generation&query=upscale');
+  });
+
+  it('encodes a search term that would otherwise change the URL', () => {
+    expect(reconstructFeedbackUrl('/apps', { query: 'a&b=c' })).toBe('/apps?query=a%26b%3Dc');
+  });
+
+  it('carries a key it has never seen rather than dropping a future area on the floor', () => {
+    expect(reconstructFeedbackUrl('/browse', { tab: 'videos' })).toBe('/browse?tab=videos');
+  });
+
+  it('is just the path when there are no filters at all — the site-bug-report shape', () => {
+    expect(reconstructFeedbackUrl('/models/123')).toBe('/models/123');
+  });
+
+  it('yields NO link when `path` is absent, rather than a confident link to /', () => {
+    expect(reconstructFeedbackUrl(undefined, { kind: 'onsite' })).toBeNull();
+    expect(reconstructFeedbackUrl(null)).toBeNull();
+  });
+
+  it('refuses a `path` that is not a path — it is client-supplied', () => {
+    expect(reconstructFeedbackUrl('https://evil.example/x')).toBeNull();
+    expect(reconstructFeedbackUrl('apps')).toBeNull();
+  });
+});
+
+describe('feedbackAreaOptions', () => {
+  it('keeps an area that exists ONLY in the table — the whole reason the union exists', () => {
+    // `bitdex-image-feed`'s producer is gone. Reading the TS registry alone would hide its rows.
+    expect(feedbackAreaOptions(['bitdex-image-feed'], ['apps-marketplace'])).toEqual([
+      'apps-marketplace',
+      'bitdex-image-feed',
+    ]);
+  });
+
+  it('keeps an area that exists ONLY in the registry, so a new surface is filterable before it has rows', () => {
+    expect(feedbackAreaOptions([], ['site-bug-report'])).toEqual(['site-bug-report']);
+  });
+
+  it('does not repeat an area present in both', () => {
+    expect(feedbackAreaOptions(['apps-marketplace'], ['apps-marketplace'])).toEqual([
+      'apps-marketplace',
+    ]);
+  });
+
+  it('drops an empty area string rather than offering a blank option', () => {
+    expect(feedbackAreaOptions([''], ['apps-marketplace'])).toEqual(['apps-marketplace']);
+  });
+});
+
+describe('splitContext', () => {
+  it('names the five keys the panel renders', () => {
+    const ctx = splitContext({
+      path: '/apps',
+      filters: { kind: 'onsite' },
+      images: ['img-1', 'img-2'],
+      screenshotId: 'shot-1',
+      sessionId: 'v913JNcgDs',
+    });
+
+    expect(ctx).toEqual({
+      path: '/apps',
+      filters: { kind: 'onsite' },
+      images: ['img-1', 'img-2'],
+      screenshotId: 'shot-1',
+      sessionId: 'v913JNcgDs',
+      other: null,
+    });
+  });
+
+  it('puts a key none of the five cover into "other" — this is what stops a future area vanishing', () => {
+    const ctx = splitContext({ path: '/apps', pagesLoaded: 3, reportedSource: 'edge' });
+
+    expect(ctx.other).toEqual({ pagesLoaded: 3, reportedSource: 'edge' });
+    expect(ctx.path).toBe('/apps');
+  });
+
+  it('shows a known key holding the wrong TYPE instead of pretending it was absent', () => {
+    const ctx = splitContext({ path: 42, images: 'not-an-array' });
+
+    expect(ctx.path).toBeNull();
+    expect(ctx.images).toEqual([]);
+    expect(ctx.other).toEqual({ path: 42, images: 'not-an-array' });
+  });
+
+  it('survives a context that is not an object — the column has no schema at rest', () => {
+    for (const bad of [null, undefined, 'x', 7, []]) {
+      expect(splitContext(bad)).toEqual({
+        path: null,
+        filters: null,
+        images: [],
+        screenshotId: null,
+        sessionId: null,
+        other: null,
+      });
+    }
+  });
+
+  it('counts the opt-in capture as an attachment alongside the reporter’s own files', () => {
+    expect(feedbackAttachmentCount(splitContext({ images: ['a', 'b'], screenshotId: 's' }))).toBe(3);
+    expect(feedbackAttachmentCount(splitContext({}))).toBe(0);
+  });
+});
+
+describe('faroSessionLink', () => {
+  const CREATED = new Date('2026-09-11T12:00:00.000Z');
+  const GRAFANA = 'https://grafana.example.test';
+  const SESSION = 'v913JNcgDs';
+
+  const link = (over: Partial<Parameters<typeof faroSessionLink>[0]> = {}) =>
+    faroSessionLink({
+      grafanaUrl: GRAFANA,
+      sessionId: SESSION,
+      createdAt: CREATED,
+      now: CREATED.getTime() + HOUR,
+      ...over,
+    });
+
+  /** The Explore pane, decoded back out of the built URL. */
+  const pane = (url: string) => {
+    const panes = new URL(url).searchParams.get('panes');
+    if (!panes) throw new Error('the built URL carries no `panes` parameter');
+    return JSON.parse(panes) as {
+      faro: {
+        queries: { expr: string; datasource: { uid: string } }[];
+        range: { from: string; to: string };
+      };
+    };
+  };
+
+  it('builds an Explore URL inside the retention window', () => {
+    const url = link();
+    expect(url).not.toBeNull();
+    expect(new URL(url!).pathname).toBe('/explore');
+    expect(new URL(url!).searchParams.get('schemaVersion')).toBe('1');
+    expect(new URL(url!).searchParams.get('orgId')).toBe('1');
+  });
+
+  /**
+   * 🔴 THE TWO-SPELLINGS HAZARD, as something a machine can check. The id appears as `session_id=`
+   * on `session_start` lines and as `event_data_session.id=` on `faro.tracing.fetch` lines, so a
+   * `| logfmt | session_id="…"` filter matches the first and silently drops the second — exactly
+   * the rows carrying traceID/spanID. A filter that returns SOME rows looks like it worked.
+   */
+  it('filters by raw substring and never by logfmt', () => {
+    const url = link()!;
+    const expr = pane(url).faro.queries[0].expr;
+
+    expect(expr).toContain(`|= "${SESSION}"`);
+    expect(expr).not.toContain('logfmt');
+    // Belt and braces: no encoding of `logfmt` can be hiding anywhere in the URL either.
+    expect(decodeURIComponent(url)).not.toContain('logfmt');
+  });
+
+  it('points at the pinned Loki datasource uid', () => {
+    expect(pane(link()!).faro.queries[0].datasource.uid).toBe('loki');
+  });
+
+  it('centres the window on the report, not on now — it must survive being clicked two days later', () => {
+    const range = pane(link()!).faro.range;
+    expect(range.from).toBe(String(CREATED.getTime() - HOUR));
+    expect(range.to).toBe(String(CREATED.getTime() + HOUR));
+  });
+
+  it('escapes a session id that would otherwise break out of the LogQL string literal', () => {
+    const expr = pane(link({ sessionId: 'a"b\\c' })!).faro.queries[0].expr;
+    expect(expr).toBe('{source="faro-rum"} |= "a\\"b\\\\c"');
+  });
+
+  it('is null past the retention window — the caller renders the expiry note instead', () => {
+    expect(
+      link({ now: CREATED.getTime() + (FARO_LOKI_RETENTION_HOURS + 1) * HOUR })
+    ).toBeNull();
+  });
+
+  /**
+   * The boundary is CLOSED ON THE EXPIRED SIDE: at exactly the retention age the sample is at the
+   * edge of eviction, and a link that resolves to nothing is the one outcome this design exists to
+   * avoid. Pinned rather than left to whichever comparison operator got typed.
+   */
+  it('treats an age of exactly the retention window as expired', () => {
+    const boundary = CREATED.getTime() + FARO_LOKI_RETENTION_HOURS * HOUR;
+    expect(link({ now: boundary })).toBeNull();
+    expect(link({ now: boundary - 1 })).not.toBeNull();
+  });
+
+  it('is null with no session id, rather than a URL with `undefined` in it', () => {
+    expect(link({ sessionId: null })).toBeNull();
+    expect(link({ sessionId: '   ' })).toBeNull();
+  });
+
+  it('is null when PUBLIC_GRAFANA_URL is unset, rather than linking to `undefined/explore`', () => {
+    expect(link({ grafanaUrl: undefined })).toBeNull();
+    expect(link({ grafanaUrl: '' })).toBeNull();
+  });
+
+  it('does not double the slash when the configured base carries a trailing one', () => {
+    expect(link({ grafanaUrl: `${GRAFANA}/` })!.startsWith(`${GRAFANA}/explore?`)).toBe(true);
+  });
+});

--- a/apps/moderator/src/lib/__tests__/feedback.test.ts
+++ b/apps/moderator/src/lib/__tests__/feedback.test.ts
@@ -4,6 +4,7 @@ import {
   faroSessionLink,
   feedbackAreaOptions,
   feedbackAttachmentCount,
+  handledByLabel,
   reconstructFeedbackUrl,
   splitContext,
 } from '$lib/feedback';
@@ -198,6 +199,37 @@ describe('splitContext', () => {
       )
     ).toBe(3);
     expect(feedbackAttachmentCount(splitContext({}))).toBe(0);
+  });
+});
+
+/**
+ * 🔴 Two INDEPENDENT nullables, and the two views of this row had drifted into being wrong in
+ * opposite directions — each correct for exactly the case the other got wrong. `handledById` is
+ * `ON DELETE SET NULL`; `User.username` is itself nullable.
+ */
+describe('handledByLabel', () => {
+  const at = new Date('2026-09-01T00:00:00.000Z');
+
+  it('names the handler when there is one', () => {
+    expect(handledByLabel({ handledByUsername: 'mod', handledById: 42, handledAt: at })).toBe(
+      'mod'
+    );
+  });
+
+  it('falls back to the id for a LIVE account with no username — not "deleted account"', () => {
+    expect(handledByLabel({ handledByUsername: null, handledById: 42, handledAt: at })).toBe('#42');
+  });
+
+  it('says the account is gone when the FK was nulled — not "#null"', () => {
+    expect(handledByLabel({ handledByUsername: null, handledById: null, handledAt: at })).toBe(
+      'deleted account'
+    );
+  });
+
+  it('is a dash for an unhandled row, whatever the other columns say', () => {
+    expect(handledByLabel({ handledByUsername: 'mod', handledById: 42, handledAt: null })).toBe(
+      '—'
+    );
   });
 });
 

--- a/apps/moderator/src/lib/entity-url.ts
+++ b/apps/moderator/src/lib/entity-url.ts
@@ -84,3 +84,8 @@ export const chatAuditUserUrl = (username: string) =>
  *  point on the moderation pages, and dropping it lands the reviewer on whichever version is current. */
 export const modelVersionUrl = (civitaiUrl: string, modelId: number, versionId: number) =>
   `${civitaiUrl}/models/${modelId}?modelVersionId=${versionId}`;
+
+/** The public Known Issues board. 🔴 THERE IS NO DEEP LINK — `src/pages/issues/index.tsx` reads no
+ *  id, so a link naming a specific issue still lands on the index. Here so that stays one claim in
+ *  one place, and so a future deep link is one edit. */
+export const issuesUrl = (civitaiUrl: string) => `${civitaiUrl}/issues`;

--- a/apps/moderator/src/lib/feedback.ts
+++ b/apps/moderator/src/lib/feedback.ts
@@ -183,6 +183,26 @@ export function splitContext(context: unknown): FeedbackContext {
   return out;
 }
 
+/**
+ * Who handled a row, for both the list column and the detail line.
+ *
+ * 🔴 ONE definition because the two views had drifted into being wrong in opposite directions, and
+ * each was right about exactly the case the other got wrong. There are two independent nullables:
+ * `handledById` is `ON DELETE SET NULL`, and `User.username` is itself nullable — so a deleted
+ * handler and a live handler with no username are DIFFERENT states, and neither may be rendered as
+ * the other. A bare `username ?? '#' + id` prints "#null" for the first; a bare
+ * `username ?? 'deleted account'` libels a live account for the second.
+ */
+export function handledByLabel(row: {
+  handledByUsername: string | null;
+  handledById: number | null;
+  handledAt: Date | string | null;
+}): string {
+  if (!row.handledAt) return '—';
+  if (row.handledByUsername) return row.handledByUsername;
+  return row.handledById != null ? `#${row.handledById}` : 'deleted account';
+}
+
 /** Attachments on a row, for the list's 📎 column. Counts the opt-in page capture as one. */
 export const feedbackAttachmentCount = (context: FeedbackContext): number =>
   context.images.length + (context.screenshotId ? 1 : 0);

--- a/apps/moderator/src/lib/feedback.ts
+++ b/apps/moderator/src/lib/feedback.ts
@@ -1,0 +1,276 @@
+// Pure decision functions behind `/feedback`. Everything here is reachable from the node test
+// project, which is the reason it is not inlined into the page: a wrong answer in any of them is
+// silent — a link to the wrong page, an area whose rows nobody can reach, a Grafana link that lands
+// on an empty pane.
+
+export const FEEDBACK_STATUSES = ['new', 'reviewed', 'actioned', 'dismissed'] as const;
+export type FeedbackStatus = (typeof FEEDBACK_STATUSES)[number];
+
+export const isFeedbackStatus = (value: string): value is FeedbackStatus =>
+  (FEEDBACK_STATUSES as readonly string[]).includes(value);
+
+export const DEFAULT_FEEDBACK_STATUSES: FeedbackStatus[] = ['new'];
+
+const FEEDBACK_STATUS_BADGE: Record<FeedbackStatus, string> = {
+  new: 'bg-blue-500/20 text-blue-300',
+  reviewed: 'bg-amber-500/20 text-amber-300',
+  actioned: 'bg-green-500/20 text-green-300',
+  dismissed: 'bg-dark-4 text-dark-2',
+};
+
+/**
+ * `Feedback.status` is a TEXT column behind a CHECK constraint, so what comes back is a `string`.
+ * A row carrying a value this app does not know renders unstyled rather than crashing the queue.
+ */
+export const feedbackStatusBadgeClass = (status: string): string =>
+  isFeedbackStatus(status) ? FEEDBACK_STATUS_BADGE[status] : '';
+
+/**
+ * The areas the PRODUCER knows about, mirrored from the main app's
+ * `src/shared/constants/feedback.constants.ts`.
+ *
+ * 🔴 A MIRROR, not the source. `apps/moderator` is a separate SvelteKit app with no path to the
+ * Next app's `src/`, and that constant is not exported from any workspace package, so there is no
+ * import that would make these one value.
+ *
+ * The drift this can suffer is bounded and harmless in the direction that matters: the option list
+ * is this list UNIONED with `SELECT DISTINCT area` (see `feedbackAreaOptions`), so an area added
+ * upstream and missing here is still filterable the moment it has a row, and an area retired
+ * upstream keeps its historical rows reachable. A stale entry here only ever adds an option that
+ * matches nothing.
+ */
+export const FEEDBACK_KNOWN_AREAS = [
+  'bitdex-image-feed',
+  'apps-marketplace',
+  'site-bug-report',
+] as const;
+
+/**
+ * The area filter's options.
+ *
+ * 🔴 THE UNION IS THE WHOLE POINT. Reading the TS registry alone hides the rows of any area retired
+ * from it, and reading the table alone hides an area that has no rows yet. Both failures are silent
+ * — an empty list reads as "no such feedback", never as "that option is missing".
+ */
+export function feedbackAreaOptions(
+  distinctAreas: readonly string[],
+  knownAreas: readonly string[] = FEEDBACK_KNOWN_AREAS
+): string[] {
+  return [...new Set([...distinctAreas, ...knownAreas])].filter(Boolean).sort();
+}
+
+export type FeedbackFilters = Record<string, string | number | boolean>;
+
+/**
+ * Filter values that mean "not filtering" on the surfaces that emit them, keyed by param name.
+ *
+ * Mirrors `APPS_STORE_DEFAULTS` + `appsStoreFiltersToQuery` in the main app: `/apps` omits a
+ * default from its own URL, so echoing one back builds a link the reporter never had.
+ * `category: 'none'` is the marketplace context builder's sentinel for "no category selected" — an
+ * explicit `undefined` fails the context schema's value union, so absence had to be spelled.
+ */
+const FILTER_DEFAULTS: Record<string, ReadonlyArray<string | number | boolean>> = {
+  kind: ['all'],
+  sort: ['top-rated'],
+  category: ['none'],
+};
+
+/**
+ * The URL the reporter was actually looking at.
+ *
+ * 🔴 `context.path` is `window.location.pathname` and carries NO query string, while on `/apps` the
+ * query string IS the view — so `path` alone links to a different page than the one the report is
+ * about. Rebuilding it is what makes a one-line complaint actionable.
+ *
+ * Returns `null` rather than a link when `path` is absent (it is `undefined` during SSR, by its own
+ * type) — a link to `/` would be a confident answer to a question nobody can answer.
+ *
+ * Unknown filter keys are CARRIED, not dropped: `filters` is a free record written by whichever
+ * surface produced the report, and silently discarding a key a future area puts there is the same
+ * defect `splitContext`'s "other" bucket exists to prevent. A spurious param on the rebuilt link is
+ * visible and inert (`/apps`' own schema is `.loose()`); a missing one is neither.
+ */
+export function reconstructFeedbackUrl(
+  path: string | null | undefined,
+  filters?: FeedbackFilters | null
+): string | null {
+  if (typeof path !== 'string' || !path.startsWith('/')) return null;
+
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(filters ?? {})) {
+    if (value === null || value === undefined) continue;
+    if (typeof value === 'string' && value.trim() === '') continue;
+    if (FILTER_DEFAULTS[key]?.includes(value)) continue;
+    params.append(key, String(value));
+  }
+
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+export type FeedbackContext = {
+  path: string | null;
+  filters: FeedbackFilters | null;
+  images: string[];
+  screenshotId: string | null;
+  sessionId: string | null;
+  /** Everything the five named keys did not claim. `null` when there is nothing left over. */
+  other: Record<string, unknown> | null;
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isFilterValue = (value: unknown): value is string | number | boolean =>
+  typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+
+/**
+ * Split a stored `context` payload into the keys this panel renders and everything else.
+ *
+ * 🔴 THE "OTHER" BUCKET IS NOT A NICETY. `feedbackContextSchema` already accepts `reportedSource`,
+ * `reportedPageSources` and `pagesLoaded`, which no current producer emits and a future area will.
+ * A panel that renders only the five keys it knows about discards the payload of every area added
+ * after it, and nothing says so.
+ *
+ * A known key holding an unexpected TYPE also lands in "other" rather than being dropped: `context`
+ * is JSONB with no schema at rest, written by a zod schema in a different app, so the shape is a
+ * claim. Showing the odd value beats pretending the key was absent.
+ */
+export function splitContext(context: unknown): FeedbackContext {
+  const out: FeedbackContext = {
+    path: null,
+    filters: null,
+    images: [],
+    screenshotId: null,
+    sessionId: null,
+    other: null,
+  };
+  if (!isPlainObject(context)) return out;
+
+  const other: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (value === undefined) continue;
+    if (key === 'path' && typeof value === 'string') {
+      out.path = value;
+    } else if (key === 'sessionId' && typeof value === 'string') {
+      out.sessionId = value;
+    } else if (key === 'screenshotId' && typeof value === 'string') {
+      out.screenshotId = value;
+    } else if (key === 'images' && Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+      out.images = value as string[];
+    } else if (key === 'filters' && isPlainObject(value) && Object.values(value).every(isFilterValue)) {
+      out.filters = value as FeedbackFilters;
+    } else {
+      other[key] = value;
+    }
+  }
+
+  if (Object.keys(other).length) out.other = other;
+  return out;
+}
+
+/** Attachments on a row, for the list's 📎 column. Counts the opt-in page capture as one. */
+export const feedbackAttachmentCount = (context: FeedbackContext): number =>
+  context.images.length + (context.screenshotId ? 1 : 0);
+
+/**
+ * Loki's global `retention_period`, which `{source="faro-rum"}` sits on — it declares no
+ * `retention_stream` override of its own.
+ *
+ * 🔴 A COPY OF A NUMBER OWNED BY ANOTHER REPO. Nothing makes the two agree. If Loki's retention is
+ * ever shortened this page starts offering links that land on nothing, and the mismatch is
+ * invisible from inside this codebase — so treat a LIVE link that returns no rows as evidence this
+ * constant is stale, not as evidence Faro is broken.
+ */
+export const FARO_LOKI_RETENTION_HOURS = 72;
+
+/** The window the Explore pane opens on, either side of the report. */
+const FARO_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * Loki's provisioned datasource uid — pinned in the GitOps values, not a generated hash, so it
+ * survives a redeploy.
+ */
+const LOKI_DATASOURCE_UID = 'loki';
+
+/**
+ * The LogQL a moderator gets dropped into.
+ *
+ * 🔴 RAW SUBSTRING (`|= "<id>"`), NEVER `| logfmt | session_id="<id>"`. The id appears under TWO
+ * keys in the same stream: `kind=event event_name=session_start` lines spell it `session_id=<id>`,
+ * while `faro.tracing.fetch` lines spell it `event_data_session.id=<id>`. A logfmt filter on
+ * `session_id` matches the first and silently drops the second — which are exactly the rows
+ * carrying `traceID`/`spanID`. A filter returning SOME rows is the worst failure available here,
+ * because it looks like it worked.
+ *
+ * The trade, stated rather than hidden: session ids are short opaque strings, so a substring match
+ * is not provably collision-free. A stray extra line is visible to the reader; a dropped tracing
+ * event is not.
+ *
+ * `JSON.stringify` builds the quoted literal so an id carrying a quote or a backslash cannot break
+ * out of it — `sessionId` is client-supplied and bounded in length only.
+ */
+export const faroSessionExpr = (sessionId: string): string =>
+  `{source="faro-rum"} |= ${JSON.stringify(sessionId)}`;
+
+/**
+ * A Grafana Explore link onto the reporter's own browser telemetry, or `null`.
+ *
+ * `now` is an ARGUMENT, never `Date.now()` inside: a function that reads the clock cannot be tested
+ * at the boundary it exists to enforce.
+ *
+ * 🔴 Null on THREE different absences, and the caller must say which one it is rendering:
+ *   - no `grafanaUrl` — the deployment has not been given `PUBLIC_GRAFANA_URL`. Emitting
+ *     `undefined/explore` instead is a link that looks live and is not.
+ *   - no `sessionId` — ordinary, not an error: Faro does not run in dev, test, preview, or an
+ *     ad-blocked session.
+ *   - the report is older than `FARO_LOKI_RETENTION_HOURS` — the rows are gone. "No logs found",
+ *     "this session produced no telemetry" and "the link is broken" are three different facts with
+ *     one observable, so the UI must name which one rather than showing an empty pane.
+ *
+ * THE BOUNDARY IS CLOSED ON THE EXPIRED SIDE: an age of exactly the retention window counts as
+ * expired. At that instant the sample is at the edge of eviction, and the one outcome this whole
+ * design exists to avoid is a link that resolves to nothing.
+ */
+export function faroSessionLink(input: {
+  grafanaUrl: string | null | undefined;
+  sessionId: string | null | undefined;
+  createdAt: Date | string;
+  now: number;
+}): string | null {
+  const base = input.grafanaUrl?.trim().replace(/\/+$/, '');
+  if (!base) return null;
+  const sessionId = input.sessionId?.trim();
+  if (!sessionId) return null;
+
+  const created = new Date(input.createdAt).getTime();
+  if (Number.isNaN(created)) return null;
+  if (input.now - created >= FARO_LOKI_RETENTION_HOURS * 60 * 60 * 1000) return null;
+
+  const pane = {
+    faro: {
+      datasource: LOKI_DATASOURCE_UID,
+      queries: [
+        {
+          refId: 'A',
+          datasource: { type: 'loki', uid: LOKI_DATASOURCE_UID },
+          editorMode: 'code',
+          queryType: 'range',
+          expr: faroSessionExpr(sessionId),
+        },
+      ],
+      // Epoch-ms STRINGS, which is the shape Grafana's own Explore writes.
+      range: {
+        from: String(created - FARO_WINDOW_MS),
+        to: String(created + FARO_WINDOW_MS),
+      },
+    },
+  };
+
+  const params = new URLSearchParams({
+    schemaVersion: '1',
+    orgId: '1',
+    panes: JSON.stringify(pane),
+  });
+  return `${base}/explore?${params.toString()}`;
+}

--- a/apps/moderator/src/lib/feedback.ts
+++ b/apps/moderator/src/lib/feedback.ts
@@ -1,8 +1,3 @@
-// Pure decision functions behind `/feedback`. Everything here is reachable from the node test
-// project, which is the reason it is not inlined into the page: a wrong answer in any of them is
-// silent — a link to the wrong page, an area whose rows nobody can reach, a Grafana link that lands
-// on an empty pane.
-
 export const FEEDBACK_STATUSES = ['new', 'reviewed', 'actioned', 'dismissed'] as const;
 export type FeedbackStatus = (typeof FEEDBACK_STATUSES)[number];
 
@@ -26,18 +21,10 @@ export const feedbackStatusBadgeClass = (status: string): string =>
   isFeedbackStatus(status) ? FEEDBACK_STATUS_BADGE[status] : '';
 
 /**
- * The areas the PRODUCER knows about, mirrored from the main app's
- * `src/shared/constants/feedback.constants.ts`.
- *
- * 🔴 A MIRROR, not the source. `apps/moderator` is a separate SvelteKit app with no path to the
- * Next app's `src/`, and that constant is not exported from any workspace package, so there is no
- * import that would make these one value.
- *
- * The drift this can suffer is bounded and harmless in the direction that matters: the option list
- * is this list UNIONED with `SELECT DISTINCT area` (see `feedbackAreaOptions`), so an area added
- * upstream and missing here is still filterable the moment it has a row, and an area retired
- * upstream keeps its historical rows reachable. A stale entry here only ever adds an option that
- * matches nothing.
+ * 🔴 A MIRROR of `FEEDBACK_AREAS` in the main app's `src/shared/constants/feedback.constants.ts`,
+ * which is not exported from any workspace package — so nothing keeps the two in step. The union in
+ * `feedbackAreaOptions` is what bounds the damage. To make them ONE value, move the constant into
+ * `@civitai/shared` and leave a re-export shim, as `basemodel.constants.ts` already does.
  */
 export const FEEDBACK_KNOWN_AREAS = [
   'bitdex-image-feed',
@@ -76,25 +63,25 @@ const FILTER_DEFAULTS: Record<string, ReadonlyArray<string | number | boolean>> 
 };
 
 /**
- * The URL the reporter was actually looking at.
- *
  * 🔴 `context.path` is `window.location.pathname` and carries NO query string, while on `/apps` the
- * query string IS the view — so `path` alone links to a different page than the one the report is
- * about. Rebuilding it is what makes a one-line complaint actionable.
+ * query string IS the view — so `path` alone links to a DIFFERENT page than the one the report is
+ * about.
  *
- * Returns `null` rather than a link when `path` is absent (it is `undefined` during SSR, by its own
- * type) — a link to `/` would be a confident answer to a question nobody can answer.
+ * `null` rather than a link when `path` is absent (it is `undefined` during SSR by its own type) or
+ * is not a plain path — it is client-supplied. Rejecting `//host` is defence in depth rather than a
+ * live fix: today's only caller concatenates onto a full ORIGIN, where `//host` stays a path. A
+ * caller that ever concatenates onto a bare scheme would be handed a host swap.
  *
- * Unknown filter keys are CARRIED, not dropped: `filters` is a free record written by whichever
- * surface produced the report, and silently discarding a key a future area puts there is the same
- * defect `splitContext`'s "other" bucket exists to prevent. A spurious param on the rebuilt link is
- * visible and inert (`/apps`' own schema is `.loose()`); a missing one is neither.
+ * Unknown filter keys are CARRIED, for the reason `splitContext`'s "other" bucket exists: a
+ * spurious param on the rebuilt link is visible and inert, a missing one is neither.
+ *
+ * The empty-string-means-absent rule here is the same one `$lib/url.ts` applies to live filters.
  */
 export function reconstructFeedbackUrl(
   path: string | null | undefined,
   filters?: FeedbackFilters | null
 ): string | null {
-  if (typeof path !== 'string' || !path.startsWith('/')) return null;
+  if (typeof path !== 'string' || !path.startsWith('/') || path.startsWith('//')) return null;
 
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(filters ?? {})) {
@@ -125,16 +112,30 @@ const isFilterValue = (value: unknown): value is string | number | boolean =>
   typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
 
 /**
- * Split a stored `context` payload into the keys this panel renders and everything else.
+ * A Cloudflare-images key, as the delivery URL builder requires one.
  *
- * 🔴 THE "OTHER" BUCKET IS NOT A NICETY. `feedbackContextSchema` already accepts `reportedSource`,
- * `reportedPageSources` and `pagesLoaded`, which no current producer emits and a future area will.
- * A panel that renders only the five keys it knows about discards the payload of every area added
- * after it, and nothing says so.
+ * 🔴 THIS IS A SECURITY GUARD, NOT A TIDINESS ONE. `getEdgeUrl` returns its argument VERBATIM when
+ * it starts with `http` or `blob` (`$lib/media/edge-url.ts`), and the producer bounds these values
+ * by LENGTH ONLY — `z.string().trim().min(1).max(100)`, no format at all. So an unfiltered id
+ * renders `<img src="https://attacker.example/x.png">` in a moderator's browser: an arbitrary
+ * outbound request, giving the reporter a read receipt naming which moderator opened their report
+ * and when. That is wider than the accepted risk, which was about objects in our OWN account.
  *
- * A known key holding an unexpected TYPE also lands in "other" rather than being dropped: `context`
- * is JSONB with no schema at rest, written by a zod schema in a different app, so the shape is a
- * claim. Showing the odd value beats pretending the key was absent.
+ * What actually closes it is that `:` and `/` are excluded, so no absolute, protocol-relative or
+ * `data:` URL can match and no path can be traversed. The leading negative lookahead is separate
+ * and smaller: without it an id spelled `httpsomething` still takes `getEdgeUrl`'s verbatim branch
+ * and renders as a broken SAME-ORIGIN relative src instead of a CDN one.
+ *
+ * A rejected value is not dropped — it goes to "other" and is shown as text — so nothing is hidden
+ * from triage, it just stops being a URL the browser fetches.
+ */
+const IMAGE_KEY = /^(?!https?|blob)[A-Za-z0-9][A-Za-z0-9_-]{7,99}$/;
+
+/**
+ * 🔴 THE "OTHER" BUCKET IS NOT A NICETY. `feedbackContextSchema` already accepts keys no current
+ * producer emits, so a panel rendering only the five it knows about discards the payload of every
+ * area added after it, silently. A known key holding an unexpected TYPE or an unusable VALUE lands
+ * there too — `context` is JSONB with no schema at rest, so its shape is a claim.
  */
 export function splitContext(context: unknown): FeedbackContext {
   const out: FeedbackContext = {
@@ -154,11 +155,24 @@ export function splitContext(context: unknown): FeedbackContext {
       out.path = value;
     } else if (key === 'sessionId' && typeof value === 'string') {
       out.sessionId = value;
-    } else if (key === 'screenshotId' && typeof value === 'string') {
+    } else if (key === 'screenshotId' && typeof value === 'string' && IMAGE_KEY.test(value)) {
       out.screenshotId = value;
-    } else if (key === 'images' && Array.isArray(value) && value.every((v) => typeof v === 'string')) {
-      out.images = value as string[];
-    } else if (key === 'filters' && isPlainObject(value) && Object.values(value).every(isFilterValue)) {
+    } else if (
+      key === 'images' &&
+      Array.isArray(value) &&
+      value.every((v) => typeof v === 'string')
+    ) {
+      // Deduplicated as well as filtered: `{#each … (id)}` THROWS on a duplicate key in production
+      // as well as in dev, and the array is client-supplied with no uniqueness constraint anywhere
+      // — so one repeated id makes the report permanently unopenable.
+      out.images = [...new Set((value as string[]).filter((v) => IMAGE_KEY.test(v)))];
+      // Anything dropped is still shown, as text, under "Other context".
+      if (out.images.length !== value.length) other[key] = value;
+    } else if (
+      key === 'filters' &&
+      isPlainObject(value) &&
+      Object.values(value).every(isFilterValue)
+    ) {
       out.filters = value as FeedbackFilters;
     } else {
       other[key] = value;

--- a/apps/moderator/src/lib/form-state.svelte.ts
+++ b/apps/moderator/src/lib/form-state.svelte.ts
@@ -32,6 +32,20 @@ export class FormState {
       onSuccess: ((data?: Record<string, unknown>) => void) | null;
       reload?: boolean;
       /**
+       * Clear the form's fields on a successful write. Defaults TRUE — the shape for an entry form,
+       * where the operator types something, posts it, and wants a blank box back.
+       *
+       * 🔴 Set FALSE for a form whose inputs are pre-filled from SERVER state, or the field is
+       * silently emptied and the next submit posts the empty value back. `update()` calls
+       * `HTMLFormElement.prototype.reset()`, which restores the element's `defaultValue` — and
+       * Svelte writes `element.value`, never `defaultValue`, so the default is the empty string.
+       * Repopulation afterwards depends on the bound expression CHANGING: `set_value` returns early
+       * when the new value equals the cached one, so a save that leaves the stored value untouched
+       * leaves the box blank over a column that still holds text. The next submit then overwrites
+       * that column with `''`.
+       */
+      reset?: boolean;
+      /**
        * Runs when the submit STARTS, before the server has answered.
        *
        * For the one thing `onSuccess` cannot do: read state that the response is about to replace.
@@ -77,7 +91,7 @@ export class FormState {
       // Reset on success ONLY. Clearing the fields after a refusal throws away what the operator
       // typed, on the one path where they need it back to fix and resubmit.
       await update({
-        reset: result.type === 'success',
+        reset: result.type === 'success' && (this.opts.reset ?? true),
         invalidateAll: this.opts.reload ?? false,
       });
       this.error =

--- a/apps/moderator/src/lib/permissions.ts
+++ b/apps/moderator/src/lib/permissions.ts
@@ -49,6 +49,20 @@ export const PERMISSIONS = [
   // apart so a role can be given the Audit queues without the account-ending half of them.
   { id: 'audit.ban.execute', label: 'Ban an account from an audit queue' },
   { id: 'csam.report.file', label: 'File a CSAM report' },
+  // Reading the feedback queue is what the `/feedback` PAGE grant means — there is deliberately no
+  // `feedback.read` id, because a permission duplicating a page grant is the weld this file's
+  // header records. These two are the writes.
+  //
+  // Two ids rather than one because the blast radius differs: a status and an internal note are
+  // moderator-only and reversible, while promoting mints a row in `Bug`, the table behind the
+  // public Known Issues board. Same split, same reason, as `audit.ban.execute`.
+  //
+  // They launch granted to the SAME roles — a promoted Bug lands with `publishedAt` NULL and is
+  // invisible without the `bugsEdit` flag, so the thing that would justify a narrower grant does
+  // not exist. Keeping the ids separate is what makes narrowing it later one tick on `/admin`
+  // instead of a rename, and a rename orphans stored grant rows.
+  { id: 'feedback.status.set', label: 'Set feedback status and triage notes' },
+  { id: 'feedback.bug.promote', label: 'Promote feedback to a Known Issue' },
 ] as const satisfies readonly { id: string; label: string }[];
 
 export type Permission = (typeof PERMISSIONS)[number];

--- a/apps/moderator/src/lib/server/__tests__/feedback-pglite.harness.ts
+++ b/apps/moderator/src/lib/server/__tests__/feedback-pglite.harness.ts
@@ -66,6 +66,18 @@ CREATE TABLE "ModActivity" (
 CREATE TYPE "DomainColor" AS ENUM ('blue', 'green', 'red', 'all');
 `;
 
+/**
+ * The table as it stands on a database that has NOT had `20260911120000_feedback_triage` applied —
+ * which is every environment until a human runs it, this page's own deploy window included.
+ */
+export async function freshPreMigrationDb(): Promise<PGlite> {
+  const db = await PGlite.create();
+  await db.exec(PRELUDE);
+  await db.exec(migration('20260521120000_add_bug_table'));
+  await db.exec(migration('20260813180000_feedback'));
+  return db;
+}
+
 export async function freshFeedbackDb(): Promise<PGlite> {
   const db = await PGlite.create();
   await db.exec(PRELUDE);

--- a/apps/moderator/src/lib/server/__tests__/feedback-pglite.harness.ts
+++ b/apps/moderator/src/lib/server/__tests__/feedback-pglite.harness.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PGlite } from '@electric-sql/pglite';
+import { Kysely } from 'kysely';
+import type { DB } from '@civitai/db-schema/kysely';
+import { pgliteDialect } from './abuse-detection-pglite.harness';
+
+/**
+ * The REAL `Feedback` migrations, applied to a real Postgres in-process.
+ *
+ * 🔴 WHY THIS TIER. Every guard in `feedback.service.ts` is a statement about WHICH ROWS MOVE — an
+ * UPDATE scoped on the status the operator was looking at, one scoped on `bugId IS NULL`, and a
+ * move back to `new` that has to CLEAR two columns rather than stamp them. A mocked builder can
+ * only be asked what it was told; it has no rows, so it cannot tell a correctly scoped UPDATE from
+ * one scoped to the whole table. Only rows can answer that.
+ *
+ * It is also the only thing in this app that puts the hand-applied migration SQL under test. The
+ * migration is applied by a human, per environment — nothing in CI runs it — so a column name the
+ * service and the generated types agree on, and the DDL does not, would otherwise reach production
+ * as a 42703 the first time a moderator clicks Save.
+ *
+ * 🔴 NOT SKIPPABLE. PGlite needs no server, so unlike the `EXPLAIN` tier next door this runs in CI
+ * and on a checkout with no database. A test that skips itself proves nothing.
+ *
+ * 🔴 ONE PLACE THIS TIER DOES NOT MODEL THE PRODUCTION DRIVER — measured, not assumed. A JS `Date`
+ * sent as a parameter against a `timestamp WITHOUT time zone` column is serialised by PGlite as UTC
+ * (`toISOString`) while the column is READ BACK as local, so the round trip is shifted by the local
+ * offset: seeding `2026-09-01T00:00:00Z`, reading it back and filtering `createdAt < thatValue`
+ * returns the row itself. node-postgres does not have this — its `prepareValue` calls `dateToString`,
+ * which emits LOCAL time with an explicit offset, matching how `postgres-date` parses the column
+ * back. So a timestamp comparison that fails HERE is not necessarily wrong in production, and one
+ * that passes here is not necessarily right. `feedback.service.ts` sidesteps it by keying its
+ * cursor on the row id; anything that must compare timestamps needs a serialiser fixed in this
+ * harness first, not a test written around the shift.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** `apps/moderator/src/lib/server/__tests__` → the repo root. */
+const MIGRATIONS = join(HERE, '../../../../../../packages/civitai-db-schema/prisma/migrations');
+
+const migration = (name: string) => readFileSync(join(MIGRATIONS, name, 'migration.sql'), 'utf8');
+
+/**
+ * The two tables `Feedback`'s foreign keys point at, cut to what these tests touch.
+ *
+ * `User` and `ModActivity` are stand-ins — their real DDL drags in most of the schema and neither
+ * is under test here. `Bug` is NOT a stand-in: it is the real `20260521120000_add_bug_table`
+ * migration, because `promoteFeedbackToBug` inserts into it and the point of the test is that the
+ * insert satisfies every NOT NULL the real table declares. `DomainColor` is declared because that
+ * migration's `domain` column is typed on it.
+ */
+const PRELUDE = `
+CREATE TABLE "User" (
+  "id" SERIAL PRIMARY KEY,
+  "username" TEXT
+);
+CREATE TABLE "ModActivity" (
+  "id" SERIAL PRIMARY KEY,
+  "userId" INTEGER,
+  "entityType" TEXT,
+  "entityId" INTEGER,
+  "activity" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TYPE "DomainColor" AS ENUM ('blue', 'green', 'red', 'all');
+`;
+
+export async function freshFeedbackDb(): Promise<PGlite> {
+  const db = await PGlite.create();
+  await db.exec(PRELUDE);
+  await db.exec(migration('20260521120000_add_bug_table'));
+  await db.exec(migration('20260813180000_feedback'));
+  // The migration under test. Applied by hand per environment — this is the only place anything
+  // executes it.
+  await db.exec(migration('20260911120000_feedback_triage'));
+  return db;
+}
+
+/** A client typed exactly as `$lib/server/db`'s, over the in-process database. */
+export const feedbackKysely = (db: PGlite): Kysely<DB> =>
+  new Kysely<DB>({ dialect: pgliteDialect(db) });
+
+export async function seedUser(db: PGlite, username: string): Promise<number> {
+  const res = await db.query<{ id: number }>(
+    'INSERT INTO "User" ("username") VALUES ($1) RETURNING "id"',
+    [username]
+  );
+  return res.rows[0].id;
+}
+
+export async function seedFeedback(
+  db: PGlite,
+  row: {
+    userId: number;
+    area?: string;
+    message?: string;
+    context?: unknown;
+    status?: string;
+    createdAt?: string;
+  }
+): Promise<number> {
+  const res = await db.query<{ id: number }>(
+    `INSERT INTO "Feedback" ("area", "userId", "message", "context", "status", "createdAt")
+     VALUES ($1, $2, $3, $4::jsonb, $5, $6) RETURNING "id"`,
+    [
+      row.area ?? 'apps-marketplace',
+      row.userId,
+      row.message ?? 'the list is empty',
+      JSON.stringify(row.context ?? {}),
+      row.status ?? 'new',
+      row.createdAt ?? '2026-09-01T12:00:00.000Z',
+    ]
+  );
+  return res.rows[0].id;
+}
+
+export async function readFeedback(db: PGlite, id: number) {
+  const res = await db.query<{
+    status: string;
+    triageNote: string | null;
+    handledById: number | null;
+    handledAt: Date | null;
+    bugId: number | null;
+  }>(
+    'SELECT "status", "triageNote", "handledById", "handledAt", "bugId" FROM "Feedback" WHERE "id" = $1',
+    [id]
+  );
+  return res.rows[0];
+}
+
+export async function countRows(db: PGlite, table: string): Promise<number> {
+  const res = await db.query<{ n: string }>(`SELECT count(*)::text AS n FROM "${table}"`);
+  return Number(res.rows[0].n);
+}

--- a/apps/moderator/src/lib/server/__tests__/feedback.service.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/feedback.service.test.ts
@@ -1,0 +1,372 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  countRows,
+  feedbackKysely,
+  freshFeedbackDb,
+  readFeedback,
+  seedFeedback,
+  seedUser,
+} from './feedback-pglite.harness';
+
+/**
+ * `feedback.service.ts`, EXECUTED against a real Postgres carrying the real migrations.
+ *
+ * Every case here is about WHICH ROWS MOVE. A mocked query builder can be asked what it was told
+ * and nothing else, so it cannot distinguish "the UPDATE was scoped on the status the operator was
+ * looking at" from "the UPDATE was scoped on the id alone" — and those two differ only when a
+ * second moderator is mid-verdict, which is exactly when it matters.
+ */
+
+const { dbHandle } = vi.hoisted(() => ({ dbHandle: { current: null as unknown } }));
+
+vi.mock('../db', () => ({
+  get dbRead() {
+    if (!dbHandle.current) throw new Error('the pglite client was not installed for this test');
+    return dbHandle.current;
+  },
+  get dbWrite() {
+    if (!dbHandle.current) throw new Error('the pglite client was not installed for this test');
+    return dbHandle.current;
+  },
+}));
+
+const service = await import('../feedback.service');
+
+let db: PGlite;
+let reporter: number;
+let moderator: number;
+
+beforeEach(async () => {
+  db = await freshFeedbackDb();
+  dbHandle.current = feedbackKysely(db);
+  reporter = await seedUser(db, 'kaeru');
+  moderator = await seedUser(db, 'mod');
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  dbHandle.current = null;
+  await db.close();
+});
+
+describe('triageFeedback', () => {
+  it('moves the row and stamps who handled it', async () => {
+    const id = await seedFeedback(db, { userId: reporter });
+
+    const result = await service.triageFeedback({
+      id,
+      status: 'dismissed',
+      expectedStatus: 'new',
+      note: 'retired surface',
+      moderatorId: moderator,
+    });
+
+    expect(result).toEqual({ ok: true, changed: true });
+    const row = await readFeedback(db, id);
+    expect(row.status).toBe('dismissed');
+    expect(row.triageNote).toBe('retired surface');
+    expect(row.handledById).toBe(moderator);
+    expect(row.handledAt).not.toBeNull();
+  });
+
+  /**
+   * 🔴 THE CONCURRENCY GUARD. Without `AND "status" = $expectedStatus` this returns
+   * `{ changed: true }` and silently replaces a colleague's verdict — with a green screen over it.
+   */
+  it('changes NOTHING when the row already moved under the operator', async () => {
+    const id = await seedFeedback(db, { userId: reporter, status: 'actioned' });
+
+    const result = await service.triageFeedback({
+      id,
+      status: 'dismissed',
+      expectedStatus: 'new',
+      note: null,
+      moderatorId: moderator,
+    });
+
+    expect(result).toEqual({ ok: true, changed: false });
+    expect((await readFeedback(db, id)).status).toBe('actioned');
+  });
+
+  it('separates a row that is GONE from one another moderator moved', async () => {
+    const result = await service.triageFeedback({
+      id: 9999,
+      status: 'reviewed',
+      expectedStatus: 'new',
+      note: null,
+      moderatorId: moderator,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'gone' });
+  });
+
+  /**
+   * 🔴 Moving a row back to `new` CLEARS the handler. Stamping it would leave "handled by
+   * <moderator>" on a row sitting in the unhandled queue — a claim the screen cannot support.
+   */
+  it('clears handledById and handledAt when a row goes back to `new`', async () => {
+    const id = await seedFeedback(db, { userId: reporter });
+    await service.triageFeedback({
+      id,
+      status: 'actioned',
+      expectedStatus: 'new',
+      note: null,
+      moderatorId: moderator,
+    });
+
+    const result = await service.triageFeedback({
+      id,
+      status: 'new',
+      expectedStatus: 'actioned',
+      note: 'reopened',
+      moderatorId: moderator,
+    });
+
+    expect(result).toEqual({ ok: true, changed: true });
+    const row = await readFeedback(db, id);
+    expect(row.status).toBe('new');
+    expect(row.handledById).toBeNull();
+    expect(row.handledAt).toBeNull();
+  });
+
+  it('touches only the row it names', async () => {
+    const id = await seedFeedback(db, { userId: reporter });
+    const other = await seedFeedback(db, { userId: reporter });
+
+    await service.triageFeedback({
+      id,
+      status: 'reviewed',
+      expectedStatus: 'new',
+      note: null,
+      moderatorId: moderator,
+    });
+
+    expect((await readFeedback(db, other)).status).toBe('new');
+  });
+
+  it('records the mod activity only when a row actually moved', async () => {
+    const id = await seedFeedback(db, { userId: reporter, status: 'actioned' });
+
+    await service.triageFeedback({
+      id,
+      status: 'reviewed',
+      expectedStatus: 'new',
+      note: null,
+      moderatorId: moderator,
+    });
+    expect(await countRows(db, 'ModActivity')).toBe(0);
+
+    await service.triageFeedback({
+      id,
+      status: 'reviewed',
+      expectedStatus: 'actioned',
+      note: null,
+      moderatorId: moderator,
+    });
+    expect(await countRows(db, 'ModActivity')).toBe(1);
+  });
+});
+
+describe('promoteFeedbackToBug', () => {
+  it('inserts a Bug that satisfies every NOT NULL the real table declares, and links it', async () => {
+    const id = await seedFeedback(db, { userId: reporter });
+
+    const result = await service.promoteFeedbackToBug({
+      id,
+      title: 'Sort resets on back',
+      summary: 'The store loses ?sort on Back.',
+      moderatorId: moderator,
+    });
+
+    expect(result).toMatchObject({ ok: true, created: true });
+    const bug = await db.query<{
+      id: number;
+      title: string;
+      summary: string;
+      status: string;
+      publishedAt: Date | null;
+      resolvedAt: Date | null;
+      content: string | null;
+      updatedAt: Date | null;
+    }>('SELECT * FROM "Bug"');
+    expect(bug.rows).toHaveLength(1);
+    expect(bug.rows[0]).toMatchObject({
+      title: 'Sort resets on back',
+      summary: 'The store loses ?sort on Back.',
+      status: 'Open',
+      // 🔴 NULL is what keeps the reporter's words off the public Known Issues board — `getBugs`
+      // hides an unpublished Bug from anyone without the `bugsEdit` flag.
+      publishedAt: null,
+      resolvedAt: null,
+      // 🔴 NULL deliberately. `content` is stored and rendered as HTML; the feedback message is
+      // plain text a user typed, and this app does not go through the sanitising zod schema.
+      content: null,
+    });
+    // `updatedAt` is `@updatedAt` in Prisma — a CLIENT-side stamp. The column is NOT NULL with no
+    // database default and this app installs no updatedAt plugin, so omitting it is a 23502.
+    expect(bug.rows[0].updatedAt).not.toBeNull();
+
+    const row = await readFeedback(db, id);
+    expect(row.bugId).toBe(bug.rows[0].id);
+    expect(row.status).toBe('actioned');
+    expect(row.handledById).toBe(moderator);
+  });
+
+  /**
+   * 🔴 `AND "bugId" IS NULL` makes double-promotion impossible — and the Bug insert must roll back
+   * WITH it, or a second click leaves an orphan row on the table the public board reads.
+   */
+  it('refuses a second promotion and leaves no orphan Bug behind', async () => {
+    const id = await seedFeedback(db, { userId: reporter });
+    await service.promoteFeedbackToBug({ id, title: 'a', summary: 'b', moderatorId: moderator });
+
+    const result = await service.promoteFeedbackToBug({
+      id,
+      title: 'a second one',
+      summary: 'b',
+      moderatorId: moderator,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'already-linked' });
+    expect(await countRows(db, 'Bug')).toBe(1);
+  });
+});
+
+describe('linkFeedbackToBug', () => {
+  it('attaches a second report to an issue that already exists', async () => {
+    const first = await seedFeedback(db, { userId: reporter });
+    const second = await seedFeedback(db, { userId: reporter });
+    const promoted = await service.promoteFeedbackToBug({
+      id: first,
+      title: 'a',
+      summary: 'b',
+      moderatorId: moderator,
+    });
+    if (!promoted.ok) throw new Error('the first promotion should have succeeded');
+
+    const result = await service.linkFeedbackToBug({
+      id: second,
+      bugId: promoted.bugId,
+      moderatorId: moderator,
+    });
+
+    expect(result).toMatchObject({ ok: true, created: false });
+    expect(await countRows(db, 'Bug')).toBe(1);
+    expect((await readFeedback(db, second)).bugId).toBe(promoted.bugId);
+  });
+
+  it('refuses an issue number that does not exist, rather than writing a dangling link', async () => {
+    const id = await seedFeedback(db, { userId: reporter });
+
+    const result = await service.linkFeedbackToBug({ id, bugId: 4242, moderatorId: moderator });
+
+    expect(result).toEqual({ ok: false, reason: 'no-such-bug' });
+    expect((await readFeedback(db, id)).bugId).toBeNull();
+  });
+});
+
+describe('reads', () => {
+  it('lists newest first, joins the reporter and pages on a keyset', async () => {
+    const older = await seedFeedback(db, {
+      userId: reporter,
+      createdAt: '2026-08-01T00:00:00.000Z',
+    });
+    const newer = await seedFeedback(db, {
+      userId: reporter,
+      createdAt: '2026-09-01T00:00:00.000Z',
+    });
+
+    const first = await service.getFeedbackList({ statuses: ['new'], limit: 1 });
+    expect(first.items.map((r) => r.id)).toEqual([newer]);
+    expect(first.items[0].username).toBe('kaeru');
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await service.getFeedbackList({
+      statuses: ['new'],
+      limit: 1,
+      cursor: service.decodeFeedbackCursor(first.nextCursor),
+    });
+    expect(second.items.map((r) => r.id)).toEqual([older]);
+    expect(second.nextCursor).toBeNull();
+  });
+
+  it('treats an empty status selection as every status, not as none', async () => {
+    await seedFeedback(db, { userId: reporter, status: 'dismissed' });
+
+    expect((await service.getFeedbackList({ statuses: [] })).items).toHaveLength(1);
+    expect((await service.getFeedbackList({ statuses: ['new'] })).items).toHaveLength(0);
+  });
+
+  it('filters by area', async () => {
+    await seedFeedback(db, { userId: reporter, area: 'apps-marketplace' });
+    await seedFeedback(db, { userId: reporter, area: 'bitdex-image-feed' });
+
+    const rows = await service.getFeedbackList({ statuses: [], area: 'bitdex-image-feed' });
+    expect(rows.items.map((r) => r.area)).toEqual(['bitdex-image-feed']);
+  });
+
+  it('counts only `new` for the sidebar badge', async () => {
+    await seedFeedback(db, { userId: reporter });
+    await seedFeedback(db, { userId: reporter, status: 'dismissed' });
+
+    expect(await service.countNewFeedback()).toBe(1);
+  });
+
+  it('reports the areas that actually have rows, including a retired one', async () => {
+    await seedFeedback(db, { userId: reporter, area: 'bitdex-image-feed' });
+
+    expect(await service.getFeedbackAreas()).toEqual(['bitdex-image-feed']);
+  });
+
+  it('lists the sibling reports on one issue and excludes the row being read', async () => {
+    const first = await seedFeedback(db, { userId: reporter });
+    const second = await seedFeedback(db, { userId: reporter });
+    const promoted = await service.promoteFeedbackToBug({
+      id: first,
+      title: 'a',
+      summary: 'b',
+      moderatorId: moderator,
+    });
+    if (!promoted.ok) throw new Error('the promotion should have succeeded');
+    await service.linkFeedbackToBug({
+      id: second,
+      bugId: promoted.bugId,
+      moderatorId: moderator,
+    });
+
+    const siblings = await service.getSiblingFeedback({
+      bugId: promoted.bugId,
+      excludeId: first,
+    });
+    expect(siblings.map((s) => s.id)).toEqual([second]);
+  });
+
+  it('surfaces the linked issue’s CURRENT title and status on the row', async () => {
+    const id = await seedFeedback(db, { userId: reporter });
+    const promoted = await service.promoteFeedbackToBug({
+      id,
+      title: 'Sort resets',
+      summary: 'b',
+      moderatorId: moderator,
+    });
+    if (!promoted.ok) throw new Error('the promotion should have succeeded');
+    // What the inbound ClickUp webhook does to `Bug.status` — the entire point of routing a
+    // promoted report through `Bug` is that the moderator sees this answer.
+    await db.query('UPDATE "Bug" SET "status" = $1 WHERE "id" = $2', ['Complete', promoted.bugId]);
+
+    const [row] = (await service.getFeedbackList({ statuses: [] })).items;
+    expect(row.bugTitle).toBe('Sort resets');
+    expect(row.bugStatus).toBe('Complete');
+  });
+});
+
+describe('decodeFeedbackCursor', () => {
+  it('refuses a hand-edited cursor rather than 500ing the queue', () => {
+    // `Feedback.id` is a Postgres integer: a larger value ERRORS the comparison rather than
+    // missing, so an unbounded cursor would 500 the page instead of finding nothing.
+    for (const bad of ['', 'abc', '0', '-4', '1.5', '2147483648', null, undefined])
+      expect(service.decodeFeedbackCursor(bad)).toBeNull();
+    expect(service.decodeFeedbackCursor('42')).toBe(42);
+  });
+});

--- a/apps/moderator/src/lib/server/__tests__/feedback.service.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/feedback.service.test.ts
@@ -396,10 +396,13 @@ describe('linkFeedbackToBug', () => {
  */
 describe('isMissingTriageColumns', () => {
   /**
-   * 🔴 AGAINST A REAL DRIVER ERROR, not a hand-built object. Both other cases in this describe
-   * construct `{ code, message }` themselves, which pins the predicate's logic and says nothing
-   * about whether `pg` puts `code` where the predicate looks. This one runs the real query against
-   * the real pre-migration table and asserts on whatever comes back.
+   * 🔴 AGAINST A REAL DRIVER ERROR, not a hand-built object. Every OTHER case in this describe
+   * constructs `{ code, message }` itself, which pins the predicate's logic and says nothing about
+   * whether `pg` puts `code` where the predicate looks. This one runs the real query against the
+   * real pre-migration table and asserts on whatever comes back.
+   *
+   * (Deliberately "every other" rather than a count: a count written beside the thing it counts
+   * drifts the next time a case is added, and this one already did.)
    */
   it('fires on the error a genuinely unmigrated table actually raises', async () => {
     const pre = await freshPreMigrationDb();

--- a/apps/moderator/src/lib/server/__tests__/feedback.service.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/feedback.service.test.ts
@@ -231,6 +231,23 @@ describe('promoteFeedbackToBug', () => {
     expect(result).toEqual({ ok: false, reason: 'already-linked' });
     expect(await countRows(db, 'Bug')).toBe(1);
   });
+
+  /**
+   * The `gone` branch reached from INSIDE the promote transaction. Distinct from
+   * `linkFeedbackToBug`'s twin: this one resolves its reason against the open transaction rather
+   * than a separate client, and it must roll the Bug insert back with it.
+   */
+  it('reports a report that vanished mid-promotion as gone, and leaves no Bug behind', async () => {
+    const result = await service.promoteFeedbackToBug({
+      id: 9999,
+      title: 'a',
+      summary: 'b',
+      moderatorId: moderator,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'gone' });
+    expect(await countRows(db, 'Bug')).toBe(0);
+  });
 });
 
 describe('linkFeedbackToBug', () => {
@@ -254,6 +271,26 @@ describe('linkFeedbackToBug', () => {
     expect(result).toMatchObject({ ok: true, created: false });
     expect(await countRows(db, 'Bug')).toBe(1);
     expect((await readFeedback(db, second)).bugId).toBe(promoted.bugId);
+  });
+
+  it('reports a DELETED report as gone, not as a conflict over an issue', async () => {
+    const id = await seedFeedback(db, { userId: reporter });
+    const promoted = await service.promoteFeedbackToBug({
+      id,
+      title: 'a',
+      summary: 'b',
+      moderatorId: moderator,
+    });
+    if (!promoted.ok) throw new Error('the promotion should have succeeded');
+    await db.query('DELETE FROM "Feedback" WHERE "id" = $1', [id]);
+
+    const result = await service.linkFeedbackToBug({
+      id,
+      bugId: promoted.bugId,
+      moderatorId: moderator,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'gone' });
   });
 
   it('refuses an issue number that does not exist, rather than writing a dangling link', async () => {
@@ -285,7 +322,7 @@ describe('reads', () => {
     const second = await service.getFeedbackList({
       statuses: ['new'],
       limit: 1,
-      cursor: service.decodeFeedbackCursor(first.nextCursor),
+      cursor: first.nextCursor,
     });
     expect(second.items.map((r) => r.id)).toEqual([older]);
     expect(second.nextCursor).toBeNull();
@@ -358,15 +395,5 @@ describe('reads', () => {
     const [row] = (await service.getFeedbackList({ statuses: [] })).items;
     expect(row.bugTitle).toBe('Sort resets');
     expect(row.bugStatus).toBe('Complete');
-  });
-});
-
-describe('decodeFeedbackCursor', () => {
-  it('refuses a hand-edited cursor rather than 500ing the queue', () => {
-    // `Feedback.id` is a Postgres integer: a larger value ERRORS the comparison rather than
-    // missing, so an unbounded cursor would 500 the page instead of finding nothing.
-    for (const bad of ['', 'abc', '0', '-4', '1.5', '2147483648', null, undefined])
-      expect(service.decodeFeedbackCursor(bad)).toBeNull();
-    expect(service.decodeFeedbackCursor('42')).toBe(42);
   });
 });

--- a/apps/moderator/src/lib/server/__tests__/feedback.service.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/feedback.service.test.ts
@@ -4,6 +4,7 @@ import {
   countRows,
   feedbackKysely,
   freshFeedbackDb,
+  freshPreMigrationDb,
   readFeedback,
   seedFeedback,
   seedUser,
@@ -139,12 +140,13 @@ describe('triageFeedback', () => {
   });
 
   /**
-   * 🔴 A row reopened to `new` while still carrying a `bugId` is a DEAD END: the panel shows the
-   * linked-issue view instead of the promote form, and `linkInTransaction` refuses any row whose
-   * `bugId` is set — so it can be neither re-promoted nor attached elsewhere, and there is no
-   * unlink control anywhere in the app.
+   * 🔴 THE LINK SURVIVES A REOPEN. Clearing it here was tried and reverted: `handledById` and
+   * `handledAt` record who acted, which a reopen retracts, but the link records that this report
+   * is ABOUT that issue, which a reopen does not make false. Clearing it destroyed that with no
+   * way back — the number is stored nowhere else — and orphaned a `Bug` that
+   * `promoteFeedbackToBug` rolls back a transaction rather than create.
    */
-  it('clears the issue link when a row goes back to `new`, so it can be triaged again', async () => {
+  it('keeps the issue link when a row goes back to `new`, and still clears the handler', async () => {
     const id = await seedFeedback(db, { userId: reporter });
     const promoted = await service.promoteFeedbackToBug({
       id,
@@ -153,7 +155,6 @@ describe('triageFeedback', () => {
       moderatorId: moderator,
     });
     if (!promoted.ok) throw new Error('the promotion should have succeeded');
-    expect((await readFeedback(db, id)).bugId).toBe(promoted.bugId);
 
     await service.triageFeedback({
       id,
@@ -163,14 +164,35 @@ describe('triageFeedback', () => {
       moderatorId: moderator,
     });
 
-    expect((await readFeedback(db, id)).bugId).toBeNull();
-    // And it is re-attachable, which is the whole point.
-    const relinked = await service.linkFeedbackToBug({
-      id,
-      bugId: promoted.bugId,
+    const row = await readFeedback(db, id);
+    expect(row.bugId).toBe(promoted.bugId);
+    expect(row.handledById).toBeNull();
+    expect(row.handledAt).toBeNull();
+  });
+
+  /** The sibling panel is the only place the association is readable; a reopen must not empty it. */
+  it('leaves a reopened row visible to its siblings', async () => {
+    const first = await seedFeedback(db, { userId: reporter });
+    const second = await seedFeedback(db, { userId: reporter });
+    const promoted = await service.promoteFeedbackToBug({
+      id: first,
+      title: 'a',
+      summary: 'b',
       moderatorId: moderator,
     });
-    expect(relinked).toMatchObject({ ok: true });
+    if (!promoted.ok) throw new Error('the promotion should have succeeded');
+    await service.linkFeedbackToBug({ id: second, bugId: promoted.bugId, moderatorId: moderator });
+
+    await service.triageFeedback({
+      id: first,
+      status: 'new',
+      expectedStatus: 'actioned',
+      note: null,
+      moderatorId: moderator,
+    });
+
+    const siblings = await service.getSiblingFeedback({ bugId: promoted.bugId, excludeId: second });
+    expect(siblings.map((r) => r.id)).toEqual([first]);
   });
 
   it('keeps the issue link on any status that is not `new`', async () => {
@@ -373,14 +395,66 @@ describe('linkFeedbackToBug', () => {
  * discrimination are pinned separately, and neither can go stale behind the other.
  */
 describe('isMissingTriageColumns', () => {
-  it('accepts exactly the undefined-column code', () => {
-    expect(service.isMissingTriageColumns({ code: '42703' })).toBe(true);
+  /**
+   * 🔴 AGAINST A REAL DRIVER ERROR, not a hand-built object. Both other cases in this describe
+   * construct `{ code, message }` themselves, which pins the predicate's logic and says nothing
+   * about whether `pg` puts `code` where the predicate looks. This one runs the real query against
+   * the real pre-migration table and asserts on whatever comes back.
+   */
+  it('fires on the error a genuinely unmigrated table actually raises', async () => {
+    const pre = await freshPreMigrationDb();
+    const previous = dbHandle.current;
+    dbHandle.current = feedbackKysely(pre);
+    try {
+      await seedUser(pre, 'someone');
+      const caught = await service.getFeedbackList({ statuses: [] }).then(
+        () => null,
+        (e: unknown) => e
+      );
+
+      expect(caught).not.toBeNull();
+      // The code is top level on `DatabaseError`; `createKyselyClients` uses a stock
+      // `PostgresDialect` over `pg.Pool`, which does not wrap it.
+      expect((caught as { code?: string }).code).toBe('42703');
+      expect(String((caught as { message?: string }).message)).toContain('does not exist');
+      expect(service.isMissingTriageColumns(caught)).toBe(true);
+    } finally {
+      dbHandle.current = previous;
+      await pre.close();
+    }
+  });
+
+  it('accepts the undefined-column code when the message names a triage column', () => {
+    for (const column of ['triageNote', 'handledById', 'handledAt', 'bugId'])
+      expect(
+        service.isMissingTriageColumns({
+          code: '42703',
+          message: `column f.${column} does not exist`,
+        })
+      ).toBe(true);
+  });
+
+  /**
+   * 🔴 THE POINT OF NARROWING IT. The page answers with one specific instruction — apply THIS
+   * migration — and `42703` is raised by any reference to any absent column. Matching the code
+   * alone would give that answer to a typo in an unrelated edit, with the `catch` suppressing the
+   * error that would otherwise have named it.
+   */
+  it('declines a 42703 about some OTHER column, so the page cannot misdirect', () => {
+    expect(
+      service.isMissingTriageColumns({
+        code: '42703',
+        message: 'column f.nsfwLevel does not exist',
+      })
+    ).toBe(false);
   });
 
   it('rejects every other database error, so an outage cannot render as an empty queue', () => {
     // 57P01 admin shutdown, 08006 connection failure, 42P01 undefined TABLE, 23505 unique violation.
     for (const code of ['57P01', '08006', '42P01', '23505', '', '4270'])
-      expect(service.isMissingTriageColumns({ code })).toBe(false);
+      expect(
+        service.isMissingTriageColumns({ code, message: 'column f.bugId does not exist' })
+      ).toBe(false);
   });
 
   it('rejects a value that is not an error object at all', () => {
@@ -394,8 +468,14 @@ describe('reads', () => {
    * 🔴 THREE rows at `limit: 2`, never two at `limit: 1`. The cursor is the LAST item's id, and at
    * a page size of one the first and last elements of a page are the same object — so a fixture
    * built that way cannot distinguish `items[items.length - 1].id` from `items[0].id`, and the
-   * mutant that swaps them SURVIVES a green run. In production `FEEDBACK_PAGE_SIZE` is 50, where
-   * that swap repeats 49 rows on page 2 and makes 49 unreachable.
+   * mutant that swaps them SURVIVES a green run.
+   *
+   * What the swap actually costs, walked against this harness rather than reasoned about: the
+   * cursor becomes the page's HIGHEST id, so page N+1 starts one id below page N's FIRST row.
+   * Seven rows at `limit: 3` paged 7-6-5 / 6-5-4 / 5-4-3 / 4-3-2 / 3-2-1 — every id still reached,
+   * each turn repeating all but one row and advancing by one. At `FEEDBACK_PAGE_SIZE` 50 that is
+   * 49 of 50 repeated per turn and a queue that drains 50× slower. NOTHING becomes unreachable;
+   * an earlier version of this comment said 49 rows did, and that was never derived.
    */
   it('lists newest first, joins the reporter and pages on a keyset', async () => {
     const oldest = await seedFeedback(db, {

--- a/apps/moderator/src/lib/server/__tests__/feedback.service.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/feedback.service.test.ts
@@ -396,13 +396,12 @@ describe('linkFeedbackToBug', () => {
  */
 describe('isMissingTriageColumns', () => {
   /**
-   * 🔴 AGAINST A REAL DRIVER ERROR, not a hand-built object. Every OTHER case in this describe
-   * constructs `{ code, message }` itself, which pins the predicate's logic and says nothing about
-   * whether `pg` puts `code` where the predicate looks. This one runs the real query against the
-   * real pre-migration table and asserts on whatever comes back.
-   *
-   * (Deliberately "every other" rather than a count: a count written beside the thing it counts
-   * drifts the next time a case is added, and this one already did.)
+   * 🔴 AGAINST A REAL DRIVER ERROR, not a hand-built object. Every other case here that feeds the
+   * predicate an ERROR-SHAPED value constructs `{ code, message }` itself, which pins the
+   * predicate's logic and says nothing about whether `pg` puts `code` where the predicate looks.
+   * (The last case in this block deliberately feeds it non-error values, so the qualifier is
+   * load-bearing rather than decorative.) This one runs the real query against the real
+   * pre-migration table and asserts on whatever comes back.
    */
   it('fires on the error a genuinely unmigrated table actually raises', async () => {
     const pre = await freshPreMigrationDb();

--- a/apps/moderator/src/lib/server/__tests__/feedback.service.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/feedback.service.test.ts
@@ -18,6 +18,14 @@ import {
  * second moderator is mid-verdict, which is exactly when it matters.
  */
 
+/**
+ * ⚠️ ONE DIMENSION THIS TIER CANNOT SEE, recorded so nobody reads a green run as covering it.
+ * Both getters below resolve to the SAME PGlite client, because PGlite is a single in-process
+ * database with no replica. So every `dbRead` vs `dbWrite` choice in the service is unpinned here:
+ * a mutant swapping either direction survives, including `feedbackExists(dbWrite, …)`, which is
+ * what decides whether a refusal says "that report is gone" or "someone else already triaged it".
+ * Those call sites are verified by reading them, not by this suite.
+ */
 const { dbHandle } = vi.hoisted(() => ({ dbHandle: { current: null as unknown } }));
 
 vi.mock('../db', () => ({
@@ -128,6 +136,62 @@ describe('triageFeedback', () => {
     expect(row.status).toBe('new');
     expect(row.handledById).toBeNull();
     expect(row.handledAt).toBeNull();
+  });
+
+  /**
+   * 🔴 A row reopened to `new` while still carrying a `bugId` is a DEAD END: the panel shows the
+   * linked-issue view instead of the promote form, and `linkInTransaction` refuses any row whose
+   * `bugId` is set — so it can be neither re-promoted nor attached elsewhere, and there is no
+   * unlink control anywhere in the app.
+   */
+  it('clears the issue link when a row goes back to `new`, so it can be triaged again', async () => {
+    const id = await seedFeedback(db, { userId: reporter });
+    const promoted = await service.promoteFeedbackToBug({
+      id,
+      title: 'a',
+      summary: 'b',
+      moderatorId: moderator,
+    });
+    if (!promoted.ok) throw new Error('the promotion should have succeeded');
+    expect((await readFeedback(db, id)).bugId).toBe(promoted.bugId);
+
+    await service.triageFeedback({
+      id,
+      status: 'new',
+      expectedStatus: 'actioned',
+      note: null,
+      moderatorId: moderator,
+    });
+
+    expect((await readFeedback(db, id)).bugId).toBeNull();
+    // And it is re-attachable, which is the whole point.
+    const relinked = await service.linkFeedbackToBug({
+      id,
+      bugId: promoted.bugId,
+      moderatorId: moderator,
+    });
+    expect(relinked).toMatchObject({ ok: true });
+  });
+
+  it('keeps the issue link on any status that is not `new`', async () => {
+    const id = await seedFeedback(db, { userId: reporter });
+    const promoted = await service.promoteFeedbackToBug({
+      id,
+      title: 'a',
+      summary: 'b',
+      moderatorId: moderator,
+    });
+    if (!promoted.ok) throw new Error('the promotion should have succeeded');
+
+    await service.triageFeedback({
+      id,
+      status: 'dismissed',
+      expectedStatus: 'actioned',
+      note: null,
+      moderatorId: moderator,
+    });
+
+    expect((await readFeedback(db, id)).bugId).toBe(promoted.bugId);
   });
 
   it('touches only the row it names', async () => {
@@ -303,28 +367,62 @@ describe('linkFeedbackToBug', () => {
   });
 });
 
+/**
+ * The predicate the page's degraded empty state turns on. Tested HERE rather than through `load`,
+ * because the route suite drives that branch with its own stub — so the branch and the
+ * discrimination are pinned separately, and neither can go stale behind the other.
+ */
+describe('isMissingTriageColumns', () => {
+  it('accepts exactly the undefined-column code', () => {
+    expect(service.isMissingTriageColumns({ code: '42703' })).toBe(true);
+  });
+
+  it('rejects every other database error, so an outage cannot render as an empty queue', () => {
+    // 57P01 admin shutdown, 08006 connection failure, 42P01 undefined TABLE, 23505 unique violation.
+    for (const code of ['57P01', '08006', '42P01', '23505', '', '4270'])
+      expect(service.isMissingTriageColumns({ code })).toBe(false);
+  });
+
+  it('rejects a value that is not an error object at all', () => {
+    for (const bad of [null, undefined, '42703', 42703, {}])
+      expect(service.isMissingTriageColumns(bad)).toBe(false);
+  });
+});
+
 describe('reads', () => {
+  /**
+   * 🔴 THREE rows at `limit: 2`, never two at `limit: 1`. The cursor is the LAST item's id, and at
+   * a page size of one the first and last elements of a page are the same object — so a fixture
+   * built that way cannot distinguish `items[items.length - 1].id` from `items[0].id`, and the
+   * mutant that swaps them SURVIVES a green run. In production `FEEDBACK_PAGE_SIZE` is 50, where
+   * that swap repeats 49 rows on page 2 and makes 49 unreachable.
+   */
   it('lists newest first, joins the reporter and pages on a keyset', async () => {
-    const older = await seedFeedback(db, {
+    const oldest = await seedFeedback(db, {
+      userId: reporter,
+      createdAt: '2026-07-01T00:00:00.000Z',
+    });
+    const middle = await seedFeedback(db, {
       userId: reporter,
       createdAt: '2026-08-01T00:00:00.000Z',
     });
-    const newer = await seedFeedback(db, {
+    const newest = await seedFeedback(db, {
       userId: reporter,
       createdAt: '2026-09-01T00:00:00.000Z',
     });
 
-    const first = await service.getFeedbackList({ statuses: ['new'], limit: 1 });
-    expect(first.items.map((r) => r.id)).toEqual([newer]);
+    const first = await service.getFeedbackList({ statuses: ['new'], limit: 2 });
+    expect(first.items.map((r) => r.id)).toEqual([newest, middle]);
     expect(first.items[0].username).toBe('kaeru');
-    expect(first.nextCursor).not.toBeNull();
+    // The LAST row of the page, not the first — the page boundary, not its start.
+    expect(first.nextCursor).toBe(middle);
 
     const second = await service.getFeedbackList({
       statuses: ['new'],
-      limit: 1,
+      limit: 2,
       cursor: first.nextCursor,
     });
-    expect(second.items.map((r) => r.id)).toEqual([older]);
+    expect(second.items.map((r) => r.id)).toEqual([oldest]);
     expect(second.nextCursor).toBeNull();
   });
 

--- a/apps/moderator/src/lib/server/access.ts
+++ b/apps/moderator/src/lib/server/access.ts
@@ -158,6 +158,9 @@ export const NAVIGATION: NavLink[] = [
     ],
   },
   { path: '/comics-review', label: 'Comics Review' },
+  // Not `informational`: this is a queue somebody works through, so it belongs in the dashboard's
+  // "needs attention" total — unlike the stuck-scan counts beside it.
+  { path: '/feedback', label: 'Feedback', countKey: 'feedbackNew' },
   // One grant covers the section. Its detail view (`/abuse/<runId>`) resolves here by prefix rather
   // than being listed: a run and its findings are one thing, and granting the list without the rows
   // would show a moderator a count they cannot open.

--- a/apps/moderator/src/lib/server/feedback.service.ts
+++ b/apps/moderator/src/lib/server/feedback.service.ts
@@ -34,33 +34,12 @@ export type FeedbackRow = {
   bugStatus: string | null;
 };
 
-/**
- * The keyset cursor is the row id, and the order is `id DESC` — NOT `createdAt DESC`.
- *
- * 🔴 The two are the same order here and the id is the better key for both of the reasons that
- * matter. `Feedback` is insert-only with `createdAt DEFAULT now()` and no path that backdates or
- * rewrites it, so id order IS arrival order; the id is also UNIQUE, where `createdAt` is not, so a
- * page boundary cannot repeat or skip rows that share a millisecond.
- *
- * It also keeps the boundary out of the driver's timestamp handling. `createdAt` is `timestamp
- * WITHOUT time zone`: node-postgres serialises a `Date` parameter as LOCAL time with an explicit
- * offset and parses the column back as local, which round-trips — but that symmetry is the
- * driver's, not Postgres', and it does not hold everywhere (PGlite, which this app's own test tier
- * runs on, serialises the same `Date` as UTC and shifts the comparison by the local offset). An
- * integer comparison has no such question attached to it.
- */
-export function decodeFeedbackCursor(value: string | null | undefined): number | null {
-  if (!value) return null;
-  const id = Number(value);
-  return Number.isInteger(id) && id > 0 && id <= 2_147_483_647 ? id : null;
-}
-
 export async function getFeedbackList(input: {
   statuses: readonly FeedbackStatus[];
   area?: string | null;
   cursor?: number | null;
   limit?: number;
-}): Promise<{ items: FeedbackRow[]; nextCursor: string | null }> {
+}): Promise<{ items: FeedbackRow[]; nextCursor: number | null }> {
   const limit = input.limit ?? FEEDBACK_PAGE_SIZE;
 
   let query = dbRead
@@ -85,7 +64,21 @@ export async function getFeedbackList(input: {
       'b.title as bugTitle',
       'b.status as bugStatus',
     ])
-    // See `decodeFeedbackCursor`: this IS newest-first, and it is total.
+    /**
+     * 🔴 `id DESC`, not `createdAt DESC`, and the keyset below compares the same column.
+     *
+     * The two are the same order here and the id is the better key twice over. `Feedback` is
+     * insert-only with `createdAt DEFAULT now()` and nothing backdates or rewrites it, so id order
+     * IS arrival order; and the id is UNIQUE where the timestamp is not, so a page boundary cannot
+     * repeat or skip rows sharing a millisecond.
+     *
+     * It also keeps the boundary out of the DRIVER's timestamp handling. `createdAt` is `timestamp
+     * WITHOUT time zone`: node-postgres serialises a `Date` parameter as local time with an
+     * explicit offset and parses the column back as local, which round-trips — but that symmetry is
+     * the driver's, not Postgres', and it does not hold everywhere (PGlite, which this app's own
+     * test tier runs on, serialises the same `Date` as UTC and shifts the comparison by the local
+     * offset). An integer comparison carries no such question.
+     */
     .orderBy('f.id', 'desc')
     .limit(limit + 1);
 
@@ -106,7 +99,7 @@ export async function getFeedbackList(input: {
 
   return {
     items,
-    nextCursor: hasMore && items.length ? String(items[items.length - 1].id) : null,
+    nextCursor: hasMore && items.length ? items[items.length - 1].id : null,
   };
 }
 
@@ -142,11 +135,19 @@ export async function getFeedbackAreas(): Promise<string[]> {
   return rows.map((r) => r.area);
 }
 
+export type FeedbackSibling = {
+  id: number;
+  area: string;
+  message: string;
+  createdAt: Date;
+  status: string;
+};
+
 /** Other reports already attached to the same Bug — what turns duplicated complaints into one issue. */
 export async function getSiblingFeedback(input: {
   bugId: number;
   excludeId: number;
-}): Promise<{ id: number; area: string; message: string; createdAt: Date; status: string }[]> {
+}): Promise<FeedbackSibling[]> {
   const rows = await dbRead
     .selectFrom('Feedback')
     .select(['id', 'area', 'message', 'createdAt', 'status'])
@@ -205,17 +206,29 @@ export async function triageFeedback(input: {
 
   // Zero rows has two causes and they need different words on screen. One extra read, only on the
   // path that already failed.
-  return (await feedbackExists(input.id)) ? { ok: true, changed: false } : { ok: false, reason: 'gone' };
+  return (await feedbackExists(dbWrite, input.id))
+    ? { ok: true, changed: false }
+    : { ok: false, reason: 'gone' };
 }
 
-async function feedbackExists(id: number): Promise<boolean> {
-  const row = await dbRead.selectFrom('Feedback').select('id').where('id', '=', id).executeTakeFirst();
+/**
+ * 🔴 Takes the client rather than closing over `dbRead`. This decides WHICH REFUSAL the operator
+ * reads, so it has to see the same snapshot as the write that just failed: on the replica a row
+ * deleted a moment ago is still present, and the answer flips from "that report is gone" to
+ * "someone else already triaged it" — the exact confusion the split exists to remove. Callers pass
+ * the primary, or the open transaction.
+ */
+async function feedbackExists(
+  db: Pick<typeof dbWrite, 'selectFrom'>,
+  id: number
+): Promise<boolean> {
+  const row = await db.selectFrom('Feedback').select('id').where('id', '=', id).executeTakeFirst();
   return !!row;
 }
 
 export type PromoteResult =
   | { ok: true; bugId: number; created: boolean }
-  | { ok: false; reason: 'already-linked' | 'no-such-bug' };
+  | { ok: false; reason: 'already-linked' | 'no-such-bug' | 'gone' };
 
 /**
  * Mint a `Bug` from a report and link it, in one transaction.
@@ -266,12 +279,12 @@ export async function promoteFeedbackToBug(input: {
       });
       // Rolls the Bug insert back with it — a row nobody linked is litter on a table the public
       // board reads.
-      if (!linked) throw new AlreadyLinked();
+      if (!linked) throw new NotLinked(await linkRefusalReason(trx, input.id));
 
       return { ok: true as const, bugId: bug.id, created: true };
     });
   } catch (e) {
-    if (e instanceof AlreadyLinked) return { ok: false, reason: 'already-linked' };
+    if (e instanceof NotLinked) return { ok: false, reason: e.reason };
     throw e;
   }
 }
@@ -282,7 +295,11 @@ export async function linkFeedbackToBug(input: {
   bugId: number;
   moderatorId: number;
 }): Promise<PromoteResult> {
-  const bug = await dbRead
+  // 🔴 `dbWrite`, NOT `dbRead`. The replica is a separate pool, and attaching is BY DESIGN the
+  // thing a moderator does seconds after promoting — read the issue number off the screen, paste it
+  // into the next report. Any replica lag turns that into "No issue with that number", which is
+  // indistinguishable from a typo. A single primary-key read on a path that is about to write.
+  const bug = await dbWrite
     .selectFrom('Bug')
     .select('id')
     .where('id', '=', input.bugId)
@@ -292,10 +309,26 @@ export async function linkFeedbackToBug(input: {
   const linked = await linkInTransaction(dbWrite, input);
   return linked
     ? { ok: true, bugId: input.bugId, created: false }
-    : { ok: false, reason: 'already-linked' };
+    : { ok: false, reason: await linkRefusalReason(dbWrite, input.id) };
 }
 
-class AlreadyLinked extends Error {}
+/**
+ * Zero rows has two causes and they need different words on screen — the same split the triage path
+ * makes. Telling a moderator to "reload to see which issue it is linked to" when the row was
+ * deleted sends them looking for something that does not exist.
+ */
+async function linkRefusalReason(
+  db: Pick<typeof dbWrite, 'selectFrom'>,
+  id: number
+): Promise<'already-linked' | 'gone'> {
+  return (await feedbackExists(db, id)) ? 'already-linked' : 'gone';
+}
+
+class NotLinked extends Error {
+  constructor(readonly reason: 'already-linked' | 'gone') {
+    super(reason);
+  }
+}
 
 /**
  * 🔴 `AND "bugId" IS NULL` makes double-promotion impossible. Zero rows means someone beat you to

--- a/apps/moderator/src/lib/server/feedback.service.ts
+++ b/apps/moderator/src/lib/server/feedback.service.ts
@@ -16,18 +16,32 @@ import type { FeedbackStatus } from '$lib/feedback';
 
 export const FEEDBACK_PAGE_SIZE = 50;
 
+/** The four columns `20260911120000_feedback_triage` adds — the only ones this page can explain. */
+const TRIAGE_COLUMNS = ['triageNote', 'handledById', 'handledAt', 'bugId'];
+
 /**
- * Postgres `undefined_column`, i.e. this database has not had
- * `20260911120000_feedback_triage` applied yet.
+ * Postgres `undefined_column` naming a column that migration adds, i.e. this database has not had
+ * it applied yet. Every migration here is applied by hand per environment, and
+ * `moderator:admin` reaches the page through `SUPER_ROLE` on day one without any `/admin` tick, so
+ * the window is real rather than theoretical.
  *
- * 🔴 Narrow ON PURPOSE — it matches ONE code and nothing else. Every migration here is applied by
- * hand per environment, so the window between this page deploying and someone running the SQL is
- * real, and `moderator:admin` reaches the page through `SUPER_ROLE` on day one without any
- * `/admin` tick. Widening this to "any database error" would render a genuine outage as an empty
- * queue, which is the failure the page exists to avoid.
+ * 🔴 THE CODE ALONE IS NOT ENOUGH, because the page answers with specific advice: apply THIS
+ * migration. `42703` is raised by any reference to any column that does not exist — a typo in a
+ * later edit, or a different unapplied migration — and matching the code alone would answer all of
+ * them with that advice, confidently and wrongly, while the `catch` suppresses the error that would
+ * otherwise have said so. Matching the column name keeps the answer as narrow as the question.
+ *
+ * Matched on the COLUMN NAME rather than on "does not exist": the name is interpolated into the
+ * message and survives `lc_messages`, the surrounding English does not. Kysely quotes identifiers,
+ * so the camel case is preserved; the real message is `column f.handledById does not exist`,
+ * measured against the pre-migration table in `feedback.service.test.ts`.
  */
-export const isMissingTriageColumns = (e: unknown): boolean =>
-  typeof e === 'object' && e !== null && (e as { code?: unknown }).code === '42703';
+export const isMissingTriageColumns = (e: unknown): boolean => {
+  if (typeof e !== 'object' || e === null) return false;
+  const { code, message } = e as { code?: unknown; message?: unknown };
+  if (code !== '42703') return false;
+  return typeof message === 'string' && TRIAGE_COLUMNS.some((c) => message.includes(c));
+};
 
 export type FeedbackRow = {
   id: number;
@@ -217,13 +231,20 @@ export async function triageFeedback(input: {
       triageNote: input.note,
       handledById: handled ? input.moderatorId : null,
       handledAt: handled ? new Date() : null,
-      // 🔴 The issue link is cleared alongside the handler, for the same reason: `new` means
-      // UNTRIAGED, and a Bug link is a triage outcome. Leaving it set puts a row in the unhandled
-      // queue showing the linked-issue panel instead of the promote form, and `linkInTransaction`
-      // refuses any row whose `bugId` is already set — so the moderator who reopened it can
-      // neither re-promote it nor attach it anywhere else, and this app has no unlink control.
-      // The `Bug` row itself is untouched; re-attaching is the issue number they just saw.
-      ...(handled ? {} : { bugId: null }),
+      // 🔴 `bugId` IS DELIBERATELY NOT TOUCHED HERE — not on any status, reopening included.
+      //
+      // Clearing it on the way back to `new` was tried and reverted. It reads as symmetric with
+      // the two columns above, and it is not: those record WHO acted, which a reopen genuinely
+      // retracts, while the link records THAT THIS REPORT IS ABOUT THAT ISSUE, which stays true.
+      // Clearing destroyed it with no way back — nothing in this app stores the number a second
+      // time, `getSiblingFeedback` drops the row from every sibling's list, and `ModActivity` has
+      // no column to put it in — and it left a `Bug` with no feedback pointing at it, which is
+      // exactly the state `promoteFeedbackToBug` runs a transaction rollback to avoid creating.
+      //
+      // ⚠️ WHAT THIS LEAVES OPEN, so the next reader sees the whole shape: a linked row can never
+      // be re-linked, because `linkInTransaction` requires `bugId IS NULL`. That is a MISSING
+      // CAPABILITY — an unlink control — and it is missing at every status, so reopening neither
+      // causes it nor is a sensible back door to it. This PR does not add one.
     })
     .where('id', '=', input.id)
     .where('status', '=', input.expectedStatus)

--- a/apps/moderator/src/lib/server/feedback.service.ts
+++ b/apps/moderator/src/lib/server/feedback.service.ts
@@ -392,6 +392,13 @@ class NotLinked extends Error {
 /**
  * 🔴 `AND "bugId" IS NULL` makes double-promotion impossible. Zero rows means someone beat you to
  * it — or the row is gone — and either way nothing should be linked to the Bug just minted.
+ *
+ * ⚠️ This clause is also what freezes a linked row: it can never be re-linked, at ANY status, and
+ * this app ships no unlink control. If you are here because you are adding one, read the note in
+ * `triageFeedback` above — it records why clearing `bugId` on a reopen was tried and reverted, and
+ * why an unlink belongs in its own action rather than as a side effect of a status change.
+ * (Deleting the `Bug` does null the column, via `ON DELETE SET NULL` on `Feedback_bugId_fkey` —
+ * that is a cascade, not a control, and it takes the issue with it.)
  */
 async function linkInTransaction(
   db: Pick<typeof dbWrite, 'updateTable'>,

--- a/apps/moderator/src/lib/server/feedback.service.ts
+++ b/apps/moderator/src/lib/server/feedback.service.ts
@@ -1,0 +1,340 @@
+import { dbRead, dbWrite } from './db';
+import { recordModActivity } from './mod-activity';
+import type { FeedbackStatus } from '$lib/feedback';
+
+/**
+ * The `Feedback` table, read and triaged.
+ *
+ * The table has been written to since 2026-08 and read by nothing — three of the four statuses its
+ * CHECK constraint allows were unreachable by any code path that existed. This module is the
+ * reader.
+ *
+ * 🔴 Every write here is scoped on the state the operator was LOOKING AT, not on the id alone, and
+ * reports the affected-row count back. Zero rows is a refusal, never a success: a triage that
+ * silently overwrites a colleague's verdict is indistinguishable, on screen, from one that worked.
+ */
+
+export const FEEDBACK_PAGE_SIZE = 50;
+
+export type FeedbackRow = {
+  id: number;
+  area: string;
+  userId: number;
+  username: string | null;
+  message: string;
+  context: unknown;
+  status: string;
+  createdAt: Date;
+  triageNote: string | null;
+  handledById: number | null;
+  handledByUsername: string | null;
+  handledAt: Date | null;
+  bugId: number | null;
+  bugTitle: string | null;
+  bugStatus: string | null;
+};
+
+/**
+ * The keyset cursor is the row id, and the order is `id DESC` — NOT `createdAt DESC`.
+ *
+ * 🔴 The two are the same order here and the id is the better key for both of the reasons that
+ * matter. `Feedback` is insert-only with `createdAt DEFAULT now()` and no path that backdates or
+ * rewrites it, so id order IS arrival order; the id is also UNIQUE, where `createdAt` is not, so a
+ * page boundary cannot repeat or skip rows that share a millisecond.
+ *
+ * It also keeps the boundary out of the driver's timestamp handling. `createdAt` is `timestamp
+ * WITHOUT time zone`: node-postgres serialises a `Date` parameter as LOCAL time with an explicit
+ * offset and parses the column back as local, which round-trips — but that symmetry is the
+ * driver's, not Postgres', and it does not hold everywhere (PGlite, which this app's own test tier
+ * runs on, serialises the same `Date` as UTC and shifts the comparison by the local offset). An
+ * integer comparison has no such question attached to it.
+ */
+export function decodeFeedbackCursor(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const id = Number(value);
+  return Number.isInteger(id) && id > 0 && id <= 2_147_483_647 ? id : null;
+}
+
+export async function getFeedbackList(input: {
+  statuses: readonly FeedbackStatus[];
+  area?: string | null;
+  cursor?: number | null;
+  limit?: number;
+}): Promise<{ items: FeedbackRow[]; nextCursor: string | null }> {
+  const limit = input.limit ?? FEEDBACK_PAGE_SIZE;
+
+  let query = dbRead
+    .selectFrom('Feedback as f')
+    .leftJoin('User as u', 'u.id', 'f.userId')
+    .leftJoin('User as h', 'h.id', 'f.handledById')
+    .leftJoin('Bug as b', 'b.id', 'f.bugId')
+    .select([
+      'f.id',
+      'f.area',
+      'f.userId',
+      'u.username',
+      'f.message',
+      'f.context',
+      'f.status',
+      'f.createdAt',
+      'f.triageNote',
+      'f.handledById',
+      'h.username as handledByUsername',
+      'f.handledAt',
+      'f.bugId',
+      'b.title as bugTitle',
+      'b.status as bugStatus',
+    ])
+    // See `decodeFeedbackCursor`: this IS newest-first, and it is total.
+    .orderBy('f.id', 'desc')
+    .limit(limit + 1);
+
+  // An empty selection is every status, said by the caller rather than implied here.
+  if (input.statuses.length) query = query.where('f.status', 'in', [...input.statuses]);
+  if (input.area) query = query.where('f.area', '=', input.area);
+  if (input.cursor) query = query.where('f.id', '<', input.cursor);
+
+  const rows = await query.execute();
+  const hasMore = rows.length > limit;
+  const items = (hasMore ? rows.slice(0, limit) : rows).map(
+    (r): FeedbackRow => ({
+      ...r,
+      createdAt: new Date(r.createdAt),
+      handledAt: r.handledAt ? new Date(r.handledAt) : null,
+    })
+  );
+
+  return {
+    items,
+    nextCursor: hasMore && items.length ? String(items[items.length - 1].id) : null,
+  };
+}
+
+/**
+ * The sidebar badge.
+ *
+ * Cheap enough to sit in `sidebar-counts.service.ts`' single `Promise.all` without `bounded()`:
+ * `Feedback_status_createdAt_idx` serves it as an index-only scan, the producer is rate-limited to
+ * five submissions per user per hour, and the whole map is behind a 60-second cache.
+ */
+export async function countNewFeedback(): Promise<number> {
+  const row = await dbRead
+    .selectFrom('Feedback')
+    .select((eb) => eb.fn.countAll<number>().as('count'))
+    .where('status', '=', 'new')
+    .executeTakeFirst();
+  return Number(row?.count ?? 0);
+}
+
+/**
+ * Areas that actually have rows.
+ *
+ * 🔴 Unioned with the TS registry at the call site (`feedbackAreaOptions`), never used alone: an
+ * area whose producer was retired still owns its history, and this is the only list that knows it.
+ */
+export async function getFeedbackAreas(): Promise<string[]> {
+  const rows = await dbRead
+    .selectFrom('Feedback')
+    .select('area')
+    .distinct()
+    .orderBy('area', 'asc')
+    .execute();
+  return rows.map((r) => r.area);
+}
+
+/** Other reports already attached to the same Bug — what turns duplicated complaints into one issue. */
+export async function getSiblingFeedback(input: {
+  bugId: number;
+  excludeId: number;
+}): Promise<{ id: number; area: string; message: string; createdAt: Date; status: string }[]> {
+  const rows = await dbRead
+    .selectFrom('Feedback')
+    .select(['id', 'area', 'message', 'createdAt', 'status'])
+    .where('bugId', '=', input.bugId)
+    .where('id', '!=', input.excludeId)
+    .orderBy('createdAt', 'desc')
+    .limit(50)
+    .execute();
+  return rows.map((r) => ({ ...r, createdAt: new Date(r.createdAt) }));
+}
+
+export type TriageResult =
+  | { ok: true; changed: true }
+  | { ok: true; changed: false }
+  | { ok: false; reason: 'gone' };
+
+/**
+ * Set a row's status and triage note in one statement.
+ *
+ * 🔴 SCOPED ON `expectedStatus` — the status the operator was looking at when they decided. Without
+ * it, two moderators reaching opposite verdicts produce one silent overwrite and two screens that
+ * both say "saved".
+ *
+ * Moving a row back to `new` CLEARS the handler rather than stamping it: "handled by" naming a
+ * moderator on a row sitting in the unhandled queue is a claim the screen cannot support.
+ */
+export async function triageFeedback(input: {
+  id: number;
+  status: FeedbackStatus;
+  expectedStatus: FeedbackStatus;
+  note: string | null;
+  moderatorId: number;
+}): Promise<TriageResult> {
+  const handled = input.status !== 'new';
+  const result = await dbWrite
+    .updateTable('Feedback')
+    .set({
+      status: input.status,
+      triageNote: input.note,
+      handledById: handled ? input.moderatorId : null,
+      handledAt: handled ? new Date() : null,
+    })
+    .where('id', '=', input.id)
+    .where('status', '=', input.expectedStatus)
+    .executeTakeFirst();
+
+  if (Number(result.numUpdatedRows) > 0) {
+    await recordModActivity({
+      userId: input.moderatorId,
+      entityType: 'feedback',
+      entityId: input.id,
+      activity: 'triage',
+    });
+    return { ok: true, changed: true };
+  }
+
+  // Zero rows has two causes and they need different words on screen. One extra read, only on the
+  // path that already failed.
+  return (await feedbackExists(input.id)) ? { ok: true, changed: false } : { ok: false, reason: 'gone' };
+}
+
+async function feedbackExists(id: number): Promise<boolean> {
+  const row = await dbRead.selectFrom('Feedback').select('id').where('id', '=', id).executeTakeFirst();
+  return !!row;
+}
+
+export type PromoteResult =
+  | { ok: true; bugId: number; created: boolean }
+  | { ok: false; reason: 'already-linked' | 'no-such-bug' };
+
+/**
+ * Mint a `Bug` from a report and link it, in one transaction.
+ *
+ * 🔴 `publishedAt` STAYS NULL, and that is what keeps the reporter's words off the public board.
+ * `getBugs` filters `publishedAt = { lte: now, not: null }` for anyone without the `bugsEdit`
+ * feature flag, so an unpublished Bug is a draft visible only to flag holders. Publishing is a
+ * separate deliberate act on `/issues`, not a side effect of triaging feedback.
+ *
+ * 🔴 `content` is left NULL ON PURPOSE. `createBugInput.content` runs through
+ * `getSanitizedStringSchema()` in the main app — the field is stored and rendered as HTML. The
+ * feedback `message` is plain text a user typed. Seeding one from the other would put
+ * user-authored text into an HTML-rendered field on a public board along a path that never
+ * sanitises it, because this app does not go through that zod schema.
+ *
+ * 🔴 `updatedAt` is supplied EXPLICITLY. It is `@updatedAt` in Prisma, which is a client-side
+ * stamp — the column is `NOT NULL` with NO database default, and this app's Kysely client installs
+ * no `updatedAtPlugin`. Omitting it is a 23502, not a default.
+ */
+export async function promoteFeedbackToBug(input: {
+  id: number;
+  title: string;
+  summary: string;
+  moderatorId: number;
+}): Promise<PromoteResult> {
+  try {
+    return await dbWrite.transaction().execute(async (trx) => {
+      const now = new Date();
+      const bug = await trx
+        .insertInto('Bug')
+        .values({
+          title: input.title,
+          summary: input.summary,
+          status: BUG_INITIAL_STATUS,
+          // Derived, not hardcoded null: with a fixed 'Open' this is always null, and a future
+          // status control on the form would make that assumption wrong silently.
+          resolvedAt: isBugClosed(BUG_INITIAL_STATUS) ? now : null,
+          publishedAt: null,
+          updatedAt: now,
+        })
+        .returning('id')
+        .executeTakeFirstOrThrow();
+
+      const linked = await linkInTransaction(trx, {
+        id: input.id,
+        bugId: bug.id,
+        moderatorId: input.moderatorId,
+      });
+      // Rolls the Bug insert back with it — a row nobody linked is litter on a table the public
+      // board reads.
+      if (!linked) throw new AlreadyLinked();
+
+      return { ok: true as const, bugId: bug.id, created: true };
+    });
+  } catch (e) {
+    if (e instanceof AlreadyLinked) return { ok: false, reason: 'already-linked' };
+    throw e;
+  }
+}
+
+/** The common case after the first promotion: the second report of the same thing gets attached. */
+export async function linkFeedbackToBug(input: {
+  id: number;
+  bugId: number;
+  moderatorId: number;
+}): Promise<PromoteResult> {
+  const bug = await dbRead
+    .selectFrom('Bug')
+    .select('id')
+    .where('id', '=', input.bugId)
+    .executeTakeFirst();
+  if (!bug) return { ok: false, reason: 'no-such-bug' };
+
+  const linked = await linkInTransaction(dbWrite, input);
+  return linked
+    ? { ok: true, bugId: input.bugId, created: false }
+    : { ok: false, reason: 'already-linked' };
+}
+
+class AlreadyLinked extends Error {}
+
+/**
+ * 🔴 `AND "bugId" IS NULL` makes double-promotion impossible. Zero rows means someone beat you to
+ * it — or the row is gone — and either way nothing should be linked to the Bug just minted.
+ */
+async function linkInTransaction(
+  db: Pick<typeof dbWrite, 'updateTable'>,
+  input: { id: number; bugId: number; moderatorId: number }
+): Promise<boolean> {
+  const result = await db
+    .updateTable('Feedback')
+    .set({
+      bugId: input.bugId,
+      status: 'actioned',
+      handledById: input.moderatorId,
+      handledAt: new Date(),
+    })
+    .where('id', '=', input.id)
+    .where('bugId', 'is', null)
+    .executeTakeFirst();
+
+  if (Number(result.numUpdatedRows) === 0) return false;
+  await recordModActivity({
+    userId: input.moderatorId,
+    entityType: 'feedback',
+    entityId: input.id,
+    activity: 'promote',
+  });
+  return true;
+}
+
+const BUG_INITIAL_STATUS = 'Open';
+
+/**
+ * Ported from the main app's `~/server/common/constants`, not re-derived.
+ *
+ * 🔴 `Bug.status` is a free-form string with no enum and no CHECK constraint — the suggestion list
+ * is autocomplete over a free-text field, and ClickUp supplies the values. "Is this closed" is a
+ * case-insensitive membership test, never a comparison to a literal.
+ */
+const BUG_CLOSED_STATUSES = ['complete', 'closed', 'done', 'resolved'];
+const isBugClosed = (status: string) => BUG_CLOSED_STATUSES.includes(status.trim().toLowerCase());

--- a/apps/moderator/src/lib/server/feedback.service.ts
+++ b/apps/moderator/src/lib/server/feedback.service.ts
@@ -16,6 +16,19 @@ import type { FeedbackStatus } from '$lib/feedback';
 
 export const FEEDBACK_PAGE_SIZE = 50;
 
+/**
+ * Postgres `undefined_column`, i.e. this database has not had
+ * `20260911120000_feedback_triage` applied yet.
+ *
+ * 🔴 Narrow ON PURPOSE — it matches ONE code and nothing else. Every migration here is applied by
+ * hand per environment, so the window between this page deploying and someone running the SQL is
+ * real, and `moderator:admin` reaches the page through `SUPER_ROLE` on day one without any
+ * `/admin` tick. Widening this to "any database error" would render a genuine outage as an empty
+ * queue, which is the failure the page exists to avoid.
+ */
+export const isMissingTriageColumns = (e: unknown): boolean =>
+  typeof e === 'object' && e !== null && (e as { code?: unknown }).code === '42703';
+
 export type FeedbackRow = {
   id: number;
   area: string;
@@ -42,6 +55,21 @@ export async function getFeedbackList(input: {
 }): Promise<{ items: FeedbackRow[]; nextCursor: number | null }> {
   const limit = input.limit ?? FEEDBACK_PAGE_SIZE;
 
+  /**
+   * ⚠️ THE REPLICA, DELIBERATELY, AND IT HAS A COST — read this before "fixing" it. Every write
+   * here reloads the page, so under replica lag an operator can see their own triage come back
+   * unapplied, and their next click then posts the STALE `expectedStatus` and is refused with
+   * "someone else already triaged this" over their own write.
+   *
+   * Left on the replica anyway: it fails CLOSED (a refusal, never a silent overwrite), it is the
+   * convention every other queue in this app follows, and a triage queue read by a handful of
+   * people is the shape where lag is least likely to be observed. `linkFeedbackToBug`'s Bug lookup
+   * goes to the primary instead, and that is not an inconsistency — there the stale answer is a
+   * flat "no issue with that number" for an issue the operator is looking at, which reads as a
+   * defect rather than as a conflict.
+   *
+   * Revisit if a moderator reports a conflict they cannot explain; the fix is this one word.
+   */
   let query = dbRead
     .selectFrom('Feedback as f')
     .leftJoin('User as u', 'u.id', 'f.userId')
@@ -189,6 +217,13 @@ export async function triageFeedback(input: {
       triageNote: input.note,
       handledById: handled ? input.moderatorId : null,
       handledAt: handled ? new Date() : null,
+      // 🔴 The issue link is cleared alongside the handler, for the same reason: `new` means
+      // UNTRIAGED, and a Bug link is a triage outcome. Leaving it set puts a row in the unhandled
+      // queue showing the linked-issue panel instead of the promote form, and `linkInTransaction`
+      // refuses any row whose `bugId` is already set — so the moderator who reopened it can
+      // neither re-promote it nor attach it anywhere else, and this app has no unlink control.
+      // The `Bug` row itself is untouched; re-attaching is the issue number they just saw.
+      ...(handled ? {} : { bugId: null }),
     })
     .where('id', '=', input.id)
     .where('status', '=', input.expectedStatus)
@@ -217,6 +252,9 @@ export async function triageFeedback(input: {
  * deleted a moment ago is still present, and the answer flips from "that report is gone" to
  * "someone else already triaged it" — the exact confusion the split exists to remove. Callers pass
  * the primary, or the open transaction.
+ *
+ * ⚠️ NOT COVERED BY A TEST. The PGlite tier binds `dbRead` and `dbWrite` to one client, so a change
+ * passing the replica here is invisible to it. Verified by reading the call sites only.
  */
 async function feedbackExists(
   db: Pick<typeof dbWrite, 'selectFrom'>,

--- a/apps/moderator/src/lib/server/sidebar-counts.service.ts
+++ b/apps/moderator/src/lib/server/sidebar-counts.service.ts
@@ -9,6 +9,7 @@ import { getImageRatingReviewCount } from './image-rating-review.service';
 import { countModeratorArticles } from './articles.service';
 import { getArticleRatingReviewCounts } from './article-rating-reviews.service';
 import { getReportCounts } from './reports.service';
+import { countNewFeedback } from './feedback.service';
 
 export type SidebarCounts = Record<string, number>;
 
@@ -30,6 +31,7 @@ async function fetchCounts(): Promise<SidebarCounts> {
     reports,
     stuckIngestion,
     ingestionErrors,
+    feedbackNew,
   ] = await Promise.all([
     getImageReviewCounts(),
     // Bitmask predicates must match the TagsOnImageNew_needsReview_idx partial index (bit 9 set, bit 10 clear).
@@ -62,6 +64,10 @@ async function fetchCounts(): Promise<SidebarCounts> {
     // Bounded: neither count is served by an index alone; see `bounded`.
     bounded(countStuckIngestion),
     bounded(countIngestionErrorImages),
+    // NOT bounded: an index-only count over a table the producer can only grow five rows per user
+    // per hour. `bounded` exists for aggregates with no index of their own — wrapping this one in a
+    // 3-second race would add a timer and a nullable to buy nothing.
+    countNewFeedback(),
   ]);
   return {
     ...modes,
@@ -72,6 +78,7 @@ async function fetchCounts(): Promise<SidebarCounts> {
     reported: Number(reported?.count ?? 0),
     articles,
     articleRatings: articleRatings.Pending,
+    feedbackNew,
     ...(stuckIngestion != null ? { stuckIngestion } : {}),
     ...(ingestionErrors != null ? { ingestionErrors } : {}),
   };

--- a/apps/moderator/src/routes/feedback/+page.server.ts
+++ b/apps/moderator/src/routes/feedback/+page.server.ts
@@ -16,6 +16,7 @@ import {
   getFeedbackAreas,
   getFeedbackList,
   getSiblingFeedback,
+  isMissingTriageColumns,
   linkFeedbackToBug,
   promoteFeedbackToBug,
   triageFeedback,
@@ -51,15 +52,43 @@ export const load: PageServerLoad = async ({ url, request }) => {
     redirect(307, canonical.pathname + canonical.search);
   }
 
-  const [list, areas] = await Promise.all([
-    getFeedbackList({
+  /**
+   * 🔴 The migration is applied BY HAND, per environment, and this page reaches production before
+   * anyone runs it. `moderator:admin` short-circuits every page grant, so the sidebar entry and its
+   * badge are live on the day this deploys — and the badge counts on `status` alone, so it renders
+   * a real number against an unmigrated database. The click is what breaks: the list selects four
+   * columns that do not exist yet.
+   *
+   * Degraded rather than thrown. An uncaught 42703 out of `load` is the error boundary plus an
+   * Axiom entry per click, and it tells the operator nothing about what to do.
+   */
+  let list: Awaited<ReturnType<typeof getFeedbackList>>;
+  let areas: string[];
+  try {
+    [list, areas] = await Promise.all([
+      getFeedbackList({
+        statuses,
+        area: area || null,
+        cursor: cursor ?? null,
+        limit: FEEDBACK_PAGE_SIZE,
+      }),
+      getFeedbackAreas(),
+    ]);
+  } catch (e) {
+    if (!isMissingTriageColumns(e)) throw e;
+    return {
+      items: [],
+      nextCursor: null,
       statuses,
-      area: area || null,
-      cursor: cursor ?? null,
-      limit: FEEDBACK_PAGE_SIZE,
-    }),
-    getFeedbackAreas(),
-  ]);
+      area,
+      open: null,
+      openVisible: false,
+      siblings: [],
+      areaOptions: [],
+      grafanaUrl: null,
+      migrationPending: true as const,
+    };
+  }
 
   // Only for the row that is actually open — this is the one read on the page that is not needed to
   // render the list.
@@ -70,6 +99,7 @@ export const load: PageServerLoad = async ({ url, request }) => {
       : [];
 
   return {
+    migrationPending: false as const,
     items: list.items,
     nextCursor: list.nextCursor,
     statuses,

--- a/apps/moderator/src/routes/feedback/+page.server.ts
+++ b/apps/moderator/src/routes/feedback/+page.server.ts
@@ -1,0 +1,171 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { z } from 'zod';
+import { env } from '$env/dynamic/public';
+import type { Actions, PageServerLoad } from './$types';
+import { requiresGrant } from '$lib/server/access';
+import { parseForm, parseQuery } from '$lib/server/query';
+import {
+  DEFAULT_FEEDBACK_STATUSES,
+  FEEDBACK_STATUSES,
+  feedbackAreaOptions,
+  isFeedbackStatus,
+} from '$lib/feedback';
+import {
+  FEEDBACK_PAGE_SIZE,
+  decodeFeedbackCursor,
+  getFeedbackAreas,
+  getFeedbackList,
+  getSiblingFeedback,
+  linkFeedbackToBug,
+  promoteFeedbackToBug,
+  triageFeedback,
+} from '$lib/server/feedback.service';
+
+const MAX_INT4 = 2_147_483_647;
+
+// Give every field a `.catch()`: query params are user-controllable, so a bad value degrades to the
+// default rather than 500ing a queue nobody can then open.
+const querySchema = z.object({
+  status: z.array(z.string()).catch([]),
+  area: z.string().trim().catch(''),
+  cursor: z.string().trim().catch(''),
+  open: z.coerce.number().int().positive().max(MAX_INT4).optional().catch(undefined),
+});
+
+export const load: PageServerLoad = async ({ url }) => {
+  // Canonicalise a bare landing so the active default is explicit and shareable. Only an ABSENT
+  // `status` gets the default — a present-but-empty `?status=` is a deliberate "all", left alone.
+  if (!url.searchParams.has('status')) {
+    const canonical = new URL(url);
+    DEFAULT_FEEDBACK_STATUSES.forEach((s) => canonical.searchParams.append('status', s));
+    redirect(307, canonical.pathname + canonical.search);
+  }
+
+  const { status, area, cursor, open } = parseQuery(url, querySchema, ['status']);
+  const statuses = status.filter(isFeedbackStatus);
+
+  const [list, areas] = await Promise.all([
+    getFeedbackList({
+      statuses,
+      area: area || null,
+      cursor: decodeFeedbackCursor(cursor),
+      limit: FEEDBACK_PAGE_SIZE,
+    }),
+    getFeedbackAreas(),
+  ]);
+
+  // Only for the row that is actually open — this is the one read on the page that is not needed to
+  // render the list.
+  const openRow = open ? list.items.find((r) => r.id === open) : undefined;
+  const siblings =
+    openRow?.bugId != null
+      ? await getSiblingFeedback({ bugId: openRow.bugId, excludeId: openRow.id })
+      : [];
+
+  return {
+    items: list.items,
+    nextCursor: list.nextCursor,
+    statuses,
+    area,
+    open: open ?? null,
+    // A shared `?open=` can name a row the current filters exclude. Said out loud rather than
+    // rendering nothing, which is indistinguishable from no row being open at all.
+    openVisible: !!openRow,
+    siblings,
+    areaOptions: feedbackAreaOptions(areas),
+    /**
+     * 🔴 NULL when unset, and the panel renders no link at all in that case. A missing base would
+     * otherwise build `undefined/explore`, which looks live and is not. The origin is deliberately
+     * absent from this repo — see `.env.example`.
+     */
+    grafanaUrl: env.PUBLIC_GRAFANA_URL?.trim() || null,
+  };
+};
+
+const statusEnum = z.enum(FEEDBACK_STATUSES);
+
+const triageSchema = z.object({
+  id: z.coerce.number().int().positive().max(MAX_INT4),
+  status: statusEnum,
+  // The status the operator was LOOKING AT. Posted by the form, never re-read from the database —
+  // re-reading it here would make the guard agree with itself.
+  expectedStatus: statusEnum,
+  note: z.string().max(5000).optional(),
+});
+
+const promoteSchema = z.object({
+  id: z.coerce.number().int().positive().max(MAX_INT4),
+  // `''` for the new-bug path; a numeric string attaches to an existing Bug instead.
+  bugId: z.string().trim().optional(),
+  title: z.string().trim().max(300).optional(),
+  summary: z.string().trim().max(5000).optional(),
+});
+
+// Page access is gated centrally in `hooks.server.ts` against `/feedback`; these two guard the
+// WRITES, which is the independent axis.
+export const actions: Actions = {
+  triage: requiresGrant('feedback.status.set', async ({ request, locals }) => {
+    const input = parseForm(triageSchema, await request.formData());
+    if (typeof input === 'string') return fail(400, { error: input });
+
+    const result = await triageFeedback({
+      id: input.id,
+      status: input.status,
+      expectedStatus: input.expectedStatus,
+      // Trimmed, and empty becomes NULL rather than an empty string — the column means "no note".
+      note: input.note?.trim() || null,
+      moderatorId: locals.user.id,
+    });
+
+    if (!result.ok)
+      return fail(410, { error: 'That feedback no longer exists.', gone: true });
+    // 🔴 Zero affected rows is a REFUSAL. The UPDATE is scoped on the status the operator was
+    // looking at, so nothing moving means someone else's verdict is already on the row.
+    if (!result.changed)
+      return fail(409, {
+        error: 'Someone else already triaged this. Reload to see the current verdict.',
+      });
+
+    return { success: true, triaged: input.id };
+  }),
+
+  promote: requiresGrant('feedback.bug.promote', async ({ request, locals }) => {
+    const input = parseForm(promoteSchema, await request.formData());
+    if (typeof input === 'string') return fail(400, { error: input });
+
+    const existingBugId = input.bugId ? Number(input.bugId) : null;
+    if (existingBugId !== null) {
+      if (!Number.isInteger(existingBugId) || existingBugId <= 0 || existingBugId > MAX_INT4)
+        return fail(400, { error: 'That is not a valid issue number.' });
+
+      const linked = await linkFeedbackToBug({
+        id: input.id,
+        bugId: existingBugId,
+        moderatorId: locals.user.id,
+      });
+      return linked.ok ? { success: true, bugId: linked.bugId } : promoteFailure(linked.reason);
+    }
+
+    // A Bug title is a summary and a feedback message is a complaint, so the moderator writes both
+    // rather than the form seeding them.
+    const title = input.title ?? '';
+    const summary = input.summary ?? '';
+    if (!title) return fail(400, { error: 'Give the issue a title.' });
+    if (!summary) return fail(400, { error: 'Write a summary — it is what the issue board shows.' });
+
+    const promoted = await promoteFeedbackToBug({
+      id: input.id,
+      title,
+      summary,
+      moderatorId: locals.user.id,
+    });
+    return promoted.ok ? { success: true, bugId: promoted.bugId } : promoteFailure(promoted.reason);
+  }),
+};
+
+const promoteFailure = (reason: 'already-linked' | 'no-such-bug') =>
+  reason === 'no-such-bug'
+    ? fail(404, { error: 'No issue with that number.' })
+    : fail(409, {
+        error: 'That feedback is already linked to an issue. Reload to see which.',
+      });

--- a/apps/moderator/src/routes/feedback/+page.server.ts
+++ b/apps/moderator/src/routes/feedback/+page.server.ts
@@ -4,6 +4,7 @@ import { env } from '$env/dynamic/public';
 import type { Actions, PageServerLoad } from './$types';
 import { requiresGrant } from '$lib/server/access';
 import { parseForm, parseQuery } from '$lib/server/query';
+import { MAX_INT4, isInt4Id } from '$lib/server/users.service';
 import {
   DEFAULT_FEEDBACK_STATUSES,
   FEEDBACK_STATUSES,
@@ -12,7 +13,6 @@ import {
 } from '$lib/feedback';
 import {
   FEEDBACK_PAGE_SIZE,
-  decodeFeedbackCursor,
   getFeedbackAreas,
   getFeedbackList,
   getSiblingFeedback,
@@ -21,34 +21,41 @@ import {
   triageFeedback,
 } from '$lib/server/feedback.service';
 
-const MAX_INT4 = 2_147_483_647;
-
 // Give every field a `.catch()`: query params are user-controllable, so a bad value degrades to the
-// default rather than 500ing a queue nobody can then open.
+// default rather than 500ing a queue nobody can then open. The int4 bound matters — a larger value
+// ERRORS the comparison in Postgres rather than missing.
 const querySchema = z.object({
   status: z.array(z.string()).catch([]),
   area: z.string().trim().catch(''),
-  cursor: z.string().trim().catch(''),
+  cursor: z.coerce.number().int().positive().max(MAX_INT4).optional().catch(undefined),
   open: z.coerce.number().int().positive().max(MAX_INT4).optional().catch(undefined),
 });
 
-export const load: PageServerLoad = async ({ url }) => {
-  // Canonicalise a bare landing so the active default is explicit and shareable. Only an ABSENT
-  // `status` gets the default — a present-but-empty `?status=` is a deliberate "all", left alone.
-  if (!url.searchParams.has('status')) {
+export const load: PageServerLoad = async ({ url, request }) => {
+  const { status, area, cursor, open } = parseQuery(url, querySchema, ['status']);
+  // A present-but-empty `?status=` is a deliberate "all"; an ABSENT one is the default view.
+  const statuses = url.searchParams.has('status')
+    ? status.filter(isFeedbackStatus)
+    : DEFAULT_FEEDBACK_STATUSES;
+
+  // Canonicalise a bare landing so the active default is explicit and shareable.
+  //
+  // 🔴 GET only. A form action posts to `?/triage`, which replaces the whole query string, so on a
+  // POST this condition is true — and a 307 PRESERVES THE METHOD, so a no-JS client would re-POST
+  // and run the action a second time, tripping its own concurrency guard and reporting a spurious
+  // conflict over a save that worked. Enhanced submits never reach `load`, so the JS path never saw
+  // it. The defaults above apply either way, so skipping the redirect changes nothing on screen.
+  if (request.method === 'GET' && !url.searchParams.has('status')) {
     const canonical = new URL(url);
     DEFAULT_FEEDBACK_STATUSES.forEach((s) => canonical.searchParams.append('status', s));
     redirect(307, canonical.pathname + canonical.search);
   }
 
-  const { status, area, cursor, open } = parseQuery(url, querySchema, ['status']);
-  const statuses = status.filter(isFeedbackStatus);
-
   const [list, areas] = await Promise.all([
     getFeedbackList({
       statuses,
       area: area || null,
-      cursor: decodeFeedbackCursor(cursor),
+      cursor: cursor ?? null,
       limit: FEEDBACK_PAGE_SIZE,
     }),
     getFeedbackAreas(),
@@ -95,7 +102,10 @@ const triageSchema = z.object({
 
 const promoteSchema = z.object({
   id: z.coerce.number().int().positive().max(MAX_INT4),
-  // `''` for the new-bug path; a numeric string attaches to an existing Bug instead.
+  // 🔴 POSTED EXPLICITLY, never inferred from whether `bugId` is blank. Inferring it sends an empty
+  // issue-number box down the create-a-new-issue branch, which then refuses with "Give the issue a
+  // title" over a form showing no title field.
+  mode: z.enum(['create', 'attach']),
   bugId: z.string().trim().optional(),
   title: z.string().trim().max(300).optional(),
   summary: z.string().trim().max(5000).optional(),
@@ -117,8 +127,7 @@ export const actions: Actions = {
       moderatorId: locals.user.id,
     });
 
-    if (!result.ok)
-      return fail(410, { error: 'That feedback no longer exists.', gone: true });
+    if (!result.ok) return fail(410, { error: 'That feedback no longer exists.', gone: true });
     // 🔴 Zero affected rows is a REFUSAL. The UPDATE is scoped on the status the operator was
     // looking at, so nothing moving means someone else's verdict is already on the row.
     if (!result.changed)
@@ -133,9 +142,12 @@ export const actions: Actions = {
     const input = parseForm(promoteSchema, await request.formData());
     if (typeof input === 'string') return fail(400, { error: input });
 
-    const existingBugId = input.bugId ? Number(input.bugId) : null;
-    if (existingBugId !== null) {
-      if (!Number.isInteger(existingBugId) || existingBugId <= 0 || existingBugId > MAX_INT4)
+    if (input.mode === 'attach') {
+      // Blank and malformed are different mistakes: telling someone who typed `abc` to "enter an
+      // issue number" is an instruction they already followed.
+      if (!input.bugId) return fail(400, { error: 'Enter an issue number.' });
+      const existingBugId = Number(input.bugId);
+      if (!isInt4Id(existingBugId))
         return fail(400, { error: 'That is not a valid issue number.' });
 
       const linked = await linkFeedbackToBug({
@@ -151,7 +163,8 @@ export const actions: Actions = {
     const title = input.title ?? '';
     const summary = input.summary ?? '';
     if (!title) return fail(400, { error: 'Give the issue a title.' });
-    if (!summary) return fail(400, { error: 'Write a summary — it is what the issue board shows.' });
+    if (!summary)
+      return fail(400, { error: 'Write a summary — it is what the issue board shows.' });
 
     const promoted = await promoteFeedbackToBug({
       id: input.id,
@@ -163,9 +176,8 @@ export const actions: Actions = {
   }),
 };
 
-const promoteFailure = (reason: 'already-linked' | 'no-such-bug') =>
-  reason === 'no-such-bug'
-    ? fail(404, { error: 'No issue with that number.' })
-    : fail(409, {
-        error: 'That feedback is already linked to an issue. Reload to see which.',
-      });
+const promoteFailure = (reason: 'already-linked' | 'no-such-bug' | 'gone') => {
+  if (reason === 'no-such-bug') return fail(404, { error: 'No issue with that number.' });
+  if (reason === 'gone') return fail(410, { error: 'That feedback no longer exists.', gone: true });
+  return fail(409, { error: 'That feedback is already linked to an issue. Reload to see which.' });
+};

--- a/apps/moderator/src/routes/feedback/+page.svelte
+++ b/apps/moderator/src/routes/feedback/+page.svelte
@@ -57,7 +57,9 @@
 {#if data.migrationPending}
   <!-- 🔴 `moderator:admin` reaches this page before anyone ticks a box on `/admin`, and the sidebar
        badge counts on `status` alone — so it renders a real number against a database that has not
-       had the triage columns applied. Says what to do instead of throwing out of `load`. -->
+       had the triage columns applied. Says what to do instead of throwing out of `load`.
+       This names ONE migration, so `isMissingTriageColumns` is keyed on that migration's own column
+       names: any other absent column still throws rather than arriving here as wrong advice. -->
   <div class="rounded-xl border border-dark-4 bg-dark-6 p-5">
     <p class="text-white">This queue is not ready yet.</p>
     <p class="mt-2 text-sm text-dark-2">

--- a/apps/moderator/src/routes/feedback/+page.svelte
+++ b/apps/moderator/src/routes/feedback/+page.svelte
@@ -17,6 +17,7 @@
   import {
     feedbackAttachmentCount,
     feedbackStatusBadgeClass,
+    handledByLabel,
     splitContext,
   } from '$lib/feedback';
   import FeedbackFilters from './FeedbackFilters.svelte';
@@ -28,14 +29,17 @@
   const rowHref = (id: number) => urlWith(page.url, { open: data.open === id ? null : id });
 
   /**
-   * 🔴 THE ONLY SURFACE A REFUSAL HAS WHEN THE PANEL IS NOT MOUNTED, which is exactly when the
-   * important ones happen. `FormState` awaits `update({ invalidateAll })` BEFORE assigning its own
-   * `error`, so a 410 (the row was deleted) or a 409 that moves the row out of the active status
-   * filter has already dropped the row from `data.items` — the panel is unmounted and its message
-   * is written to a dead instance. A no-JS submit has no panel at all, because posting to
-   * `?/triage` replaces the query string and takes `?open=` with it.
+   * 🔴 THE NO-JS SURFACE, and only that. Deleting it as dead code is the mistake to avoid.
    *
-   * Gated on `openVisible` so a refusal the panel CAN still show is not rendered twice.
+   * Without JS the browser posts a full page load to `/feedback?/triage`, so `load` re-runs against
+   * a URL carrying no `?open=`: no panel is rendered, and this is the only thing that tells the
+   * operator their triage was refused.
+   *
+   * With JS it is unreachable, and the `openVisible` gate is what makes that true. `update()`
+   * re-runs `load` ONLY on success (`@sveltejs/kit@2.66.0`, `runtime/app/forms.js:99-107` — both
+   * the reset and `invalidateAll()` sit inside `if (result.type === 'success')`), so a refusal
+   * leaves `data` untouched, the row open, `openVisible` true, and the panel mounted to render its
+   * own message. The two surfaces cover disjoint paths; neither is redundant.
    */
   const pageError = $derived(
     !data.openVisible && form && 'error' in form && form.error ? String(form.error) : null
@@ -50,111 +54,125 @@
   </p>
 </header>
 
-<FeedbackFilters
-  statuses={data.statuses}
-  area={data.area}
-  areaOptions={data.areaOptions}
-  shown={data.items.length}
-/>
+{#if data.migrationPending}
+  <!-- 🔴 `moderator:admin` reaches this page before anyone ticks a box on `/admin`, and the sidebar
+       badge counts on `status` alone — so it renders a real number against a database that has not
+       had the triage columns applied. Says what to do instead of throwing out of `load`. -->
+  <div class="rounded-xl border border-dark-4 bg-dark-6 p-5">
+    <p class="text-white">This queue is not ready yet.</p>
+    <p class="mt-2 text-sm text-dark-2">
+      Its migration has not been applied to this database. Migrations here are run by hand, per
+      environment — apply <code>20260911120000_feedback_triage</code> and reload. The sidebar count
+      reads a column that already exists, which is why it still shows a number.
+    </p>
+  </div>
+{:else}
+  <FeedbackFilters
+    statuses={data.statuses}
+    area={data.area}
+    areaOptions={data.areaOptions}
+    shown={data.items.length}
+  />
 
-{#if pageError}
-  <ErrorAlert message={pageError} class="mb-4" />
-{:else if data.open !== null && !data.openVisible}
-  <!-- Only when there is no refusal to show: "clear the filters" is the wrong advice for a row that
-       was just deleted, and that is the case where both would otherwise render. -->
-  <p class="mb-4 text-sm text-dark-2">
-    Report #{data.open} is not in this view — clear the filters to open it.
-  </p>
-{/if}
+  {#if pageError}
+    <ErrorAlert message={pageError} class="mb-4" />
+  {:else if data.open !== null && !data.openVisible}
+    <!-- Only when there is no refusal to show: "clear the filters" is the wrong advice for a row
+         that was just deleted, and that is the case where both would otherwise render. -->
+    <p class="mb-4 text-sm text-dark-2">
+      Report #{data.open} is not in this view — clear the filters to open it.
+    </p>
+  {/if}
 
-<div class="rounded-xl border border-dark-4 bg-dark-6">
-  <Table>
-    <TableHeader>
-      <TableRow>
-        <TableHead>Age</TableHead>
-        <TableHead>Area</TableHead>
-        <TableHead>User</TableHead>
-        <TableHead>Message</TableHead>
-        <TableHead class="text-right">📎</TableHead>
-        <TableHead>Status</TableHead>
-        <TableHead>Handled</TableHead>
-        <TableHead>Issue</TableHead>
-        <TableHead class="w-px"></TableHead>
-      </TableRow>
-    </TableHeader>
-    <TableBody>
-      {#each data.items as row (row.id)}
-        {@const context = splitContext(row.context)}
-        {@const attachments = feedbackAttachmentCount(context)}
-        {@const open = data.open === row.id}
+  <div class="rounded-xl border border-dark-4 bg-dark-6">
+    <Table>
+      <TableHeader>
         <TableRow>
-          <TableCell class="whitespace-nowrap tabular-nums" title={dateTime(row.createdAt)}>
-            {shortAge(row.createdAt)}
-          </TableCell>
-          <TableCell><Badge variant="outline">{row.area}</Badge></TableCell>
-          <TableCell>
-            {#if row.username}
-              <a href={userLookupUrl(row.username)} class={LINK_CLASS}>{row.username}</a>
-            {:else}
-              <span class="text-dark-2">#{row.userId}</span>
-            {/if}
-          </TableCell>
-          <TableCell class="max-w-md">
-            <span class="line-clamp-1 text-sm text-dark-2" title={row.message}>{row.message}</span>
-          </TableCell>
-          <TableCell class="text-right tabular-nums text-dark-2">{attachments || ''}</TableCell>
-          <TableCell>
-            <Badge class={feedbackStatusBadgeClass(row.status)}>{row.status}</Badge>
-          </TableCell>
-          <TableCell class="whitespace-nowrap text-sm text-dark-2">
-            {row.handledByUsername ?? (row.handledAt ? 'deleted account' : '—')}
-          </TableCell>
-          <TableCell class="whitespace-nowrap tabular-nums">
-            {#if row.bugId}
-              <a
-                href={issuesUrl(data.civitaiUrl)}
-                target="_blank"
-                rel="noreferrer"
-                class={LINK_CLASS}
-              >
-                #{row.bugId}
-              </a>
-            {:else}
-              <span class="text-dark-2">—</span>
-            {/if}
-          </TableCell>
-          <TableCell>
-            <a href={rowHref(row.id)} class={LINK_CLASS} aria-expanded={open}>
-              {open ? 'Close' : 'Open'}
-            </a>
-          </TableCell>
+          <TableHead>Age</TableHead>
+          <TableHead>Area</TableHead>
+          <TableHead>User</TableHead>
+          <TableHead>Message</TableHead>
+          <TableHead class="text-right">📎</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Handled</TableHead>
+          <TableHead>Issue</TableHead>
+          <TableHead class="w-px"></TableHead>
         </TableRow>
-        {#if open}
+      </TableHeader>
+      <TableBody>
+        {#each data.items as row (row.id)}
+          {@const context = splitContext(row.context)}
+          {@const attachments = feedbackAttachmentCount(context)}
+          {@const open = data.open === row.id}
           <TableRow>
-            <TableCell colspan={9} class="bg-dark-7/40 p-0">
-              <FeedbackDetail
-                {row}
-                {context}
-                siblings={data.siblings}
-                grafanaUrl={data.grafanaUrl}
-                civitaiUrl={data.civitaiUrl}
-                canTriage={!!data.grants['feedback.status.set']}
-                canPromote={!!data.grants['feedback.bug.promote']}
-              />
+            <TableCell class="whitespace-nowrap tabular-nums" title={dateTime(row.createdAt)}>
+              {shortAge(row.createdAt)}
+            </TableCell>
+            <TableCell><Badge variant="outline">{row.area}</Badge></TableCell>
+            <TableCell>
+              {#if row.username}
+                <a href={userLookupUrl(row.username)} class={LINK_CLASS}>{row.username}</a>
+              {:else}
+                <span class="text-dark-2">#{row.userId}</span>
+              {/if}
+            </TableCell>
+            <TableCell class="max-w-md">
+              <span class="line-clamp-1 text-sm text-dark-2" title={row.message}>{row.message}</span>
+            </TableCell>
+            <TableCell class="text-right tabular-nums text-dark-2">{attachments || ''}</TableCell>
+            <TableCell>
+              <Badge class={feedbackStatusBadgeClass(row.status)}>{row.status}</Badge>
+            </TableCell>
+            <TableCell class="whitespace-nowrap text-sm text-dark-2">
+              {handledByLabel(row)}
+            </TableCell>
+            <TableCell class="whitespace-nowrap tabular-nums">
+              {#if row.bugId}
+                <a
+                  href={issuesUrl(data.civitaiUrl)}
+                  target="_blank"
+                  rel="noreferrer"
+                  class={LINK_CLASS}
+                >
+                  #{row.bugId}
+                </a>
+              {:else}
+                <span class="text-dark-2">—</span>
+              {/if}
+            </TableCell>
+            <TableCell>
+              <a href={rowHref(row.id)} class={LINK_CLASS} aria-expanded={open}>
+                {open ? 'Close' : 'Open'}
+              </a>
             </TableCell>
           </TableRow>
-        {/if}
-      {:else}
-        <TableRow>
-          <TableCell colspan={9} class="py-8 text-center text-dark-2">
-            No feedback matches this view.
-          </TableCell>
-        </TableRow>
-      {/each}
-    </TableBody>
-  </Table>
-</div>
+          {#if open}
+            <TableRow>
+              <TableCell colspan={9} class="bg-dark-7/40 p-0">
+                <FeedbackDetail
+                  {row}
+                  {context}
+                  siblings={data.siblings}
+                  grafanaUrl={data.grafanaUrl}
+                  civitaiUrl={data.civitaiUrl}
+                  canTriage={!!data.grants['feedback.status.set']}
+                  canPromote={!!data.grants['feedback.bug.promote']}
+                />
+              </TableCell>
+            </TableRow>
+          {/if}
+        {:else}
+          <TableRow>
+            <TableCell colspan={9} class="py-8 text-center text-dark-2">
+              No feedback matches this view.
+            </TableCell>
+          </TableRow>
+        {/each}
+      </TableBody>
+    </Table>
+  </div>
 
-<CursorPager
-  href={data.nextCursor ? urlWith(page.url, { cursor: data.nextCursor, open: null }) : null}
-/>
+  <CursorPager
+    href={data.nextCursor ? urlWith(page.url, { cursor: data.nextCursor, open: null }) : null}
+  />
+{/if}

--- a/apps/moderator/src/routes/feedback/+page.svelte
+++ b/apps/moderator/src/routes/feedback/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import { page } from '$app/state';
   import {
     Table,
@@ -10,45 +9,37 @@
     TableRow,
   } from '@civitai/ui/components/ui/table/index.js';
   import { Badge } from '@civitai/ui/components/ui/badge/index.js';
-  import * as Select from '@civitai/ui/components/ui/select/index.js';
-  import { MultiCombobox } from '@civitai/ui/components/ui/multi-combobox/index.js';
-  import { Label } from '@civitai/ui/components/ui/label/index.js';
   import CursorPager from '$lib/components/CursorPager.svelte';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
-  import { LINK_CLASS, dateTime, num, shortAge } from '$lib/format';
-  import { userLookupUrl } from '$lib/entity-url';
-  import { urlWith, urlWithMulti } from '$lib/url';
+  import { LINK_CLASS, dateTime, shortAge } from '$lib/format';
+  import { issuesUrl, userLookupUrl } from '$lib/entity-url';
+  import { urlWith } from '$lib/url';
   import {
-    FEEDBACK_STATUSES,
     feedbackAttachmentCount,
     feedbackStatusBadgeClass,
     splitContext,
   } from '$lib/feedback';
+  import FeedbackFilters from './FeedbackFilters.svelte';
   import FeedbackDetail from './FeedbackDetail.svelte';
   import type { ActionData, PageData } from './$types';
 
   let { data, form }: { data: PageData; form: ActionData } = $props();
 
-  const statusOptions = FEEDBACK_STATUSES.map((s) => ({ value: s, label: s }));
-  const areaLabel = $derived(data.area || 'Area — any');
+  const rowHref = (id: number) => urlWith(page.url, { open: data.open === id ? null : id });
 
-  // `emptyMeansAll`: an ABSENT `status` falls back to the default view, so a cleared filter has to
-  // survive as `?status=` or clearing it silently reapplies `new`.
-  const applyStatus = (values: string[]) =>
-    goto(urlWithMulti(clearedUrl(), 'status', values, { emptyMeansAll: true }));
-  const applyArea = (value: string) => goto(urlWith(clearedUrl(), { area: value || null }));
-
-  // Any filter change invalidates the keyset, and it closes the open row: the cursor points into a
-  // result set that no longer exists, and `?open=` would name a row the new filters may exclude.
-  function clearedUrl() {
-    const next = new URL(page.url);
-    next.searchParams.delete('cursor');
-    next.searchParams.delete('open');
-    return next;
-  }
-
-  const rowHref = (id: number) =>
-    urlWith(page.url, { open: data.open === id ? null : id });
+  /**
+   * 🔴 THE ONLY SURFACE A REFUSAL HAS WHEN THE PANEL IS NOT MOUNTED, which is exactly when the
+   * important ones happen. `FormState` awaits `update({ invalidateAll })` BEFORE assigning its own
+   * `error`, so a 410 (the row was deleted) or a 409 that moves the row out of the active status
+   * filter has already dropped the row from `data.items` — the panel is unmounted and its message
+   * is written to a dead instance. A no-JS submit has no panel at all, because posting to
+   * `?/triage` replaces the query string and takes `?open=` with it.
+   *
+   * Gated on `openVisible` so a refusal the panel CAN still show is not rendered twice.
+   */
+  const pageError = $derived(
+    !data.openVisible && form && 'error' in form && form.error ? String(form.error) : null
+  );
 </script>
 
 <header class="page-header">
@@ -59,40 +50,24 @@
   </p>
 </header>
 
-<div class="mb-4 flex flex-wrap items-end gap-x-4 gap-y-3">
-  <div class="flex flex-col gap-1">
-    <Label for="feedback-status" class="text-xs text-dark-2">Status</Label>
-    <MultiCombobox
-      options={statusOptions}
-      value={data.statuses}
-      onValueChange={applyStatus}
-      placeholder="Search statuses…"
-    />
-  </div>
+<FeedbackFilters
+  statuses={data.statuses}
+  area={data.area}
+  areaOptions={data.areaOptions}
+  shown={data.items.length}
+/>
 
-  <div class="flex flex-col gap-1">
-    <Label for="feedback-area" class="text-xs text-dark-2">Area</Label>
-    <Select.Root type="single" value={data.area} onValueChange={applyArea}>
-      <Select.Trigger id="feedback-area" class="w-56">{areaLabel}</Select.Trigger>
-      <Select.Content>
-        <Select.Item value="">Area — any</Select.Item>
-        {#each data.areaOptions as option (option)}
-          <Select.Item value={option}>{option}</Select.Item>
-        {/each}
-      </Select.Content>
-    </Select.Root>
-  </div>
-
-  <span class="pb-1.5 text-xs text-dark-2">{num(data.items.length)} shown</span>
-</div>
-
-{#if data.open !== null && !data.openVisible}
+{#if pageError}
+  <ErrorAlert message={pageError} class="mb-4" />
+{:else if data.open !== null && !data.openVisible}
+  <!-- Only when there is no refusal to show: "clear the filters" is the wrong advice for a row that
+       was just deleted, and that is the case where both would otherwise render. -->
   <p class="mb-4 text-sm text-dark-2">
     Report #{data.open} is not in this view — clear the filters to open it.
   </p>
 {/if}
 
-<div class="rounded-xl border border-dark-4">
+<div class="rounded-xl border border-dark-4 bg-dark-6">
   <Table>
     <TableHeader>
       <TableRow>
@@ -136,7 +111,12 @@
           </TableCell>
           <TableCell class="whitespace-nowrap tabular-nums">
             {#if row.bugId}
-              <a href={`${data.civitaiUrl}/issues`} target="_blank" rel="noreferrer" class={LINK_CLASS}>
+              <a
+                href={issuesUrl(data.civitaiUrl)}
+                target="_blank"
+                rel="noreferrer"
+                class={LINK_CLASS}
+              >
                 #{row.bugId}
               </a>
             {:else}
@@ -175,10 +155,6 @@
   </Table>
 </div>
 
-<!-- The page-level `form` object carries a refusal raised on a row that a reload may have closed.
-     Rendered here as well as in the panel so a denial is never invisible. -->
-{#if form && 'error' in form && form.error}
-  <ErrorAlert message={String(form.error)} class="mt-4" />
-{/if}
-
-<CursorPager href={data.nextCursor ? urlWith(page.url, { cursor: data.nextCursor, open: null }) : null} />
+<CursorPager
+  href={data.nextCursor ? urlWith(page.url, { cursor: data.nextCursor, open: null }) : null}
+/>

--- a/apps/moderator/src/routes/feedback/+page.svelte
+++ b/apps/moderator/src/routes/feedback/+page.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
+  import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+  } from '@civitai/ui/components/ui/table/index.js';
+  import { Badge } from '@civitai/ui/components/ui/badge/index.js';
+  import * as Select from '@civitai/ui/components/ui/select/index.js';
+  import { MultiCombobox } from '@civitai/ui/components/ui/multi-combobox/index.js';
+  import { Label } from '@civitai/ui/components/ui/label/index.js';
+  import CursorPager from '$lib/components/CursorPager.svelte';
+  import ErrorAlert from '$lib/components/ErrorAlert.svelte';
+  import { LINK_CLASS, dateTime, num, shortAge } from '$lib/format';
+  import { userLookupUrl } from '$lib/entity-url';
+  import { urlWith, urlWithMulti } from '$lib/url';
+  import {
+    FEEDBACK_STATUSES,
+    feedbackAttachmentCount,
+    feedbackStatusBadgeClass,
+    splitContext,
+  } from '$lib/feedback';
+  import FeedbackDetail from './FeedbackDetail.svelte';
+  import type { ActionData, PageData } from './$types';
+
+  let { data, form }: { data: PageData; form: ActionData } = $props();
+
+  const statusOptions = FEEDBACK_STATUSES.map((s) => ({ value: s, label: s }));
+  const areaLabel = $derived(data.area || 'Area — any');
+
+  // `emptyMeansAll`: an ABSENT `status` falls back to the default view, so a cleared filter has to
+  // survive as `?status=` or clearing it silently reapplies `new`.
+  const applyStatus = (values: string[]) =>
+    goto(urlWithMulti(clearedUrl(), 'status', values, { emptyMeansAll: true }));
+  const applyArea = (value: string) => goto(urlWith(clearedUrl(), { area: value || null }));
+
+  // Any filter change invalidates the keyset, and it closes the open row: the cursor points into a
+  // result set that no longer exists, and `?open=` would name a row the new filters may exclude.
+  function clearedUrl() {
+    const next = new URL(page.url);
+    next.searchParams.delete('cursor');
+    next.searchParams.delete('open');
+    return next;
+  }
+
+  const rowHref = (id: number) =>
+    urlWith(page.url, { open: data.open === id ? null : id });
+</script>
+
+<header class="page-header">
+  <h1>Feedback</h1>
+  <p>
+    In-product reports from the site's feedback prompts, newest first. Everything under
+    <strong>Context</strong> is what the reporter's browser said — a claim, not evidence.
+  </p>
+</header>
+
+<div class="mb-4 flex flex-wrap items-end gap-x-4 gap-y-3">
+  <div class="flex flex-col gap-1">
+    <Label for="feedback-status" class="text-xs text-dark-2">Status</Label>
+    <MultiCombobox
+      options={statusOptions}
+      value={data.statuses}
+      onValueChange={applyStatus}
+      placeholder="Search statuses…"
+    />
+  </div>
+
+  <div class="flex flex-col gap-1">
+    <Label for="feedback-area" class="text-xs text-dark-2">Area</Label>
+    <Select.Root type="single" value={data.area} onValueChange={applyArea}>
+      <Select.Trigger id="feedback-area" class="w-56">{areaLabel}</Select.Trigger>
+      <Select.Content>
+        <Select.Item value="">Area — any</Select.Item>
+        {#each data.areaOptions as option (option)}
+          <Select.Item value={option}>{option}</Select.Item>
+        {/each}
+      </Select.Content>
+    </Select.Root>
+  </div>
+
+  <span class="pb-1.5 text-xs text-dark-2">{num(data.items.length)} shown</span>
+</div>
+
+{#if data.open !== null && !data.openVisible}
+  <p class="mb-4 text-sm text-dark-2">
+    Report #{data.open} is not in this view — clear the filters to open it.
+  </p>
+{/if}
+
+<div class="rounded-xl border border-dark-4">
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHead>Age</TableHead>
+        <TableHead>Area</TableHead>
+        <TableHead>User</TableHead>
+        <TableHead>Message</TableHead>
+        <TableHead class="text-right">📎</TableHead>
+        <TableHead>Status</TableHead>
+        <TableHead>Handled</TableHead>
+        <TableHead>Issue</TableHead>
+        <TableHead class="w-px"></TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {#each data.items as row (row.id)}
+        {@const context = splitContext(row.context)}
+        {@const attachments = feedbackAttachmentCount(context)}
+        {@const open = data.open === row.id}
+        <TableRow>
+          <TableCell class="whitespace-nowrap tabular-nums" title={dateTime(row.createdAt)}>
+            {shortAge(row.createdAt)}
+          </TableCell>
+          <TableCell><Badge variant="outline">{row.area}</Badge></TableCell>
+          <TableCell>
+            {#if row.username}
+              <a href={userLookupUrl(row.username)} class={LINK_CLASS}>{row.username}</a>
+            {:else}
+              <span class="text-dark-2">#{row.userId}</span>
+            {/if}
+          </TableCell>
+          <TableCell class="max-w-md">
+            <span class="line-clamp-1 text-sm text-dark-2" title={row.message}>{row.message}</span>
+          </TableCell>
+          <TableCell class="text-right tabular-nums text-dark-2">{attachments || ''}</TableCell>
+          <TableCell>
+            <Badge class={feedbackStatusBadgeClass(row.status)}>{row.status}</Badge>
+          </TableCell>
+          <TableCell class="whitespace-nowrap text-sm text-dark-2">
+            {row.handledByUsername ?? (row.handledAt ? 'deleted account' : '—')}
+          </TableCell>
+          <TableCell class="whitespace-nowrap tabular-nums">
+            {#if row.bugId}
+              <a href={`${data.civitaiUrl}/issues`} target="_blank" rel="noreferrer" class={LINK_CLASS}>
+                #{row.bugId}
+              </a>
+            {:else}
+              <span class="text-dark-2">—</span>
+            {/if}
+          </TableCell>
+          <TableCell>
+            <a href={rowHref(row.id)} class={LINK_CLASS} aria-expanded={open}>
+              {open ? 'Close' : 'Open'}
+            </a>
+          </TableCell>
+        </TableRow>
+        {#if open}
+          <TableRow>
+            <TableCell colspan={9} class="bg-dark-7/40 p-0">
+              <FeedbackDetail
+                {row}
+                {context}
+                siblings={data.siblings}
+                grafanaUrl={data.grafanaUrl}
+                civitaiUrl={data.civitaiUrl}
+                canTriage={!!data.grants['feedback.status.set']}
+                canPromote={!!data.grants['feedback.bug.promote']}
+              />
+            </TableCell>
+          </TableRow>
+        {/if}
+      {:else}
+        <TableRow>
+          <TableCell colspan={9} class="py-8 text-center text-dark-2">
+            No feedback matches this view.
+          </TableCell>
+        </TableRow>
+      {/each}
+    </TableBody>
+  </Table>
+</div>
+
+<!-- The page-level `form` object carries a refusal raised on a row that a reload may have closed.
+     Rendered here as well as in the panel so a denial is never invisible. -->
+{#if form && 'error' in form && form.error}
+  <ErrorAlert message={String(form.error)} class="mt-4" />
+{/if}
+
+<CursorPager href={data.nextCursor ? urlWith(page.url, { cursor: data.nextCursor, open: null }) : null} />

--- a/apps/moderator/src/routes/feedback/FeedbackContext.svelte
+++ b/apps/moderator/src/routes/feedback/FeedbackContext.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  import { Button } from '@civitai/ui/components/ui/button/index.js';
+  import EdgeImage from '$lib/components/EdgeImage.svelte';
+  import { LINK_CLASS, dateTime } from '$lib/format';
+  import {
+    FARO_LOKI_RETENTION_HOURS,
+    faroSessionLink,
+    reconstructFeedbackUrl,
+    type FeedbackContext,
+  } from '$lib/feedback';
+
+  /**
+   * What the reporter's browser said, rendered as a claim rather than as evidence — the heading is
+   * where they SAID they were.
+   */
+  let {
+    context,
+    createdAt,
+    civitaiUrl,
+    grafanaUrl,
+  }: {
+    context: FeedbackContext;
+    createdAt: Date | string;
+    civitaiUrl: string;
+    grafanaUrl: string | null;
+  } = $props();
+
+  const reconstructed = $derived(reconstructFeedbackUrl(context.path, context.filters));
+  // `now` is read once per render rather than inside the helper: a function that reads the clock
+  // cannot be tested at the boundary it exists to enforce.
+  const faroHref = $derived(
+    faroSessionLink({
+      grafanaUrl,
+      sessionId: context.sessionId,
+      createdAt,
+      now: Date.now(),
+    })
+  );
+
+  let copyState = $state<'idle' | 'copied' | 'failed'>('idle');
+  async function copySession() {
+    if (!context.sessionId) return;
+    // `writeText` rejects outside a secure context and when the permission is refused. An
+    // unhandled rejection here would leave the button looking like it did nothing.
+    try {
+      await navigator.clipboard.writeText(context.sessionId);
+      copyState = 'copied';
+    } catch {
+      copyState = 'failed';
+    }
+  }
+</script>
+
+<section class="flex flex-col gap-2">
+  <h3 class="text-xs font-semibold tracking-wide text-dark-2 uppercase">
+    Where the reporter said they were
+    <span class="ml-2 font-normal normal-case">{dateTime(createdAt)}</span>
+  </h3>
+
+  {#if reconstructed}
+    <!-- 🔴 `context.path` is a bare pathname. On a page whose whole view lives in the query string,
+         linking `path` alone lands somewhere the report is not about. -->
+    <a
+      href={`${civitaiUrl}${reconstructed}`}
+      target="_blank"
+      rel="noreferrer"
+      class={`${LINK_CLASS} font-mono text-sm`}
+    >
+      {reconstructed}
+    </a>
+  {:else}
+    <p class="text-sm text-dark-2">No path reported.</p>
+  {/if}
+
+  {#if context.filters}
+    <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-0.5 text-sm">
+      {#each Object.entries(context.filters) as [key, value] (key)}
+        <dt class="text-dark-2">{key}</dt>
+        <!-- `none` is the marketplace builder's sentinel for "no category selected", written
+             because an explicit `undefined` fails the context schema's value union. It is not a
+             category called "none". -->
+        <dd class="font-mono">{value === 'none' ? '(none)' : value === '' ? '—' : String(value)}</dd>
+      {/each}
+    </dl>
+  {/if}
+
+  <div class="flex flex-wrap items-center gap-2 text-sm">
+    <span class="text-dark-2">Session</span>
+    {#if context.sessionId}
+      <code class="font-mono">{context.sessionId}</code>
+      <Button size="sm" variant="ghost" onclick={copySession}>
+        {copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Copy'}
+      </Button>
+      {#if faroHref}
+        <a href={faroHref} target="_blank" rel="noreferrer" class={LINK_CLASS}>Open in Grafana</a>
+      {:else if !grafanaUrl}
+        <!-- 🔴 Three different facts share one observable — expired data, a session that produced
+             no telemetry, and a link that was never configured. Each is named rather than shown as
+             an empty Explore pane. -->
+        <span class="text-dark-2">No Grafana link — PUBLIC_GRAFANA_URL is not set.</span>
+      {:else}
+        <span class="text-dark-2">
+          Faro session data for this report expired ({FARO_LOKI_RETENTION_HOURS} h Loki retention).
+        </span>
+      {/if}
+    {:else}
+      <span class="text-dark-2">
+        None reported — ordinary, Faro does not run in dev, preview or an ad-blocked session.
+      </span>
+    {/if}
+  </div>
+</section>
+
+<section class="flex flex-col gap-2">
+  <h3 class="text-xs font-semibold tracking-wide text-dark-2 uppercase">Attachments</h3>
+  {#if context.images.length || context.screenshotId}
+    <!-- 🔴 These are ids the CLIENT said it uploaded. Nothing proved the objects exist, that they
+         belong to the reporter, or that a capture is of the page named in `path` — so a page
+         capture can carry NSFW content or another user's UI, and the id is attacker-chosen.
+         Accepted; row-level expansion is the containment (nothing loads until a row is opened).
+         The one-line mitigation if this page ever reaches a non-moderator is `blur={40}` here plus
+         a click to clear it. -->
+    <div class="flex flex-wrap gap-3">
+      {#each context.images as id (id)}
+        <figure class="flex flex-col gap-1">
+          <EdgeImage src={id} width={320} class="max-h-64 w-auto rounded-lg border border-dark-4" />
+          <figcaption class="text-xs text-dark-2">Attached by the reporter</figcaption>
+        </figure>
+      {/each}
+      {#if context.screenshotId}
+        <figure class="flex flex-col gap-1">
+          <EdgeImage
+            src={context.screenshotId}
+            width={320}
+            class="max-h-64 w-auto rounded-lg border border-dark-4"
+          />
+          <figcaption class="text-xs text-dark-2">Opt-in capture of their own viewport</figcaption>
+        </figure>
+      {/if}
+    </div>
+  {:else}
+    <p class="text-sm text-dark-2">(none)</p>
+  {/if}
+</section>
+
+{#if context.other}
+  <section class="flex flex-col gap-2">
+    <!-- 🔴 Dumped verbatim. `feedbackContextSchema` already accepts keys no current producer emits,
+         and a panel rendering only the keys it knows about discards every future area's payload. -->
+    <h3 class="text-xs font-semibold tracking-wide text-dark-2 uppercase">Other context</h3>
+    <pre class="max-h-64 overflow-auto rounded-lg border border-dark-4 bg-dark-7 p-3 text-xs">{JSON.stringify(
+        context.other,
+        null,
+        2
+      )}</pre>
+  </section>
+{/if}

--- a/apps/moderator/src/routes/feedback/FeedbackContextPanel.svelte
+++ b/apps/moderator/src/routes/feedback/FeedbackContextPanel.svelte
@@ -32,8 +32,17 @@
   );
 
   let copyState = $state<'idle' | 'copied' | 'failed'>('idle');
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // The label is transient, so the timer is the one thing here that lives outside Svelte: cleared
+  // on a re-click and on unmount, or it fires against a destroyed component.
+  $effect(() => () => {
+    if (copyTimer) clearTimeout(copyTimer);
+  });
+
   async function copySession() {
     if (!context.sessionId) return;
+    if (copyTimer) clearTimeout(copyTimer);
     // `writeText` rejects outside a secure context and when the permission is refused. An
     // unhandled rejection here would leave the button looking like it did nothing.
     try {
@@ -42,6 +51,7 @@
     } catch {
       copyState = 'failed';
     }
+    copyTimer = setTimeout(() => (copyState = 'idle'), 2000);
   }
 </script>
 

--- a/apps/moderator/src/routes/feedback/FeedbackContextPanel.svelte
+++ b/apps/moderator/src/routes/feedback/FeedbackContextPanel.svelte
@@ -9,10 +9,6 @@
     type FeedbackContext,
   } from '$lib/feedback';
 
-  /**
-   * What the reporter's browser said, rendered as a claim rather than as evidence — the heading is
-   * where they SAID they were.
-   */
   let {
     context,
     createdAt,
@@ -26,8 +22,6 @@
   } = $props();
 
   const reconstructed = $derived(reconstructFeedbackUrl(context.path, context.filters));
-  // `now` is read once per render rather than inside the helper: a function that reads the clock
-  // cannot be tested at the boundary it exists to enforce.
   const faroHref = $derived(
     faroSessionLink({
       grafanaUrl,
@@ -52,14 +46,12 @@
 </script>
 
 <section class="flex flex-col gap-2">
-  <h3 class="text-xs font-semibold tracking-wide text-dark-2 uppercase">
+  <h3 class="text-xs tracking-wide text-dark-2 uppercase">
     Where the reporter said they were
     <span class="ml-2 font-normal normal-case">{dateTime(createdAt)}</span>
   </h3>
 
   {#if reconstructed}
-    <!-- 🔴 `context.path` is a bare pathname. On a page whose whole view lives in the query string,
-         linking `path` alone lands somewhere the report is not about. -->
     <a
       href={`${civitaiUrl}${reconstructed}`}
       target="_blank"
@@ -76,9 +68,7 @@
     <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-0.5 text-sm">
       {#each Object.entries(context.filters) as [key, value] (key)}
         <dt class="text-dark-2">{key}</dt>
-        <!-- `none` is the marketplace builder's sentinel for "no category selected", written
-             because an explicit `undefined` fails the context schema's value union. It is not a
-             category called "none". -->
+        <!-- `none` is the "no category selected" sentinel, not a category named "none". -->
         <dd class="font-mono">{value === 'none' ? '(none)' : value === '' ? '—' : String(value)}</dd>
       {/each}
     </dl>
@@ -91,12 +81,11 @@
       <Button size="sm" variant="ghost" onclick={copySession}>
         {copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Copy'}
       </Button>
+      <!-- 🔴 Expired data, a session that produced no telemetry, and an unconfigured link share one
+           observable — an empty Explore pane. Each is named instead. -->
       {#if faroHref}
         <a href={faroHref} target="_blank" rel="noreferrer" class={LINK_CLASS}>Open in Grafana</a>
       {:else if !grafanaUrl}
-        <!-- 🔴 Three different facts share one observable — expired data, a session that produced
-             no telemetry, and a link that was never configured. Each is named rather than shown as
-             an empty Explore pane. -->
         <span class="text-dark-2">No Grafana link — PUBLIC_GRAFANA_URL is not set.</span>
       {:else}
         <span class="text-dark-2">
@@ -112,30 +101,25 @@
 </section>
 
 <section class="flex flex-col gap-2">
-  <h3 class="text-xs font-semibold tracking-wide text-dark-2 uppercase">Attachments</h3>
+  <h3 class="text-xs tracking-wide text-dark-2 uppercase">Attachments</h3>
+  {#snippet thumbnail(id: string, caption: string)}
+    <figure class="flex flex-col gap-1">
+      <EdgeImage src={id} width={320} class="max-h-64 w-auto rounded-lg border border-dark-4" />
+      <figcaption class="text-xs text-dark-2">{caption}</figcaption>
+    </figure>
+  {/snippet}
+
   {#if context.images.length || context.screenshotId}
-    <!-- 🔴 These are ids the CLIENT said it uploaded. Nothing proved the objects exist, that they
-         belong to the reporter, or that a capture is of the page named in `path` — so a page
-         capture can carry NSFW content or another user's UI, and the id is attacker-chosen.
-         Accepted; row-level expansion is the containment (nothing loads until a row is opened).
-         The one-line mitigation if this page ever reaches a non-moderator is `blur={40}` here plus
-         a click to clear it. -->
+    <!-- 🔴 Unverified, client-supplied ids: a page capture can carry NSFW content or another user's
+         UI. Row-level expansion IS the containment — nothing loads until a moderator opens a row —
+         so do not hoist these into the list. If this page ever reaches a non-moderator, add
+         `blur={40}` and a click to clear. -->
     <div class="flex flex-wrap gap-3">
       {#each context.images as id (id)}
-        <figure class="flex flex-col gap-1">
-          <EdgeImage src={id} width={320} class="max-h-64 w-auto rounded-lg border border-dark-4" />
-          <figcaption class="text-xs text-dark-2">Attached by the reporter</figcaption>
-        </figure>
+        {@render thumbnail(id, 'Attached by the reporter')}
       {/each}
       {#if context.screenshotId}
-        <figure class="flex flex-col gap-1">
-          <EdgeImage
-            src={context.screenshotId}
-            width={320}
-            class="max-h-64 w-auto rounded-lg border border-dark-4"
-          />
-          <figcaption class="text-xs text-dark-2">Opt-in capture of their own viewport</figcaption>
-        </figure>
+        {@render thumbnail(context.screenshotId, 'Opt-in capture of their own viewport')}
       {/if}
     </div>
   {:else}
@@ -147,7 +131,7 @@
   <section class="flex flex-col gap-2">
     <!-- 🔴 Dumped verbatim. `feedbackContextSchema` already accepts keys no current producer emits,
          and a panel rendering only the keys it knows about discards every future area's payload. -->
-    <h3 class="text-xs font-semibold tracking-wide text-dark-2 uppercase">Other context</h3>
+    <h3 class="text-xs tracking-wide text-dark-2 uppercase">Other context</h3>
     <pre class="max-h-64 overflow-auto rounded-lg border border-dark-4 bg-dark-7 p-3 text-xs">{JSON.stringify(
         context.other,
         null,

--- a/apps/moderator/src/routes/feedback/FeedbackDetail.svelte
+++ b/apps/moderator/src/routes/feedback/FeedbackDetail.svelte
@@ -6,7 +6,7 @@
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
   import { FormState } from '$lib/form-state.svelte';
   import { dateTime } from '$lib/format';
-  import { FEEDBACK_STATUSES, type FeedbackContext } from '$lib/feedback';
+  import { FEEDBACK_STATUSES, handledByLabel, type FeedbackContext } from '$lib/feedback';
   import FeedbackContextPanel from './FeedbackContextPanel.svelte';
   import FeedbackPromote from './FeedbackPromote.svelte';
   import type { FeedbackRow, FeedbackSibling } from '$lib/server/feedback.service';
@@ -83,16 +83,17 @@
       </p>
     {/if}
 
-    <!-- 🔴 OUTSIDE the `canTriage` arm, for the same reason as `FeedbackPromote`'s: `reload: true`
-         re-runs `load` BEFORE the message is assigned, so a 403 raised by a grant revoked mid-session
-         flips this to the permission paragraph and unmounts an alert nested in the form's arm. -->
+    <!-- 🔴 The JS-path surface for a refusal on this form, and the only one: `+page.svelte`'s
+         `pageError` is gated on `openVisible`, which stays true whenever this panel is mounted.
+         Its position outside the `canTriage` arm carries no guarantee — nothing re-renders this
+         section while a refusal is pending, because `update()` re-runs `load` on success only. -->
     {#if triageForm.error}
       <ErrorAlert message={triageForm.error} />
     {/if}
 
     {#if row.handledAt}
       <p class="text-xs text-dark-2">
-        Handled by {row.handledByUsername ?? `#${row.handledById}`} on {dateTime(row.handledAt)}
+        Handled by {handledByLabel(row)} on {dateTime(row.handledAt)}
       </p>
     {/if}
   </section>

--- a/apps/moderator/src/routes/feedback/FeedbackDetail.svelte
+++ b/apps/moderator/src/routes/feedback/FeedbackDetail.svelte
@@ -1,19 +1,15 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
-  import { page } from '$app/state';
   import { Button } from '@civitai/ui/components/ui/button/index.js';
-  import { Input } from '@civitai/ui/components/ui/input/index.js';
   import { Label } from '@civitai/ui/components/ui/label/index.js';
   import { Textarea } from '@civitai/ui/components/ui/textarea/index.js';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
   import { FormState } from '$lib/form-state.svelte';
-  import { LINK_CLASS, dateTime, shortAge } from '$lib/format';
-  import { urlWith } from '$lib/url';
+  import { dateTime } from '$lib/format';
   import { FEEDBACK_STATUSES, type FeedbackContext } from '$lib/feedback';
-  import FeedbackContextPanel from './FeedbackContext.svelte';
-  import type { FeedbackRow } from '$lib/server/feedback.service';
-
-  type Sibling = { id: number; area: string; message: string; createdAt: Date; status: string };
+  import FeedbackContextPanel from './FeedbackContextPanel.svelte';
+  import FeedbackPromote from './FeedbackPromote.svelte';
+  import type { FeedbackRow, FeedbackSibling } from '$lib/server/feedback.service';
 
   let {
     row,
@@ -26,21 +22,20 @@
   }: {
     row: FeedbackRow;
     context: FeedbackContext;
-    siblings: Sibling[];
+    siblings: FeedbackSibling[];
     grafanaUrl: string | null;
     civitaiUrl: string;
     canTriage: boolean;
     canPromote: boolean;
   } = $props();
 
-  // `reload` on both: the panel renders the row's own stored state, so a write that does not re-run
-  // `load` leaves the operator looking at what they replaced.
-  const triageForm = new FormState({ onSuccess: null, reload: true });
-  const promoteForm = new FormState({ onSuccess: null, reload: true });
-
-  // Which half of the promote form is armed. Not a URL concern — it is a local choice, and opening
-  // another row unmounts this component along with it.
-  let attachMode = $state(false);
+  /**
+   * 🔴 `reset: false`. The note box is pre-filled from the COLUMN, and a reset blanks it without
+   * repopulating — the bound expression is unchanged by a status-only save, so Svelte does not
+   * rewrite it. The operator's next status click would then post an empty note and destroy the
+   * stored one, with a green screen over it.
+   */
+  const triageForm = new FormState({ onSuccess: null, reload: true, reset: false });
 </script>
 
 <div class="flex flex-col gap-6 p-5 text-left">
@@ -49,7 +44,7 @@
   <FeedbackContextPanel {context} createdAt={row.createdAt} {civitaiUrl} {grafanaUrl} />
 
   <section class="flex flex-col gap-3">
-    <h3 class="text-xs font-semibold tracking-wide text-dark-2 uppercase">Triage</h3>
+    <h3 class="text-xs tracking-wide text-dark-2 uppercase">Triage</h3>
 
     {#if canTriage}
       <form method="POST" action="?/triage" use:enhance={triageForm.enhance} class="flex flex-col gap-3">
@@ -62,6 +57,7 @@
           <Label for={`note-${row.id}`} class="text-xs text-dark-2">
             Internal note — never seeded into an issue
           </Label>
+          <!-- Every status click rewrites this column, so the box must always carry the stored note. -->
           <Textarea id={`note-${row.id}`} name="note" rows={2} value={row.triageNote ?? ''} />
         </div>
 
@@ -80,14 +76,18 @@
           {/each}
         </div>
       </form>
-      {#if triageForm.error}
-        <ErrorAlert message={triageForm.error} />
-      {/if}
     {:else}
       <p class="text-sm text-dark-2">
         You can read this queue but not triage it — that needs the “Set feedback status and triage
         notes” permission.
       </p>
+    {/if}
+
+    <!-- 🔴 OUTSIDE the `canTriage` arm, for the same reason as `FeedbackPromote`'s: `reload: true`
+         re-runs `load` BEFORE the message is assigned, so a 403 raised by a grant revoked mid-session
+         flips this to the permission paragraph and unmounts an alert nested in the form's arm. -->
+    {#if triageForm.error}
+      <ErrorAlert message={triageForm.error} />
     {/if}
 
     {#if row.handledAt}
@@ -97,87 +97,5 @@
     {/if}
   </section>
 
-  <section class="flex flex-col gap-3">
-    <h3 class="text-xs font-semibold tracking-wide text-dark-2 uppercase">Known issue</h3>
-
-    {#if row.bugId}
-      <p class="text-sm">
-        Linked to issue
-        <a href={`${civitaiUrl}/issues`} target="_blank" rel="noreferrer" class={LINK_CLASS}>
-          #{row.bugId}
-        </a>
-        — {row.bugTitle ?? 'untitled'}
-        <span class="text-dark-2">({row.bugStatus ?? 'unknown status'})</span>
-      </p>
-      {#if siblings.length}
-        <div class="flex flex-col gap-1">
-          <p class="text-sm text-dark-2">
-            {siblings.length} other report{siblings.length === 1 ? '' : 's'} linked to this issue
-          </p>
-          <ul class="flex flex-col gap-1 text-sm">
-            {#each siblings as sibling (sibling.id)}
-              <li>
-                <a href={urlWith(page.url, { open: sibling.id })} class={LINK_CLASS}>
-                  {shortAge(sibling.createdAt)} · {sibling.area}
-                </a>
-                <span class="text-dark-2"> — {sibling.message.split('\n')[0]}</span>
-              </li>
-            {/each}
-          </ul>
-        </div>
-      {/if}
-    {:else if canPromote}
-      <!-- 🔴 No ClickUp call, because there is none to make: this repo holds a ClickUp WEBHOOK
-           secret and nothing else — no token, no client, no list id. The task is still created by
-           hand and its URL pasted onto the issue. The issue lands UNPUBLISHED, so promoting cannot
-           put a reporter's words on the public board. -->
-      <form method="POST" action="?/promote" use:enhance={promoteForm.enhance} class="flex flex-col gap-3">
-        <input type="hidden" name="id" value={row.id} />
-
-        {#if attachMode}
-          <div class="flex flex-col gap-1">
-            <Label for={`bug-${row.id}`} class="text-xs text-dark-2">Existing issue number</Label>
-            <Input id={`bug-${row.id}`} name="bugId" inputmode="numeric" class="w-40" />
-          </div>
-        {:else}
-          <div class="flex flex-col gap-1">
-            <Label for={`title-${row.id}`} class="text-xs text-dark-2">
-              Issue title — a summary, not the complaint
-            </Label>
-            <Input id={`title-${row.id}`} name="title" />
-          </div>
-          <div class="flex flex-col gap-1">
-            <Label for={`summary-${row.id}`} class="text-xs text-dark-2">
-              Summary — what the issue board shows
-            </Label>
-            <Textarea id={`summary-${row.id}`} name="summary" rows={2} />
-          </div>
-        {/if}
-
-        <div class="flex flex-wrap items-center gap-2">
-          <Button type="submit" size="sm" disabled={promoteForm.submitting}>
-            {attachMode ? 'Attach to issue' : 'Create issue'}
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            onclick={() => {
-              attachMode = !attachMode;
-              promoteForm.error = null;
-            }}
-          >
-            {attachMode ? 'Create a new issue instead' : 'Attach to an existing issue instead'}
-          </Button>
-        </div>
-      </form>
-      {#if promoteForm.error}
-        <ErrorAlert message={promoteForm.error} />
-      {/if}
-    {:else}
-      <p class="text-sm text-dark-2">
-        Not linked to an issue. Promoting needs the “Promote feedback to a Known Issue” permission.
-      </p>
-    {/if}
-  </section>
+  <FeedbackPromote {row} {siblings} {civitaiUrl} {canPromote} />
 </div>

--- a/apps/moderator/src/routes/feedback/FeedbackDetail.svelte
+++ b/apps/moderator/src/routes/feedback/FeedbackDetail.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import { page } from '$app/state';
+  import { Button } from '@civitai/ui/components/ui/button/index.js';
+  import { Input } from '@civitai/ui/components/ui/input/index.js';
+  import { Label } from '@civitai/ui/components/ui/label/index.js';
+  import { Textarea } from '@civitai/ui/components/ui/textarea/index.js';
+  import ErrorAlert from '$lib/components/ErrorAlert.svelte';
+  import { FormState } from '$lib/form-state.svelte';
+  import { LINK_CLASS, dateTime, shortAge } from '$lib/format';
+  import { urlWith } from '$lib/url';
+  import { FEEDBACK_STATUSES, type FeedbackContext } from '$lib/feedback';
+  import FeedbackContextPanel from './FeedbackContext.svelte';
+  import type { FeedbackRow } from '$lib/server/feedback.service';
+
+  type Sibling = { id: number; area: string; message: string; createdAt: Date; status: string };
+
+  let {
+    row,
+    context,
+    siblings,
+    grafanaUrl,
+    civitaiUrl,
+    canTriage,
+    canPromote,
+  }: {
+    row: FeedbackRow;
+    context: FeedbackContext;
+    siblings: Sibling[];
+    grafanaUrl: string | null;
+    civitaiUrl: string;
+    canTriage: boolean;
+    canPromote: boolean;
+  } = $props();
+
+  // `reload` on both: the panel renders the row's own stored state, so a write that does not re-run
+  // `load` leaves the operator looking at what they replaced.
+  const triageForm = new FormState({ onSuccess: null, reload: true });
+  const promoteForm = new FormState({ onSuccess: null, reload: true });
+
+  // Which half of the promote form is armed. Not a URL concern — it is a local choice, and opening
+  // another row unmounts this component along with it.
+  let attachMode = $state(false);
+</script>
+
+<div class="flex flex-col gap-6 p-5 text-left">
+  <p class="wrap-break-word text-sm whitespace-pre-wrap">{row.message}</p>
+
+  <FeedbackContextPanel {context} createdAt={row.createdAt} {civitaiUrl} {grafanaUrl} />
+
+  <section class="flex flex-col gap-3">
+    <h3 class="text-xs font-semibold tracking-wide text-dark-2 uppercase">Triage</h3>
+
+    {#if canTriage}
+      <form method="POST" action="?/triage" use:enhance={triageForm.enhance} class="flex flex-col gap-3">
+        <input type="hidden" name="id" value={row.id} />
+        <!-- 🔴 The status the operator is LOOKING AT rides along, and the UPDATE is scoped on it.
+             Without it a second moderator's verdict silently overwrites the first. -->
+        <input type="hidden" name="expectedStatus" value={row.status} />
+
+        <div class="flex flex-col gap-1">
+          <Label for={`note-${row.id}`} class="text-xs text-dark-2">
+            Internal note — never seeded into an issue
+          </Label>
+          <Textarea id={`note-${row.id}`} name="note" rows={2} value={row.triageNote ?? ''} />
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          {#each FEEDBACK_STATUSES as status (status)}
+            <Button
+              type="submit"
+              name="status"
+              value={status}
+              size="sm"
+              variant={status === row.status ? 'default' : 'outline'}
+              disabled={triageForm.submitting}
+            >
+              {status === row.status ? `Save (${status})` : status}
+            </Button>
+          {/each}
+        </div>
+      </form>
+      {#if triageForm.error}
+        <ErrorAlert message={triageForm.error} />
+      {/if}
+    {:else}
+      <p class="text-sm text-dark-2">
+        You can read this queue but not triage it — that needs the “Set feedback status and triage
+        notes” permission.
+      </p>
+    {/if}
+
+    {#if row.handledAt}
+      <p class="text-xs text-dark-2">
+        Handled by {row.handledByUsername ?? `#${row.handledById}`} on {dateTime(row.handledAt)}
+      </p>
+    {/if}
+  </section>
+
+  <section class="flex flex-col gap-3">
+    <h3 class="text-xs font-semibold tracking-wide text-dark-2 uppercase">Known issue</h3>
+
+    {#if row.bugId}
+      <p class="text-sm">
+        Linked to issue
+        <a href={`${civitaiUrl}/issues`} target="_blank" rel="noreferrer" class={LINK_CLASS}>
+          #{row.bugId}
+        </a>
+        — {row.bugTitle ?? 'untitled'}
+        <span class="text-dark-2">({row.bugStatus ?? 'unknown status'})</span>
+      </p>
+      {#if siblings.length}
+        <div class="flex flex-col gap-1">
+          <p class="text-sm text-dark-2">
+            {siblings.length} other report{siblings.length === 1 ? '' : 's'} linked to this issue
+          </p>
+          <ul class="flex flex-col gap-1 text-sm">
+            {#each siblings as sibling (sibling.id)}
+              <li>
+                <a href={urlWith(page.url, { open: sibling.id })} class={LINK_CLASS}>
+                  {shortAge(sibling.createdAt)} · {sibling.area}
+                </a>
+                <span class="text-dark-2"> — {sibling.message.split('\n')[0]}</span>
+              </li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+    {:else if canPromote}
+      <!-- 🔴 No ClickUp call, because there is none to make: this repo holds a ClickUp WEBHOOK
+           secret and nothing else — no token, no client, no list id. The task is still created by
+           hand and its URL pasted onto the issue. The issue lands UNPUBLISHED, so promoting cannot
+           put a reporter's words on the public board. -->
+      <form method="POST" action="?/promote" use:enhance={promoteForm.enhance} class="flex flex-col gap-3">
+        <input type="hidden" name="id" value={row.id} />
+
+        {#if attachMode}
+          <div class="flex flex-col gap-1">
+            <Label for={`bug-${row.id}`} class="text-xs text-dark-2">Existing issue number</Label>
+            <Input id={`bug-${row.id}`} name="bugId" inputmode="numeric" class="w-40" />
+          </div>
+        {:else}
+          <div class="flex flex-col gap-1">
+            <Label for={`title-${row.id}`} class="text-xs text-dark-2">
+              Issue title — a summary, not the complaint
+            </Label>
+            <Input id={`title-${row.id}`} name="title" />
+          </div>
+          <div class="flex flex-col gap-1">
+            <Label for={`summary-${row.id}`} class="text-xs text-dark-2">
+              Summary — what the issue board shows
+            </Label>
+            <Textarea id={`summary-${row.id}`} name="summary" rows={2} />
+          </div>
+        {/if}
+
+        <div class="flex flex-wrap items-center gap-2">
+          <Button type="submit" size="sm" disabled={promoteForm.submitting}>
+            {attachMode ? 'Attach to issue' : 'Create issue'}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onclick={() => {
+              attachMode = !attachMode;
+              promoteForm.error = null;
+            }}
+          >
+            {attachMode ? 'Create a new issue instead' : 'Attach to an existing issue instead'}
+          </Button>
+        </div>
+      </form>
+      {#if promoteForm.error}
+        <ErrorAlert message={promoteForm.error} />
+      {/if}
+    {:else}
+      <p class="text-sm text-dark-2">
+        Not linked to an issue. Promoting needs the “Promote feedback to a Known Issue” permission.
+      </p>
+    {/if}
+  </section>
+</div>

--- a/apps/moderator/src/routes/feedback/FeedbackFilters.svelte
+++ b/apps/moderator/src/routes/feedback/FeedbackFilters.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
+  import { Label } from '@civitai/ui/components/ui/label/index.js';
+  import * as Select from '@civitai/ui/components/ui/select/index.js';
+  import { MultiCombobox } from '@civitai/ui/components/ui/multi-combobox/index.js';
+  import { num } from '$lib/format';
+  import { clearPaging } from '$lib/paging';
+  import { urlWith, urlWithMulti } from '$lib/url';
+  import { FEEDBACK_STATUSES } from '$lib/feedback';
+
+  let {
+    statuses,
+    area,
+    areaOptions,
+    shown,
+  }: {
+    statuses: string[];
+    area: string;
+    areaOptions: string[];
+    shown: number;
+  } = $props();
+
+  const statusOptions = FEEDBACK_STATUSES.map((s) => ({ value: s, label: s }));
+  const areaLabel = $derived(area || 'Area — any');
+
+  /**
+   * Any filter change invalidates the keyset AND closes the open row: the cursor points into a
+   * result set that no longer exists, and `?open=` can name a row the new filters exclude.
+   */
+  function clearedUrl() {
+    const next = new URL(page.url);
+    clearPaging(next.searchParams);
+    next.searchParams.delete('open');
+    return next;
+  }
+
+  // `emptyMeansAll`: an ABSENT `status` falls back to the default view, so a cleared filter has to
+  // survive as `?status=` or clearing it silently reapplies `new`.
+  const applyStatus = (values: string[]) =>
+    goto(urlWithMulti(clearedUrl(), 'status', values, { emptyMeansAll: true }));
+  const applyArea = (value: string) => goto(urlWith(clearedUrl(), { area: value || null }));
+</script>
+
+<div class="mb-4 flex flex-wrap items-end gap-x-4 gap-y-3">
+  <div class="flex flex-col gap-1">
+    <!-- A span, not a `Label for=`: MultiCombobox takes no id, so a `for` would point at nothing. -->
+    <span class="text-xs text-dark-2">Status</span>
+    <!-- Function bindings on both controls: these primitives declare `value` as `$bindable` and
+         write to it on interaction, so a plain prop leaves a child-local override that Svelte only
+         discards when the parent yields a DIFFERENT value. `load` owns this state — the URL is the
+         source of truth — so each control reads from it and writes through `goto`. -->
+    <MultiCombobox
+      options={statusOptions}
+      bind:value={() => statuses, (v) => applyStatus(v)}
+      placeholder="Search statuses…"
+    />
+  </div>
+
+  <div class="flex flex-col gap-1">
+    <Label for="feedback-area" class="text-xs text-dark-2">Area</Label>
+    <Select.Root type="single" bind:value={() => area, (v) => applyArea(v ?? '')}>
+      <Select.Trigger id="feedback-area" class="w-56">{areaLabel}</Select.Trigger>
+      <Select.Content>
+        <Select.Item value="">Area — any</Select.Item>
+        {#each areaOptions as option (option)}
+          <Select.Item value={option}>{option}</Select.Item>
+        {/each}
+      </Select.Content>
+    </Select.Root>
+  </div>
+
+  <span class="pb-1.5 text-xs text-dark-2">{num(shown)} shown</span>
+</div>

--- a/apps/moderator/src/routes/feedback/FeedbackPromote.svelte
+++ b/apps/moderator/src/routes/feedback/FeedbackPromote.svelte
@@ -9,7 +9,7 @@
   import { FormState } from '$lib/form-state.svelte';
   import { LINK_CLASS, shortAge } from '$lib/format';
   import { issuesUrl } from '$lib/entity-url';
-  import { urlWith } from '$lib/url';
+  import { clearPaging } from '$lib/paging';
   import type { FeedbackRow, FeedbackSibling } from '$lib/server/feedback.service';
 
   let {
@@ -24,7 +24,25 @@
     canPromote: boolean;
   } = $props();
 
-  const promoteForm = new FormState({ onSuccess: null, reload: true });
+  /**
+   * 🔴 `reset: false`, matching the triage form. This form carries hidden `id` and `mode` inputs,
+   * and Svelte writes their `value` property rather than `defaultValue` — so `reset()` blanks both
+   * and leaves a form that would post neither. Nothing depends on that today, because the only
+   * path that resets is a success and a success replaces this form with the linked-issue view. The
+   * asymmetry is the hazard: the next person to add a field here inherits a live trap.
+   */
+  const promoteForm = new FormState({ onSuccess: null, reload: true, reset: false });
+
+  /**
+   * A sibling can sit on an earlier keyset page, where carrying this page's `?cursor=` lands the
+   * operator on "not in this view" for a row that plainly exists.
+   */
+  function siblingHref(id: number) {
+    const next = new URL(page.url);
+    clearPaging(next.searchParams);
+    next.searchParams.set('open', String(id));
+    return next.pathname + next.search;
+  }
 
   let attachMode = $state(false);
 </script>
@@ -49,7 +67,7 @@
         <ul class="flex flex-col gap-1 text-sm">
           {#each siblings as sibling (sibling.id)}
             <li>
-              <a href={urlWith(page.url, { open: sibling.id })} class={LINK_CLASS}>
+              <a href={siblingHref(sibling.id)} class={LINK_CLASS}>
                 {shortAge(sibling.createdAt)} · {sibling.area}
               </a>
               <span class="text-dark-2"> — {sibling.message.split('\n')[0]}</span>
@@ -113,10 +131,10 @@
     </p>
   {/if}
 
-  <!-- 🔴 OUTSIDE the branch chain above, not inside the form's arm. A 409 "already linked" means the
-       row gained a `bugId`, and the reload that precedes the message being assigned flips this
-       section to the linked view — so an alert nested in the form's arm is unmounted before it can
-       render, and the operator sees the panel silently swap with their typed title gone. -->
+  <!-- 🔴 The JS-path surface for a refusal on this form, and the only one: `+page.svelte`'s
+       `pageError` is gated on `openVisible`, which stays true whenever this panel is mounted.
+       Its position outside the branch chain carries no guarantee — nothing re-renders this section
+       while a refusal is pending, because `update()` re-runs `load` on success only. -->
   {#if promoteForm.error}
     <ErrorAlert message={promoteForm.error} />
   {/if}

--- a/apps/moderator/src/routes/feedback/FeedbackPromote.svelte
+++ b/apps/moderator/src/routes/feedback/FeedbackPromote.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import { page } from '$app/state';
+  import { Button } from '@civitai/ui/components/ui/button/index.js';
+  import { Input } from '@civitai/ui/components/ui/input/index.js';
+  import { Label } from '@civitai/ui/components/ui/label/index.js';
+  import { Textarea } from '@civitai/ui/components/ui/textarea/index.js';
+  import ErrorAlert from '$lib/components/ErrorAlert.svelte';
+  import { FormState } from '$lib/form-state.svelte';
+  import { LINK_CLASS, shortAge } from '$lib/format';
+  import { issuesUrl } from '$lib/entity-url';
+  import { urlWith } from '$lib/url';
+  import type { FeedbackRow, FeedbackSibling } from '$lib/server/feedback.service';
+
+  let {
+    row,
+    siblings,
+    civitaiUrl,
+    canPromote,
+  }: {
+    row: FeedbackRow;
+    siblings: FeedbackSibling[];
+    civitaiUrl: string;
+    canPromote: boolean;
+  } = $props();
+
+  const promoteForm = new FormState({ onSuccess: null, reload: true });
+
+  let attachMode = $state(false);
+</script>
+
+<section class="flex flex-col gap-3">
+  <h3 class="text-xs tracking-wide text-dark-2 uppercase">Known issue</h3>
+
+  {#if row.bugId}
+    <p class="text-sm">
+      Linked to issue
+      <a href={issuesUrl(civitaiUrl)} target="_blank" rel="noreferrer" class={LINK_CLASS}>
+        #{row.bugId}
+      </a>
+      — {row.bugTitle ?? 'untitled'}
+      <span class="text-dark-2">({row.bugStatus ?? 'unknown status'})</span>
+    </p>
+    {#if siblings.length}
+      <div class="flex flex-col gap-1">
+        <p class="text-sm text-dark-2">
+          {siblings.length} other report{siblings.length === 1 ? '' : 's'} linked to this issue
+        </p>
+        <ul class="flex flex-col gap-1 text-sm">
+          {#each siblings as sibling (sibling.id)}
+            <li>
+              <a href={urlWith(page.url, { open: sibling.id })} class={LINK_CLASS}>
+                {shortAge(sibling.createdAt)} · {sibling.area}
+              </a>
+              <span class="text-dark-2"> — {sibling.message.split('\n')[0]}</span>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+  {:else if canPromote}
+    <form method="POST" action="?/promote" use:enhance={promoteForm.enhance} class="flex flex-col gap-3">
+      <input type="hidden" name="id" value={row.id} />
+      <!-- 🔴 The mode is POSTED, never inferred server-side from whether the number box is blank:
+           inferring it sends an empty box down the create-an-issue branch, which then refuses with
+           a message naming fields this form is not showing. -->
+      <input type="hidden" name="mode" value={attachMode ? 'attach' : 'create'} />
+
+      {#if attachMode}
+        <div class="flex flex-col gap-1">
+          <Label for={`bug-${row.id}`} class="text-xs text-dark-2">Existing issue number</Label>
+          <Input id={`bug-${row.id}`} name="bugId" inputmode="numeric" class="w-40" />
+        </div>
+      {:else}
+        <div class="flex flex-col gap-1">
+          <Label for={`title-${row.id}`} class="text-xs text-dark-2">
+            Issue title — a summary, not the complaint
+          </Label>
+          <Input id={`title-${row.id}`} name="title" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <Label for={`summary-${row.id}`} class="text-xs text-dark-2">
+            Summary — what the issue board shows
+          </Label>
+          <Textarea id={`summary-${row.id}`} name="summary" rows={2} />
+        </div>
+      {/if}
+
+      <div class="flex flex-wrap items-center gap-2">
+        <Button type="submit" size="sm" disabled={promoteForm.submitting}>
+          {attachMode ? 'Attach to issue' : 'Create issue'}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onclick={() => {
+            attachMode = !attachMode;
+            promoteForm.error = null;
+          }}
+        >
+          {attachMode ? 'Create a new issue instead' : 'Attach to an existing issue instead'}
+        </Button>
+      </div>
+      <p class="text-xs text-dark-2">
+        The issue lands unpublished, so nothing reaches the public board until someone publishes it
+        there. The ClickUp task is still made by hand.
+      </p>
+    </form>
+  {:else}
+    <p class="text-sm text-dark-2">
+      Not linked to an issue. Promoting needs the “Promote feedback to a Known Issue” permission.
+    </p>
+  {/if}
+
+  <!-- 🔴 OUTSIDE the branch chain above, not inside the form's arm. A 409 "already linked" means the
+       row gained a `bugId`, and the reload that precedes the message being assigned flips this
+       section to the linked view — so an alert nested in the form's arm is unmounted before it can
+       render, and the operator sees the panel silently swap with their typed title gone. -->
+  {#if promoteForm.error}
+    <ErrorAlert message={promoteForm.error} />
+  {/if}
+</section>

--- a/apps/moderator/src/routes/feedback/__tests__/feedback-actions.test.ts
+++ b/apps/moderator/src/routes/feedback/__tests__/feedback-actions.test.ts
@@ -23,6 +23,11 @@ vi.mock('$lib/server/db', () => ({ dbRead: {}, dbWrite: {} }));
 
 vi.mock('$lib/server/feedback.service', () => ({
   FEEDBACK_PAGE_SIZE: 50,
+  // A stand-in that mirrors the real predicate. It pins the BRANCH only — that `load` degrades when
+  // this says yes and rethrows when it says no. Which errors it says yes TO is pinned separately,
+  // against the real function, in `lib/server/__tests__/feedback.service.test.ts`.
+  isMissingTriageColumns: (e: unknown) =>
+    typeof e === 'object' && e !== null && (e as { code?: unknown }).code === '42703',
   getFeedbackList,
   getFeedbackAreas,
   getSiblingFeedback,
@@ -117,6 +122,32 @@ describe('load', () => {
     const result = await loaded('?status=');
 
     expect(result.statuses).toEqual([]);
+  });
+
+  /**
+   * 🔴 Every migration here is applied BY HAND, and `moderator:admin` reaches this page through
+   * `SUPER_ROLE` before anyone ticks a box on `/admin` — so the window where the page is live
+   * against an unmigrated database is real, not theoretical.
+   */
+  it('degrades to an explanatory empty state when the triage columns do not exist yet', async () => {
+    getFeedbackList.mockRejectedValueOnce(
+      Object.assign(new Error('column f.triageNote does not exist'), { code: '42703' })
+    );
+
+    const result = await loaded('?status=new');
+
+    expect(result.migrationPending).toBe(true);
+    expect(result.items).toEqual([]);
+  });
+
+  it('still THROWS any other database error, rather than rendering an outage as an empty queue', async () => {
+    getFeedbackList.mockRejectedValueOnce(
+      Object.assign(new Error('connection terminated'), { code: '57P01' })
+    );
+
+    await expect(Promise.resolve(load(loadEvent('?status=new')))).rejects.toThrow(
+      'connection terminated'
+    );
   });
 
   it('degrades a cursor Postgres would ERROR on, rather than passing it to the query', async () => {

--- a/apps/moderator/src/routes/feedback/__tests__/feedback-actions.test.ts
+++ b/apps/moderator/src/routes/feedback/__tests__/feedback-actions.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * What only the action layer decides: that a service outcome is TRANSLATED rather than discarded,
+ * and that both writes sit behind their own grant.
+ *
+ * Zero affected rows is the case that matters. The `triage` UPDATE is scoped on the status the
+ * operator was looking at, so "nothing moved" means a colleague's verdict is already on the row —
+ * reporting that as success is a silent overwrite with a green screen over it.
+ */
+
+const triageFeedback = vi.fn();
+const promoteFeedbackToBug = vi.fn();
+const linkFeedbackToBug = vi.fn();
+const getFeedbackList = vi.fn(async () => ({ items: [], nextCursor: null }));
+const getFeedbackAreas = vi.fn(async () => [] as string[]);
+const getSiblingFeedback = vi.fn(async () => []);
+
+// `$lib/server/query` reaches `users.service` → `db`, which demands DATABASE_URL at MODULE scope.
+// Stubbed rather than fed a URL: the point of that demand is that a suite can never open a
+// connection to whatever a developer's `.env` happens to point at.
+vi.mock('$lib/server/db', () => ({ dbRead: {}, dbWrite: {} }));
+
+vi.mock('$lib/server/feedback.service', () => ({
+  FEEDBACK_PAGE_SIZE: 50,
+  decodeFeedbackCursor: () => null,
+  getFeedbackList,
+  getFeedbackAreas,
+  getSiblingFeedback,
+  triageFeedback,
+  promoteFeedbackToBug,
+  linkFeedbackToBug,
+}));
+
+const { actions } = await import('../+page.server');
+
+const MOD = { id: 7 };
+
+/**
+ * A REAL `FormData`, not a Map: `Map.get` returns `undefined` where `FormData.get` returns `null`,
+ * and the two land on opposite sides of several guards.
+ */
+const event = (form: Record<string, string> = {}, grants: Record<string, true> = ALL_GRANTS) => {
+  const data = new FormData();
+  for (const [key, value] of Object.entries(form)) data.append(key, value);
+  return {
+    request: { formData: async () => data },
+    locals: { user: MOD, grants },
+  } as never;
+};
+
+const ALL_GRANTS = { 'feedback.status.set': true, 'feedback.bug.promote': true } as const;
+
+/**
+ * A `fail()` result, unwrapped.
+ *
+ * The shape is asserted rather than assumed: a success carries neither `status` nor `data`, so
+ * without this a refusal that turned into a success failed with `Cannot read properties of
+ * undefined` from inside this helper — a message that names the helper instead of the claim, and
+ * would read the same for any unrelated shape change.
+ */
+const failure = (result: unknown) => {
+  const r = result as { status?: number; data?: { error?: string } } | null;
+  if (typeof r?.status !== 'number' || !r.data)
+    throw new Error(`expected a fail() result, got ${JSON.stringify(result)}`);
+  return { status: r.status, error: r.data.error };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  triageFeedback.mockResolvedValue({ ok: true, changed: true });
+  promoteFeedbackToBug.mockResolvedValue({ ok: true, bugId: 99, created: true });
+  linkFeedbackToBug.mockResolvedValue({ ok: true, bugId: 42, created: false });
+});
+
+describe('triage action', () => {
+  const form = (over: Record<string, string> = {}) => ({
+    id: '5',
+    status: 'reviewed',
+    expectedStatus: 'new',
+    note: 'dupe of #1187',
+    ...over,
+  });
+
+  it('passes the status the operator was looking at through as the concurrency guard', async () => {
+    const result = await actions.triage(event(form()));
+
+    expect(triageFeedback).toHaveBeenCalledWith({
+      id: 5,
+      status: 'reviewed',
+      expectedStatus: 'new',
+      note: 'dupe of #1187',
+      moderatorId: 7,
+    });
+    expect(result).toMatchObject({ success: true, triaged: 5 });
+  });
+
+  it('is a 409, not a success, when the UPDATE touched no rows', async () => {
+    triageFeedback.mockResolvedValue({ ok: true, changed: false });
+
+    const result = await actions.triage(event(form()));
+
+    expect(failure(result)).toEqual({
+      status: 409,
+      error: 'Someone else already triaged this. Reload to see the current verdict.',
+    });
+  });
+
+  it('separates a row that is GONE from one another moderator moved', async () => {
+    triageFeedback.mockResolvedValue({ ok: false, reason: 'gone' });
+
+    const result = await actions.triage(event(form()));
+
+    expect(failure(result).status).toBe(410);
+  });
+
+  it('stores an empty note as null rather than an empty string', async () => {
+    await actions.triage(event(form({ note: '   ' })));
+
+    expect(triageFeedback).toHaveBeenCalledWith(expect.objectContaining({ note: null }));
+  });
+
+  /**
+   * Moving a row back to `new` must clear the handler — "handled by" naming a moderator on a row
+   * sitting in the unhandled queue is a claim the screen cannot support. The action's job is to
+   * pass `status: 'new'` through faithfully; the service is what clears the two columns, and
+   * `feedback-service.pglite.test.ts` asserts the rows.
+   */
+  it('passes a move back to `new` through to the service unchanged', async () => {
+    await actions.triage(event(form({ status: 'new', expectedStatus: 'actioned' })));
+
+    expect(triageFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'new', expectedStatus: 'actioned' })
+    );
+  });
+
+  it('rejects a status the CHECK constraint would refuse, without reaching the service', async () => {
+    const result = await actions.triage(event(form({ status: 'wontfix' })));
+
+    expect(failure(result).status).toBe(400);
+    expect(triageFeedback).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing expectedStatus — without it there is no concurrency guard at all', async () => {
+    const data = new FormData();
+    data.append('id', '5');
+    data.append('status', 'reviewed');
+    const result = await actions.triage({
+      request: { formData: async () => data },
+      locals: { user: MOD, grants: ALL_GRANTS },
+    } as never);
+
+    expect(failure(result).status).toBe(400);
+    expect(triageFeedback).not.toHaveBeenCalled();
+  });
+
+  it('refuses without the grant, and refuses before touching the service', async () => {
+    const result = await actions.triage(event(form(), {}));
+
+    expect(failure(result).status).toBe(403);
+    expect(triageFeedback).not.toHaveBeenCalled();
+  });
+});
+
+describe('promote action', () => {
+  it('mints an issue from the moderator’s own title and summary', async () => {
+    const result = await actions.promote(
+      event({ id: '5', title: 'Sort resets on back', summary: 'The store loses ?sort on Back.' })
+    );
+
+    expect(promoteFeedbackToBug).toHaveBeenCalledWith({
+      id: 5,
+      title: 'Sort resets on back',
+      summary: 'The store loses ?sort on Back.',
+      moderatorId: 7,
+    });
+    expect(result).toMatchObject({ success: true, bugId: 99 });
+  });
+
+  it('attaches to an existing issue instead of filing a second one', async () => {
+    const result = await actions.promote(event({ id: '5', bugId: '42' }));
+
+    expect(linkFeedbackToBug).toHaveBeenCalledWith({ id: 5, bugId: 42, moderatorId: 7 });
+    expect(promoteFeedbackToBug).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ success: true, bugId: 42 });
+  });
+
+  it('is a 409 when someone already linked the row — and attempts NO issue insert', async () => {
+    promoteFeedbackToBug.mockResolvedValue({ ok: false, reason: 'already-linked' });
+
+    const result = await actions.promote(event({ id: '5', title: 't', summary: 's' }));
+
+    expect(failure(result)).toEqual({
+      status: 409,
+      error: 'That feedback is already linked to an issue. Reload to see which.',
+    });
+  });
+
+  it('is a 404 for an issue number that does not exist', async () => {
+    linkFeedbackToBug.mockResolvedValue({ ok: false, reason: 'no-such-bug' });
+
+    const result = await actions.promote(event({ id: '5', bugId: '42' }));
+
+    expect(failure(result).status).toBe(404);
+  });
+
+  /**
+   * The summary is what the Known Issues board renders, and `createBugInput` requires it. Refusing
+   * here rather than writing an empty one keeps a blank row off a public board.
+   */
+  it('refuses a blank title or summary without inserting anything', async () => {
+    expect(failure(await actions.promote(event({ id: '5', summary: 's' }))).status).toBe(400);
+    expect(failure(await actions.promote(event({ id: '5', title: 't' }))).status).toBe(400);
+    expect(promoteFeedbackToBug).not.toHaveBeenCalled();
+  });
+
+  it('refuses a non-numeric issue number without reaching either service', async () => {
+    const result = await actions.promote(event({ id: '5', bugId: 'abc' }));
+
+    expect(failure(result).status).toBe(400);
+    expect(linkFeedbackToBug).not.toHaveBeenCalled();
+    expect(promoteFeedbackToBug).not.toHaveBeenCalled();
+  });
+
+  it('refuses without the promote grant — it is a SEPARATE axis from triaging', async () => {
+    const result = await actions.promote(
+      event({ id: '5', title: 't', summary: 's' }, { 'feedback.status.set': true })
+    );
+
+    expect(failure(result).status).toBe(403);
+    expect(promoteFeedbackToBug).not.toHaveBeenCalled();
+  });
+});

--- a/apps/moderator/src/routes/feedback/__tests__/feedback-actions.test.ts
+++ b/apps/moderator/src/routes/feedback/__tests__/feedback-actions.test.ts
@@ -23,7 +23,6 @@ vi.mock('$lib/server/db', () => ({ dbRead: {}, dbWrite: {} }));
 
 vi.mock('$lib/server/feedback.service', () => ({
   FEEDBACK_PAGE_SIZE: 50,
-  decodeFeedbackCursor: () => null,
   getFeedbackList,
   getFeedbackAreas,
   getSiblingFeedback,
@@ -32,7 +31,7 @@ vi.mock('$lib/server/feedback.service', () => ({
   linkFeedbackToBug,
 }));
 
-const { actions } = await import('../+page.server');
+const { actions, load } = await import('../+page.server');
 
 const MOD = { id: 7 };
 
@@ -71,6 +70,67 @@ beforeEach(() => {
   triageFeedback.mockResolvedValue({ ok: true, changed: true });
   promoteFeedbackToBug.mockResolvedValue({ ok: true, bugId: 99, created: true });
   linkFeedbackToBug.mockResolvedValue({ ok: true, bugId: 42, created: false });
+});
+
+/**
+ * `load` is exercised here too, because two of its decisions are invisible to a typecheck and
+ * neither has any other coverage: whether the canonicalising redirect can fire on a POST, and
+ * whether a hand-edited cursor degrades instead of reaching Postgres.
+ */
+describe('load', () => {
+  const loadEvent = (search: string, method = 'GET') =>
+    ({
+      url: new URL(`https://moderator.test/feedback${search}`),
+      request: { method },
+    } as never);
+
+  /** `load`'s declared return includes `void`, because `redirect()` throws out of it. */
+  const loaded = async (search: string, method = 'GET') => {
+    const result = await load(loadEvent(search, method));
+    if (!result) throw new Error('load returned nothing where a page payload was expected');
+    return result;
+  };
+
+  it('canonicalises a bare landing onto the default view', async () => {
+    // `redirect()` throws; SvelteKit's own object carries `status` and `location`.
+    const thrown = await Promise.resolve(load(loadEvent(''))).catch((e: unknown) => e);
+
+    expect(thrown).toMatchObject({ status: 307 });
+    expect((thrown as { location: string }).location).toBe('/feedback?status=new');
+    expect(getFeedbackList).not.toHaveBeenCalled();
+  });
+
+  /**
+   * 🔴 A form action posts to `?/triage`, which REPLACES the query string — so without the method
+   * guard this redirect fires on the POST, and a 307 preserves the method. A no-JS client would
+   * re-POST, run the action a second time, trip its own concurrency guard and be told a save that
+   * worked had conflicted.
+   */
+  it('does NOT redirect a POST, and still applies the default view to it', async () => {
+    const result = await loaded('?%2Ftriage=', 'POST');
+
+    expect(result.statuses).toEqual(['new']);
+    expect(getFeedbackList).toHaveBeenCalledWith(expect.objectContaining({ statuses: ['new'] }));
+  });
+
+  it('treats a present-but-empty `?status=` as an explicit all, not as the default', async () => {
+    const result = await loaded('?status=');
+
+    expect(result.statuses).toEqual([]);
+  });
+
+  it('degrades a cursor Postgres would ERROR on, rather than passing it to the query', async () => {
+    // `Feedback.id` is an int4: a larger value errors the comparison instead of missing.
+    for (const bad of ['2147483648', 'abc', '0', '-4', '1.5']) {
+      vi.clearAllMocks();
+      await loaded(`?status=new&cursor=${bad}`);
+      expect(getFeedbackList).toHaveBeenCalledWith(expect.objectContaining({ cursor: null }));
+    }
+
+    vi.clearAllMocks();
+    await loaded('?status=new&cursor=42');
+    expect(getFeedbackList).toHaveBeenCalledWith(expect.objectContaining({ cursor: 42 }));
+  });
 });
 
 describe('triage action', () => {
@@ -124,7 +184,7 @@ describe('triage action', () => {
    * Moving a row back to `new` must clear the handler — "handled by" naming a moderator on a row
    * sitting in the unhandled queue is a claim the screen cannot support. The action's job is to
    * pass `status: 'new'` through faithfully; the service is what clears the two columns, and
-   * `feedback-service.pglite.test.ts` asserts the rows.
+   * `feedback.service.test.ts` asserts the rows.
    */
   it('passes a move back to `new` through to the service unchanged', async () => {
     await actions.triage(event(form({ status: 'new', expectedStatus: 'actioned' })));
@@ -165,7 +225,12 @@ describe('triage action', () => {
 describe('promote action', () => {
   it('mints an issue from the moderator’s own title and summary', async () => {
     const result = await actions.promote(
-      event({ id: '5', title: 'Sort resets on back', summary: 'The store loses ?sort on Back.' })
+      event({
+        id: '5',
+        mode: 'create',
+        title: 'Sort resets on back',
+        summary: 'The store loses ?sort on Back.',
+      })
     );
 
     expect(promoteFeedbackToBug).toHaveBeenCalledWith({
@@ -178,7 +243,7 @@ describe('promote action', () => {
   });
 
   it('attaches to an existing issue instead of filing a second one', async () => {
-    const result = await actions.promote(event({ id: '5', bugId: '42' }));
+    const result = await actions.promote(event({ id: '5', mode: 'attach', bugId: '42' }));
 
     expect(linkFeedbackToBug).toHaveBeenCalledWith({ id: 5, bugId: 42, moderatorId: 7 });
     expect(promoteFeedbackToBug).not.toHaveBeenCalled();
@@ -188,7 +253,9 @@ describe('promote action', () => {
   it('is a 409 when someone already linked the row — and attempts NO issue insert', async () => {
     promoteFeedbackToBug.mockResolvedValue({ ok: false, reason: 'already-linked' });
 
-    const result = await actions.promote(event({ id: '5', title: 't', summary: 's' }));
+    const result = await actions.promote(
+      event({ id: '5', mode: 'create', title: 't', summary: 's' })
+    );
 
     expect(failure(result)).toEqual({
       status: 409,
@@ -199,7 +266,7 @@ describe('promote action', () => {
   it('is a 404 for an issue number that does not exist', async () => {
     linkFeedbackToBug.mockResolvedValue({ ok: false, reason: 'no-such-bug' });
 
-    const result = await actions.promote(event({ id: '5', bugId: '42' }));
+    const result = await actions.promote(event({ id: '5', mode: 'attach', bugId: '42' }));
 
     expect(failure(result).status).toBe(404);
   });
@@ -209,22 +276,49 @@ describe('promote action', () => {
    * here rather than writing an empty one keeps a blank row off a public board.
    */
   it('refuses a blank title or summary without inserting anything', async () => {
-    expect(failure(await actions.promote(event({ id: '5', summary: 's' }))).status).toBe(400);
-    expect(failure(await actions.promote(event({ id: '5', title: 't' }))).status).toBe(400);
+    expect(
+      failure(await actions.promote(event({ id: '5', mode: 'create', summary: 's' }))).status
+    ).toBe(400);
+    expect(
+      failure(await actions.promote(event({ id: '5', mode: 'create', title: 't' }))).status
+    ).toBe(400);
     expect(promoteFeedbackToBug).not.toHaveBeenCalled();
   });
 
   it('refuses a non-numeric issue number without reaching either service', async () => {
-    const result = await actions.promote(event({ id: '5', bugId: 'abc' }));
+    const result = await actions.promote(event({ id: '5', mode: 'attach', bugId: 'abc' }));
 
-    expect(failure(result).status).toBe(400);
+    // Not "enter an issue number" — they did enter one.
+    expect(failure(result)).toEqual({ status: 400, error: 'That is not a valid issue number.' });
     expect(linkFeedbackToBug).not.toHaveBeenCalled();
     expect(promoteFeedbackToBug).not.toHaveBeenCalled();
   });
 
+  /**
+   * 🔴 The mode is POSTED, not inferred from whether the number box is blank. Inferring it sent an
+   * empty box down the create-an-issue branch, which refused with "Give the issue a title" over a
+   * form showing neither a title nor a summary field.
+   */
+  it('tells an empty attach form to enter an issue number, not to write a title', async () => {
+    const result = await actions.promote(event({ id: '5', mode: 'attach', bugId: '' }));
+
+    expect(failure(result)).toEqual({ status: 400, error: 'Enter an issue number.' });
+    expect(promoteFeedbackToBug).not.toHaveBeenCalled();
+  });
+
+  it('is a 410 when the report itself was deleted, not a conflict over an issue', async () => {
+    promoteFeedbackToBug.mockResolvedValue({ ok: false, reason: 'gone' });
+
+    const result = await actions.promote(
+      event({ id: '5', mode: 'create', title: 't', summary: 's' })
+    );
+
+    expect(failure(result).status).toBe(410);
+  });
+
   it('refuses without the promote grant — it is a SEPARATE axis from triaging', async () => {
     const result = await actions.promote(
-      event({ id: '5', title: 't', summary: 's' }, { 'feedback.status.set': true })
+      event({ id: '5', mode: 'create', title: 't', summary: 's' }, { 'feedback.status.set': true })
     );
 
     expect(failure(result).status).toBe(403);

--- a/apps/moderator/src/routes/feedback/__tests__/feedback-actions.test.ts
+++ b/apps/moderator/src/routes/feedback/__tests__/feedback-actions.test.ts
@@ -23,9 +23,11 @@ vi.mock('$lib/server/db', () => ({ dbRead: {}, dbWrite: {} }));
 
 vi.mock('$lib/server/feedback.service', () => ({
   FEEDBACK_PAGE_SIZE: 50,
-  // A stand-in that mirrors the real predicate. It pins the BRANCH only — that `load` degrades when
-  // this says yes and rethrows when it says no. Which errors it says yes TO is pinned separately,
-  // against the real function, in `lib/server/__tests__/feedback.service.test.ts`.
+  // 🔴 A STAND-IN, NOT A MIRROR — deliberately cruder than the real predicate, which also requires
+  // the message to name one of the four migrated columns. It exists to pin the BRANCH only: that
+  // `load` degrades when this answers yes and rethrows when it answers no. WHICH errors earn a yes
+  // is pinned against the real function in `lib/server/__tests__/feedback.service.test.ts`,
+  // including against an error a genuinely unmigrated table raised.
   isMissingTriageColumns: (e: unknown) =>
     typeof e === 'object' && e !== null && (e as { code?: unknown }).code === '42703',
   getFeedbackList,
@@ -131,7 +133,7 @@ describe('load', () => {
    */
   it('degrades to an explanatory empty state when the triage columns do not exist yet', async () => {
     getFeedbackList.mockRejectedValueOnce(
-      Object.assign(new Error('column f.triageNote does not exist'), { code: '42703' })
+      Object.assign(new Error('column f.handledById does not exist'), { code: '42703' })
     );
 
     const result = await loaded('?status=new');

--- a/apps/moderator/vitest.config.ts
+++ b/apps/moderator/vitest.config.ts
@@ -46,6 +46,9 @@ export default defineConfig({
     alias: {
       $lib: from('./src/lib'),
       '$env/dynamic/private': from('./src/test/env.mock.ts'),
+      // Same stub. Route modules that read a PUBLIC_ variable (the /feedback Grafana base) are
+      // otherwise unimportable here, so their actions could not be tested at all.
+      '$env/dynamic/public': from('./src/test/env.mock.ts'),
     },
   },
   test: {

--- a/docs/moderator-app/feedback-triage-proposal-2026-09-11.md
+++ b/docs/moderator-app/feedback-triage-proposal-2026-09-11.md
@@ -445,6 +445,20 @@ the page can render, instead of a silent overwrite of a colleague's verdict.
 Moving a row **back to `new`** must clear `handledById`/`handledAt` rather than stamp them — otherwise
 "handled by" says a moderator handled something that is sitting in the unhandled queue.
 
+🔴 **`bugId` is NOT cleared with them, on any status.** Those two columns record *who acted*, which a
+reopen genuinely retracts; the link records that *this report is about that issue*, which a reopen does
+not make false. Clearing it was implemented during review and reverted: the number is stored nowhere
+else, so the association became unrecoverable from inside the app, `getSiblingFeedback` silently
+dropped the row from every sibling's "other reports linked to this issue" list, and the `Bug` was left
+with nothing pointing at it — the state `promote` runs a transaction rollback specifically to avoid
+creating.
+
+⚠️ **What that leaves open, stated rather than hidden:** a linked row can never be re-linked, because
+the promote path requires `bugId IS NULL`. That is a missing capability — an **unlink control** — and
+it is missing at every status, so reopening neither causes it nor is a sensible back door to it. Not
+in this scope; whoever adds it should add it as its own action rather than as a side effect of a
+status change.
+
 Records `recordModActivity({ entityType: 'feedback', entityId: id, activity: 'triage' })` for the same
 reason every other mutation in this app does.
 

--- a/packages/civitai-db-schema/prisma/migrations/20260911120000_feedback_triage/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260911120000_feedback_triage/migration.sql
@@ -17,12 +17,18 @@
 -- image and the schema are never deployed atomically.
 --   * Migration first → a no-op. Nothing reads these columns until the moderator
 --                       page ships.
---   * Page first      → the page's own reads and writes fail. It is reachable
---                       only by a role someone has ticked on `/admin`, and no
---                       role holds it on the day it merges, so the blast radius
---                       is whoever grants it first. Nothing user-facing is
---                       affected either way: the submit path does not touch
---                       these columns.
+--   * Page first      → the page's own reads fail (42703) until this is applied.
+--                       🔴 It is reachable on day one WITHOUT any `/admin` tick:
+--                       `allows()` in apps/moderator/src/lib/server/access.ts
+--                       short-circuits true for SUPER_ROLE, so every
+--                       `moderator:admin` sees the nav entry the moment the page
+--                       deploys — and the sidebar badge counts on `status` alone,
+--                       so it renders a real number against an unmigrated
+--                       database. The page catches that one error code and says
+--                       so rather than throwing, so the cost is an unusable queue
+--                       and not an error boundary. Nothing user-facing is
+--                       affected either way: the submit path does not touch these
+--                       columns.
 --
 -- 🔴 The hazard `20260901120000_app_listing_beta` records — a Prisma call with no
 -- explicit `select` emits `RETURNING <every scalar the MODEL declares>` and raises

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -467,6 +467,7 @@ model User {
   metrics              UserMetric[]
   reports              Report[]
   feedback             Feedback[]
+  feedbackHandled      Feedback[]                 @relation("FeedbackHandledBy")
   questions            Question[]
   answers              Answer[]
   commentsv2           CommentV2[]
@@ -2361,8 +2362,17 @@ model Feedback {
   status    String   @default("new")
   createdAt DateTime @default(now())
 
+  /// Moderator-internal. Never seeded into a Bug — a Bug is public, this is not.
+  triageNote  String?
+  handledById Int?
+  handledBy   User?     @relation("FeedbackHandledBy", fields: [handledById], references: [id], onDelete: SetNull)
+  handledAt   DateTime?
+  bugId       Int?
+  bug         Bug?      @relation(fields: [bugId], references: [id], onDelete: SetNull)
+
   @@index([area, status, createdAt(sort: Desc)])
   @@index([userId, createdAt(sort: Desc)])
+  @@index([status, createdAt(sort: Desc)])
 }
 
 enum ApiKeyType {
@@ -5916,6 +5926,7 @@ model Bug {
   disabled    Boolean       @default(false)
   domain      DomainColor[] @default([all])
   tags        String[]      @default([])
+  feedback    Feedback[]
 
   @@index([status, publishedAt])
 }

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -2327,6 +2327,13 @@ export type Feedback = {
   context: Generated<unknown>;
   status: Generated<string>;
   createdAt: Generated<Timestamp>;
+  /**
+   * Moderator-internal. Never seeded into a Bug — a Bug is public, this is not.
+   */
+  triageNote: string | null;
+  handledById: number | null;
+  handledAt: Timestamp | null;
+  bugId: number | null;
 };
 export type File = {
   id: Generated<number>;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -539,6 +539,7 @@ export interface User {
   metrics?: UserMetric[];
   reports?: Report[];
   feedback?: Feedback[];
+  feedbackHandled?: Feedback[];
   questions?: Question[];
   answers?: Answer[];
   commentsv2?: CommentV2[];
@@ -1816,6 +1817,12 @@ export interface Feedback {
   context: JsonValue;
   status: string;
   createdAt: Date;
+  triageNote: string | null;
+  handledById: number | null;
+  handledBy?: User | null;
+  handledAt: Date | null;
+  bugId: number | null;
+  bug?: Bug | null;
 }
 
 export interface ApiKey {
@@ -3864,6 +3871,7 @@ export interface Bug {
   disabled: boolean;
   domain: DomainColor[];
   tags: string[];
+  feedback?: Feedback[];
 }
 
 export interface NewOrderPlayer {


### PR DESCRIPTION
Implements the approved design in `docs/moderator-app/feedback-triage-proposal-2026-09-11.md`
(merged in #4777). The onsite feedback prompts have been writing to a table nothing reads — three of
the four statuses `Feedback_status_check` allows were unreachable by any code path that existed.
This is the reader.

## 🔴 Three things a merge does NOT do

1. **The migration is merged but NOT APPLIED to any environment.**
   `packages/civitai-db-schema/prisma/migrations/20260911120000_feedback_triage/migration.sql`
   landed with the design doc. Nothing applies it — this repo has no `prisma migrate deploy` in any
   deploy path and `_prisma_migrations` is not the source of truth. **A human must apply it by hand
   to production and to the dev clone.** Until then the page's reads and writes fail against those
   databases. It is additive, idempotent, and metadata-only (four NULLable columns, two FKs, one
   index), so it is safe to apply while the site is up, and either order of migration-vs-deploy is
   safe — the submit path touches none of these columns.

   This PR contains only the `schema.full.prisma` model edit and the regenerated files.

2. **The page ships INVISIBLE.** A new page has no `AppPageAccess` row, so on the day this merges
   only `moderator:admin` can reach `/feedback`, and the two new permissions are held by nobody.
   Three ticks are needed on `/admin`:
   - the `/feedback` **page** box, for each role that should reach the queue;
   - **Set feedback status and triage notes** (`feedback.status.set`);
   - **Promote feedback to a Known Issue** (`feedback.bug.promote`) — the *same* roles as the
     previous one. A promoted `Bug` lands with `publishedAt` NULL and is therefore invisible to
     anyone without the `bugsEdit` flag, so the thing that would justify a narrower grant does not
     exist yet. The ids stay separate so narrowing it later is one tick rather than a rename, and a
     rename orphans stored `grant:<id>` rows.

3. **`PUBLIC_GRAFANA_URL` must be set on the moderator deployment**, or the Faro session deep link
   silently does not render. Unset is a supported state — `faroSessionLink` returns `null` rather
   than building `undefined/explore` — so the only thing that reports the gap is a line inside an
   expanded row. The variable is documented in `apps/moderator/.env.example` and left blank there
   **on purpose**: this repository is public and that origin is internal. Take the value from the
   deployment config.

## What it does

- **`/feedback`** — one page, not a route per area. Status (multi) and area (single) filters live in
  the URL, `?status=new` is canonicalised onto a bare landing, and a present-but-empty `?status=`
  means "explicitly all". Keyset paging on the row id.
- **Inline `?open=<id>` detail**, so the operator keeps their place after an action re-runs `load`
  and the expanded state survives a shared link.
- **The context payload is rendered as a claim, not as evidence** — the heading says where the
  reporter *said* they were. `context.path` is `window.location.pathname` and carries no query
  string, so on a page whose whole view lives in the query string it links somewhere the report is
  not about; the panel rebuilds the URL from `path` + `filters`, omitting the values that equal the
  store's own defaults. `category: 'none'` renders as `(none)` and is omitted from the link — it is
  a sentinel for "nothing selected", not a category. Any key the five named ones do not claim is
  dumped verbatim under **Other context**, so a future area's payload cannot vanish silently.
- **An age-aware Grafana Explore link** on the Faro session id. Inside the 72 h Loki retention it is
  a link; past it there is no link and an explicit expiry note, because *"the data expired"*, *"this
  session produced no telemetry"* and *"the link is broken"* are three different facts with one
  observable. The LogQL is the raw substring filter `|= "<id>"` and never `| logfmt | session_id=`:
  the id appears under two different keys in that stream, and a logfmt filter matches one and
  silently drops the rows carrying `traceID`/`spanID`. That is pinned by a test.
- **Attachments render inline as thumbnails** (the operator's decision, recorded in the design doc
  §3 with the risk stated). These are ids the client *said* it uploaded — nothing proves the objects
  exist or belong to the reporter — so row-level expansion is the containment: nothing loads until a
  moderator opens a row. The one-line mitigation if this page ever reaches a non-moderator is
  `blur={40}` plus a click to clear, noted at the call site.
- **`triage`** — status and an internal note in one `UPDATE`, scoped on the status the operator was
  looking at. Zero affected rows is a **409**, not a success. Moving a row back to `new` clears
  `handledById`/`handledAt` rather than stamping them.
- **`promote`** — mints a `Bug` and links it in one transaction, or attaches to an existing issue.
  `publishedAt` stays NULL (that is what keeps the reporter's words off the public board) and
  `content` stays NULL (it is stored and rendered as HTML, and this app does not go through the
  sanitising zod schema). The link is scoped `AND "bugId" IS NULL`, and the `Bug` insert rolls back
  with it. **No ClickUp call** — the repo has a ClickUp webhook secret and nothing else, so the task
  is still created by hand and its URL pasted onto the issue.
- **`feedbackNew` sidebar count** — `count(*) WHERE status = 'new'`, in the existing 60-second-cached
  map, not `bounded()`.

## Divergences from the design doc

Called out rather than followed silently. The doc was written without running anything.

1. **`Bug.updatedAt` is NOT NULL with no database default**, and the doc's field table does not
   mention it. It is Prisma `@updatedAt`, i.e. a client-side stamp, and this app's Kysely client
   installs no `updatedAtPlugin` — so a Kysely insert that omits it is a `23502`, not a default. It
   is now supplied explicitly, and a test breaks if it is dropped.
2. **`FEEDBACK_AREAS` has grown to three** (`site-bug-report` was added with the support menu's
   "Report a bug" drawer); the doc says two. It changes nothing about the design — it is the
   argument the doc already makes for unioning the registry with `SELECT DISTINCT area`.
3. **That constant cannot be imported.** It lives in the Next app's `src/shared/constants/` and is
   not exported from any workspace package, so `apps/moderator` has no path to it. It is mirrored in
   `$lib/feedback.ts` with the drift noted at the declaration. The drift is bounded in the direction
   that matters: the option list is the mirror UNIONED with the distinct areas in the table, so an
   area added upstream is filterable the moment it has a row, and a stale entry only ever offers an
   option that matches nothing.
4. **The keyset is the row id alone, not `(createdAt, id)`** — which is what the doc asked for, and
   it is also the more robust choice. `Feedback` is insert-only with `createdAt DEFAULT now()`, so
   id order *is* arrival order, the id is unique where the timestamp is not, and an integer
   comparison has no driver-dependent timestamp serialisation attached to it. The consequence: the
   `ORDER BY` is not served by the new `(status, createdAt DESC)` index. At 26 rows every plan is a
   sequential scan anyway — the migration's own comment says the index is for the table's future —
   and the sidebar count does use it.
5. **`?open=<id>` naming a row the current filters exclude** now says so on screen. Rendering
   nothing would be indistinguishable from no row being open.

## Verification

Reported separately, because they answer different questions.

- **`pnpm --filter @civitai/moderator-app typecheck`** (svelte-check): `9461 FILES 0 ERRORS 0
  WARNINGS`. The instrument was validated — a deliberate type error in `$lib/feedback.ts` produced
  `1 ERRORS`, and was removed.
- **`pnpm --filter @civitai/moderator-app test`**: `58 passed | 1 skipped (59) files`, `715 passed |
  40 skipped (755) tests`. Running the three new files alone gives `71 passed (71)`, so the
  remaining 644 are the pre-existing suite, unchanged.
- **`build`** run once (it is the only thing that catches an optional parameter in a `.svelte`
  signature): green.
- **ESLint** clean on every changed file; **Prettier** clean on every added file (the blocking half
  of that job) and on every modified one.
- **`pnpm run db:check-generated`**: exits 0 against the committed tree. It exits 1 against an
  uncommitted regeneration, which is how it was watched to go red.
- **`pnpm --filter @civitai/db-schema drift:gate`**: `NEW, enforced (blocking): 0`, and byte-identical
  output before and after the schema edit (`17` pending-migration warnings either way, none of them
  `Feedback` — the captured catalog predates the table).

A **typecheck cannot see a wrong predicate, a mis-attributed row, or a status transition that never
lands**, so every behavioural claim rests on the tests — and each of those was watched to fail.

- **`src/lib/__tests__/feedback.test.ts`** (31) — `reconstructFeedbackUrl`, `feedbackAreaOptions`,
  `splitContext`, `faroSessionLink`. `now` is an argument to `faroSessionLink`, never `Date.now()`
  inside, so the 72 h boundary is testable at all; it is pinned closed on the expired side and
  asserted from both directions.
- **`src/lib/server/__tests__/feedback.service.test.ts`** (19) — the service EXECUTED against a real
  Postgres (PGlite, in-process) carrying the **real migration files**, including the hand-applied
  `20260911120000_feedback_triage` one. This is the only thing in the repo that runs that SQL. A
  mocked builder cannot answer "did this UPDATE touch a row it should not have", which is what every
  guard here is about.
- **`src/routes/feedback/__tests__/feedback-actions.test.ts`** (21) — outcome translation, both
  grants, and a `load` suite pinning the GET-only redirect and the cursor bound.

**Mutation battery: 31 mutants across four rounds, all killed, each with the named test's own
assertion.** The harness was controlled in both directions first — each `-t` filter selects exactly
one test unmutated, and a filter matching nothing reports `27 skipped` and **exits 0**, so every
verdict was read off the result count, never the exit code. (That control earned its keep: one
filter silently matched nothing because a `?` in the test name is a regex quantifier.)

| # | mutation | how it died |
|---|---|---|
| 1 | `\|= "<id>"` → `\| logfmt \| session_id=` | `expected '…logfmt…' to contain '\|= "v913JNcgDs"'` |
| 2 | retention boundary `>=` → `>` | `expected 'https://…/explore?…' to be null` |
| 3 | drop the unset-`grafanaUrl` guard | `expected 'undefined/explore?…' to be null` |
| 4 | drop the absent-`sessionId` guard | `expected '…/explore?…' to be null` |
| 5 | stop omitting store defaults | `expected '/apps?kind=all&category=none&sort=top…' to be '/apps'` |
| 6 | absent `path` → `/` | `expected '/?kind=onsite' to be null` |
| 7 | area options from the registry only | `expected ['apps-marketplace'] to deeply equal [… 'bitdex-image-feed']` |
| 8 | drop the "other context" bucket | `expected null to deeply equal { pagesLoaded: 3, … }` |
| 9 | drop `AND status = $expectedStatus` | `expected { changed: true } to deeply equal { changed: false }` |
| 10 | stamp the handler unconditionally | `expected 2 to be null` |
| 11 | drop `AND "bugId" IS NULL` | `expected { ok: true, bugId: 2 } to deeply equal { ok: false, reason: 'already-linked' }` |
| 12 | omit `updatedAt` on the Bug insert | `null value in column "updatedAt" … violates not-null constraint` |
| 13 | `publishedAt: now` | diff shows `publishedAt` non-null |
| 14 | treat 0 affected rows as success | `expected a fail() result, got {"success":true,"triaged":5}` |
| 15–16 | drop `requiresGrant` on either action | `expected a fail() result, got {"success":true,…}` |
| 17 | collapse gone-vs-already-moved | `expected { changed: false } to deeply equal { ok: false, reason: 'gone' }` |
| 18 | record mod activity unconditionally | `expected 1 to be +0` |
| 19 | accept a URL as an attachment id | `expected [ …(2) ] to deeply equal [ 'real-image-key-1' ]` |
| 20 | accept a URL as a screenshot id | `expected 'https://attacker.example/x.png' to be null` |
| 21 | stop deduplicating ids | `expected [ 'same', 'same' ] to deeply equal [ 'same' ]` |
| 22 | drop the `//host` guard | `expected '//evil.example/x' to be null` |
| 23 | infer the promote mode from a blank box | wrong refusal text |
| 24 | collapse promote's 410 into a 409 | `expected 409 to be 410` |
| 25 | hardcode the link refusal to `already-linked` | `expected {…'already-linked'} to deeply equal {…'gone'}` |
| 26 | let the redirect fire on a POST | the 307 throws, with `location: '/feedback?%2Ftriage=&status=new'` |
| 27 | drop the int4 bound on the cursor | `expected "vi.fn()" to be called with [ {"cursor": null} ] ` |
| 28 | drop the `http`/`blob` lookahead | `expected [ 'httpabcdefgh', … ] to deeply equal []` |
| 29 | merge the two attach refusals | wrong refusal text |
| 30 | treat an empty `?status=` as the default | `expected [ 'new' ] to deeply equal []` |
| 31 | hardcode promote's in-transaction refusal | `expected {…'already-linked'} to deeply equal {…'gone'}` |

Mutants 14–16 first died inside the test's own unwrap helper with a bare `TypeError` — a message
naming the helper rather than the claim. The helper now asserts the shape, so they fail with the
sentence above.

### Reviews

`svelte-correctness-review`, `svelte-idiom-review` and `svelte-abstraction-review` over the segment,
then **three delta audits** over the fix rounds, because an audit fix resets the verification gate.
That was not ceremony: the second round's own fix — removing a duplicated error alert — silently
removed the only surface a `410` had, and the third round's fix left the same hole one component
over. The last round came back clean, which ended the ladder. Findings and fixes are in the second
commit's message.

**One claim that rests on reading rather than on a test:** the triage-note fix. Component behaviour
is unreachable from this app's node-env suite (there is no browser-test project in any SvelteKit app
here), so the reset hazard was verified against SvelteKit's `fallback_callback` and Svelte's
`set_value` directly, not by driving the form. Worth clicking once.

### One thing that cannot be desk-checked

**Click the Grafana link once**, against a report less than 72 h old, and confirm it lands on rows
rather than an empty pane. The datasource uid and the `panes` format are from the design doc's live
investigation, but a URL built from documentation is a claim about the documentation — and a link
tested against an expired session proves only that expiry works. Every row in the table today is
already past the window, so this needs a fresh row in the dev clone.

### Note on the check list

`preview / smoke-tests` is **failing on every recent PR in this repo** (verified on #4771, #4776 and
#4777 — identical `1 failed`, different authors). It is pre-existing and unrelated to this change.
