### PR TITLE
fix(jobs): make the archive lock survive the disconnect that was discarding it

### DIFF
--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -67,6 +67,7 @@ import { handleAuctions } from '~/server/jobs/handle-auctions';
 import { ingestImages, removeBlockedImages } from '~/server/jobs/image-ingestion';
 import { imagesCreatedEvents } from '~/server/jobs/images-created-events';
 import type { Job } from '~/server/jobs/job';
+import { createDisconnectHandler } from '~/server/jobs/job';
 import { jobQueueJobs } from '~/server/jobs/job-queue';
 import { newOrderJobs } from '~/server/jobs/new-order-jobs';
 import { placementJobs } from '~/server/jobs/placement-jobs';
@@ -277,10 +278,12 @@ export default WebhookEndpoint(async (req, res) => {
 
     const jobRunner = run({ req });
 
-    const cancelHandler = async () => {
-      await jobRunner.cancel();
-      await lock.release();
-    };
+    // Cancel the context, and release the lock UNLESS the job opted out of that release. See
+    // `createDisconnectHandler` and `JobOptions.keepLockOnDisconnect`: for a job that legitimately
+    // runs longer than the caller's client timeout, releasing here hands the freed lock straight
+    // to the caller's retry and produces two concurrent runs of the same work. Default is
+    // unchanged — cancel then release.
+    const cancelHandler = createDisconnectHandler(options, jobRunner, lock);
 
     res.on('close', cancelHandler);
     result = await jobRunner.result;

--- a/src/server/jobs/__tests__/job-disconnect-lock.test.ts
+++ b/src/server/jobs/__tests__/job-disconnect-lock.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import { createDisconnectHandler, createJob } from '~/server/jobs/job';
+
+/**
+ * What happens to a job's redis lock when the client that triggered the run hangs up.
+ *
+ * THE HAZARD. The external scheduler holds the trigger request open and gives it a client-side
+ * timeout, then retries. Historically the route's close handler released the lock, so a run longer
+ * than that timeout lost its lock at the disconnect no matter how large `lockExpiration` was — and
+ * the retry then acquired the freed lock and started a second, competing run of the same work.
+ * `keepLockOnDisconnect` is the opt-out from that release. This file pins BOTH arms: that the flag
+ * changes the handler, and that its absence leaves the historical behaviour byte-for-byte intact.
+ *
+ * The assertions drive the REAL factory the route installs, with spies standing in only for the
+ * runner and the lock. The route itself imports every job in the application and so cannot be
+ * loaded here; the last case below checks the wiring against the route's source instead, and says
+ * what that is and is not worth.
+ */
+
+const RUN_JOBS_ROUTE = path.resolve(
+  __dirname,
+  '../../../pages/api/webhooks/run-jobs/[[...run]].ts'
+);
+
+function harness(options: Parameters<typeof createDisconnectHandler>[0]) {
+  const cancel = vi.fn(async () => undefined);
+  const release = vi.fn(async () => undefined);
+  return { cancel, release, handler: createDisconnectHandler(options, { cancel }, { release }) };
+}
+
+describe('a client disconnect releases the job lock unless the job opted out', () => {
+  it('DEFAULT (option absent): cancels the context AND releases the lock', async () => {
+    // The pre-existing behaviour, and the one every job in the tree but the opted-in ones gets.
+    const { cancel, release, handler } = harness({});
+
+    await handler();
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('DEFAULT (option explicitly false): still releases', async () => {
+    // `false` must be indistinguishable from absent — a job that writes the field out to say "no"
+    // must not accidentally get the opt-in.
+    const { cancel, release, handler } = harness({ keepLockOnDisconnect: false });
+
+    await handler();
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('OPT-IN: cancels the context but does NOT release the lock', async () => {
+    const { cancel, release, handler } = harness({ keepLockOnDisconnect: true });
+
+    await handler();
+
+    // Cancel still fires: the flag is about the LOCK, not about whether jobs that poll
+    // `checkIfCanceled` are told to stop. Dropping the cancel would silently change every
+    // cancellation-aware job that ever adopts this option.
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it('a job built by createJob without the option gets the releasing handler', async () => {
+    // The default arrives via `createJob`'s option spread, not just via a hand-written literal —
+    // this is the path a real job's `options` object actually takes.
+    const job = createJob('probe-disconnect-default', '20 */1 * * *', async () => undefined);
+    const { cancel, release, handler } = harness(job.options);
+
+    expect(job.options.keepLockOnDisconnect).toBeUndefined();
+    await handler();
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('a job built by createJob WITH the option gets the holding handler', async () => {
+    const job = createJob('probe-disconnect-optin', '20 */1 * * *', async () => undefined, {
+      keepLockOnDisconnect: true,
+    });
+    const { cancel, release, handler } = harness(job.options);
+
+    await handler();
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(release).not.toHaveBeenCalled();
+  });
+});
+
+describe('the run-jobs route builds its close handler from this factory', () => {
+  it('installs createDisconnectHandler(options, jobRunner, lock) as the close handler', () => {
+    // 🔴 WHAT THIS IS: a source read, because importing that route pulls in every job in the
+    // application. WHAT IT IS WORTH: it catches the route re-inlining the two awaits — which would
+    // leave every test above green while the option did nothing in production — and nothing more.
+    // It cannot tell you the handler behaves correctly; the cases above do that.
+    const source = readFileSync(RUN_JOBS_ROUTE, 'utf8');
+
+    expect(source).toContain(
+      'const cancelHandler = createDisconnectHandler(options, jobRunner, lock);'
+    );
+    expect(source).toContain("res.on('close', cancelHandler)");
+    // The `options` passed above must be the dispatched job's, not a literal.
+    expect(source).toContain('const { name, run, options } = job;');
+  });
+});

--- a/src/server/jobs/__tests__/job-disconnect-lock.test.ts
+++ b/src/server/jobs/__tests__/job-disconnect-lock.test.ts
@@ -39,6 +39,10 @@ describe('a client disconnect releases the job lock unless the job opted out', (
 
     expect(cancel).toHaveBeenCalledTimes(1);
     expect(release).toHaveBeenCalledTimes(1);
+    // Counts alone leave the ORDER free: releasing before the context is canceled hands the lock
+    // back while the run is still live and not yet told to stop, which is the window the retry
+    // needs to start a competing run. Inverting the two awaits keeps both counts at 1.
+    expect(cancel.mock.invocationCallOrder[0]).toBeLessThan(release.mock.invocationCallOrder[0]);
   });
 
   it('DEFAULT (option explicitly false): still releases', async () => {
@@ -93,15 +97,24 @@ describe('a client disconnect releases the job lock unless the job opted out', (
 describe('the run-jobs route builds its close handler from this factory', () => {
   it('installs createDisconnectHandler(options, jobRunner, lock) as the close handler', () => {
     // 🔴 WHAT THIS IS: a source read, because importing that route pulls in every job in the
-    // application. WHAT IT IS WORTH: it catches the route re-inlining the two awaits — which would
-    // leave every test above green while the option did nothing in production — and nothing more.
-    // It cannot tell you the handler behaves correctly; the cases above do that.
+    // application. WHAT IT IS WORTH: it catches the route re-inlining the two awaits, and it
+    // catches the registration being moved to where it can never fire during a run — either of
+    // which would leave every test above green while the option did nothing in production. It
+    // cannot tell you the handler behaves correctly; the cases above do that, and it cannot tell
+    // you the handler is ever removed again, which nothing here checks.
     const source = readFileSync(RUN_JOBS_ROUTE, 'utf8');
 
     expect(source).toContain(
       'const cancelHandler = createDisconnectHandler(options, jobRunner, lock);'
     );
     expect(source).toContain("res.on('close', cancelHandler)");
+    // Presence is not the mechanism — POSITION is. Registered after the run is awaited, the
+    // handler is installed only once the run it was meant to protect has already finished: the
+    // opt-in becomes inert AND every other job silently loses its disconnect release, with the
+    // substring above still present.
+    expect(source.indexOf("res.on('close', cancelHandler)")).toBeLessThan(
+      source.indexOf('result = await jobRunner.result')
+    );
     // The `options` passed above must be the dispatched job's, not a literal.
     expect(source).toContain('const { name, run, options } = job;');
   });

--- a/src/server/jobs/__tests__/process-csam.test.ts
+++ b/src/server/jobs/__tests__/process-csam.test.ts
@@ -22,8 +22,12 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('~/server/services/csam.service-new', () => mocks);
 
-import { CSAM_ARCHIVE_JOB_LOCK_SECONDS, csamJobs } from '~/server/jobs/process-csam';
-import { createJob } from '~/server/jobs/job';
+import {
+  CSAM_ARCHIVE_JOB_LOCK_SECONDS,
+  CSAM_ARCHIVE_MEASURED_PASS_SECONDS,
+  csamJobs,
+} from '~/server/jobs/process-csam';
+import { createDisconnectHandler, createJob } from '~/server/jobs/job';
 import { loggingMock } from '~/__tests__/mocks/logging.mock';
 
 const archiveJob = csamJobs.find((job) => job.name === 'archive-csam-reports');
@@ -110,9 +114,14 @@ describe('archive-csam-reports batch isolation', () => {
 
 describe('the archive job asks for a lock that can hold a real archival pass', () => {
   // The hazard this pins: the run-jobs route hard-caps the hold at `lockExpiration` and then
-  // releases the lock while the run continues, so a value shorter than a pass lets the next
-  // hourly tick start a second, concurrent archive of the same report. Reverting the override
+  // releases the lock while the run continues, so a value shorter than a pass lets a later
+  // hourly tick start a second, competing archive of the same report. Reverting the override
   // must fail here, not be discovered in production.
+  //
+  // 🔴 `options.dedicated` is DELIBERATELY NOT ASSERTED HERE. It reads like a duplicate-run
+  // mitigation and is not one: nothing in the tree reads it (grep `options.dedicated`), so a test
+  // pinning it to `true` would report coverage of a field whose value cannot change any behaviour.
+  // See the note on `JobOptions.dedicated`.
 
   it('is the named constant, not createJob’s inherited default', () => {
     const inherited = createJob('probe', '20 */1 * * *', async () => undefined);
@@ -134,10 +143,62 @@ describe('the archive job asks for a lock that can hold a real archival pass', (
     expect(CSAM_ARCHIVE_JOB_LOCK_SECONDS).toBeGreaterThan(cronPeriodSeconds);
   });
 
-  it('keeps the single-pod restriction, which the lock does not replace', () => {
-    // `dedicated` bounds WHERE the job runs; the lock bounds WHETHER a second run may start.
-    // Adding the lock must not cost the other half.
-    expect(archiveJob!.options.dedicated).toBe(true);
+  it('🔴 clears the MEASURED pass with headroom, not merely the cron period', () => {
+    // Why the cron-period guard above is not enough on its own: it, and both guards before it, are
+    // satisfied by 3601 — one second over the hour, and a fraction of a pass that has actually been
+    // observed. This is the assertion that ties the constant to the thing it is sized against.
+    //
+    // The multiple is 2×, and it is a floor rather than a target for two independent reasons, both
+    // recorded on CSAM_ARCHIVE_MEASURED_PASS_SECONDS: the measurement is a single-REPORT time while
+    // a tick archives the whole outstanding batch serially, and one observation says nothing about
+    // the tail. 2× is the least headroom the sizing argument can be read as claiming.
+    expect(CSAM_ARCHIVE_JOB_LOCK_SECONDS).toBeGreaterThanOrEqual(
+      2 * CSAM_ARCHIVE_MEASURED_PASS_SECONDS
+    );
+
+    // The other direction, which `keepLockOnDisconnect` made a real cost: an alive-but-wedged run
+    // now holds this lock for its full duration and archival does not resume until it expires.
+    // Growing the value without revisiting that trade-off should fail here.
+    expect(CSAM_ARCHIVE_JOB_LOCK_SECONDS).toBeLessThanOrEqual(8 * 60 * 60);
+  });
+});
+
+describe('the archive job’s lock survives the caller hanging up', () => {
+  // 🔴 THE HALF THAT MAKES THE CONSTANT ABOVE MEAN ANYTHING. The caller holds the trigger request
+  // open under a client-side timeout and retries; a pass longer than that timeout loses its socket.
+  // On the default path the route's close handler releases the lock there and then — throwing the
+  // whole `lockExpiration` budget away in exactly the case it was sized for — and the retry starts
+  // the competing pass. These cases drive the REAL handler the route installs, using this job's own
+  // options object, so they fail if the opt-in is dropped from the job OR broken in the factory.
+  //
+  // The generic contract, both arms, plus the route-wiring check: `job-disconnect-lock.test.ts`.
+
+  function harness(options: Parameters<typeof createDisconnectHandler>[0]) {
+    const cancel = vi.fn(async () => undefined);
+    const release = vi.fn(async () => undefined);
+    return { cancel, release, handler: createDisconnectHandler(options, { cancel }, { release }) };
+  }
+
+  it('a disconnect cancels the context but leaves the lock held', async () => {
+    const { cancel, release, handler } = harness(archiveJob!.options);
+
+    await handler();
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: the sibling job, which does not opt in, still releases on a disconnect', async () => {
+    // Same handler, same harness, a real un-opted job — so a green above is a fact about the
+    // opt-in and not about the harness. This is also the default-unchanged claim, checked against
+    // a job that ships today rather than a fixture.
+    expect(sendJob!.options.keepLockOnDisconnect).toBeUndefined();
+    const { cancel, release, handler } = harness(sendJob!.options);
+
+    await handler();
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/server/jobs/__tests__/process-csam.test.ts
+++ b/src/server/jobs/__tests__/process-csam.test.ts
@@ -22,7 +22,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('~/server/services/csam.service-new', () => mocks);
 
-import { csamJobs } from '~/server/jobs/process-csam';
+import { CSAM_ARCHIVE_JOB_LOCK_SECONDS, csamJobs } from '~/server/jobs/process-csam';
+import { createJob } from '~/server/jobs/job';
 import { loggingMock } from '~/__tests__/mocks/logging.mock';
 
 const archiveJob = csamJobs.find((job) => job.name === 'archive-csam-reports');
@@ -104,6 +105,39 @@ describe('archive-csam-reports batch isolation', () => {
       .map(([arg]) => arg as { subType?: string; message?: unknown })
       .filter((arg) => arg?.subType === 'archive-data');
     expect(logged[0].message).toBe('synthetic archive failure');
+  });
+});
+
+describe('the archive job asks for a lock that can hold a real archival pass', () => {
+  // The hazard this pins: the run-jobs route hard-caps the hold at `lockExpiration` and then
+  // releases the lock while the run continues, so a value shorter than a pass lets the next
+  // hourly tick start a second, concurrent archive of the same report. Reverting the override
+  // must fail here, not be discovered in production.
+
+  it('is the named constant, not createJob’s inherited default', () => {
+    const inherited = createJob('probe', '20 */1 * * *', async () => undefined);
+
+    expect(archiveJob!.options.lockExpiration).toBe(CSAM_ARCHIVE_JOB_LOCK_SECONDS);
+    // The non-vacuous half: an "override" that is not actually longer than the inherited default
+    // leaves the duplicate-run hazard exactly where it was.
+    expect(CSAM_ARCHIVE_JOB_LOCK_SECONDS).toBeGreaterThan(inherited.options.lockExpiration);
+  });
+
+  it('outlives the cron period it is scheduled on', () => {
+    // Asserting the schedule as well as the number is what makes this a RELATIONSHIP rather than
+    // two independent literals: if the cron is ever made faster or slower, this fails instead of
+    // silently comparing the lock against a period the job no longer runs at.
+    expect(archiveJob!.cron).toBe('20 */1 * * *'); // hourly
+    const cronPeriodSeconds = 60 * 60;
+
+    // Below this the job can overlap ITSELF regardless of how long any single report takes.
+    expect(CSAM_ARCHIVE_JOB_LOCK_SECONDS).toBeGreaterThan(cronPeriodSeconds);
+  });
+
+  it('keeps the single-pod restriction, which the lock does not replace', () => {
+    // `dedicated` bounds WHERE the job runs; the lock bounds WHETHER a second run may start.
+    // Adding the lock must not cost the other half.
+    expect(archiveJob!.options.dedicated).toBe(true);
   });
 });
 

--- a/src/server/jobs/__tests__/process-csam.test.ts
+++ b/src/server/jobs/__tests__/process-csam.test.ts
@@ -152,6 +152,14 @@ describe('the archive job asks for a lock that can hold a real archival pass', (
     // recorded on CSAM_ARCHIVE_MEASURED_PASS_SECONDS: the measurement is a single-REPORT time while
     // a tick archives the whole outstanding batch serially, and one observation says nothing about
     // the tail. 2× is the least headroom the sizing argument can be read as claiming.
+    //
+    // 🔴 The yardstick is pinned to its literal first, and that is what makes the ratio below a
+    // guard at all. Both operands live in `process-csam.ts`; with only the lock pinned, shrinking
+    // the measurement satisfies the ratio for any lock value, so the exact mutant this case exists
+    // to kill — a lock cut back to just over the cron period — survives a one-token edit to the
+    // constant it is supposedly measured against. Re-measuring the pass must land here and force
+    // the lock to be re-argued, not silently re-baseline the headroom it is checked with.
+    expect(CSAM_ARCHIVE_MEASURED_PASS_SECONDS).toBe(80 * 60);
     expect(CSAM_ARCHIVE_JOB_LOCK_SECONDS).toBeGreaterThanOrEqual(
       2 * CSAM_ARCHIVE_MEASURED_PASS_SECONDS
     );

--- a/src/server/jobs/job.ts
+++ b/src/server/jobs/job.ts
@@ -19,8 +19,37 @@ export type JobOptions = {
   shouldWait: boolean;
   lockExpiration: number;
   queue?: string;
-  /** restrict job to only run on a single pod */
+  /**
+   * Declared intent that the job run on a single pod.
+   *
+   * 🔴 INERT. Nothing in this tree reads `options.dedicated` — it is set on a handful of jobs,
+   * serialised out by `/api/internal/get-jobs`, and dropped by the scheduler's DTO. Setting it
+   * changes no behaviour. Left in place as the declaration it is; do not cite it as a
+   * duplicate-run mitigation.
+   */
   dedicated?: boolean;
+  /**
+   * Opt-in: when the HTTP client that triggered this run hangs up, cancel the job context but
+   * LEAVE THE REDIS LOCK HELD.
+   *
+   * Absent or `false` — the default for every job — is the historical behaviour: a disconnect
+   * cancels AND releases.
+   *
+   * Why an opt-in exists at all: the external scheduler holds the trigger request open and gives
+   * it a client-side timeout. A run that outlives that timeout loses the socket, and releasing on
+   * that close throws away the whole `lockExpiration` budget precisely in the case it was sized
+   * for — the scheduler's automatic retry then acquires the freed lock and starts a competing
+   * second run of the same work. Set this only on jobs that (a) legitimately run longer than the
+   * scheduler's client timeout and (b) are harmful to run twice concurrently, and set
+   * `lockExpiration` deliberately, because with this on it is the only thing bounding the hold.
+   *
+   * The cost it buys, stated plainly: a run that is ALIVE BUT WEDGED now holds the lock for the
+   * full `lockExpiration` instead of losing it at the disconnect, so the job does not run again
+   * until that expires. A pod that DIES does not pay this — the redis key carries a ~10s TTL
+   * refreshed by an in-process interval (see `acquireLock` in the run-jobs route), so a dead
+   * pod's lock lapses within seconds regardless of this option.
+   */
+  keepLockOnDisconnect?: boolean;
 };
 
 export type JobStatus = 'running' | 'canceled' | 'finished';
@@ -130,6 +159,33 @@ export function createJob(
       ...options,
     },
   } as Job;
+}
+
+/**
+ * Builds the handler the run-jobs route installs on `res.on('close')` — i.e. what happens when the
+ * client that triggered a run hangs up mid-run.
+ *
+ * It lives here, not inline in the route, for one reason: the route imports every job in the
+ * application, so nothing about it can be exercised in a unit test. This is the one decision in
+ * that handler that has a behavioural contract worth pinning, so it is extracted to where a test
+ * can drive it with a real job's own `options`. The route must keep calling this rather than
+ * re-inlining the two awaits — `job-disconnect-lock.test.ts` reads the route source to check that.
+ *
+ * `cancel()` runs in BOTH branches on purpose. It is what flips the job context to `canceled`, and
+ * jobs that poll `checkIfCanceled` must still stop when the caller goes away; `keepLockOnDisconnect`
+ * is about the LOCK, not about whether the job is told to stop.
+ */
+export function createDisconnectHandler(
+  options: Pick<JobOptions, 'keepLockOnDisconnect'>,
+  jobRunner: { cancel: () => Promise<void> },
+  lock: { release: () => Promise<void> }
+): () => Promise<void> {
+  return async () => {
+    await jobRunner.cancel();
+    // Default (absent/false): release, exactly as before this option existed.
+    if (options.keepLockOnDisconnect) return;
+    await lock.release();
+  };
 }
 
 export async function getJobDate(key: string, defaultValue?: Date) {

--- a/src/server/jobs/process-csam.ts
+++ b/src/server/jobs/process-csam.ts
@@ -52,6 +52,43 @@ const sendCsamReportsJob = createJob(
   { dedicated: true }
 );
 
+/**
+ * Lock hold for `archive-csam-reports`, overriding `createJob`'s 5-minute default.
+ *
+ * WHY AN OVERRIDE AT ALL. The run-jobs route hard-caps the lock hold at exactly this value and
+ * then RELEASES the lock while the run keeps going (`acquireLock` in the run-jobs webhook). At the
+ * inherited 300s against an hourly cron, an archive that runs longer than five minutes — the
+ * normal case for a reported user with a very large image library, one such pass having been
+ * measured end to end at roughly 80 minutes — self-releases about five minutes in, and every
+ * subsequent hourly tick is then free to start a second, concurrent archive of the same report
+ * from scratch. That has happened in production: concurrency reached three simultaneous passes,
+ * each re-downloading the same evidence, and the only thing that stopped it was an operator
+ * suppressing the later ticks by hand. `dedicated: true` does not help — it pins the job to one
+ * pod, it does not stop that pod starting the job again on the next tick. Same mitigation, same
+ * reason, as `blurb-fanout` and `bot-account-detection`.
+ *
+ * WHY THIS VALUE — THE TRADE-OFF, BOTH DIRECTIONS.
+ * Too short and the duplicate-run hazard above simply returns. The floor for closing it at all is
+ * the hourly cron period, and the working floor is well above that: a tick archives the whole
+ * outstanding batch serially, not one report, and libraries substantially larger than the
+ * ~80-minute one exist in the population.
+ * Too long costs less than it looks. A clean finish releases the lock immediately, a client
+ * disconnect releases it, and a pod that dies outright does NOT hold it for this long — the redis
+ * key carries a ~10s TTL refreshed by an in-process interval, so a dead pod's lock lapses within
+ * seconds. The only case that pays the full value is a run that is alive but wedged; there the
+ * cost is real, and it is that archival stalls until this expires.
+ * Four hours sits a few multiples above the measured pass while staying bounded low enough that
+ * such a wedge clears itself within a shift instead of requiring a human.
+ *
+ * 🔴 The exact figure is a JUDGEMENT CALL, not a derivation. What exists is one measured
+ * ~80-minute pass plus a count of accounts above that size class; that is not a duration
+ * distribution, and a batch total is not a single-report time. What would replace this with an
+ * arithmetic bound is a per-report archive-duration histogram — p99 against library size, and the
+ * per-tick batch total. Until that exists, read 4h as a ceiling sized off a single observation,
+ * not as a reservation.
+ */
+export const CSAM_ARCHIVE_JOB_LOCK_SECONDS = 4 * 60 * 60;
+
 const archiveCsamReportDataJob = createJob(
   'archive-csam-reports',
   '20 */1 * * *',
@@ -71,7 +108,9 @@ const archiveCsamReportDataJob = createJob(
       }
     }
   },
-  { dedicated: true }
+  // `dedicated` stays: it is the one-pod restriction, and it is orthogonal to the lock — see
+  // CSAM_ARCHIVE_JOB_LOCK_SECONDS above for why the inherited 300s default is the wrong hold.
+  { dedicated: true, lockExpiration: CSAM_ARCHIVE_JOB_LOCK_SECONDS }
 );
 
 // Unfinished, deliberately not in `csamJobs` — the removal step has never been written, so

--- a/src/server/jobs/process-csam.ts
+++ b/src/server/jobs/process-csam.ts
@@ -53,39 +53,60 @@ const sendCsamReportsJob = createJob(
 );
 
 /**
- * Lock hold for `archive-csam-reports`, overriding `createJob`'s 5-minute default.
+ * One `archive-csam-reports` pass, measured end to end for a report covering a large image library.
  *
- * WHY AN OVERRIDE AT ALL. The run-jobs route hard-caps the lock hold at exactly this value and
- * then RELEASES the lock while the run keeps going (`acquireLock` in the run-jobs webhook). At the
- * inherited 300s against an hourly cron, an archive that runs longer than five minutes — the
- * normal case for a reported user with a very large image library, one such pass having been
- * measured end to end at roughly 80 minutes — self-releases about five minutes in, and every
- * subsequent hourly tick is then free to start a second, concurrent archive of the same report
- * from scratch. That has happened in production: concurrency reached three simultaneous passes,
- * each re-downloading the same evidence, and the only thing that stopped it was an operator
- * suppressing the later ticks by hand. `dedicated: true` does not help — it pins the job to one
- * pod, it does not stop that pod starting the job again on the next tick. Same mitigation, same
- * reason, as `blurb-fanout` and `bot-account-detection`.
+ * Rounded up from a SINGLE observation. It is a sighting, not a distribution, and it is a
+ * single-report time while a tick archives the whole outstanding batch serially — so treat it as a
+ * floor on how long a pass can take, never as an expected value. Named and exported so the lock
+ * below is checkably sized against something instead of being a bare literal.
+ */
+export const CSAM_ARCHIVE_MEASURED_PASS_SECONDS = 80 * 60;
+
+/**
+ * How long `archive-csam-reports` may hold its run lock, overriding `createJob`'s 5-minute default.
  *
- * WHY THIS VALUE — THE TRADE-OFF, BOTH DIRECTIONS.
- * Too short and the duplicate-run hazard above simply returns. The floor for closing it at all is
- * the hourly cron period, and the working floor is well above that: a tick archives the whole
- * outstanding batch serially, not one report, and libraries substantially larger than the
- * ~80-minute one exist in the population.
- * Too long costs less than it looks. A clean finish releases the lock immediately, a client
- * disconnect releases it, and a pod that dies outright does NOT hold it for this long — the redis
- * key carries a ~10s TTL refreshed by an in-process interval, so a dead pod's lock lapses within
- * seconds. The only case that pays the full value is a run that is alive but wedged; there the
- * cost is real, and it is that archival stalls until this expires.
- * Four hours sits a few multiples above the measured pass while staying bounded low enough that
- * such a wedge clears itself within a shift instead of requiring a human.
+ * WHY AN OVERRIDE. The run-jobs route hard-caps the hold at exactly this value and then releases
+ * the lock while the run keeps going (`acquireLock`, `src/pages/api/webhooks/run-jobs/[[...run]].ts`).
+ * At the inherited 300s against an hourly cron, an archive that runs longer than five minutes — the
+ * ordinary case for a report covering a large image library, one pass having been measured at
+ * CSAM_ARCHIVE_MEASURED_PASS_SECONDS — self-releases about five minutes in, and a later tick is then
+ * free to start a second, competing archive of the same report from scratch, re-fetching everything
+ * the first pass is still fetching. Same mitigation, same reason, as `blurb-fanout` and
+ * `bot-account-detection`.
  *
- * 🔴 The exact figure is a JUDGEMENT CALL, not a derivation. What exists is one measured
- * ~80-minute pass plus a count of accounts above that size class; that is not a duration
- * distribution, and a batch total is not a single-report time. What would replace this with an
- * arithmetic bound is a per-report archive-duration histogram — p99 against library size, and the
- * per-tick batch total. Until that exists, read 4h as a ceiling sized off a single observation,
- * not as a reservation.
+ * 🔴 `dedicated: true` DOES NOT CLOSE THIS, and its name invites the opposite reading. Nothing in
+ * the tree reads `options.dedicated` (see `JobOptions`) — it is declared, set on a handful of jobs,
+ * serialised to the scheduler and discarded there. It is inert. It would not close this even if it
+ * were honoured: restricting the job to one pod says nothing about that pod starting it again on
+ * the next tick.
+ *
+ * WHY THE LOCK IS ALSO HELD PAST A CLIENT DISCONNECT (`keepLockOnDisconnect`). Without that flag
+ * this constant governs nothing here. The caller holds the trigger request open under its own
+ * client-side timeout and retries when that fires; a pass longer than the timeout therefore loses
+ * its socket, the route's close handler runs, and the default release throws the entire budget away
+ * — long before four hours could matter — leaving the retry free to start the competing pass above.
+ * The job deliberately does NOT poll `checkIfCanceled` and must not be made to: a pass of the
+ * measured length necessarily outlives the caller's timeout and finishes only because this job
+ * keeps running after the disconnect, so a cancelling version would be killed at every retry's
+ * timeout and never complete a long archive at all. The lock, not cancellation, is the mitigation —
+ * and it has to survive the disconnect in order to be one.
+ *
+ * WHY THIS VALUE — THE COST, BOTH DIRECTIONS.
+ * Too short and the duplicate-run hazard returns. The absolute floor is the hourly cron period; the
+ * working floor is well above it, because a tick archives the whole outstanding batch serially and
+ * libraries larger than the measured one exist.
+ * Too long is now a REAL cost, and `keepLockOnDisconnect` is what makes it real: a run that is alive
+ * but wedged holds this lock for its full duration, and archival does not resume until it expires.
+ * A clean finish still releases immediately, and a pod that DIES does not pay it at all — the redis
+ * key carries a ~10s TTL refreshed by an in-process interval, so a crashed pod's lock lapses within
+ * seconds regardless of this value. Four hours sits a few multiples above the measured pass while
+ * staying bounded low enough that a wedge clears itself rather than needing a human.
+ *
+ * 🔴 The exact figure is a JUDGEMENT CALL, not a derivation: one measured pass is not a duration
+ * distribution, and a single-report time is not a per-tick batch total. What would replace it with
+ * an arithmetic bound is a per-report archive-duration histogram — p99 against library size — plus
+ * that batch total. Until that exists, read 4h as a ceiling sized off one observation, not as a
+ * reservation.
  */
 export const CSAM_ARCHIVE_JOB_LOCK_SECONDS = 4 * 60 * 60;
 
@@ -108,9 +129,15 @@ const archiveCsamReportDataJob = createJob(
       }
     }
   },
-  // `dedicated` stays: it is the one-pod restriction, and it is orthogonal to the lock — see
-  // CSAM_ARCHIVE_JOB_LOCK_SECONDS above for why the inherited 300s default is the wrong hold.
-  { dedicated: true, lockExpiration: CSAM_ARCHIVE_JOB_LOCK_SECONDS }
+  // `keepLockOnDisconnect` is load-bearing, not a refinement: without it the close handler releases
+  // the lock the moment the caller's request times out, and `lockExpiration` never gets to govern
+  // anything. `dedicated` stays as a declaration of intent only — nothing reads it. See
+  // CSAM_ARCHIVE_JOB_LOCK_SECONDS above for the whole argument, including what the held lock costs.
+  {
+    dedicated: true,
+    lockExpiration: CSAM_ARCHIVE_JOB_LOCK_SECONDS,
+    keepLockOnDisconnect: true,
+  }
 );
 
 // Unfinished, deliberately not in `csamJobs` — the removal step has never been written, so


### PR DESCRIPTION
## The problem

`archive-csam-reports` passes only `{ dedicated: true }`, so it inherits `createJob`'s default `lockExpiration: 5 * 60` (`src/server/jobs/job.ts`).

The run-jobs route hard-caps the lock hold at exactly `lockExpiration` and then **releases the lock while the run keeps going** (`acquireLock`, `src/pages/api/webhooks/run-jobs/[[...run]].ts`). Against this job's hourly cron that means: any pass longer than five minutes runs unlocked for the rest of its life, and a later tick is then free to start **a second, competing archive of the same report from scratch**, re-fetching everything the first pass is still fetching.

That is not theoretical about the durations involved: one archival pass for a report covering a large image library was measured end to end at roughly **80 minutes**.

`dedicated: true` does not close it. It reads like a duplicate-run mitigation and is not one — see the correction below.

Same failure `blurb-fanout` documents in its own comment, and the same mitigation `bot-account-detection` calls out ("`lockExpiration` IS THE MITIGATION FOR THE DUPLICATE RUN, and it is the only one").

## 🔴 The first version of this PR did not work

An adversarial audit found the fix largely inert, and this is the part worth reading.

A 4-hour `lockExpiration` alone changes nothing here, because of what the route does on a client disconnect:

```js
const cancelHandler = async () => {
  await jobRunner.cancel();
  await lock.release();   // <-- throws the whole 4h budget away
};
res.on('close', cancelHandler);
```

The caller holds the trigger request open under its own client-side timeout and retries. A pass longer than that timeout therefore loses its socket, `cancelHandler` fires, and the lock is released **long before four hours could matter** — precisely in the case the constant was sized for. The retry then acquires the freed lock and starts the competing pass. The constant was right; it never got to apply.

🔴 **The intuitive fix — wiring `ctx.checkIfCanceled()` into the archive loop — is the wrong direction and would make things worse.** The measured ~80-minute pass necessarily outlives the caller's timeout, and it completes *only* because this job ignores cancellation and keeps running past the disconnect. A cancelling version would be killed at the first timeout, and every retry would be killed at its own — a livelock for any report whose archive exceeds the caller's timeout, with no pass ever finishing.

(`bot-account-detection` does wire `checkCanceled`, and its comment says so does not prevent its duplicate. That job has a different harm model — duplicate finding-sets already written to a board, which cancelling cannot undo — so its comment is not a general claim.)

## The change

**1. `JobOptions.keepLockOnDisconnect?: boolean`** — opt-in. When set, a client disconnect cancels the job context but leaves the redis lock held.

The route's close handler is now built by `createDisconnectHandler` in `src/server/jobs/job.ts`. It lives there rather than inline because the route imports every job in the application and so cannot be loaded in a unit test; extracting the one decision with a behavioural contract puts it where a test can drive it with a real job's own `options` object.

- `cancel()` runs in **both** arms on purpose. It is what flips the context to `canceled`, and jobs that poll `checkIfCanceled` must still stop when the caller goes away. The flag is about the lock, not about whether the job is told to stop.
- **Default behaviour is unchanged.** Absent or `false` → cancel then release, exactly as before. `JobOptions` fields are read in exactly one non-test place (`options.lockExpiration` at the route's `acquireLock` call) plus three test files; nothing else in the tree consumes the type.
- **What the option costs, stated at the field:** a run that is *alive but wedged* now holds the lock for the full `lockExpiration` instead of losing it at the disconnect. A pod that **dies** does not pay this — the redis key carries a ~10s TTL refreshed by an in-process interval, so a crashed pod's lock lapses within seconds regardless.

**2. `archive-csam-reports` opts in**, keeping `CSAM_ARCHIVE_JOB_LOCK_SECONDS = 4 * 60 * 60`. With the lock no longer discarded at the disconnect, that constant is finally the thing bounding the duplicate.

**Why 4h — the trade-off, both directions.** *Too short* and the hazard returns; the absolute floor is the hourly cron period and the working floor is well above it, because a tick archives the whole outstanding batch serially and libraries larger than the measured one exist. *Too long* is now a **real** cost, and the opt-in is what makes it real — see the wedge case above. 4h sits a few multiples above the measured pass while keeping a wedge self-clearing.

🔴 **The figure is a judgement call, not a derivation, and the comment says so.** One measured pass is not a duration distribution, and a single-report time is not a per-tick batch total. What would replace it with an arithmetic bound is a per-report archive-duration histogram (p99 against library size) plus that batch total.

## 🔴 Two corrections to the first version

**`dedicated: true` does not pin the job to one pod.** `options.dedicated` is read **nowhere** in the tree: it is declared on `JobOptions`, set on a handful of jobs, serialised out by `/api/internal/get-jobs`, and dropped by the scheduler's DTO. It is inert. It would not close this hazard even if it were honoured — restricting the job to one pod says nothing about that pod starting it again on the next tick. The claim is corrected at the field and at the job, and **the test asserting `dedicated === true` is gone** rather than left reporting coverage of a field whose value cannot change behaviour.

**The three lock guards were all satisfied by `3601`.** Each pinned the constant above the cron period (3600), so one second over the hour passed all of them while being a fraction of a pass that has actually been observed. Adds `CSAM_ARCHIVE_MEASURED_PASS_SECONDS`, and asserts the lock clears **twice** it — plus an upper bound, because the wedge cost is now real and growing the value should force a re-read of that trade-off.

## Tests

`src/server/jobs/__tests__/job-disconnect-lock.test.ts` (new) — the generic contract, both arms, driving the real factory with spies for the runner and the lock; plus a source-read check that the route still installs it (labelled for what it is worth: it catches a re-inline, and nothing more).

`src/server/jobs/__tests__/process-csam.test.ts` — the archive job's **own** `options` object through the same handler (lock held, context still cancelled), with the sibling `send-csam-reports` job as the control: same handler, same harness, a real un-opted job that still releases. That control is the default-unchanged claim, checked against a job that ships today rather than a fixture.

Every guard watched to fail on its own isolated mutation:

| Mutation | Failing assertion |
|---|---|
| lock `4h` → `3601` | `expected 3601 to be greater than or equal to 9600` — and the three older guards **stayed green** (12 passed), which is the F3 finding reproduced |
| `keepLockOnDisconnect` dropped from the job | `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| factory always releases (early return deleted) | same message, 3 cases across both files |
| factory never releases (return made unconditional) | `expected "vi.fn()" to be called 1 times, but got 0 times` — all 4 default/control cases |
| `await jobRunner.cancel()` dropped | same message, all 7 cases |
| route re-inlines the two awaits | source guard red; the pre-existing route guard in `job-wiring.test.ts` stayed **green**, i.e. the new one covers something the old one could not |

## Verification

- `node scripts/typecheck.mjs` → **0 type errors** (122s).
- `vitest run --project 'unit*'` over `process-csam.test.ts` → **11 passed before, 13 after**; with `job-disconnect-lock.test.ts`, `challenge-jobs-scale.test.ts`, `job-wiring.test.ts`, `job-longtask-label.test.ts` and `job-metrics-exposure.test.ts` → **6 files, 41 tests, all passing**.
- Prettier clean on all five changed files (it flagged one file before `--write`, so the clean verdict is not a fact about the glob). ESLint on the five files reports only pre-existing findings on untouched lines.

**Not established:** the route itself is never loaded in a test, so "the route passes the dispatched job's `options` to the factory" rests on the source read above, not on execution. And no live/production observation was made of a retry being refused while a long pass holds the lock — the argument for that is the mechanism plus the unit-level behaviour of the handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XGXdA1zw5Kwj7UyF1pr8Q
