### PR TITLE
fix(training-studio): run svelte-kit sync before the element build

### DIFF
--- a/apps/training-studio/package.json
+++ b/apps/training-studio/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build --config vite.element.config.ts && svelte-kit sync && vite build",
+    "build": "svelte-kit sync && vite build --config vite.element.config.ts && vite build",
     "preview": "vite preview",
     "prepare": "svelte-kit sync",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",


### PR DESCRIPTION
Every Training Studio release since **0.0.4** has produced no image — `0.0.4`, `0.0.5` and `0.0.7` all failed the container build. One-line cause, one-line fix.

## Cause

`apps/training-studio/tsconfig.json` extends `./.svelte-kit/tsconfig.json`, which `svelte-kit sync` **generates** and `.gitignore` excludes. The `build` script ran the element build first:

```
vite build --config vite.element.config.ts && svelte-kit sync && vite build
```

so in a clean tree that first `vite` resolves the app tsconfig before `.svelte-kit/` exists:

```
▲ Cannot find base config file "./.svelte-kit/tsconfig.json" [tsconfig.json]
✗ [vite:esbuild] failed to resolve "extends":"./.svelte-kit/tsconfig.json"
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @civitai/training-studio-app build
```

It passes locally only because `prepare` (= `svelte-kit sync`) has already run on a dev machine, leaving `.svelte-kit/` in the tree. The Dockerfile installs with `--ignore-scripts`, so `prepare` never runs there and the directory never exists.

`svelte-kit sync` only writes `.svelte-kit/` and is idempotent, so moving it to the front costs nothing and satisfies both `vite` invocations.

**The version boundary is the proof:** `0.0.3`'s script was `svelte-kit sync && vite build` and built fine. The element build was prepended in the web-component extraction, released as `0.0.4` — and every release since has failed.

## Verification — watched it fail, then pass

Real Dockerfile, same context, same command, only the script order differing:

| | result |
|---|---|
| **before** | exit `1` at `Dockerfile:47`, the `extends` error above, **no image produced** |
| **after** | exit `0`, image written |

The "no image produced" half matters — the exit code alone would not distinguish a build that failed from a wrapper that swallowed the status, so I checked `docker images` came back empty on the red run and populated on the green one.

And the built image carries the bundle this is all for:

```
build/client/element/civitai-training-studio.js            102 B
build/client/element/CivitaiTrainingStudio-BeR2Jd5s.js     1.0 MB
build/client/element/civitai-training-studio.css           259 KB
```

## One note for whoever serves these

The entry is a **102-byte stub** that dynamically imports the content-hashed chunk beside it:

```js
customElements.get("civitai-training-studio") || await import("./CivitaiTrainingStudio-BeR2Jd5s.js");
```

The browser fetches that chunk in CORS mode too, so anything gating or CORS-ing the element path has to cover the **whole directory**, not just the named entry — and the hash changes every build, so an exact-filename list could not be maintained anyway.

## Deliberately not included

`build:element` on its own has the same latent ordering bug in a clean tree. Left alone: it is a dev convenience script, always run after an install that has generated `.svelte-kit/`, and widening the fix to it is a separate call.

## Review gates

`apps/training-studio/CLAUDE.md` names two. Stating where each stands rather than implying both ran:

- **Adversarial `/svelte-review`** — not run. It reviews Svelte component code; this changes one npm script and touches no `.svelte` file.
- **Maintainer OK** — given on this exact diff before the commit was made.
