### PR TITLE
fix(training-studio): give the embedded studio the PUBLIC orchestrator origin

### DIFF
--- a/src/__tests__/pages/training-studio-embed-orchestrator-origin.test.ts
+++ b/src/__tests__/pages/training-studio-embed-orchestrator-origin.test.ts
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { clientSchema } from '~/env/client-schema';
+
+/**
+ * The embedded Training Studio must hand the BROWSER a public orchestrator origin.
+ *
+ * The web component calls the orchestrator directly from the browser
+ * (`docs/training-studio-web-component.md`), so its `config.orchestratorEndpoint` is consumed by
+ * client code. `ORCHESTRATOR_ENDPOINT` is the server's IN-CLUSTER address
+ * (`http://orchestration-api.orchestration-poc.svc.cluster.local:8080`). Passing it to the element
+ * produced, on every mount of /training-studio:
+ *
+ *     Mixed Content: … requested an insecure resource 'http://orchestration-api.…:8080/v2/…'
+ *     GET http://orchestration-api.…svc.cluster.local:8080/v2/consumer/workflows
+ *         net::ERR_NAME_NOT_RESOLVED
+ *
+ * Two independent guards below, because the two halves fail differently: the schema half catches a
+ * public default that is secretly an internal address, and the source half catches the server-only
+ * key creeping back into a browser-facing module. Neither subsumes the other.
+ *
+ * 🔴 What this does NOT cover: it cannot prove the element actually reaches the orchestrator, only
+ * that no in-cluster value is wired to it. The reachability claim is a live probe (preflight +
+ * a 401 on /v2/consumer/workflows from the page's origin), not a unit test.
+ */
+
+const SERVER_KEY = 'ORCHESTRATOR_ENDPOINT';
+const PUBLIC_KEY = `NEXT_PUBLIC_${SERVER_KEY}`;
+
+/** Modules whose contents are consumed by, or sent to, a browser. */
+const BROWSER_FACING = [
+  // Builds the element's host config.
+  'pages/training-studio/index.tsx',
+  // Its JSON response goes straight to the page.
+  'pages/api/training-studio/host.ts',
+];
+
+/**
+ * Strip comments so a reference *explaining* the hazard does not read as the hazard. Both files
+ * deliberately name `ORCHESTRATOR_ENDPOINT` in prose to warn against re-adding it; a raw substring
+ * scan would flag exactly the comments that exist to prevent the bug. Controls below prove the
+ * stripper distinguishes the two cases — without them this guard could be passing because it sees
+ * nothing at all.
+ */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+/** Server-key references in CODE, with the public key's occurrences removed first — `PUBLIC_KEY`
+ *  contains `SERVER_KEY` as a substring, so searching naively would match every correct use. */
+function serverKeyRefsInCode(source: string): number {
+  const code = stripComments(source).split(PUBLIC_KEY).join('');
+  return code.split(SERVER_KEY).length - 1;
+}
+
+describe('training-studio embed: browser gets the public orchestrator origin', () => {
+  it('the instrument works: it sees a code reference and ignores a comment', () => {
+    // Positive control — a reassuring zero is worthless until the scanner has been shown to count.
+    expect(serverKeyRefsInCode(`const a = env.${SERVER_KEY};`)).toBe(1);
+    expect(serverKeyRefsInCode(`/* do not use ${SERVER_KEY} */`)).toBe(0);
+    expect(serverKeyRefsInCode(`// never pass ${SERVER_KEY} to the browser`)).toBe(0);
+    // The public key must not register as the server key despite containing it.
+    expect(serverKeyRefsInCode(`const a = env.${PUBLIC_KEY};`)).toBe(0);
+    // A URL containing `//` must not swallow the rest of the line as a comment.
+    expect(serverKeyRefsInCode(`const a = 'http://x'; const b = env.${SERVER_KEY};`)).toBe(1);
+  });
+
+  it.each(BROWSER_FACING)('%s does not read the server-only endpoint', (relative: string) => {
+    const full = path.resolve(__dirname, '../..', relative);
+    expect(fs.existsSync(full), `${relative} should exist`).toBe(true);
+    expect(serverKeyRefsInCode(fs.readFileSync(full, 'utf8'))).toBe(0);
+  });
+
+  it('the public endpoint default is a reachable public origin, not an internal address', () => {
+    // Read the default through the real schema rather than re-stating the literal.
+    const value = clientSchema.shape[PUBLIC_KEY].parse(undefined);
+
+    expect(value.startsWith('https://')).toBe(true);
+    expect(value).not.toContain('.svc.cluster.local');
+    expect(value).not.toContain('.local');
+    expect(value).not.toContain('localhost');
+    // An explicit port is the tell of an in-cluster service address; a public origin needs none.
+    expect(value.replace('https://', '')).not.toContain(':');
+  });
+});

--- a/src/env/client-schema.ts
+++ b/src/env/client-schema.ts
@@ -18,6 +18,14 @@ export const clientSchema = z.object({
   NEXT_PUBLIC_SIGNALS_ENDPOINT: z.string().optional(),
   NEXT_PUBLIC_MODERATOR_APP_URL: z.url().default('https://moderator.civitai.com'),
   NEXT_PUBLIC_TRAINING_STUDIO_URL: z.url().default('https://training.civitai.com'),
+  // 🔴 The BROWSER-facing orchestrator origin, and deliberately NOT the server-side
+  // `ORCHESTRATOR_ENDPOINT`. That one is an in-cluster address
+  // (`http://orchestration-api.…svc.cluster.local:8080`), so handing it to client code yields a
+  // mixed-content warning and `ERR_NAME_NOT_RESOLVED` — which is exactly what the embedded Training
+  // Studio did until this existed. The web component calls the orchestrator DIRECTLY from the
+  // browser (docs/training-studio-web-component.md), so it needs the public origin. Keep the two
+  // separate: server code keeps using `ORCHESTRATOR_ENDPOINT`, browser code uses this.
+  NEXT_PUBLIC_ORCHESTRATOR_ENDPOINT: z.url().default('https://orchestration.civitai.com'),
   NEXT_PUBLIC_GPTT_UUID: z.string().optional(),
   NEXT_PUBLIC_GPTT_UUID_ALT: z.string().optional(),
   NEXT_PUBLIC_GPTT_UUID_GREEN: z.string().optional(),
@@ -89,6 +97,7 @@ export const clientEnv = {
   NEXT_PUBLIC_SIGNALS_ENDPOINT: process.env.NEXT_PUBLIC_SIGNALS_ENDPOINT,
   NEXT_PUBLIC_MODERATOR_APP_URL: process.env.NEXT_PUBLIC_MODERATOR_APP_URL,
   NEXT_PUBLIC_TRAINING_STUDIO_URL: process.env.NEXT_PUBLIC_TRAINING_STUDIO_URL,
+  NEXT_PUBLIC_ORCHESTRATOR_ENDPOINT: process.env.NEXT_PUBLIC_ORCHESTRATOR_ENDPOINT,
   NEXT_PUBLIC_GPTT_UUID: process.env.NEXT_PUBLIC_GPTT_UUID,
   NEXT_PUBLIC_GPTT_UUID_ALT: process.env.NEXT_PUBLIC_GPTT_UUID_ALT,
   NEXT_PUBLIC_GPTT_UUID_GREEN: process.env.NEXT_PUBLIC_GPTT_UUID_GREEN,

--- a/src/pages/api/training-studio/host.ts
+++ b/src/pages/api/training-studio/host.ts
@@ -14,9 +14,10 @@ import { Flags } from '~/shared/utils/flags';
 /**
  * Host side of the embedded Training Studio (docs/training-studio-web-component.md).
  *
- * GET → { token, orchestratorEndpoint, orchestratorMode } for the CALLER — /training-studio
- * implements the element's `getOrchestratorToken()` provider with this. No params; no side effects
- * beyond the token cache getOrchestratorToken already keeps.
+ * GET → { token, orchestratorMode } for the CALLER — /training-studio implements the element's
+ * `getOrchestratorToken()` provider with this. No params; no side effects beyond the token cache
+ * getOrchestratorToken already keeps. The orchestrator URL is NOT part of the response — see the
+ * note at the `res.json` below.
  *
  * The token spends Buzz orchestrator-side, so this mirrors `guardedProcedure`'s gates (trpc.ts:
  * banned → onboarded → muted → email-verified) plus the page's feature flag — keep them in step.
@@ -62,9 +63,13 @@ export default AuthedEndpoint(async (req, res, user) => {
     });
 
   res.setHeader('Cache-Control', 'no-store');
+  // 🔴 No `orchestratorEndpoint` here, deliberately. It used to return `env.ORCHESTRATOR_ENDPOINT`,
+  // which is the in-cluster address — a value that must never reach a browser, for the same reason
+  // the dev-token guard above exists. Nothing consumed it (the only caller, /training-studio, reads
+  // `.token` alone), so it was a leak with no purpose. The browser gets the PUBLIC origin from
+  // `NEXT_PUBLIC_ORCHESTRATOR_ENDPOINT` instead. Do not re-add it from the server env.
   res.json({
     token,
-    orchestratorEndpoint: env.ORCHESTRATOR_ENDPOINT,
     orchestratorMode: env.ORCHESTRATOR_MODE === 'dev' ? 'dev' : 'prod',
   });
 });

--- a/src/pages/training-studio/index.tsx
+++ b/src/pages/training-studio/index.tsx
@@ -50,7 +50,13 @@ export const getServerSideProps = createServerSideProps({
         // Config rides in as props so el.host can be set the moment the element upgrades — a
         // config fetch on the critical path put ~600ms of "Waiting for a host context…" on every
         // mount. Tokens still mint per-call through /api/training-studio/host.
-        orchestratorEndpoint: serverEnv.ORCHESTRATOR_ENDPOINT ?? null,
+        //
+        // 🔴 The orchestrator URL is deliberately NOT among these props. It is read from the CLIENT
+        // env below instead, because the element calls the orchestrator from the BROWSER. Passing
+        // `serverEnv.ORCHESTRATOR_ENDPOINT` here is what broke the embed: that value is the
+        // in-cluster address, so the browser got a mixed-content warning and ERR_NAME_NOT_RESOLVED.
+        // Sourcing it from the client env makes the mistake unavailable rather than merely fixed —
+        // there is no server-only value in scope to pass.
         orchestratorMode:
           serverEnv.ORCHESTRATOR_MODE === 'dev' ? ('dev' as const) : ('prod' as const),
       },
@@ -58,13 +64,9 @@ export const getServerSideProps = createServerSideProps({
   },
 });
 
-function TrainingStudioEmbed({
-  orchestratorEndpoint,
-  orchestratorMode,
-}: {
-  orchestratorEndpoint: string | null;
-  orchestratorMode: 'dev' | 'prod';
-}) {
+function TrainingStudioEmbed({ orchestratorMode }: { orchestratorMode: 'dev' | 'prod' }) {
+  // Browser-facing, so the PUBLIC origin — never the server's in-cluster `ORCHESTRATOR_ENDPOINT`.
+  const orchestratorEndpoint = env.NEXT_PUBLIC_ORCHESTRATOR_ENDPOINT;
   const ref = useRef<HTMLElement>(null);
   const [error, setError] = useState<string | null>(null);
   const [elReady, setElReady] = useState(false);


### PR DESCRIPTION
`/training-studio` handed the **browser** a server-only, in-cluster address, so every mount failed:

```
Mixed Content: 'https://civitai.com/training-studio' … requested an insecure resource
  'http://orchestration-api.orchestration-poc.svc.cluster.local:8080/v2/…'
GET http://orchestration-api.…svc.cluster.local:8080/v2/consumer/workflows
    net::ERR_NAME_NOT_RESOLVED
```

## Why

The web component calls the orchestrator **directly from the browser** (`docs/training-studio-web-component.md`), so `config.orchestratorEndpoint` is consumed by client code. The page passed `serverEnv.ORCHESTRATOR_ENDPOINT` — correct for server-side callers, unresolvable and non-HTTPS in a browser.

This is a regression the web-component extraction introduced: those calls used to be `/api/*` wrappers running server-side, where an in-cluster URL is right. The refactor moved them into the browser and kept passing the server value. It surfaced only now because it was **masked** — the element bundle never loaded, so the fetch never ran.

**The standalone studio is not affected.** It still reaches the orchestrator server-side through its own routes (`apps/training-studio/src/lib/server/orchestrator.ts`, `$env/dynamic/private`) and does not mount the element.

## Fix — structural, not a value swap

- **New client env `NEXT_PUBLIC_ORCHESTRATOR_ENDPOINT`**, defaulting to `https://orchestration.civitai.com`. This follows its two closest siblings exactly — `NEXT_PUBLIC_TRAINING_STUDIO_URL` and `NEXT_PUBLIC_MODERATOR_APP_URL` are both `z.url().default(...)` and both unset in the deployed ConfigMap — so **no cluster change is needed** and there's no deploy-ordering hazard.
- **The page reads that client env directly; the prop is gone.** There is no longer a server-only value in scope to pass by mistake, so the bug is *unavailable* rather than merely corrected.
- **`/api/training-studio/host` no longer returns `orchestratorEndpoint` at all.** Nothing consumed it — its only caller reads `.token` — so it was a pure leak of the in-cluster address into a browser response, in the same file that already refuses to hand the shared dev token to a browser.

Server-side use of `ORCHESTRATOR_ENDPOINT` is untouched.

## Verified the target is usable before pointing the browser at it

Both `orchestration.civitai.com` and `orchestration-new.civitai.com` catch-all to the same `orchestration-api` service the in-cluster URL names. From `Origin: https://civitai.com`:

| probe | result |
|---|---|
| preflight `OPTIONS` w/ `Access-Control-Request-Headers: authorization` | `200`, `access-control-allow-headers: authorization` |
| `GET /v2/consumer/workflows`, no credentials | `401` + `access-control-allow-origin` — route exists, CORS applied |

Same for `https://civitai.red`. No token was sent; the `401` is the evidence.

## Test

`src/__tests__/pages/training-studio-embed-orchestrator-origin.test.ts` pins both halves, which fail differently — a public default that is secretly internal, and the server-only key creeping back into a browser-facing module.

**Watched to fail on the pre-change files** (1 server-key reference each) and pass after (0 each).

Comments are stripped before scanning, because both files deliberately **name** the key in prose to warn against re-adding it — a raw substring scan would flag exactly the comments that exist to prevent the bug. Five instrument controls pin that, including that `NEXT_PUBLIC_ORCHESTRATOR_ENDPOINT` is not counted as `ORCHESTRATOR_ENDPOINT` despite containing it, and that a `//` inside a URL doesn't swallow the line.

The existing `env/client-schema` sweep already covers the new key's same-name passthrough, so that half isn't restated.

⚠️ Local caveat: the worktree has no `node_modules`, so I ran the guard's logic as plain JS over the real pre/post file contents rather than through vitest. CI runs the actual test.

## Not addressed here

The embed also omits the optional `imageLocation`, `traceMode` and `getBuzzBalances` host fields, so images may not resolve, the live trace stays off, and balances are hidden. These degrade silently rather than erroring and need an authenticated page load to confirm — separate from this fix.
