### PR TITLE
fix(apps): show manifest ∩ approvedScopes on the permissions surface, via one shared helper

### DIFF
--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
@@ -90,8 +90,9 @@ function DrawerBody({ appBlockId, appName }: { appBlockId: string; appName?: str
             because the section's only source WAS install-backed; `listMyScopeGrants` now also
             enumerates live `app_user_scope_grants` rows, so install-only is the narrow
             overstatement in the other direction. Still not the bare "Granted permissions"
-            #4722 rejected: the list below is the app's APPROVED set (what the mint honours),
-            not the user's granted set — see the comment on `BlockScopeList` below. */}
+            #4722 rejected: the list below is the app's EFFECTIVE set
+            (`manifest.scopes ∩ approved_scopes`), not the user's granted set — see the comment
+            on `BlockScopeList` below. */}
         <Text fw={600} size="sm">
           Permissions from your installs and consents
         </Text>
@@ -117,39 +118,59 @@ function DrawerBody({ appBlockId, appName }: { appBlockId: string; appName?: str
              The label still matters for what remains: an app with NEITHER an install NOR a
              consent grant, where absence of a row is still not absence of access.
 
-             🔴 `grant.scopes` IS THE APP'S APPROVED SET (`AppBlock.approved_scopes`), NOT THE
-             VIEWER'S GRANTED SET. ⚠️ THIS COMMENT PREVIOUSLY SAID "MANIFEST-DECLARED SET" —
-             true until the operator decision to display the set the MINT honours: the service
-             now reads `approvedScopes` with NO manifest fallback
-             (`user-app-surface.service.ts`; the mint contract is stated in
-             `block-registry.service.ts` — "The mint sources scopes from `approvedScopes` (the
-             pinned, mod-reviewed set — NEVER the raw manifest)").
-             ⚠️ AN EARLIER REVISION OF THIS COMMENT SAID "granted ⊆ manifest BY CONSTRUCTION".
-             THAT IS FALSE and the containment holds only AT GRANT TIME — and it is equally
-             false for the approved set, because BOTH columns are replaced by the same write.
-             Two writes break it afterwards, and they compose: `recordScopeGrant` UNIONS on
-             re-consent (`grantedScopes = existing ∪ incoming`, `scope-grant.service.ts:232`
-             and `:263`) and nothing ever writes a non-null `revoked_at`, so the granted set
-             only GROWS; meanwhile a subsequent approved version REPLACES `manifest` +
-             `approvedScopes` IN PLACE on the same `AppBlock` row
-             (`publish-request.service.ts`, "Subsequent version: refresh manifest + version +
-             approvedScopes"), while the grant is unique on `(userId, appBlockId)` and
-             survives. So a publisher who DROPS a scope in v2 leaves the viewer holding a
-             granted scope that is in neither the manifest nor `approvedScopes`.
+             🔴 `grant.scopes` IS THE APP'S EFFECTIVE SET — `manifest.scopes ∩
+             AppBlock.approved_scopes`, computed by the shared `effectiveBlockScopes` helper
+             (`src/shared/constants/block-effective-scopes.ts`) — NOT THE VIEWER'S GRANTED SET.
 
-             Consequence for this list, in BOTH directions, and 🔴 THE SWAP TO `approvedScopes`
-             MOVED ONLY ONE OF THEM: it OVERSTATES when the displayed set is wider than what
-             the viewer granted (the ordinary case) — improved, since `approvedScopes ⊆
-             manifest.scopes` wherever a moderator narrowed an approval — and it UNDERSTATES
-             when a version removed a scope the viewer still holds, which the swap does NOT
-             fix and if anything makes marginally WORSE, precisely because the displayed set is
-             now the narrower of the two. The understatement is the direction a "permissions you
-             granted" surface most needs to show, since nothing else reveals it and a later
-             version re-declaring that scope is signed through by `partitionByConsent` with NO
-             fresh prompt.
+             ⚠️ TWO EARLIER REVISIONS OF THIS COMMENT WERE WRONG ABOUT WHICH SET THIS IS, and the
+             second was wrong about WHY. It first said "MANIFEST-DECLARED SET"; it then said
+             "APPROVED SET … the set the MINT honours", citing `block-registry.service.ts`'s "The
+             mint sources scopes from `approvedScopes` … NEVER the raw manifest". That sentence was
+             MISAPPLIED, not misquoted: it is true of the DEV-TUNNEL author mint, in whose docblock
+             it sits, and `src/pages/api/v1/block-tokens/index.ts` really does
+             `clampTunnelDeclaredScopes(app.approvedScopes)` on that path. The PRODUCTION
+             run-token mint — the one the apps listed here use — is the OTHER path, and it builds
+             the signed set FROM THE MANIFEST (`requestedScopes = knownManifestScopes`) with
+             `approved_scopes` as an all-or-nothing 403 veto. Nothing displayed here is "what the
+             mint will issue a token for" in any case: that mint refuses unless
+             `status === 'approved'`, and `listMyScopeGrants` has NO status filter, so this list
+             routinely renders apps no production token can be minted for at all.
 
-             Pre-existing, and STILL NOT changed here — the operator decision above was taken on
-             a different axis (which of manifest-vs-approved to display) and does not settle the
+             ⚠️ A THIRD CLAIM IS DELETED RATHER THAN REPHRASED: there is NO per-scope
+             moderator-narrowing mechanism, so `approvedScopes ⊆ manifest.scopes` is NOT an
+             invariant and "a moderator narrowed the approval" was never a reachable reason for a
+             divergence. The approve paths write `approvedScopes = manifestScopes` verbatim
+             (`publish-request.service.ts`), and that flow is the only writer. The claim that the
+             two columns are therefore always replaced together is also false — see
+             `src/server/services/blocks/app-listing.service.ts`, which carries the same
+             retraction and names the counterexample: `src/pages/api/v1/developer/
+             block-manifests.ts` replaces `manifest` + `version` and sets `status: 'pending'`
+             WITHOUT touching `approved_scopes`. That publisher-push path is the ONLY source of
+             skew, and it skews BOTH ways — v2 adding a scope leaves the approval narrower, v2
+             dropping one leaves the approval naming a scope the manifest no longer requests.
+             The intersection is the only set that is correct in both rows, which is why it is
+             what this list now shows.
+
+             ⚠️ AN EARLIER REVISION ALSO SAID "granted ⊆ manifest BY CONSTRUCTION". THAT IS FALSE;
+             the containment holds only AT GRANT TIME. Two writes break it afterwards, and they
+             compose: `recordScopeGrant` UNIONS on re-consent (`grantedScopes = existing ∪
+             incoming`, `scope-grant.service.ts:232` and `:263`) and nothing ever writes a
+             non-null `revoked_at`, so the granted set only GROWS; meanwhile an approved
+             subsequent version replaces `manifest` + `approvedScopes` in place on the same
+             `AppBlock` row, while the grant is unique on `(userId, appBlockId)` and survives. So
+             a publisher who DROPS a scope in v2 leaves the viewer holding a granted scope that
+             is in neither the manifest nor `approvedScopes`.
+
+             Consequence for this list, in BOTH directions. It OVERSTATES when the effective set
+             is wider than what the viewer granted (the ordinary case). It UNDERSTATES when a
+             version removed a scope the viewer still holds — and the intersection does not fix
+             that direction, because the dropped scope is absent from the manifest too. The
+             understatement is the direction a "permissions you granted" surface most needs to
+             show, since nothing else reveals it and a later version re-declaring that scope is
+             signed through by `partitionByConsent` with NO fresh prompt.
+
+             Pre-existing, and STILL NOT changed here — the operator decision was taken on a
+             different axis (which app-side set to display) and does not settle the
              granted-vs-declared question: `grantedScopes` is not on `ScopeGrantSurface` at all,
              and it is EMPTY for an install-backed row carrying no consent grant, so showing it
              is a new field plus a per-row choice of which set to show — not a swap. Widening the

--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
@@ -126,9 +126,15 @@ function DrawerBody({ appBlockId, appName }: { appBlockId: string; appName?: str
              second was wrong about WHY. It first said "MANIFEST-DECLARED SET"; it then said
              "APPROVED SET … the set the MINT honours", citing `block-registry.service.ts`'s "The
              mint sources scopes from `approvedScopes` … NEVER the raw manifest". That sentence was
-             MISAPPLIED, not misquoted: it is true of the DEV-TUNNEL author mint, in whose docblock
-             it sits, and `src/pages/api/v1/block-tokens/index.ts` really does
-             `clampTunnelDeclaredScopes(app.approvedScopes)` on that path. The PRODUCTION
+             MISAPPLIED, not misquoted: it is true of exactly ONE of the THREE scope-sourcing
+             sites — the OWNED-NON-APPROVED dev-tunnel mint, resolved by
+             `resolveOwnedNonApprovedPageBlock`, in whose docblock it sits — and
+             `src/pages/api/v1/block-tokens/index.ts:650` really does
+             `clampTunnelDeclaredScopes(app.approvedScopes)` on that path. ⚠️ "The dev-tunnel author
+             mint" does NOT identify it: the OTHER dev-tunnel author mint
+             (`resolveDevPageBlockForAuthor`, `:469`) sources
+             `clampTunnelDeclaredScopes(app.scopes)` — the author's own declared manifest, never
+             the column. The PRODUCTION
              run-token mint — the one the apps listed here use — is the OTHER path, and it builds
              the signed set FROM THE MANIFEST (`requestedScopes = knownManifestScopes`) with
              `approved_scopes` as an all-or-nothing 403 veto. Nothing displayed here is "what the

--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
@@ -135,7 +135,7 @@ function DrawerBody({ appBlockId, appName }: { appBlockId: string; appName?: str
              (`resolveDevPageBlockForAuthor`, `:469`) sources
              `clampTunnelDeclaredScopes(app.scopes)` — the author's own declared manifest, never
              the column. The PRODUCTION
-             run-token mint — the one the apps listed here use — is the OTHER path, and it builds
+             run-token mint — the one the apps listed here use — is the THIRD path, and it builds
              the signed set FROM THE MANIFEST (`requestedScopes = knownManifestScopes`) with
              `approved_scopes` as an all-or-nothing 403 veto. Nothing displayed here is "what the
              mint will issue a token for" in any case: that mint refuses unless

--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.tsx
@@ -90,8 +90,8 @@ function DrawerBody({ appBlockId, appName }: { appBlockId: string; appName?: str
             because the section's only source WAS install-backed; `listMyScopeGrants` now also
             enumerates live `app_user_scope_grants` rows, so install-only is the narrow
             overstatement in the other direction. Still not the bare "Granted permissions"
-            #4722 rejected: the list below is the app's MANIFEST set, not the user's granted
-            set — see the comment on `BlockScopeList` below. */}
+            #4722 rejected: the list below is the app's APPROVED set (what the mint honours),
+            not the user's granted set — see the comment on `BlockScopeList` below. */}
         <Text fw={600} size="sm">
           Permissions from your installs and consents
         </Text>
@@ -117,31 +117,44 @@ function DrawerBody({ appBlockId, appName }: { appBlockId: string; appName?: str
              The label still matters for what remains: an app with NEITHER an install NOR a
              consent grant, where absence of a row is still not absence of access.
 
-             🔴 `grant.scopes` IS THE APP'S MANIFEST-DECLARED SET, NOT THE VIEWER'S GRANTED SET.
+             🔴 `grant.scopes` IS THE APP'S APPROVED SET (`AppBlock.approved_scopes`), NOT THE
+             VIEWER'S GRANTED SET. ⚠️ THIS COMMENT PREVIOUSLY SAID "MANIFEST-DECLARED SET" —
+             true until the operator decision to display the set the MINT honours: the service
+             now reads `approvedScopes` with NO manifest fallback
+             (`user-app-surface.service.ts`; the mint contract is stated in
+             `block-registry.service.ts` — "The mint sources scopes from `approvedScopes` (the
+             pinned, mod-reviewed set — NEVER the raw manifest)").
              ⚠️ AN EARLIER REVISION OF THIS COMMENT SAID "granted ⊆ manifest BY CONSTRUCTION".
-             THAT IS FALSE and the containment holds only AT GRANT TIME. Two writes break it
-             afterwards, and they compose: `recordScopeGrant` UNIONS on re-consent
-             (`grantedScopes = existing ∪ incoming`, `scope-grant.service.ts:232` and `:263`)
-             and nothing ever writes a non-null `revoked_at`, so the granted set only GROWS;
-             meanwhile a subsequent approved version REPLACES `manifest` + `approvedScopes`
-             IN PLACE on the same `AppBlock` row (`publish-request.service.ts`, "Subsequent
-             version: refresh manifest + version + approvedScopes"), while the grant is unique
-             on `(userId, appBlockId)` and survives. So a publisher who DROPS a scope in v2
-             leaves the viewer holding a granted scope that is no longer in the manifest.
+             THAT IS FALSE and the containment holds only AT GRANT TIME — and it is equally
+             false for the approved set, because BOTH columns are replaced by the same write.
+             Two writes break it afterwards, and they compose: `recordScopeGrant` UNIONS on
+             re-consent (`grantedScopes = existing ∪ incoming`, `scope-grant.service.ts:232`
+             and `:263`) and nothing ever writes a non-null `revoked_at`, so the granted set
+             only GROWS; meanwhile a subsequent approved version REPLACES `manifest` +
+             `approvedScopes` IN PLACE on the same `AppBlock` row
+             (`publish-request.service.ts`, "Subsequent version: refresh manifest + version +
+             approvedScopes"), while the grant is unique on `(userId, appBlockId)` and
+             survives. So a publisher who DROPS a scope in v2 leaves the viewer holding a
+             granted scope that is in neither the manifest nor `approvedScopes`.
 
-             Consequence for this list, in BOTH directions: it OVERSTATES when the manifest
-             declares more than the viewer granted (the ordinary case), and UNDERSTATES when a
-             version removed a scope the viewer still holds — the second being the one a
-             "permissions you granted" surface most needs to show, since nothing else reveals
-             it and a later version re-declaring that scope is signed through by
-             `partitionByConsent` with NO fresh prompt.
+             Consequence for this list, in BOTH directions, and 🔴 THE SWAP TO `approvedScopes`
+             MOVED ONLY ONE OF THEM: it OVERSTATES when the displayed set is wider than what
+             the viewer granted (the ordinary case) — improved, since `approvedScopes ⊆
+             manifest.scopes` wherever a moderator narrowed an approval — and it UNDERSTATES
+             when a version removed a scope the viewer still holds, which the swap does NOT
+             fix and if anything makes marginally WORSE, precisely because the displayed set is
+             now the narrower of the two. The understatement is the direction a "permissions you
+             granted" surface most needs to show, since nothing else reveals it and a later
+             version re-declaring that scope is signed through by `partitionByConsent` with NO
+             fresh prompt.
 
-             Pre-existing, and deliberately NOT changed here: `grantedScopes` is not on
-             `ScopeGrantSurface` at all, and it is EMPTY for an install-backed row carrying no
-             consent grant, so this is a new field plus a per-row choice of which set to show —
-             not a swap. Widening the population makes it the common case rather than a
-             ~4-row edge, so it is recorded as an open decision rather than silently
-             expanded — see the PR discussion. */
+             Pre-existing, and STILL NOT changed here — the operator decision above was taken on
+             a different axis (which of manifest-vs-approved to display) and does not settle the
+             granted-vs-declared question: `grantedScopes` is not on `ScopeGrantSurface` at all,
+             and it is EMPTY for an install-backed row carrying no consent grant, so showing it
+             is a new field plus a per-row choice of which set to show — not a swap. Widening the
+             population makes it the common case rather than a ~4-row edge, so it remains an open
+             decision rather than something silently expanded — see the PR discussion. */
           <BlockScopeList
             scopes={grant?.scopes ?? []}
             emptyLabel="No permissions recorded from an install or consent for this app — which is not the same as no access. Anything it has actually done on your account is listed under Recent activity below."

--- a/src/components/Apps/BlockScopeList.tsx
+++ b/src/components/Apps/BlockScopeList.tsx
@@ -4,12 +4,28 @@ import { isSensitiveBlockScope } from '~/shared/constants/block-scope.constants'
 import { SCOPE_DESCRIPTIONS } from '~/server/services/blocks/scope-descriptions.constants';
 
 /**
- * Renders a block's declared JWT scopes as a badge + friendly-description
- * list. Shared by the install/manage modal (pre-Save disclosure — UX audit
- * H3) and the /apps/activity "Apps & permissions" panel so the two surfaces
- * never drift. Unknown scopes (not in SCOPE_DESCRIPTIONS) render as a bare
- * badge with an italic "(no description)" — keeping the description map a soft
- * contract so new scopes ship without breaking the UI.
+ * Renders a list of block scope ids as a badge + friendly-description list. Unknown scopes (not
+ * in SCOPE_DESCRIPTIONS) render as a bare badge with an italic "(no description)" — keeping the
+ * description map a soft contract so new scopes ship without breaking the UI.
+ *
+ * 🔴 THIS COMPONENT IS PRESENTATION ONLY AND MAKES NO CLAIM ABOUT WHICH SET IT IS HANDED.
+ * ⚠️ The previous docstring said it was "shared by the install/manage modal … and the
+ * /apps/activity panel so the two surfaces never drift". That guarantee was false and is DELETED
+ * rather than restated: there are FOUR call sites and they are fed from THREE different sets, by
+ * design —
+ *
+ *   - `src/pages/apps/activity.tsx` and `src/components/AppBlocks/AppPermissionsActivityDrawer.tsx`
+ *     pass `listMyScopeGrants().scopes` = `manifest.scopes ∩ approved_scopes`.
+ *   - `src/components/Apps/AppSettingsModal.tsx` passes `installConfig?.scopes ?? manifest.scopes
+ *     ?? []` — that same intersection when `getInstallConfig` has resolved, but falling back to
+ *     the RAW manifest on the Manage path when it has not. Pre-existing; not changed here.
+ *   - `src/components/Apps/AppListingDetailBody.tsx` passes `detail.scopes` = RAW
+ *     `approved_scopes`, with no intersection, deliberately — it is a PUBLIC pre-launch
+ *     disclosure and over-disclosing the stale approval is the safe direction there. The
+ *     reasoning lives at `src/server/services/blocks/app-listing.service.ts`; do not "align" it.
+ *
+ * So the set is the CALLER'S choice and each caller documents its own. A docstring here that
+ * promised they agree would read as coverage while providing none.
  */
 export function BlockScopeList({
   scopes,

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -412,9 +412,9 @@ const SPEND_SCOPE = 'ai:write:budgeted';
  * branch.
  *
  * ⚠️ KNOWN LIMIT, STATED RATHER THAN PAPERED OVER: `grantScopes` requires the app to be
- * `approved` AND the sent scope to be inside `manifest ∩ approvedScopes`. If an app is
- * later un-approved, or a moderator narrows its approved set so it no longer includes
- * `ai:write:budgeted`, this control surfaces the server's error instead of editing —
+ * `approved` AND the sent scope to be inside `manifest ∩ approvedScopes`. If an app is later
+ * un-approved, or a new version drops `ai:write:budgeted` from its manifest so it falls out of
+ * that intersection, this control surfaces the server's error instead of editing —
  * the user's stored limit is then not editable here. It is also not ENFORCING anything
  * in that state (no token can carry the spend scope, so no spend reaches the budget),
  * so nothing is stuck at a ceiling; the limit is simply frozen until the app is
@@ -596,9 +596,13 @@ function ScopeGrantsPanel() {
             <Divider />
             <BlockScopeList scopes={grant.scopes} />
             {/* Only for an app the viewer has actually GRANTED the spend scope to —
-                `spendScopeGranted` is the grant row, not the manifest. A budget on an
-                app that cannot spend bounds nothing, and the server would ignore the
-                write. */}
+                `spendScopeGranted` is the viewer's GRANT ROW, not the app-side set rendered by
+                `BlockScopeList` just above (which is `manifest.scopes ∩ approved_scopes`, what
+                the app may be granted). ⚠️ This sentence used to contrast the grant with "the
+                manifest"; that named the wrong set once the displayed list became the
+                intersection. The identical sentence in `AppPermissionsActivityDrawer` was
+                corrected and this sibling was missed. A budget on an app that cannot spend bounds
+                nothing, and the server would ignore the write. */}
             {grant.spendScopeGranted ? (
               <>
                 <Divider />

--- a/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
@@ -167,20 +167,37 @@ describe('blocks.getInstallConfig', () => {
     expect(out).not.toHaveProperty('name');
   });
 
-  // H3 disclosure correctness: the install modal shows these scopes at the
-  // authorization moment, so they MUST equal the mint ceiling (manifest ∩
-  // approvedScopes), NOT the raw self-declared manifest. A scope the mod did
-  // NOT approve will never be minted — disclosing it would over-state, and an
-  // internal/unapproved scope id the manifest declares must not leak. Mirrors
-  // grantScopes' ceiling + getAppDetail's approved-only projection.
-  it('discloses only manifest ∩ approvedScopes — drops mod-narrowed/unapproved scopes', async () => {
+  // H3 disclosure correctness: the install modal shows these scopes at the authorization
+  // moment, so they MUST equal `manifest.scopes ∩ approvedScopes` — the shared
+  // `effectiveBlockScopes` rule — and NOT the raw self-declared manifest. Disclosing a scope
+  // outside the approval would over-state what the user is consenting to, and an
+  // internal/unapproved scope id the manifest declares must not leak.
+  //
+  // ⚠️ DO NOT CALL THAT SET "THE MINT CEILING" — an earlier revision of this comment did, and it
+  // is the same false mint model retracted at `src/shared/constants/block-effective-scopes.ts`.
+  // No mint computes this intersection: the PRODUCTION mint
+  // (`src/pages/api/v1/block-tokens/index.ts:1054`) signs the MANIFEST filtered to the known
+  // vocabulary and uses `approvedScopes` only as an all-or-nothing 403 veto; the two dev-tunnel
+  // mints source `app.scopes` (`:469`, `resolveDevPageBlockForAuthor`) and `app.approvedScopes`
+  // (`:650`, `resolveOwnedNonApprovedPageBlock`) respectively.
+  //
+  // What this set DOES mirror is `grantScopes`' consent ceiling — same helper, same module,
+  // asserted in "the approved-scope consent ceiling" block below. It does NOT mirror
+  // `getAppDetail`/`scopesSummary`, which project RAW `approved_scopes` with no intersection at
+  // all; that is deliberate for the public pre-launch disclosure. See the retraction at
+  // `src/server/routers/blocks.router.ts` (the `getInstallConfig` call site).
+  it('discloses only manifest ∩ approvedScopes — drops scopes outside the approval', async () => {
     mockDbReadAppBlockFindUnique.mockResolvedValue({
       status: 'approved',
       manifest: {
         name: 'overclaiming app',
         scopes: ['ai:write:budgeted', 'models:read:self', 'social:tip:self', 'INTERNAL_secret'],
       },
-      // The moderator narrowed approval to a subset; the other two are NOT granted.
+      // A STALE-WIDER MANIFEST, not a moderator narrowing — there is no per-scope narrowing
+      // mechanism. The approve paths write `approvedScopes = manifestScopes` verbatim
+      // (`publish-request.service.ts`), so the only way the two diverge like this is a later
+      // publisher push: `src/pages/api/v1/developer/block-manifests.ts` replaces `manifest` and
+      // sets `status:'pending'` without touching `approved_scopes`. The other two are NOT granted.
       approvedScopes: ['ai:write:budgeted', 'models:read:self'],
     });
     const caller = blocksRouter.createCaller(authedCtx(42) as never);
@@ -414,5 +431,83 @@ describe('blocks.grantScopes — consent budget', () => {
       })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
     expect(grantMock.create).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * `blocks.grantScopes` — THE CONSENT CEILING (`manifest.scopes ∩ approvedScopes`).
+ *
+ * 🔴 WHY THIS BLOCK EXISTS. This is the ONE site in the codebase that decides what a user can
+ * CONSENT TO, and until this block it had NO behavioural coverage at all. Measured on the
+ * pre-existing suite: replacing the ceiling with the RAW MANIFEST — the WIDENING direction, i.e.
+ * ignoring `approvedScopes` entirely — left the file at 16/16 passed, byte-identical to HEAD. The
+ * reason was fixture shape, not a missing assertion: every `grantScopes` fixture above uses a
+ * manifest and an approval that OVERLAP on the scope under test, so no fixture could distinguish
+ * "intersected with the approval" from "took the manifest". The ceiling's own error string
+ * appeared in 0 of 1994 test files.
+ *
+ * So both cases below deliberately use `manifest ⊋ approved` — a stale-wider manifest, which is
+ * reachable via `src/pages/api/v1/developer/block-manifests.ts` (it replaces `manifest` and sets
+ * `status:'pending'` without touching `approved_scopes`). Each one FAILS under the raw-manifest
+ * widening mutant, on its own assertion.
+ */
+describe('blocks.grantScopes — the approved-scope consent ceiling', () => {
+  function consentCtx(userId = 42) {
+    const ctx = authedCtx(userId, false) as unknown as { features: Record<string, unknown> };
+    ctx.features = { ...ctx.features, appBlocks: true };
+    return ctx;
+  }
+
+  const grantMock = dbMock.dbWrite.appUserScopeGrant;
+
+  beforeEach(() => {
+    // manifest ⊋ approved: `social:tip:self` is DECLARED but was never approved. It is a
+    // real, sensitive, spend-adjacent scope, not a synthetic id — the over-grant this gate
+    // exists to stop.
+    mockDbReadAppBlockFindUnique.mockResolvedValue({
+      status: 'approved',
+      version: '2.0.0',
+      manifest: {
+        name: 'stale-wider manifest',
+        scopes: ['models:read:self', 'social:tip:self'],
+      },
+      approvedScopes: ['models:read:self'],
+    });
+    grantMock.findUnique.mockReset();
+    grantMock.create.mockReset();
+    grantMock.update.mockReset();
+    grantMock.findUnique.mockResolvedValue(null);
+    grantMock.create.mockResolvedValue({});
+    grantMock.update.mockResolvedValue({});
+  });
+
+  it('🔴 DROPS a declared-but-unapproved scope from the grant, and never writes it', async () => {
+    const caller = blocksRouter.createCaller(consentCtx() as never);
+    const out = await caller.grantScopes({
+      appBlockId: 'ab_stale_wider',
+      scopes: ['models:read:self', 'social:tip:self'],
+    });
+    // The response must not claim the user consented to something outside the approval…
+    expect(out.granted).toEqual(['models:read:self']);
+    expect(out.granted).not.toContain('social:tip:self');
+    // …and the unapproved scope must not reach the PERSISTED grant either, which is what the
+    // enforcement path later reads back.
+    const written = grantMock.create.mock.calls[0][0].data;
+    expect(written.grantedScopes).toEqual(['models:read:self']);
+    expect(written.grantedScopes).not.toContain('social:tip:self');
+  });
+
+  it('🔴 REFUSES outright when EVERY requested scope is outside the approval', async () => {
+    const caller = blocksRouter.createCaller(consentCtx() as never);
+    await expect(
+      caller.grantScopes({ appBlockId: 'ab_stale_wider', scopes: ['social:tip:self'] })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      // Pinned as the literal the call site emits — it appeared in no test file before this one,
+      // so a reworded or relocated ceiling check had nothing asserting it.
+      message: 'none of the requested scopes are within the app’s approved manifest',
+    });
+    expect(grantMock.create).not.toHaveBeenCalled();
+    expect(grantMock.update).not.toHaveBeenCalled();
   });
 });

--- a/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
@@ -325,14 +325,20 @@ describe('blocks.getInstallConfig', () => {
  * vocabulary can spend — so a budget sent without it is IGNORED rather than rejected.
  * See the call site for why ignoring beats erroring.
  */
-describe('blocks.grantScopes — consent budget', () => {
-  /** ctx with the appBlocks feature on (the proc gates on `ctx.features.appBlocks`). */
-  function consentCtx(userId = 42) {
-    const ctx = authedCtx(userId, false) as unknown as { features: Record<string, unknown> };
-    ctx.features = { ...ctx.features, appBlocks: true };
-    return ctx;
-  }
+/**
+ * ctx with the appBlocks feature on (the proc gates on `ctx.features.appBlocks`).
+ *
+ * Module-scoped because BOTH `grantScopes` describes below need it. A `function` declared inside a
+ * `describe` callback is scoped to that callback, so the second block could not see the first one's
+ * copy and carried a byte-identical duplicate.
+ */
+function consentCtx(userId = 42) {
+  const ctx = authedCtx(userId, false) as unknown as { features: Record<string, unknown> };
+  ctx.features = { ...ctx.features, appBlocks: true };
+  return ctx;
+}
 
+describe('blocks.grantScopes — consent budget', () => {
   const grantMock = dbMock.dbWrite.appUserScopeGrant;
 
   beforeEach(() => {
@@ -452,12 +458,6 @@ describe('blocks.grantScopes — consent budget', () => {
  * widening mutant, on its own assertion.
  */
 describe('blocks.grantScopes — the approved-scope consent ceiling', () => {
-  function consentCtx(userId = 42) {
-    const ctx = authedCtx(userId, false) as unknown as { features: Record<string, unknown> };
-    ctx.features = { ...ctx.features, appBlocks: true };
-    return ctx;
-  }
-
   const grantMock = dbMock.dbWrite.appUserScopeGrant;
 
   beforeEach(() => {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -200,6 +200,7 @@ import type { ModelType } from '~/shared/utils/prisma/enums';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
 import { BuzzTypes, TransactionType } from '~/shared/constants/buzz.constants';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { effectiveBlockScopes } from '~/shared/constants/block-effective-scopes';
 import {
   getBlockAllowedAccountTypes,
   isPayoutEligibleBuzz,
@@ -2777,15 +2778,15 @@ export const blocksRouter = router({
       if (block.status !== 'approved') {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'App block is not approved' });
       }
-      // Ceiling = manifest.scopes ∩ approvedScopes. The user may only consent
-      // to scopes inside that ceiling; anything else is dropped.
-      const manifestScopes = Array.isArray((block.manifest as { scopes?: unknown }).scopes)
-        ? (block.manifest as { scopes: unknown[] }).scopes.filter(
-            (s): s is string => typeof s === 'string'
-          )
-        : [];
-      const approved = new Set(block.approvedScopes ?? []);
-      const ceiling = new Set(manifestScopes.filter((s) => approved.has(s)));
+      // Ceiling = manifest.scopes ∩ approvedScopes, via the SHARED `effectiveBlockScopes`
+      // helper — the same rule, from the same module, as `getInstallConfig`'s install-time
+      // disclosure, `BlockRegistry.recordInstallConsent`'s grant set, and the permissions tab
+      // (`listMyScopeGrants`). The user may only consent to scopes inside that ceiling;
+      // anything else is dropped. Membership is all this site needs, so the helper's order and
+      // de-duplication are not observable here.
+      const ceiling = new Set(
+        effectiveBlockScopes(block.manifest as { scopes?: unknown }, block.approvedScopes)
+      );
       const toGrant = input.scopes.filter((s) => ceiling.has(s));
       if (toGrant.length === 0) {
         throw new TRPCError({
@@ -3334,18 +3335,23 @@ export const blocksRouter = router({
       // manifestSettingsSchema so a malformed/absent declaration yields {} (the
       // form renders no fields rather than throwing).
       const parsedSettings = manifestSettingsSchema.safeParse(manifest.settings ?? {});
-      // `scopes` = manifest.scopes ∩ approvedScopes — the SAME mod-narrowed
-      // ceiling grantScopes (above) enforces at mint and getAppDetail/
-      // scopesSummary expose on the public surfaces. The disclosure must match
-      // what the app can actually be granted: surfacing raw `manifest.scopes`
-      // would over-state (list scopes the mod did NOT approve, so the app will
-      // never be minted them) and could leak an unapproved/internal scope id
-      // the manifest declares but approval dropped.
-      const manifestScopes = Array.isArray(manifest.scopes)
-        ? manifest.scopes.filter((s): s is string => typeof s === 'string')
-        : [];
-      const approved = new Set(block.approvedScopes ?? []);
-      const scopes = manifestScopes.filter((s) => approved.has(s));
+      // `scopes` = manifest.scopes ∩ approvedScopes, via the SHARED `effectiveBlockScopes`
+      // helper — the same rule `grantScopes` (above) enforces as its consent ceiling,
+      // `BlockRegistry.recordInstallConsent` uses to pick a grant set, and the permissions tab
+      // (`listMyScopeGrants`) displays. The disclosure must match what the app can actually be
+      // granted: surfacing raw `manifest.scopes` would over-state (list scopes outside the
+      // approved snapshot, which `grantScopes` would refuse) and could leak an
+      // unapproved/internal scope id the manifest declares but the approval does not carry.
+      //
+      // ⚠️ AN EARLIER REVISION OF THIS COMMENT CALLED THE CEILING "mod-narrowed" AND CLAIMED
+      // `getAppDetail`/`scopesSummary` EXPOSE THE SAME SET. BOTH HALVES WERE FALSE. There is no
+      // per-scope narrowing mechanism — the approve paths write `approvedScopes =
+      // manifestScopes` verbatim (`publish-request.service.ts`), so the skew comes from the
+      // publisher-push path instead. And `getAppDetail`/`scopesSummary`/the app-listing detail
+      // DTO all project RAW `approved_scopes` with NO intersection; that is deliberate for a
+      // public pre-launch disclosure and is reasoned about at
+      // `src/server/services/blocks/app-listing.service.ts`. Do not "align" them here.
+      const scopes = effectiveBlockScopes(manifest, block.approvedScopes);
       return {
         settings: parsedSettings.success ? parsedSettings.data : {},
         scopes,

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -44,6 +44,7 @@ import {
   toPublicScreenshots,
 } from '~/server/schema/blocks/subscription.schema';
 import { isLaunchSlot, PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
+import { effectiveBlockScopes } from '~/shared/constants/block-effective-scopes';
 import { isMatureContentRating } from '~/server/utils/server-domain';
 
 const CACHE_TTL_SECONDS = 60;
@@ -2309,16 +2310,15 @@ export class BlockRegistry {
     approvedScopes: string[];
   }): Promise<void> {
     const { recordScopeGrant, consentGatedScopes } = await import('./blocks/scope-grant.service');
-    // The app's effective scope set = manifest.scopes ∩ approvedScopes (the
-    // moderator-approved snapshot is the ceiling). Grant only the consent-
-    // gated subset of that — exempt scopes never need a grant.
-    const manifestScopes = Array.isArray((opts.manifest as { scopes?: unknown }).scopes)
-      ? (opts.manifest as { scopes: unknown[] }).scopes.filter(
-          (s): s is string => typeof s === 'string'
-        )
-      : [];
-    const approved = new Set(opts.approvedScopes ?? []);
-    const effective = manifestScopes.filter((s) => approved.has(s));
+    // The app's effective scope set = manifest.scopes ∩ approvedScopes, via the SHARED
+    // `effectiveBlockScopes` helper — the same rule `blocks.router`'s `grantScopes` enforces as
+    // its consent ceiling and `getInstallConfig` discloses at install time, and the permissions
+    // tab (`listMyScopeGrants`) displays. Grant only the consent-gated subset of that — exempt
+    // scopes never need a grant.
+    const effective = effectiveBlockScopes(
+      opts.manifest as { scopes?: unknown },
+      opts.approvedScopes
+    );
     const toGrant = consentGatedScopes(effective);
     await recordScopeGrant({
       userId: opts.userId,

--- a/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
@@ -306,9 +306,9 @@ describe('listMyScopeGrants', () => {
 
   // ── `spendScopeGranted` — whether the viewer's GRANT actually carries
   // `ai:write:budgeted`. The budget editor on /apps/activity keys off this, and it is
-  // NOT derivable from `scopes` (which is the app's MANIFEST-declared set, i.e. what it
-  // ASKED for). Offering a limit control off the manifest would render a field the
-  // server silently drops, because `grantScopes` ignores a budget for an app that does
+  // NOT derivable from `scopes` (which is the app's APPROVED set, i.e. what the mint will
+  // issue a token for). Offering a limit control off the approved set would render a field
+  // the server silently drops, because `grantScopes` ignores a budget for an app that does
   // not hold the spend scope.
   it('spendScopeGranted is TRUE when the GRANT row carries ai:write:budgeted', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
@@ -325,9 +325,10 @@ describe('listMyScopeGrants', () => {
     expect(result[0].spendScopeGranted).toBe(true);
   });
 
-  // 🔴 THE DISCRIMINATING CASE: the app DECLARES the spend scope in its manifest, and
-  // the user has NOT granted it. Reading the manifest would answer `true` here.
-  it('spendScopeGranted is FALSE when only the MANIFEST declares the spend scope', async () => {
+  // 🔴 THE DISCRIMINATING CASE: the app is APPROVED for the spend scope (and declares it in
+  // its manifest), and the user has NOT granted it. Deriving `spendScopeGranted` from either
+  // of those app-side sets would answer `true` here.
+  it('spendScopeGranted is FALSE when only the APP (manifest + approval) carries the spend scope', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
     mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
       pinnedSub({
@@ -346,7 +347,7 @@ describe('listMyScopeGrants', () => {
       },
     ]);
     const result = await listMyScopeGrants(42);
-    expect(result[0].scopes).toEqual(['ai:write:budgeted']); // manifest says yes…
+    expect(result[0].scopes).toEqual(['ai:write:budgeted']); // the app is approved for it…
     expect(result[0].spendScopeGranted).toBe(false); // …the grant says no
   });
 
@@ -401,31 +402,64 @@ describe('listMyScopeGrants', () => {
     await expect(listMyScopeGrants(42)).rejects.toThrow(/connection refused/);
   });
 
-  it('reads scopes from the joined manifest.scopes', async () => {
+  // ── WHICH SET IS DISPLAYED. `scopes` is `AppBlock.approved_scopes` — the pinned,
+  // mod-reviewed set the MINT issues tokens for ("The mint sources scopes from
+  // `approvedScopes` (the pinned, mod-reviewed set — NEVER the raw manifest)",
+  // `block-registry.service.ts`) — and NEVER `manifest.scopes`, which is only the dev's
+  // stated wishlist. The four tests below pin that, including both directions of the
+  // divergence the swap exists for.
+
+  it('reads scopes from approvedScopes, NOT the joined manifest.scopes', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
     mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
       pinnedSub({
         appBlock: appBlock({
           manifest: { name: 'Hello', scopes: ['ai:write:budgeted', 'buzz:read:self'] },
-        }),
-      }),
-    ]);
-    const result = await listMyScopeGrants(42);
-    expect(result[0].scopes).toEqual(['ai:write:budgeted', 'buzz:read:self']);
-  });
-
-  it('falls back to approvedScopes when manifest.scopes is missing', async () => {
-    const { listMyScopeGrants } = await import('../user-app-surface.service');
-    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
-      pinnedSub({
-        appBlock: appBlock({
-          manifest: { name: 'Hello' }, // no scopes
           approvedScopes: ['models:read:self'],
         }),
       }),
     ]);
     const result = await listMyScopeGrants(42);
     expect(result[0].scopes).toEqual(['models:read:self']);
+  });
+
+  // 🔴 THE DISCRIMINATING CASE for this change: the manifest is a STRICT SUPERSET of the
+  // approval, i.e. a moderator narrowed what the app may actually do. The displayed set must
+  // be the narrow one, because that is the only one the mint will honour. Every value here is
+  // pairwise distinct and distinct from the constant the assertion names, so a mutant that
+  // hardcodes a literal cannot survive.
+  it('shows ONLY the approved set when the manifest declares a strict superset', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
+      pinnedSub({
+        appBlock: appBlock({
+          manifest: {
+            name: 'Hello',
+            scopes: ['ai:write:budgeted', 'buzz:read:self', 'collections:read:private'],
+          },
+          approvedScopes: ['buzz:read:self'],
+        }),
+      }),
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].scopes).toEqual(['buzz:read:self']);
+  });
+
+  // 🔴 NO FALLBACK. An app approved for NOTHING displays nothing, even though its manifest
+  // still asks for things — a fallback here would restore the whole over-report, in exactly
+  // the case that matters most.
+  it('emits an empty scopes array for an EMPTY approval, never falling back to the manifest', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
+      pinnedSub({
+        appBlock: appBlock({
+          manifest: { name: 'Hello', scopes: ['models:read:self', 'images:write:self'] },
+          approvedScopes: [],
+        }),
+      }),
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].scopes).toEqual([]);
   });
 
   it('emits an empty scopes array when neither manifest nor approvedScopes carry scopes', async () => {

--- a/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
@@ -409,8 +409,12 @@ describe('listMyScopeGrants', () => {
   //
   // ⚠️ AN EARLIER REVISION OF THIS BLOCK SAID `scopes` IS `approved_scopes`, "the set the MINT
   // issues tokens for", citing `block-registry.service.ts`. The citation was MISAPPLIED: that
-  // sentence describes the DEV-TUNNEL author mint (`clampTunnelDeclaredScopes(app.approvedScopes)`),
-  // not the PRODUCTION run-token mint, which sources from the MANIFEST
+  // sentence describes exactly ONE of the THREE scope-sourcing sites — the OWNED-NON-APPROVED
+  // dev-tunnel mint, `resolveOwnedNonApprovedPageBlock` at `block-tokens/index.ts:650`
+  // (`clampTunnelDeclaredScopes(app.approvedScopes)`). ⚠️ "The dev-tunnel author mint" does NOT
+  // identify it — the OTHER dev-tunnel author mint (`resolveDevPageBlockForAuthor`, `:469`) sources
+  // `clampTunnelDeclaredScopes(app.scopes)`, the author's own declared manifest. Neither is
+  // the PRODUCTION run-token mint, which sources from the MANIFEST
   // (`requestedScopes = knownManifestScopes`) with `approved_scopes` as an all-or-nothing 403 veto
   // and refuses entirely unless `status === 'approved'` — something this query does not filter on.
   // So nothing here is "what the mint will issue a token for"; these are the scopes the app may be
@@ -607,8 +611,16 @@ describe('listMyScopeGrants', () => {
   // with no per-element check — see `publish-request.service.ts`.)
   //
   // Both fixtures make the MANIFEST a superset of the well-formed approved values, so the result
-  // is attributable to the approved-side handling rather than to an empty intersection.
-  it('drops non-string elements from a malformed approvedScopes array', async () => {
+  // is not explained away by an empty intersection.
+  //
+  // 🔴 BUT THE FIRST ONE ATTRIBUTES TO NO GUARD, AND AN EARLIER REVISION OF THIS BLOCK CLAIMED IT
+  // DID ("attributable to the approved-side handling"). Its non-string elements sit on the
+  // APPROVED side only, and a non-string on one side cannot match a string on the other — so the
+  // case passes whether or not the helper does any non-string filtering. It pins the OUTPUT
+  // CONTRACT at this read site, nothing finer. The guard-level pin lives at the helper
+  // (`src/shared/constants/__tests__/block-effective-scopes.test.ts`, the BOTH-columns case); the
+  // third case below is this suite's seam-level mirror of it.
+  it('a one-sided non-string in approvedScopes never reaches the output', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
     mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
       pinnedSub({
@@ -623,6 +635,25 @@ describe('listMyScopeGrants', () => {
     ]);
     const result = await listMyScopeGrants(42);
     expect(result[0].scopes).toEqual(['buzz:read:self', 'collections:read:private']);
+  });
+
+  // 🔴 THE SAME non-string in BOTH columns — the shape that makes it an intersection MEMBER, and
+  // so the only one that can fail if the helper's non-string handling is dropped. This is the
+  // seam-level mirror of the helper's own both-columns case: it pins that `listMyScopeGrants`
+  // really routes through that handling rather than re-deriving the rule, which is what would put
+  // a `42` into a `<Badge>` label and a `SCOPE_DESCRIPTIONS` lookup on the permissions tab.
+  it('🔴 drops a non-string present in BOTH the manifest and approvedScopes', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
+      pinnedSub({
+        appBlock: appBlock({
+          manifest: { name: 'Hello', scopes: [42, 'buzz:read:self'] },
+          approvedScopes: [42, 'buzz:read:self'],
+        }),
+      }),
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].scopes).toEqual(['buzz:read:self']);
   });
 
   // The fixture is a non-null SCALAR on purpose: `null` alone cannot distinguish the

--- a/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
@@ -304,12 +304,11 @@ describe('listMyScopeGrants', () => {
     expect(result[0].buzzBudgetPerDay).toBeNull();
   });
 
-  // ── `spendScopeGranted` — whether the viewer's GRANT actually carries
-  // `ai:write:budgeted`. The budget editor on /apps/activity keys off this, and it is
-  // NOT derivable from `scopes` (which is the app's APPROVED set, i.e. what the mint will
-  // issue a token for). Offering a limit control off the approved set would render a field
-  // the server silently drops, because `grantScopes` ignores a budget for an app that does
-  // not hold the spend scope.
+  // ── `spendScopeGranted` — whether the viewer's GRANT actually carries `ai:write:budgeted`. The
+  // budget editor on /apps/activity keys off this, and it is NOT derivable from `scopes` (which is
+  // an APP-SIDE set — `manifest.scopes ∩ approved_scopes`, what the app may be granted). Offering
+  // a limit control off an app-side set would render a field the server silently drops, because
+  // `grantScopes` ignores a budget for an app that does not hold the spend scope.
   it('spendScopeGranted is TRUE when the GRANT row carries ai:write:budgeted', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
     mockDbRead.blockUserSubscription.findMany.mockResolvedValue([pinnedSub()]);
@@ -347,7 +346,7 @@ describe('listMyScopeGrants', () => {
       },
     ]);
     const result = await listMyScopeGrants(42);
-    expect(result[0].scopes).toEqual(['ai:write:budgeted']); // the app is approved for it…
+    expect(result[0].scopes).toEqual(['ai:write:budgeted']); // the app may be granted it…
     expect(result[0].spendScopeGranted).toBe(false); // …the grant says no
   });
 
@@ -402,33 +401,31 @@ describe('listMyScopeGrants', () => {
     await expect(listMyScopeGrants(42)).rejects.toThrow(/connection refused/);
   });
 
-  // ── WHICH SET IS DISPLAYED. `scopes` is `AppBlock.approved_scopes` — the pinned,
-  // mod-reviewed set the MINT issues tokens for ("The mint sources scopes from
-  // `approvedScopes` (the pinned, mod-reviewed set — NEVER the raw manifest)",
-  // `block-registry.service.ts`) — and NEVER `manifest.scopes`, which is only the dev's
-  // stated wishlist. The four tests below pin that, including both directions of the
-  // divergence the swap exists for.
+  // ── WHICH SET IS DISPLAYED. `scopes` is the app's EFFECTIVE set —
+  // `manifest.scopes ∩ AppBlock.approved_scopes` — computed by the shared `effectiveBlockScopes`
+  // helper (`src/shared/constants/block-effective-scopes.ts`), which is also the consent ceiling
+  // `grantScopes` enforces, the set `getInstallConfig` discloses at install time, and the set
+  // `BlockRegistry.recordInstallConsent` grants from.
+  //
+  // ⚠️ AN EARLIER REVISION OF THIS BLOCK SAID `scopes` IS `approved_scopes`, "the set the MINT
+  // issues tokens for", citing `block-registry.service.ts`. The citation was MISAPPLIED: that
+  // sentence describes the DEV-TUNNEL author mint (`clampTunnelDeclaredScopes(app.approvedScopes)`),
+  // not the PRODUCTION run-token mint, which sources from the MANIFEST
+  // (`requestedScopes = knownManifestScopes`) with `approved_scopes` as an all-or-nothing 403 veto
+  // and refuses entirely unless `status === 'approved'` — something this query does not filter on.
+  // So nothing here is "what the mint will issue a token for"; these are the scopes the app may be
+  // GRANTED and exercised with.
+  //
+  // Why the intersection and not either column: `src/pages/api/v1/developer/block-manifests.ts`
+  // replaces `manifest` + `version` and sets `status: 'pending'` WITHOUT touching
+  // `approved_scopes`, so the two diverge in BOTH directions. There is no per-scope moderator
+  // narrowing (the approve paths write `approvedScopes = manifestScopes` verbatim), so a
+  // divergence is always a stale-approval-vs-new-manifest skew. Both directions are pinned below.
 
-  it('reads scopes from approvedScopes, NOT the joined manifest.scopes', async () => {
-    const { listMyScopeGrants } = await import('../user-app-surface.service');
-    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
-      pinnedSub({
-        appBlock: appBlock({
-          manifest: { name: 'Hello', scopes: ['ai:write:budgeted', 'buzz:read:self'] },
-          approvedScopes: ['models:read:self'],
-        }),
-      }),
-    ]);
-    const result = await listMyScopeGrants(42);
-    expect(result[0].scopes).toEqual(['models:read:self']);
-  });
-
-  // 🔴 THE DISCRIMINATING CASE for this change: the manifest is a STRICT SUPERSET of the
-  // approval, i.e. a moderator narrowed what the app may actually do. The displayed set must
-  // be the narrow one, because that is the only one the mint will honour. Every value here is
-  // pairwise distinct and distinct from the constant the assertion names, so a mutant that
-  // hardcodes a literal cannot survive.
-  it('shows ONLY the approved set when the manifest declares a strict superset', async () => {
+  // 🔴 DIRECTION 1 — `manifest ⊋ approved` (a v2 manifest ADDED a scope, so the approval snapshot
+  // is narrower). The displayed set must be the narrow one; showing the manifest would disclose a
+  // scope outside the approved snapshot.
+  it('manifest ⊋ approved: shows the intersection, not the wider manifest', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
     mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
       pinnedSub({
@@ -445,9 +442,148 @@ describe('listMyScopeGrants', () => {
     expect(result[0].scopes).toEqual(['buzz:read:self']);
   });
 
-  // 🔴 NO FALLBACK. An app approved for NOTHING displays nothing, even though its manifest
-  // still asks for things — a fallback here would restore the whole over-report, in exactly
-  // the case that matters most.
+  // 🔴 DIRECTION 2 — `manifest ⊊ approved` (a v2 manifest DROPPED a scope, so the approval
+  // snapshot is WIDER and names something the current manifest no longer requests). THIS IS THE
+  // REGRESSION TEST FOR THE DEFECT THIS CHANGE FIXES: displaying `approved_scopes` here reports
+  // `ai:write:budgeted` — a spend scope the app does not ask for and cannot be granted — which is
+  // a NEW over-report in exactly the direction the change exists to remove. Red against the
+  // display-approvedScopes implementation, green against the intersection.
+  it('manifest ⊊ approved: shows the intersection, NOT the stale wider approval', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
+      pinnedSub({
+        appBlock: appBlock({
+          manifest: { name: 'Hello', scopes: ['buzz:read:self'] },
+          approvedScopes: ['buzz:read:self', 'ai:write:budgeted'],
+        }),
+      }),
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].scopes).toEqual(['buzz:read:self']);
+    expect(result[0].scopes).not.toContain('ai:write:budgeted');
+  });
+
+  // Neither side contains the other — distinguishes a real intersection from "whichever column is
+  // shorter", which both single-direction tests above would accept.
+  it('partial overlap: shows only the scopes present in BOTH sets', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
+      pinnedSub({
+        appBlock: appBlock({
+          manifest: { name: 'Hello', scopes: ['models:read:self', 'buzz:read:self'] },
+          approvedScopes: ['buzz:read:self', 'ai:write:budgeted'],
+        }),
+      }),
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].scopes).toEqual(['buzz:read:self']);
+  });
+
+  // 🔴 FIXES 🟡-3 — A MEASURED-FALSE MUTATION-RESISTANCE CLAIM, REPLACED BY ONE THAT HOLDS.
+  // The previous annotation on the superset test read: "Every value here is pairwise distinct and
+  // distinct from the constant the assertion names, so a mutant that hardcodes a literal cannot
+  // survive." That was FALSE. The asserted value of an INTERSECTION is necessarily drawn from both
+  // input sets, so `'buzz:read:self'` was unavoidably a manifest element too, and the mutant
+  // `const displayedScopes = ['buzz:read:self']` PASSED that test. The claim is not achievable for
+  // any single-row equality assertion, so it is not softened — it is replaced by a structural
+  // property that is actually true:
+  //
+  // TWO ROWS WITH DISJOINT EXPECTED INTERSECTIONS. `listMyScopeGrants` computes the set once per
+  // row inside a loop, so NO single hardcoded literal array can satisfy both rows at once — any
+  // `displayedScopes = [<fixed literal>]` mutant fails at least one of the two assertions below,
+  // and a mutant returning either raw column fails too (each row's manifest and approval differ
+  // from its intersection).
+  //
+  // MEASURED, not asserted — mutants run against this suite (61 tests), each confirmed to have
+  // actually executed rather than failing to import:
+  //   `['buzz:read:self']`         → 8 failed, THIS test among them (it survived the old fixture)
+  //   `['models:read:self']`       → 11 failed, THIS test among them
+  //   `['collections:read:private']` → 11 failed, THIS test among them
+  //   raw `approved_scopes`        → 5 failed, THIS test among them
+  //   raw `manifest.scopes`        → 7 failed, THIS test among them
+  //   positive control `[]`        → 8 failed (proves the suite can go red at all)
+  // ⚠️ NOTE WHAT IS *NOT* CLAIMED: `['buzz:read:self']` still PASSES the `manifest ⊋ approved`
+  // test above, because that test's expected value IS `['buzz:read:self']`. A single-row equality
+  // assertion can never kill a mutant that hardcodes its own expectation — which is precisely why
+  // the claim was moved here instead of being restated there.
+  it('two apps in one read get their OWN intersections (no single literal can satisfy both)', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
+      blanketSub({
+        appBlockId: 'apb_a',
+        appBlock: appBlock({
+          id: 'apb_a',
+          blockId: 'alpha',
+          manifest: { name: 'Alpha', scopes: ['models:read:self', 'buzz:read:self'] },
+          approvedScopes: ['models:read:self', 'ai:write:budgeted'],
+        }),
+      }),
+      blanketSub({
+        appBlockId: 'apb_b',
+        appBlock: appBlock({
+          id: 'apb_b',
+          blockId: 'beta',
+          manifest: { name: 'Beta', scopes: ['collections:read:private', 'images:write:self'] },
+          approvedScopes: ['user:read:self', 'collections:read:private'],
+        }),
+      }),
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result.map((r) => r.name)).toEqual(['Alpha', 'Beta']);
+    expect(result[0].scopes).toEqual(['models:read:self']);
+    expect(result[1].scopes).toEqual(['collections:read:private']);
+  });
+
+  // 🔴 ORDER IS OBSERVABLE — this array is rendered as a badge list. MANIFEST order, which is what
+  // the pre-existing open-coded sites produced and what the mint uses; the fixture distinguishes
+  // it from approval order and from sorted, which coincide with each other here.
+  it('preserves MANIFEST order, not approval order and not sorted', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
+      pinnedSub({
+        appBlock: appBlock({
+          manifest: {
+            name: 'Hello',
+            scopes: ['collections:read:private', 'ai:write:budgeted', 'buzz:read:self'],
+          },
+          approvedScopes: ['ai:write:budgeted', 'buzz:read:self', 'collections:read:private'],
+        }),
+      }),
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].scopes).toEqual([
+      'collections:read:private',
+      'ai:write:budgeted',
+      'buzz:read:self',
+    ]);
+  });
+
+  // 🔴 IDENTITY PIN FOR THE CONSOLIDATION. The expectation is DERIVED BY CALLING the shared helper
+  // rather than hand-copied as a literal, because a "mirrors X" guard asserted against a copy on
+  // each side pins nothing — tighten one side and its own literal and both stay green while the two
+  // diverge. The helper's own expectations are literals (`block-effective-scopes.test.ts`); this
+  // asserts the SERVICE agrees with the helper on a value neither column alone would produce.
+  it('agrees with effectiveBlockScopes on the same inputs (derived, not copied)', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    const { effectiveBlockScopes } = await import('~/shared/constants/block-effective-scopes');
+    const manifest = {
+      name: 'Hello',
+      scopes: ['collections:read:private', 'models:read:self', 'buzz:read:self'],
+    };
+    const approvedScopes = ['buzz:read:self', 'collections:read:private', 'ai:write:budgeted'];
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
+      pinnedSub({ appBlock: appBlock({ manifest, approvedScopes }) }),
+    ]);
+    const result = await listMyScopeGrants(42);
+    const expected = effectiveBlockScopes(manifest, approvedScopes);
+    // Guard the guard: a helper that returned [] would make the comparison vacuous.
+    expect(expected.length).toBeGreaterThan(1);
+    expect(result[0].scopes).toEqual(expected);
+  });
+
+  // 🔴 NO FALLBACK TO THE MANIFEST. An app approved for NOTHING displays nothing, even though its
+  // manifest still asks for things — a fallback here would restore the whole over-report, in
+  // exactly the case that matters most.
   it('emits an empty scopes array for an EMPTY approval, never falling back to the manifest', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
     mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
@@ -462,17 +598,25 @@ describe('listMyScopeGrants', () => {
     expect(result[0].scopes).toEqual([]);
   });
 
-  // ⚠️ THE NEXT TWO ARE INVARIANT GUARDS, NOT REGRESSION COVERAGE — labelled as such rather
-  // than counted. Prisma types `approvedScopes` as `string[]`, so nothing in this codebase
-  // can produce either shape; they pin the JSON/DB-boundary defensiveness at the read site
-  // so a later "the type says string[], drop the guard" edit fails instead of shipping a
-  // non-string into a `<Badge>` key and a scope-description lookup.
+  // ⚠️ THE NEXT TWO ARE INVARIANT GUARDS, NOT REGRESSION COVERAGE — labelled as such rather than
+  // counted. Prisma types `approvedScopes` as `string[]`, so nothing in this codebase produces
+  // either shape at this read site; they pin the JSON/DB-boundary defensiveness so a later "the
+  // type says string[], drop the guard" edit fails instead of shipping a non-string into a
+  // `<Badge>` key and a scope-description lookup. (The non-string ELEMENT case is the less
+  // hypothetical of the two: the approve paths write `manifest.scopes as string[]`, a bare cast
+  // with no per-element check — see `publish-request.service.ts`.)
+  //
+  // Both fixtures make the MANIFEST a superset of the well-formed approved values, so the result
+  // is attributable to the approved-side handling rather than to an empty intersection.
   it('drops non-string elements from a malformed approvedScopes array', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
     mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
       pinnedSub({
         appBlock: appBlock({
-          manifest: { name: 'Hello', scopes: ['models:read:self'] },
+          manifest: {
+            name: 'Hello',
+            scopes: ['buzz:read:self', 'collections:read:private', 'models:read:self'],
+          },
           approvedScopes: [null, 'buzz:read:self', 42, undefined, 'collections:read:private'],
         }),
       }),
@@ -482,16 +626,17 @@ describe('listMyScopeGrants', () => {
   });
 
   // The fixture is a non-null SCALAR on purpose: `null` alone cannot distinguish the
-  // `Array.isArray` guard from a weaker `(x ?? []).filter(…)`, because `null ?? []` also
-  // yields `[]`. A bare string is the realistic JSON-column mishap AND it makes the weaker
-  // shape throw `.filter is not a function`, so this case pins the guard rather than the
-  // nullishness.
+  // `Array.isArray` guard from a weaker `(x ?? []).filter(…)`, because `null ?? []` also yields
+  // `[]`. A bare string is the realistic JSON-column mishap AND it makes the weaker shape throw
+  // `.filter is not a function`, so this case pins the guard rather than the nullishness. The
+  // manifest deliberately CONTAINS that same scope id, so a correct `[]` cannot be mistaken for an
+  // empty intersection.
   it('emits an empty scopes array when approvedScopes is not an array at all', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
     mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
       pinnedSub({
         appBlock: appBlock({
-          manifest: { name: 'Hello', scopes: ['models:read:self'] },
+          manifest: { name: 'Hello', scopes: ['buzz:read:self', 'models:read:self'] },
           approvedScopes: 'buzz:read:self',
         }),
       }),

--- a/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
@@ -462,6 +462,44 @@ describe('listMyScopeGrants', () => {
     expect(result[0].scopes).toEqual([]);
   });
 
+  // ⚠️ THE NEXT TWO ARE INVARIANT GUARDS, NOT REGRESSION COVERAGE — labelled as such rather
+  // than counted. Prisma types `approvedScopes` as `string[]`, so nothing in this codebase
+  // can produce either shape; they pin the JSON/DB-boundary defensiveness at the read site
+  // so a later "the type says string[], drop the guard" edit fails instead of shipping a
+  // non-string into a `<Badge>` key and a scope-description lookup.
+  it('drops non-string elements from a malformed approvedScopes array', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
+      pinnedSub({
+        appBlock: appBlock({
+          manifest: { name: 'Hello', scopes: ['models:read:self'] },
+          approvedScopes: [null, 'buzz:read:self', 42, undefined, 'collections:read:private'],
+        }),
+      }),
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].scopes).toEqual(['buzz:read:self', 'collections:read:private']);
+  });
+
+  // The fixture is a non-null SCALAR on purpose: `null` alone cannot distinguish the
+  // `Array.isArray` guard from a weaker `(x ?? []).filter(…)`, because `null ?? []` also
+  // yields `[]`. A bare string is the realistic JSON-column mishap AND it makes the weaker
+  // shape throw `.filter is not a function`, so this case pins the guard rather than the
+  // nullishness.
+  it('emits an empty scopes array when approvedScopes is not an array at all', async () => {
+    const { listMyScopeGrants } = await import('../user-app-surface.service');
+    mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
+      pinnedSub({
+        appBlock: appBlock({
+          manifest: { name: 'Hello', scopes: ['models:read:self'] },
+          approvedScopes: 'buzz:read:self',
+        }),
+      }),
+    ]);
+    const result = await listMyScopeGrants(42);
+    expect(result[0].scopes).toEqual([]);
+  });
+
   it('emits an empty scopes array when neither manifest nor approvedScopes carry scopes', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
     mockDbRead.blockUserSubscription.findMany.mockResolvedValue([

--- a/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
@@ -498,14 +498,23 @@ describe('listMyScopeGrants', () => {
   // and a mutant returning either raw column fails too (each row's manifest and approval differ
   // from its intersection).
   //
-  // MEASURED, not asserted — mutants run against this suite (61 tests), each confirmed to have
-  // actually executed rather than failing to import:
-  //   `['buzz:read:self']`         → 8 failed, THIS test among them (it survived the old fixture)
-  //   `['models:read:self']`       → 11 failed, THIS test among them
-  //   `['collections:read:private']` → 11 failed, THIS test among them
-  //   raw `approved_scopes`        → 5 failed, THIS test among them
-  //   raw `manifest.scopes`        → 7 failed, THIS test among them
-  //   positive control `[]`        → 8 failed (proves the suite can go red at all)
+  // MEASURED, not asserted — each mutant below was applied to `displayedScopes` in
+  // `user-app-surface.service.ts` and this file run warm, confirmed to have actually executed
+  // rather than failing to import. Every one of them fails THIS test:
+  //   `['buzz:read:self']`           (it survived the old single-row fixture)
+  //   `['models:read:self']`
+  //   `['collections:read:private']`
+  //   raw `approved_scopes`
+  //   raw `manifest.scopes`
+  //   positive control `[]`          (proves the suite can go red at all)
+  //
+  // ⚠️ NO AGGREGATE FAILURE COUNTS HERE, DELIBERATELY. An earlier revision listed a per-mutant
+  // "N failed" figure alongside a suite size of 61; re-measuring against the suite as it now
+  // stands (62 tests) moved four of the six — `['models:read:self']` and
+  // `['collections:read:private']` 11→12, raw `approved_scopes` 5→8, the `[]` control 8→9. The
+  // per-mutant count is a fact about the whole file's fixtures and drifts whenever any test is
+  // added; "THIS test fails under each mutant" is the claim that actually carries the coverage,
+  // and it re-verified true in all six. Re-derive a count if you need one; do not quote one here.
   // ⚠️ NOTE WHAT IS *NOT* CLAIMED: `['buzz:read:self']` still PASSES the `manifest ⊋ approved`
   // test above, because that test's expected value IS `['buzz:read:self']`. A single-row equality
   // assertion can never kill a mutant that hardcodes its own expectation — which is precisely why
@@ -638,10 +647,21 @@ describe('listMyScopeGrants', () => {
   });
 
   // 🔴 THE SAME non-string in BOTH columns — the shape that makes it an intersection MEMBER, and
-  // so the only one that can fail if the helper's non-string handling is dropped. This is the
-  // seam-level mirror of the helper's own both-columns case: it pins that `listMyScopeGrants`
-  // really routes through that handling rather than re-deriving the rule, which is what would put
-  // a `42` into a `<Badge>` label and a `SCOPE_DESCRIPTIONS` lookup on the permissions tab.
+  // so the only case in this file that can fail if the helper's non-string handling is dropped.
+  // Measured: deleting the helper's `typeof scope !== 'string'` guard fails exactly 1 of this
+  // file's 62 tests, this one — which is what would otherwise put a `42` into a `<Badge>` label
+  // and a `SCOPE_DESCRIPTIONS` lookup on the permissions tab. It is the seam-level mirror of the
+  // helper's own both-columns case: it pins that GUARD'S BEHAVIOUR as observed through
+  // `listMyScopeGrants`.
+  //
+  // ⚠️ IT DOES NOT PIN ROUTING, AND AN EARLIER REVISION OF THIS COMMENT CLAIMED IT DID ("pins
+  // that `listMyScopeGrants` really routes through that handling rather than re-deriving the
+  // rule"). Measured false: replacing the `effectiveBlockScopes(...)` call with an inline
+  // re-derivation carrying the same `typeof` guard left all 62 tests in this file PASSING.
+  // Routing is pinned elsewhere — by `block-effective-scopes.call-sites.test.ts`'s "every expected
+  // call site actually CALLS it (an import alone is not use)", which went red under that same
+  // mutant (`expected [ Array(1) ] to deeply equal []`). Nothing is unguarded; the sentence named
+  // the wrong test.
   it('🔴 drops a non-string present in BOTH the manifest and approvedScopes', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
     mockDbRead.blockUserSubscription.findMany.mockResolvedValue([
@@ -658,10 +678,17 @@ describe('listMyScopeGrants', () => {
 
   // The fixture is a non-null SCALAR on purpose: `null` alone cannot distinguish the
   // `Array.isArray` guard from a weaker `(x ?? []).filter(…)`, because `null ?? []` also yields
-  // `[]`. A bare string is the realistic JSON-column mishap AND it makes the weaker shape throw
-  // `.filter is not a function`, so this case pins the guard rather than the nullishness. The
-  // manifest deliberately CONTAINS that same scope id, so a correct `[]` cannot be mistaken for an
-  // empty intersection.
+  // `[]`, whereas a scalar makes that weaker shape throw `.filter is not a function`. The manifest
+  // deliberately CONTAINS that same scope id, so a correct `[]` cannot be mistaken for an empty
+  // intersection.
+  //
+  // ⚠️ AN EARLIER REVISION ADDED "so this case pins the guard rather than the nullishness". That
+  // is FALSE for a STRING scalar and is withdrawn: measured, removing the helper's approved-side
+  // `Array.isArray` clause leaves this case PASSING, because `new Set('buzz:read:self')` is a Set
+  // of single characters that no scope id matches, so the result is `[]` either way. What pins the
+  // clause against deletion is the NON-ITERABLE fixture at the helper
+  // (`src/shared/constants/__tests__/block-effective-scopes.test.ts`, the number case). This case
+  // pins the output contract at the seam, nothing finer.
   it('emits an empty scopes array when approvedScopes is not an array at all', async () => {
     const { listMyScopeGrants } = await import('../user-app-surface.service');
     mockDbRead.blockUserSubscription.findMany.mockResolvedValue([

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -331,7 +331,7 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
     // mint" does NOT identify it: the OTHER dev-tunnel author mint
     // (`resolveDevPageBlockForAuthor`, `:469`) sources `clampTunnelDeclaredScopes(app.scopes)` —
     // the author's own declared manifest, not the column. The PRODUCTION run-token mint that
-    // the apps on this page actually use is the other path, and it sources from the MANIFEST
+    // the apps on this page actually use is the THIRD path, and it sources from the MANIFEST
     // (`requestedScopes = knownManifestScopes`) with `approved_scopes` as an all-or-nothing 403
     // veto. It also refuses unless `status === 'approved'`, and this query has no status filter,
     // so this list renders apps no production token can be minted for at all. See

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -49,6 +49,13 @@ export type ScopeGrantSurface = {
   slug: string;
   name: string;
   iconUrl?: string;
+  /**
+   * The app's APPROVED scopes (`AppBlock.approved_scopes`) — the pinned, mod-reviewed set
+   * the mint issues tokens for. NOT the raw manifest (the dev's wishlist, which may be
+   * wider) and NOT `granted_scopes` (the consent-gated subset, which is narrower because it
+   * omits every `CONSENT_EXEMPT_SCOPES` entry the token still carries). See the comment at
+   * the assignment site in `listMyScopeGrants` for why there is no manifest fallback.
+   */
   scopes: string[];
   /**
    * The per-UTC-day Buzz ceiling the VIEWER set for this app at consent time, or
@@ -69,11 +76,12 @@ export type ScopeGrantSurface = {
    * `ai:write:budgeted` — the one scope in the vocabulary that can spend their Buzz.
    *
    * 🔴 THIS IS NOT DERIVABLE FROM `scopes` ABOVE, and that is why it exists. `scopes`
-   * is the app's MANIFEST-declared set (what it asks for); this is the USER'S GRANT
-   * (what they agreed to). The budget editor on /apps/activity keys off this one: a
-   * budget only bounds something when the spend scope is granted, and `grantScopes`
-   * IGNORES a budget sent for an app that does not hold it — so offering the control
-   * off the manifest set would render a field whose value the server silently drops.
+   * is the app's APPROVED set (`AppBlock.approved_scopes` — what the mint will issue a
+   * token for); this is the USER'S GRANT (what they agreed to). The budget editor on
+   * /apps/activity keys off this one: a budget only bounds something when the spend scope
+   * is granted, and `grantScopes` IGNORES a budget sent for an app that does not hold it —
+   * so offering the control off the approved set would render a field whose value the
+   * server silently drops.
    */
   spendScopeGranted: boolean;
   surfaces: {
@@ -281,30 +289,46 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
 
   const result: ScopeGrantSurface[] = [];
   for (const [appBlockId, entry] of byAppBlock.entries()) {
+    // Only PRESENTATION fields are read off the manifest here. `scopes` is deliberately not
+    // in this cast — see the assignment below — so that reaching for it is a visible change.
     const manifest = (entry.appBlock.manifest ?? {}) as {
       name?: unknown;
       iconUrl?: unknown;
-      scopes?: unknown;
     };
     const manifestName = typeof manifest.name === 'string' ? manifest.name : entry.appBlock.blockId;
     const iconUrl =
       typeof manifest.iconUrl === 'string' && manifest.iconUrl.length > 0
         ? manifest.iconUrl
         : undefined;
-    // Prefer the manifest-declared scopes (the dev's stated intent). The
-    // approved_scopes column is the moderator-narrowed set used at JWT
-    // issuance; surfacing both would be confusing for v0. Fall back to
-    // approved_scopes when manifest.scopes is missing or malformed.
-    const manifestScopes = Array.isArray(manifest.scopes)
-      ? (manifest.scopes.filter((s) => typeof s === 'string') as string[])
-      : entry.appBlock.approvedScopes ?? [];
+    // 🔴 DISPLAY `approved_scopes` — THE SET THE MINT ACTUALLY HONOURS — AND NEVER THE
+    // RAW MANIFEST. `src/server/services/block-registry.service.ts` states the contract
+    // for token issuance: "The mint sources scopes from `approvedScopes` (the pinned,
+    // mod-reviewed set — NEVER the raw manifest)". A manifest `scopes` array is only the
+    // dev's stated WISHLIST; a moderator may approve a narrower set, and the token then
+    // carries only that narrower set. Showing the manifest would over-report what the app
+    // can do on the one page whose whole job is to tell the viewer what it can do.
+    //
+    // 🔴 NO FALLBACK TO `manifest.scopes`. An app approved for nothing must display
+    // nothing — a fallback would restore the exact over-report this guards against, in
+    // precisely the case that matters (an app whose approval was narrowed to empty while
+    // its manifest still asks for everything).
+    //
+    // NOT `granted_scopes`: that is only the consent-gated subset, so it UNDER-reports by
+    // omitting every `CONSENT_EXEMPT_SCOPES` entry the token really carries.
+    //
+    // The `Array.isArray` guard (defaulting to `[]`) and the `typeof s === 'string'` filter
+    // stay defensive: this value comes off a JSON/DB boundary, so neither its presence, its
+    // shape, nor its element types are runtime guarantees whatever the Prisma type says.
+    const displayedScopes = Array.isArray(entry.appBlock.approvedScopes)
+      ? entry.appBlock.approvedScopes.filter((s) => typeof s === 'string')
+      : [];
 
     result.push({
       appBlockId,
       slug: entry.appBlock.blockId,
       name: manifestName,
       iconUrl,
-      scopes: manifestScopes,
+      scopes: displayedScopes,
       buzzBudgetPerDay: budgetByAppBlock.get(appBlockId) ?? null,
       spendScopeGranted: spendGrantedByAppBlock.has(appBlockId),
       surfaces: {

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -21,6 +21,7 @@ import {
   isBlockActionDetail,
   type BlockActionDetail,
 } from '~/shared/constants/block-action-detail';
+import { effectiveBlockScopes } from '~/shared/constants/block-effective-scopes';
 
 /**
  * The SYNTHETIC (non-FK-resolving) `appBlockId` claim namespaces a PRE-APPROVAL
@@ -50,11 +51,17 @@ export type ScopeGrantSurface = {
   name: string;
   iconUrl?: string;
   /**
-   * The app's APPROVED scopes (`AppBlock.approved_scopes`) — the pinned, mod-reviewed set
-   * the mint issues tokens for. NOT the raw manifest (the dev's wishlist, which may be
-   * wider) and NOT `granted_scopes` (the consent-gated subset, which is narrower because it
-   * omits every `CONSENT_EXEMPT_SCOPES` entry the token still carries). See the comment at
-   * the assignment site in `listMyScopeGrants` for why there is no manifest fallback.
+   * The app's EFFECTIVE scope set — `manifest.scopes ∩ AppBlock.approved_scopes`, computed by
+   * the shared `effectiveBlockScopes` helper, in manifest order and de-duplicated.
+   *
+   * NEITHER column alone: the manifest is the dev's declaration and can be replaced without
+   * re-approval, the approval is a snapshot that can name a scope a newer manifest has
+   * dropped. NOT `granted_scopes` either (the consent-gated subset, narrower because it omits
+   * every `CONSENT_EXEMPT_SCOPES` entry a token still carries).
+   *
+   * 🔴 NOT "what the mint will issue a token for" — that claim was here and it was false in
+   * two ways; see the assignment site in `listMyScopeGrants`. These are the scopes the app may
+   * be granted and exercised with.
    */
   scopes: string[];
   /**
@@ -75,13 +82,12 @@ export type ScopeGrantSurface = {
    * True when the viewer's LIVE (non-revoked) grant row for this app actually carries
    * `ai:write:budgeted` — the one scope in the vocabulary that can spend their Buzz.
    *
-   * 🔴 THIS IS NOT DERIVABLE FROM `scopes` ABOVE, and that is why it exists. `scopes`
-   * is the app's APPROVED set (`AppBlock.approved_scopes` — what the mint will issue a
-   * token for); this is the USER'S GRANT (what they agreed to). The budget editor on
-   * /apps/activity keys off this one: a budget only bounds something when the spend scope
-   * is granted, and `grantScopes` IGNORES a budget sent for an app that does not hold it —
-   * so offering the control off the approved set would render a field whose value the
-   * server silently drops.
+   * 🔴 THIS IS NOT DERIVABLE FROM `scopes` ABOVE, and that is why it exists. `scopes` is an
+   * APP-SIDE set (`manifest.scopes ∩ approved_scopes` — what the app may be granted); this is
+   * the USER'S GRANT (what they actually agreed to). The budget editor on /apps/activity keys
+   * off this one: a budget only bounds something when the spend scope is granted, and
+   * `grantScopes` IGNORES a budget sent for an app that does not hold it — so offering the
+   * control off an app-side set would render a field whose value the server silently drops.
    */
   spendScopeGranted: boolean;
   surfaces: {
@@ -289,8 +295,10 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
 
   const result: ScopeGrantSurface[] = [];
   for (const [appBlockId, entry] of byAppBlock.entries()) {
-    // Only PRESENTATION fields are read off the manifest here. `scopes` is deliberately not
-    // in this cast — see the assignment below — so that reaching for it is a visible change.
+    // Presentation fields only. `scopes` is deliberately NOT read through this cast even
+    // though the effective set now needs it — the shared helper takes the raw manifest and
+    // owns that extraction, so there is exactly one place that decides what a malformed
+    // `scopes` value means.
     const manifest = (entry.appBlock.manifest ?? {}) as {
       name?: unknown;
       iconUrl?: unknown;
@@ -300,28 +308,38 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
       typeof manifest.iconUrl === 'string' && manifest.iconUrl.length > 0
         ? manifest.iconUrl
         : undefined;
-    // 🔴 DISPLAY `approved_scopes` — THE SET THE MINT ACTUALLY HONOURS — AND NEVER THE
-    // RAW MANIFEST. `src/server/services/block-registry.service.ts` states the contract
-    // for token issuance: "The mint sources scopes from `approvedScopes` (the pinned,
-    // mod-reviewed set — NEVER the raw manifest)". A manifest `scopes` array is only the
-    // dev's stated WISHLIST; a moderator may approve a narrower set, and the token then
-    // carries only that narrower set. Showing the manifest would over-report what the app
-    // can do on the one page whose whole job is to tell the viewer what it can do.
+    // 🔴 DISPLAY `manifest.scopes ∩ approved_scopes` — NEITHER COLUMN ALONE. The shared
+    // helper owns the rule, the JSON-boundary defensiveness, and the order/de-dup contract;
+    // see `effectiveBlockScopes` for why the intersection is the only set that is correct in
+    // both divergence directions, and for the same rule's other call sites.
     //
-    // 🔴 NO FALLBACK TO `manifest.scopes`. An app approved for nothing must display
-    // nothing — a fallback would restore the exact over-report this guards against, in
-    // precisely the case that matters (an app whose approval was narrowed to empty while
-    // its manifest still asks for everything).
+    // The short version, because this is the surface the divergence is most visible on: a
+    // publisher push (`src/pages/api/v1/developer/block-manifests.ts`) replaces `manifest`
+    // and sets `status: 'pending'` without touching `approved_scopes`, and this query has NO
+    // status filter, so a pending-v2 app still renders here. A v2 that ADDS a scope leaves
+    // `manifest ⊋ approved`, where showing the manifest over-reports; a v2 that DROPS one
+    // leaves `manifest ⊊ approved`, where showing the approval over-reports a scope the
+    // current manifest no longer even requests. Only the intersection is right in both.
+    //
+    // 🔴 DO NOT DESCRIBE THIS AS "WHAT THE MINT WILL ISSUE A TOKEN FOR" — an earlier revision
+    // of this comment did, citing `block-registry.service.ts`, and the citation was being
+    // misapplied rather than misquoted. That sentence ("The mint sources scopes from
+    // `approvedScopes` … NEVER the raw manifest") is TRUE of the DEV-TUNNEL author mint, whose
+    // docblock it lives in — `block-tokens/index.ts` really does
+    // `clampTunnelDeclaredScopes(app.approvedScopes)` there. The PRODUCTION run-token mint that
+    // the apps on this page actually use is the other path, and it sources from the MANIFEST
+    // (`requestedScopes = knownManifestScopes`) with `approved_scopes` as an all-or-nothing 403
+    // veto. It also refuses unless `status === 'approved'`, and this query has no status filter,
+    // so this list renders apps no production token can be minted for at all. See
+    // `effectiveBlockScopes` for the full statement. The honest claim is the narrower one: these
+    // are the scopes the app may be granted and exercised with.
     //
     // NOT `granted_scopes`: that is only the consent-gated subset, so it UNDER-reports by
-    // omitting every `CONSENT_EXEMPT_SCOPES` entry the token really carries.
-    //
-    // The `Array.isArray` guard (defaulting to `[]`) and the `typeof s === 'string'` filter
-    // stay defensive: this value comes off a JSON/DB boundary, so neither its presence, its
-    // shape, nor its element types are runtime guarantees whatever the Prisma type says.
-    const displayedScopes = Array.isArray(entry.appBlock.approvedScopes)
-      ? entry.appBlock.approvedScopes.filter((s) => typeof s === 'string')
-      : [];
+    // omitting every `CONSENT_EXEMPT_SCOPES` entry a token really carries.
+    const displayedScopes = effectiveBlockScopes(
+      entry.appBlock.manifest as { scopes?: unknown } | null,
+      entry.appBlock.approvedScopes
+    );
 
     result.push({
       appBlockId,

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -324,9 +324,13 @@ export async function listMyScopeGrants(userId: number): Promise<ScopeGrantSurfa
     // 🔴 DO NOT DESCRIBE THIS AS "WHAT THE MINT WILL ISSUE A TOKEN FOR" — an earlier revision
     // of this comment did, citing `block-registry.service.ts`, and the citation was being
     // misapplied rather than misquoted. That sentence ("The mint sources scopes from
-    // `approvedScopes` … NEVER the raw manifest") is TRUE of the DEV-TUNNEL author mint, whose
-    // docblock it lives in — `block-tokens/index.ts` really does
-    // `clampTunnelDeclaredScopes(app.approvedScopes)` there. The PRODUCTION run-token mint that
+    // `approvedScopes` … NEVER the raw manifest") is TRUE of exactly ONE of the THREE
+    // scope-sourcing sites: the OWNED-NON-APPROVED dev-tunnel mint, resolved by
+    // `resolveOwnedNonApprovedPageBlock`, whose docblock it lives in — `block-tokens/index.ts:650`
+    // really does `clampTunnelDeclaredScopes(app.approvedScopes)` there. ⚠️ "The dev-tunnel author
+    // mint" does NOT identify it: the OTHER dev-tunnel author mint
+    // (`resolveDevPageBlockForAuthor`, `:469`) sources `clampTunnelDeclaredScopes(app.scopes)` —
+    // the author's own declared manifest, not the column. The PRODUCTION run-token mint that
     // the apps on this page actually use is the other path, and it sources from the MANIFEST
     // (`requestedScopes = knownManifestScopes`) with `approved_scopes` as an all-or-nothing 403
     // veto. It also refuses unless `status === 'approved'`, and this query has no status filter,

--- a/src/shared/constants/__tests__/block-effective-scopes.call-sites.test.ts
+++ b/src/shared/constants/__tests__/block-effective-scopes.call-sites.test.ts
@@ -1,0 +1,128 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join, relative, sep } from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * CONSOLIDATION LEDGER for `effectiveBlockScopes` — `manifest.scopes ∩ approved_scopes`.
+ *
+ * 🔴 WHY A LEDGER AND NOT A PAIR OF LITERALS. This rule was open-coded at THREE sites before this
+ * change (the `grantScopes` consent ceiling, `getInstallConfig`'s install-time disclosure, and
+ * `BlockRegistry.recordInstallConsent`'s grant set) and a fourth surface — the permissions tab —
+ * was about to become a fourth variant. A "these two agree" guard written as a hand-copied literal
+ * on each side pins NOTHING: tighten one side and its own literal and both stay green while the two
+ * have silently diverged. So this asserts the RELATIONSHIP instead — that the named modules get the
+ * rule from the shared symbol and no longer carry their own copy of it.
+ *
+ * GROWTH-AND-SHRINK GATED, deliberately, in the shape `app-access.call-site-ledger.test.ts` already
+ * established in this repo. A NEW importer must be added here consciously (is it really the same
+ * rule?), and a REMOVED one fails too (did someone re-open-code it?). Either way the failure names
+ * the file.
+ *
+ * This is a STRUCTURAL check and it is not sufficient on its own — it type-checks past a wrong
+ * argument. The behavioural half lives in `block-effective-scopes.test.ts` (literal expectations for
+ * the helper), `user-app-surface.orchestration.test.ts` (helper-derived expectations at the
+ * permissions-tab site) and `blocks.router.getInstallConfig.test.ts` (literal expectations at the
+ * two router sites).
+ */
+
+const SRC = join(process.cwd(), 'src');
+const MODULE_SPECIFIER = "from '~/shared/constants/block-effective-scopes'";
+
+/** Every module that is expected to consume the shared rule, and what it uses it for. */
+const EXPECTED_CALL_SITES: Record<string, string> = {
+  'server/routers/blocks.router.ts':
+    'grantScopes consent ceiling + getInstallConfig install-time disclosure',
+  'server/services/block-registry.service.ts': 'recordInstallConsent grant set',
+  'server/services/blocks/user-app-surface.service.ts':
+    'listMyScopeGrants — the /apps/activity permissions tab',
+};
+
+/**
+ * The signature of every pre-existing open-coded copy: a `Set` built straight from the
+ * `approvedScopes` column, to be `.has()`-tested against the manifest array. Matching this is how
+ * the guard notices someone re-deriving the rule locally instead of calling the helper.
+ */
+const OPEN_CODED_INTERSECTION = /new Set\(\s*[A-Za-z0-9_.?[\]]*approvedScopes/i;
+
+function read(relativePath: string): string {
+  return readFileSync(join(SRC, relativePath), 'utf8');
+}
+
+/** Recursive walk — no `glob` dependency in this repo, so this is hand-rolled on purpose. */
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+      sourceFiles(full, out);
+    } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      out.push(relative(SRC, full).split(sep).join('/'));
+    }
+  }
+  return out;
+}
+
+/** Strip comments — the modules deliberately DISCUSS the old shape in prose. */
+function codeOnly(body: string): string {
+  return body.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+describe('effectiveBlockScopes consolidation ledger', () => {
+  // ── INSTRUMENT VALIDATION. Both halves, before any verdict below is believed: the walk must
+  // actually find files, and the open-coded-intersection regex must actually match the shape it
+  // claims to detect. A reassuring "0 offenders" from a probe wired to nothing is indistinguishable
+  // from a real pass.
+  it('the source walk finds files and the open-coded regex matches a known-bad sample', () => {
+    const files = sourceFiles(SRC);
+    expect(files.length).toBeGreaterThan(500);
+    expect(files).toContain('shared/constants/block-effective-scopes.ts');
+    // POSITIVE control — the exact shape the three sites used to carry.
+    expect(
+      OPEN_CODED_INTERSECTION.test('const approved = new Set(block.approvedScopes ?? []);')
+    ).toBe(true);
+    expect(
+      OPEN_CODED_INTERSECTION.test('const approved = new Set(opts.approvedScopes ?? []);')
+    ).toBe(true);
+    // NEGATIVE control — the consolidated shape must NOT match, or the guard below would be
+    // permanently red and therefore worthless.
+    expect(
+      OPEN_CODED_INTERSECTION.test(
+        'const ceiling = new Set(effectiveBlockScopes(block.manifest, block.approvedScopes));'
+      )
+    ).toBe(false);
+  });
+
+  it('every expected call site imports the shared symbol', () => {
+    const missing = Object.keys(EXPECTED_CALL_SITES).filter(
+      (file) => !read(file).includes('import { effectiveBlockScopes }')
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('every expected call site actually CALLS it (an import alone is not use)', () => {
+    const notCalled = Object.keys(EXPECTED_CALL_SITES).filter(
+      (file) => !codeOnly(read(file)).includes('effectiveBlockScopes(')
+    );
+    expect(notCalled).toEqual([]);
+  });
+
+  // 🔴 GROWTH-AND-SHRINK GATE. `EXPECTED_CALL_SITES` must be the COMPLETE set of production
+  // importers under `src/`, so a new consumer cannot appear without a deliberate edit here and an
+  // existing one cannot quietly drop the shared rule.
+  it('the ledger is the complete set of production importers', () => {
+    const importers = sourceFiles(SRC)
+      .filter((f) => f !== 'shared/constants/block-effective-scopes.ts')
+      .filter((f) => read(f).includes(MODULE_SPECIFIER))
+      .sort();
+    expect(importers).toEqual(Object.keys(EXPECTED_CALL_SITES).sort());
+  });
+
+  // 🔴 NO CONSOLIDATED SITE MAY RE-OPEN-CODE THE RULE — the thing that would silently regenerate
+  // the divergence the consolidation removed.
+  it('no consolidated module still builds its own approved-scope Set to intersect with', () => {
+    const offenders = Object.keys(EXPECTED_CALL_SITES).filter((file) =>
+      OPEN_CODED_INTERSECTION.test(codeOnly(read(file)))
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/shared/constants/__tests__/block-effective-scopes.call-sites.test.ts
+++ b/src/shared/constants/__tests__/block-effective-scopes.call-sites.test.ts
@@ -10,8 +10,14 @@ import { describe, expect, it } from 'vitest';
  * `BlockRegistry.recordInstallConsent`'s grant set) and a fourth surface — the permissions tab —
  * was about to become a fourth variant. A "these two agree" guard written as a hand-copied literal
  * on each side pins NOTHING: tighten one side and its own literal and both stay green while the two
- * have silently diverged. So this asserts the RELATIONSHIP instead — that the named modules get the
- * rule from the shared symbol and no longer carry their own copy of it.
+ * have silently diverged. So this asserts the RELATIONSHIP instead — that the named modules IMPORT
+ * the shared symbol and CALL it.
+ *
+ * ⚠️ THAT IS THE WHOLE STRUCTURAL CLAIM, AND IT IS NARROWER THAN "THEY NO LONGER CARRY THEIR OWN
+ * COPY OF THE RULE" — an earlier revision of this paragraph asserted the wider one. The only check
+ * here that looks for a surviving local copy is the spelling tripwire at the bottom, and it sees
+ * exactly the two token shapes listed in `OPEN_CODED_SPELLINGS`; read that docstring before
+ * treating a green run as an absence of re-derivation.
  *
  * GROWTH-AND-SHRINK GATED, deliberately, in the shape `app-access.call-site-ledger.test.ts` already
  * established in this repo. A NEW importer must be added here consciously (is it really the same
@@ -19,10 +25,16 @@ import { describe, expect, it } from 'vitest';
  * the file.
  *
  * This is a STRUCTURAL check and it is not sufficient on its own — it type-checks past a wrong
- * argument. The behavioural half lives in `block-effective-scopes.test.ts` (literal expectations for
- * the helper), `user-app-surface.orchestration.test.ts` (helper-derived expectations at the
- * permissions-tab site) and `blocks.router.getInstallConfig.test.ts` (literal expectations at the
- * two router sites).
+ * argument. The behavioural coverage that exists lives in `block-effective-scopes.test.ts` (literal
+ * expectations for the helper), `user-app-surface.orchestration.test.ts` (both literal and
+ * helper-derived expectations at the permissions-tab site) and
+ * `blocks.router.getInstallConfig.test.ts` (literal expectations at the two router sites).
+ *
+ * ⚠️ THAT IS THREE OF THE FOUR LEDGERED CALL SITES, NOT ALL FOUR.
+ * `BlockRegistry.recordInstallConsent` has NO behavioural test anywhere: measured by grepping
+ * `recordInstallConsent` across every `*.test.ts`/`*.test.tsx` under `src/`, the only two hits are
+ * THIS file and the prose of `user-app-surface.orchestration.test.ts`. So for that site the import
+ * ledger below is the only thing asserting anything at all, and it cannot see a wrong argument.
  */
 
 const SRC = join(process.cwd(), 'src');
@@ -64,7 +76,15 @@ const OPEN_CODED_SPELLINGS: { name: string; re: RegExp }[] = [
   },
   {
     name: 'an .includes() test against the approvedScopes column',
-    re: /approvedScopes\s*(?:\?\?\s*\[\]\s*)?\)?\s*\.includes\(/i,
+    // The `)` is reachable ONLY as the close of a `(… ?? [])` wrapper, never on its own.
+    // ⚠️ An earlier revision made it independently optional (`(?:\?\?\s*\[\]\s*)?\)?`), which
+    // FALSE-POSITIVED on the CONSOLIDATED call: in
+    // `effectiveBlockScopes(block.manifest, block.approvedScopes).includes('ai:write:budgeted')`
+    // the bare `\)?` absorbed the helper call's own closing paren, so the tripwire reported a
+    // module that USES the helper as carrying an open-coded spelling. Measured through the real
+    // gate: planted in `user-app-surface.service.ts`, the offenders test went red
+    // (`expected [ Array(1) ] to deeply equal []`). The third negative control below pins it.
+    re: /approvedScopes\s*(?:\?\?\s*\[\]\s*\))?\s*\.includes\(/i,
   },
 ];
 
@@ -108,6 +128,10 @@ describe('effectiveBlockScopes consolidation ledger', () => {
 
     // POSITIVE control, PER SPELLING — each entry must be shown to match something, or a dead
     // regex sits in the list contributing a silent `false` to `hasOpenCodedSpelling`.
+    // The length assertion is what makes this test's title ("EVERY open-coded spelling") true by
+    // construction: the controls below are hand-written per entry, so adding a third spelling
+    // without a control would otherwise leave the title claiming coverage it does not have.
+    expect(OPEN_CODED_SPELLINGS).toHaveLength(2);
     const [setShape, includesShape] = OPEN_CODED_SPELLINGS;
     expect(setShape.re.test('const approved = new Set(block.approvedScopes ?? []);')).toBe(true);
     expect(setShape.re.test('const approved = new Set(opts.approvedScopes ?? []);')).toBe(true);
@@ -138,6 +162,14 @@ describe('effectiveBlockScopes consolidation ledger', () => {
     ).toBe(false);
     expect(
       hasOpenCodedSpelling('const scopes = effectiveBlockScopes(manifest, block.approvedScopes);')
+    ).toBe(false);
+    // …and the THIRD negative control: a `.includes()` applied to the HELPER'S OWN RESULT. Both
+    // controls above stop before a `.includes(`, so neither could see the false positive the
+    // `.includes()` regex used to produce on correctly consolidated code.
+    expect(
+      hasOpenCodedSpelling(
+        "const grantsSpend = effectiveBlockScopes(block.manifest, block.approvedScopes).includes('ai:write:budgeted');"
+      )
     ).toBe(false);
   });
 

--- a/src/shared/constants/__tests__/block-effective-scopes.call-sites.test.ts
+++ b/src/shared/constants/__tests__/block-effective-scopes.call-sites.test.ts
@@ -38,11 +38,40 @@ const EXPECTED_CALL_SITES: Record<string, string> = {
 };
 
 /**
- * The signature of every pre-existing open-coded copy: a `Set` built straight from the
- * `approvedScopes` column, to be `.has()`-tested against the manifest array. Matching this is how
- * the guard notices someone re-deriving the rule locally instead of calling the helper.
+ * 🔴 A SPELLING CHECK, NOT A STRUCTURAL ONE — and the docstring is deliberately no wider than
+ * that. These two token shapes are ALL it can see:
+ *   (a) a `Set` built straight from the `approvedScopes` column, to be `.has()`-tested against
+ *       the manifest array — the shape all three pre-existing open-coded copies used;
+ *   (b) an `.includes()` test against the column, the other idiomatic spelling of the same
+ *       intersection.
+ *
+ * Anything else walks straight past: a `reduce`, a `Map` keyed on the column, a local alias
+ * assigned from `approvedScopes` before the intersection, or the rule re-derived in a different
+ * module. An earlier revision of this docstring claimed the check "notices someone re-deriving
+ * the rule locally", which is a coverage claim the regex cannot honour —
+ * `manifestScopes.filter((s) => block.approvedScopes.includes(s))` was not matched by it at all.
+ * Adding (b) closes that one counter-example; it does not make the check structural.
+ *
+ * So read a green result as "neither of these two spellings is present in the ledgered modules",
+ * never as "the rule is not re-derived anywhere". The STRUCTURAL guarantee in this file is the
+ * importer ledger below (`the ledger is the complete set of production importers`) — that is the
+ * check to lean on.
  */
-const OPEN_CODED_INTERSECTION = /new Set\(\s*[A-Za-z0-9_.?[\]]*approvedScopes/i;
+const OPEN_CODED_SPELLINGS: { name: string; re: RegExp }[] = [
+  {
+    name: 'a Set built from the approvedScopes column',
+    re: /new Set\(\s*[A-Za-z0-9_.?[\]]*approvedScopes/i,
+  },
+  {
+    name: 'an .includes() test against the approvedScopes column',
+    re: /approvedScopes\s*(?:\?\?\s*\[\]\s*)?\)?\s*\.includes\(/i,
+  },
+];
+
+/** True iff ANY known open-coded spelling appears. */
+function hasOpenCodedSpelling(body: string): boolean {
+  return OPEN_CODED_SPELLINGS.some(({ re }) => re.test(body));
+}
 
 function read(relativePath: string): string {
   return readFileSync(join(SRC, relativePath), 'utf8');
@@ -72,23 +101,43 @@ describe('effectiveBlockScopes consolidation ledger', () => {
   // actually find files, and the open-coded-intersection regex must actually match the shape it
   // claims to detect. A reassuring "0 offenders" from a probe wired to nothing is indistinguishable
   // from a real pass.
-  it('the source walk finds files and the open-coded regex matches a known-bad sample', () => {
+  it('the source walk finds files and EVERY open-coded spelling matches a known-bad sample', () => {
     const files = sourceFiles(SRC);
     expect(files.length).toBeGreaterThan(500);
     expect(files).toContain('shared/constants/block-effective-scopes.ts');
-    // POSITIVE control — the exact shape the three sites used to carry.
+
+    // POSITIVE control, PER SPELLING — each entry must be shown to match something, or a dead
+    // regex sits in the list contributing a silent `false` to `hasOpenCodedSpelling`.
+    const [setShape, includesShape] = OPEN_CODED_SPELLINGS;
+    expect(setShape.re.test('const approved = new Set(block.approvedScopes ?? []);')).toBe(true);
+    expect(setShape.re.test('const approved = new Set(opts.approvedScopes ?? []);')).toBe(true);
     expect(
-      OPEN_CODED_INTERSECTION.test('const approved = new Set(block.approvedScopes ?? []);')
+      includesShape.re.test('manifestScopes.filter((s) => block.approvedScopes.includes(s))')
     ).toBe(true);
     expect(
-      OPEN_CODED_INTERSECTION.test('const approved = new Set(opts.approvedScopes ?? []);')
+      includesShape.re.test(
+        'manifestScopes.filter((s) => (block.approvedScopes ?? []).includes(s))'
+      )
     ).toBe(true);
+
+    // …and the aggregate must fire on each of them too, so a spelling cannot be matched in
+    // isolation while the function that actually gates ignores it.
+    expect(hasOpenCodedSpelling('const approved = new Set(block.approvedScopes ?? []);')).toBe(
+      true
+    );
+    expect(
+      hasOpenCodedSpelling('manifestScopes.filter((s) => block.approvedScopes.includes(s))')
+    ).toBe(true);
+
     // NEGATIVE control — the consolidated shape must NOT match, or the guard below would be
     // permanently red and therefore worthless.
     expect(
-      OPEN_CODED_INTERSECTION.test(
+      hasOpenCodedSpelling(
         'const ceiling = new Set(effectiveBlockScopes(block.manifest, block.approvedScopes));'
       )
+    ).toBe(false);
+    expect(
+      hasOpenCodedSpelling('const scopes = effectiveBlockScopes(manifest, block.approvedScopes);')
     ).toBe(false);
   });
 
@@ -117,11 +166,13 @@ describe('effectiveBlockScopes consolidation ledger', () => {
     expect(importers).toEqual(Object.keys(EXPECTED_CALL_SITES).sort());
   });
 
-  // 🔴 NO CONSOLIDATED SITE MAY RE-OPEN-CODE THE RULE — the thing that would silently regenerate
-  // the divergence the consolidation removed.
-  it('no consolidated module still builds its own approved-scope Set to intersect with', () => {
+  // 🔴 SPELLING-SCOPED, BY CONSTRUCTION — see `OPEN_CODED_SPELLINGS`. This catches the two known
+  // token shapes regenerating at a ledgered site. It is NOT a proof that the rule is computed in
+  // one place; the importer ledger above is the structural half of that claim, and this is a
+  // cheap tripwire over the spellings we have actually seen written.
+  it('no ledgered module carries either KNOWN open-coded spelling of the intersection', () => {
     const offenders = Object.keys(EXPECTED_CALL_SITES).filter((file) =>
-      OPEN_CODED_INTERSECTION.test(codeOnly(read(file)))
+      hasOpenCodedSpelling(codeOnly(read(file)))
     );
     expect(offenders).toEqual([]);
   });

--- a/src/shared/constants/__tests__/block-effective-scopes.test.ts
+++ b/src/shared/constants/__tests__/block-effective-scopes.test.ts
@@ -88,8 +88,17 @@ describe('effectiveBlockScopes', () => {
   // purely hypothetical is a non-string ELEMENT: the approve paths write
   // `manifest.scopes as string[]` — a bare cast with no per-element check
   // (`publish-request.service.ts`) — so a malformed manifest can land one in the column.
+  //
+  // 🔴 WHAT THE NEXT TWO CASES DO AND DO NOT PIN. They assert the OUTPUT CONTRACT — a
+  // one-sided non-string never reaches the result — and nothing about any particular guard.
+  // Measured: with a non-string on one side only, deleting the implementation's `typeof` guard
+  // changes NOTHING, because a non-string on one side cannot match a string on the other. They
+  // were previously annotated as covering "the approved-side handling"; that was wrong, and an
+  // earlier revision's approved-side filter was certified by the first of them without being
+  // reachable from it. The guard-level pin is the BOTH-SIDES case below — that is the only
+  // fixture in this file that can fail when the implementation's non-string handling is removed.
 
-  it('drops non-string elements on the APPROVED side', () => {
+  it('a one-sided non-string on the APPROVED side never reaches the output', () => {
     expect(
       effectiveBlockScopes({ scopes: ['buzz:read:self', 'models:read:self'] }, [
         null,
@@ -101,13 +110,29 @@ describe('effectiveBlockScopes', () => {
     ).toEqual(['buzz:read:self', 'models:read:self']);
   });
 
-  it('drops non-string elements on the MANIFEST side', () => {
+  it('a one-sided non-string on the MANIFEST side never reaches the output', () => {
     expect(
       effectiveBlockScopes({ scopes: [null, 'buzz:read:self', 7, 'models:read:self'] }, [
         'buzz:read:self',
         'models:read:self',
       ])
     ).toEqual(['buzz:read:self', 'models:read:self']);
+  });
+
+  // 🔴 THE GUARD-LEVEL PIN, AND THE ONLY NON-STRING CASE HERE THAT CAN FAIL. The SAME
+  // non-string sits in BOTH columns, which is what makes it an intersection member and so
+  // defeats the "one side filters, the other cannot match" mutual redundancy that made every
+  // one-sided fixture blind. Measured against the fixture below:
+  //   both guards present / only the approved filter removed / only the loop guard removed
+  //     → ['buzz:read:self']          (identical — one-sided fixtures cannot distinguish these)
+  //   both removed                    → [42, 'buzz:read:self']   ← the leak this case catches
+  // The implementation now carries ONE guard (the loop `typeof`), so this case kills it on its
+  // own. A `42` that survived here would reach a `<Badge>` label and a `SCOPE_DESCRIPTIONS`
+  // lookup via `BlockScopeList`.
+  it('🔴 drops a non-string present in BOTH columns — the case a one-sided fixture cannot see', () => {
+    expect(
+      effectiveBlockScopes({ scopes: [42, 'buzz:read:self'] }, [42, 'buzz:read:self'])
+    ).toEqual(['buzz:read:self']);
   });
 
   // A non-null SCALAR on purpose: `null` alone cannot distinguish the `Array.isArray` guard from a

--- a/src/shared/constants/__tests__/block-effective-scopes.test.ts
+++ b/src/shared/constants/__tests__/block-effective-scopes.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import { effectiveBlockScopes } from '~/shared/constants/block-effective-scopes';
+
+/**
+ * `effectiveBlockScopes` — the single shared definition of `manifest.scopes ∩ approved_scopes`.
+ *
+ * This is the module whose expectations are pinned as LITERALS. The consuming sites are pinned
+ * against the helper itself (see `block-effective-scopes.call-sites.test.ts` and the
+ * helper-derived assertions in `user-app-surface.orchestration.test.ts`), which is the right split
+ * for a consolidation: literals here, identity there. Deriving the helper's OWN expectations from
+ * the helper would assert nothing.
+ */
+describe('effectiveBlockScopes', () => {
+  // ── THE TWO DIVERGENCE DIRECTIONS. Both are reachable through
+  // `src/pages/api/v1/developer/block-manifests.ts`, which replaces `manifest` + `version` and
+  // sets `status: 'pending'` without touching `approved_scopes`.
+
+  it('manifest ⊋ approved (v2 ADDED a scope): returns the approved subset, not the manifest', () => {
+    expect(
+      effectiveBlockScopes(
+        { scopes: ['models:read:self', 'ai:write:budgeted', 'collections:read:private'] },
+        ['models:read:self', 'collections:read:private']
+      )
+    ).toEqual(['models:read:self', 'collections:read:private']);
+  });
+
+  // 🔴 THE NEW DEFECT THIS CONSOLIDATION EXISTS TO CLOSE. A v2 manifest that DROPPED a scope
+  // leaves `approved_scopes` naming something the current manifest no longer requests. Returning
+  // the approval here would re-introduce an over-report in the very direction the change targets.
+  it('manifest ⊊ approved (v2 DROPPED a scope): returns the manifest subset, NOT the stale approval', () => {
+    expect(
+      effectiveBlockScopes({ scopes: ['models:read:self'] }, [
+        'models:read:self',
+        'ai:write:budgeted',
+      ])
+    ).toEqual(['models:read:self']);
+  });
+
+  // Neither side contains the other — the case that distinguishes a real intersection from
+  // "whichever column is shorter".
+  it('returns only the overlap when neither side contains the other', () => {
+    expect(
+      effectiveBlockScopes({ scopes: ['models:read:self', 'buzz:read:self'] }, [
+        'buzz:read:self',
+        'ai:write:budgeted',
+      ])
+    ).toEqual(['buzz:read:self']);
+  });
+
+  it('returns [] for a disjoint manifest and approval', () => {
+    expect(effectiveBlockScopes({ scopes: ['models:read:self'] }, ['ai:write:budgeted'])).toEqual(
+      []
+    );
+  });
+
+  // ── ORDER AND DE-DUPLICATION — observable, because callers render this array as a badge list.
+
+  // 🔴 MANIFEST ORDER, NOT APPROVAL ORDER, AND NOT SORTED. The fixture makes all three answers
+  // distinguishable: manifest order is [c, a, b], approval order is [a, b, c], sorted would be
+  // [a, b, c] as well. Only the manifest-order implementation produces the expectation below.
+  it('preserves MANIFEST order (distinguishable from approval order and from sorted)', () => {
+    expect(
+      effectiveBlockScopes(
+        { scopes: ['collections:read:private', 'ai:write:budgeted', 'buzz:read:self'] },
+        ['ai:write:budgeted', 'buzz:read:self', 'collections:read:private']
+      )
+    ).toEqual(['collections:read:private', 'ai:write:budgeted', 'buzz:read:self']);
+  });
+
+  it('de-duplicates a repeated manifest scope, keeping the first occurrence', () => {
+    expect(
+      effectiveBlockScopes({ scopes: ['buzz:read:self', 'models:read:self', 'buzz:read:self'] }, [
+        'models:read:self',
+        'buzz:read:self',
+      ])
+    ).toEqual(['buzz:read:self', 'models:read:self']);
+  });
+
+  it('de-duplicates a repeated APPROVED scope without duplicating the output', () => {
+    expect(
+      effectiveBlockScopes({ scopes: ['buzz:read:self'] }, ['buzz:read:self', 'buzz:read:self'])
+    ).toEqual(['buzz:read:self']);
+  });
+
+  // ── JSON/DB-BOUNDARY DEFENSIVENESS. These are INVARIANT GUARDS, not regression coverage:
+  // Prisma types `approvedScopes` as `string[]`, so nothing in the codebase produces most of
+  // these shapes today. They are labelled as such rather than counted. The one that is NOT
+  // purely hypothetical is a non-string ELEMENT: the approve paths write
+  // `manifest.scopes as string[]` — a bare cast with no per-element check
+  // (`publish-request.service.ts`) — so a malformed manifest can land one in the column.
+
+  it('drops non-string elements on the APPROVED side', () => {
+    expect(
+      effectiveBlockScopes({ scopes: ['buzz:read:self', 'models:read:self'] }, [
+        null,
+        'buzz:read:self',
+        42,
+        undefined,
+        'models:read:self',
+      ])
+    ).toEqual(['buzz:read:self', 'models:read:self']);
+  });
+
+  it('drops non-string elements on the MANIFEST side', () => {
+    expect(
+      effectiveBlockScopes({ scopes: [null, 'buzz:read:self', 7, 'models:read:self'] }, [
+        'buzz:read:self',
+        'models:read:self',
+      ])
+    ).toEqual(['buzz:read:self', 'models:read:self']);
+  });
+
+  // A non-null SCALAR on purpose: `null` alone cannot distinguish the `Array.isArray` guard from a
+  // weaker `(x ?? []).filter(…)`, because `null ?? []` also yields `[]`. A bare string is the
+  // realistic JSON-column mishap AND it makes the weaker shape throw
+  // `.filter is not a function`, so this pins the guard rather than the nullishness.
+  it('returns [] when approvedScopes is a non-array scalar, rather than throwing', () => {
+    expect(
+      effectiveBlockScopes(
+        { scopes: ['buzz:read:self', 'models:read:self'] },
+        'buzz:read:self' as unknown
+      )
+    ).toEqual([]);
+  });
+
+  it('returns [] when manifest.scopes is a non-array scalar, rather than throwing', () => {
+    expect(effectiveBlockScopes({ scopes: 'buzz:read:self' }, ['buzz:read:self'])).toEqual([]);
+  });
+
+  it('returns [] for a missing manifest.scopes, a null manifest, and an undefined manifest', () => {
+    expect(effectiveBlockScopes({}, ['buzz:read:self'])).toEqual([]);
+    expect(effectiveBlockScopes(null, ['buzz:read:self'])).toEqual([]);
+    expect(effectiveBlockScopes(undefined, ['buzz:read:self'])).toEqual([]);
+  });
+
+  it('returns [] for an empty approval even when the manifest declares scopes', () => {
+    expect(effectiveBlockScopes({ scopes: ['models:read:self'] }, [])).toEqual([]);
+  });
+
+  it('returns [] for a null/undefined approval even when the manifest declares scopes', () => {
+    expect(effectiveBlockScopes({ scopes: ['models:read:self'] }, null)).toEqual([]);
+    expect(effectiveBlockScopes({ scopes: ['models:read:self'] }, undefined)).toEqual([]);
+  });
+
+  // Not filtered to the known scope vocabulary — none of the call sites did that, and the mint
+  // applies its own `isKnownBlockScope` filter. An unknown id that IS in both columns passes
+  // through, which is what keeps this a pure consolidation rather than a behaviour change.
+  it('does NOT filter to the known scope vocabulary', () => {
+    expect(effectiveBlockScopes({ scopes: ['not:a:real:scope'] }, ['not:a:real:scope'])).toEqual([
+      'not:a:real:scope',
+    ]);
+  });
+
+  it('never returns the input arrays by reference', () => {
+    const manifestScopes = ['buzz:read:self'];
+    const approved = ['buzz:read:self'];
+    const out = effectiveBlockScopes({ scopes: manifestScopes }, approved);
+    expect(out).not.toBe(manifestScopes);
+    expect(out).not.toBe(approved);
+  });
+});

--- a/src/shared/constants/__tests__/block-effective-scopes.test.ts
+++ b/src/shared/constants/__tests__/block-effective-scopes.test.ts
@@ -4,11 +4,14 @@ import { effectiveBlockScopes } from '~/shared/constants/block-effective-scopes'
 /**
  * `effectiveBlockScopes` — the single shared definition of `manifest.scopes ∩ approved_scopes`.
  *
- * This is the module whose expectations are pinned as LITERALS. The consuming sites are pinned
- * against the helper itself (see `block-effective-scopes.call-sites.test.ts` and the
- * helper-derived assertions in `user-app-surface.orchestration.test.ts`), which is the right split
- * for a consolidation: literals here, identity there. Deriving the helper's OWN expectations from
- * the helper would assert nothing.
+ * This is the module whose expectations are pinned as LITERALS — deriving the helper's OWN
+ * expectations from the helper would assert nothing.
+ *
+ * ⚠️ AN EARLIER REVISION SAID "the consuming sites are pinned against the helper itself". That is
+ * true of exactly ONE of them: `user-app-surface.orchestration.test.ts`'s "agrees with
+ * effectiveBlockScopes on the same inputs (derived, not copied)". The two router sites in
+ * `blocks.router.getInstallConfig.test.ts` are pinned with LITERALS, the same way this file is, and
+ * `block-effective-scopes.call-sites.test.ts` asserts import-and-call structure, not values.
  */
 describe('effectiveBlockScopes', () => {
   // ── THE TWO DIVERGENCE DIRECTIONS. Both are reachable through
@@ -55,9 +58,12 @@ describe('effectiveBlockScopes', () => {
 
   // ── ORDER AND DE-DUPLICATION — observable, because callers render this array as a badge list.
 
-  // 🔴 MANIFEST ORDER, NOT APPROVAL ORDER, AND NOT SORTED. The fixture makes all three answers
-  // distinguishable: manifest order is [c, a, b], approval order is [a, b, c], sorted would be
-  // [a, b, c] as well. Only the manifest-order implementation produces the expectation below.
+  // 🔴 MANIFEST ORDER, NOT APPROVAL ORDER, AND NOT SORTED. Manifest order is [c, a, b] while
+  // approval order and sorted are both [a, b, c] — so the fixture separates manifest order from
+  // the other two answers, and only the manifest-order implementation produces the expectation
+  // below. ⚠️ It does NOT separate approval order from sorted: those two coincide here, and an
+  // earlier revision of this comment claimed "all three answers distinguishable" while showing
+  // the coincidence in the same sentence.
   it('preserves MANIFEST order (distinguishable from approval order and from sorted)', () => {
     expect(
       effectiveBlockScopes(
@@ -135,10 +141,24 @@ describe('effectiveBlockScopes', () => {
     ).toEqual(['buzz:read:self']);
   });
 
-  // A non-null SCALAR on purpose: `null` alone cannot distinguish the `Array.isArray` guard from a
-  // weaker `(x ?? []).filter(…)`, because `null ?? []` also yields `[]`. A bare string is the
-  // realistic JSON-column mishap AND it makes the weaker shape throw
-  // `.filter is not a function`, so this pins the guard rather than the nullishness.
+  // ── `Array.isArray` ON BOTH SIDES. A non-null SCALAR on purpose: `null` alone cannot
+  // distinguish the guard from a weaker `(x ?? []).filter(…)`, because `null ?? []` also yields
+  // `[]`, whereas a scalar makes that weaker shape throw `.filter is not a function`.
+  //
+  // 🔴 BUT A *STRING* SCALAR DOES NOT PIN THE GUARD'S PRESENCE, AND BOTH OF THE NEXT TWO CASES
+  // USED TO CLAIM IT DID ("so this pins the guard rather than the nullishness"). Measured by
+  // removing one `Array.isArray` clause at a time and running this file plus
+  // `user-app-surface.orchestration.test.ts` (79 tests):
+  //   · approved-side clause removed → 79 passed, 0 failed. `new Set('buzz:read:self')` builds a
+  //     Set of single CHARACTERS, no multi-character scope id matches, and the result is `[]`
+  //     either way — so neither string fixture could see it. NOTHING in either suite killed it.
+  //   · manifest-side clause removed → 4 failed, and NOT this case: `for (const scope of
+  //     'buzz:read:self')` iterates characters that match nothing, again `[]`. The tests that
+  //     actually killed it were "returns [] for a missing manifest.scopes, a null manifest, and an
+  //     undefined manifest" (iterating `undefined` throws) and three rows in the seam suite.
+  // So the two string cases pin the OUTPUT CONTRACT for a realistic JSON-column mishap, and they
+  // distinguish the guard from the weaker `(x ?? []).filter(…)` shape. They do NOT pin the clause
+  // against deletion. The NUMBER case below is what does, and it is why it was added.
   it('returns [] when approvedScopes is a non-array scalar, rather than throwing', () => {
     expect(
       effectiveBlockScopes(
@@ -150,6 +170,16 @@ describe('effectiveBlockScopes', () => {
 
   it('returns [] when manifest.scopes is a non-array scalar, rather than throwing', () => {
     expect(effectiveBlockScopes({ scopes: 'buzz:read:self' }, ['buzz:read:self'])).toEqual([]);
+  });
+
+  // 🔴 THE KILLING FIXTURE FOR THE APPROVED-SIDE `Array.isArray` CLAUSE — a NON-ITERABLE scalar.
+  // A number is not iterable, so with the clause gone `new Set(42)` throws
+  // `TypeError: number 42 is not iterable` instead of returning `[]`. That is the one shape a
+  // string cannot produce, which is exactly why every string fixture left the clause alive.
+  // Asserted on the approved side alone so a failure attributes to THAT clause: the manifest-side
+  // clause is already killed by the missing/null/undefined-manifest case above.
+  it('🔴 returns [] for a NON-ITERABLE approvedScopes — the only shape that kills its isArray guard', () => {
+    expect(effectiveBlockScopes({ scopes: ['buzz:read:self'] }, 42 as unknown)).toEqual([]);
   });
 
   it('returns [] for a missing manifest.scopes, a null manifest, and an undefined manifest', () => {

--- a/src/shared/constants/block-effective-scopes.ts
+++ b/src/shared/constants/block-effective-scopes.ts
@@ -19,19 +19,40 @@
  * correct in both.
  *
  * 🔴 THIS IS NOT "WHAT THE MINT WILL ISSUE A TOKEN FOR" — do not re-describe it that way, and
- * note that "THE mint" is itself the ambiguity that produced the false claim. There are TWO
- * scope-sourcing paths in `src/pages/api/v1/block-tokens/index.ts`:
+ * note that "THE mint" is itself the ambiguity that produced the false claim. There are THREE
+ * scope-sourcing sites in `src/pages/api/v1/block-tokens/index.ts`, and none of them computes
+ * this intersection. Each is named by its RESOLVER, because two of the three are author mints
+ * and "the dev-tunnel mint" does not identify either one:
  *
- *   - The PRODUCTION run-token mint (the install/subscription/page path) derives the signed set
- *     from the MANIFEST — `requestedScopes = knownManifestScopes`, the manifest filtered to the
- *     known vocabulary — and uses `approved_scopes` as an ALL-OR-NOTHING VETO
- *     (`outsideApproved.length > 0` → 403), never as a source. It also refuses outright unless
+ *   - `:1054` — the PRODUCTION run-token mint (the install/subscription/page path). Sources the
+ *     MANIFEST: `requestedScopes = knownManifestScopes`, the manifest filtered to the known
+ *     vocabulary. `approved_scopes` is an ALL-OR-NOTHING VETO here
+ *     (`outsideApproved.length > 0` → 403), never a source, and the path refuses outright unless
  *     `status === 'approved'`.
- *   - The DEV-TUNNEL author mint (`resolveDevPageBlockForAuthor`) DOES source from the column:
- *     `clampTunnelDeclaredScopes(app.approvedScopes)`. `block-registry.service.ts`'s sentence
- *     "The mint sources scopes from `approvedScopes` … NEVER the raw manifest" is TRUE, and is
- *     about THIS path — it sits in that path's own docblock. Reading it as a statement about the
- *     production mint is the error; the sentence itself is not wrong.
+ *   - `:469` — the EPHEMERAL dev-tunnel mint, resolved by `resolveDevPageBlockForAuthor`.
+ *     Sources the AUTHOR'S OWN declared scopes: `clampTunnelDeclaredScopes(app.scopes)`. NOT
+ *     `approvedScopes` — that app was never reviewed, so there is no approval to source.
+ *   - `:650` — the OWNED-NON-APPROVED dev-tunnel mint, resolved by
+ *     `resolveOwnedNonApprovedPageBlock`. Sources the column:
+ *     `clampTunnelDeclaredScopes(app.approvedScopes)`. This is the ONLY one of the three that
+ *     reads `approvedScopes` as its scope source.
+ *
+ * `block-registry.service.ts`'s sentence "The mint sources scopes from `approvedScopes` … NEVER
+ * the raw manifest" is TRUE of `:650` ONLY. It sits at
+ * `src/server/services/block-registry.service.ts:329`, in the docblock of
+ * `OwnedNonApprovedPageBlockResolution` — that path's own type, not the ephemeral path's and not
+ * the production path's. Reading it as a statement about either of those is the error; the
+ * sentence itself is not wrong.
+ *
+ * 🔴 WHY THE ATTRIBUTION MATTERS, AND THE ONE THING NOT TO TRANSPLANT.
+ * `block-tokens/index.ts:640-650` carries a LOAD-BEARING SPEND-SAFETY INVARIANT stated in terms
+ * of the column — `approvedScopes` non-empty ⟹ the app was moderator-approved at some point, so
+ * `clampTunnelDeclaredScopes([])` cannot invent `ai:write:budgeted` for a never-approved app.
+ * That argument is written at, and is about, `:650`. It CANNOT be carried over to `:469`, which
+ * does not read the column at all. What `:469`'s own spend safety rests on is NOT established
+ * here and was not measured — do not infer it from `:650`'s comment, and do not write one in.
+ * Read `:455-480` (the resolver call passes `unsubmittedSpendAllowed`, and `resolveDevBuzzBudget`
+ * is called on the clamp's output) if you need the answer.
  *
  * The production signed set is narrower than this function's result in any case:
  * `manifest ∩ known-vocabulary ∩ approved ∩ per-user-grant ∩ anon/page rules`. This function
@@ -68,17 +89,50 @@ export type BlockScopeManifestInput = { scopes?: unknown } | null | undefined;
  *     (`getInstallConfig` and `recordInstallConsent` both `filter` the manifest array), and
  *     what the mint uses (`requestedScopes = knownManifestScopes`). Adopting it is what makes
  *     every site agree; sorting would have changed three sites to suit one.
- *   - **De-duplicated, first occurrence wins.** A repeated scope would render a duplicate
- *     React `key` on the same badge list. The pre-existing sites did NOT de-duplicate; this
- *     is the one deliberate behaviour change of the consolidation, and it is a no-op for
- *     every current consumer (a `Set` ceiling, a `recordScopeGrant` that unions, and a
- *     manifest the validator already rejects duplicates in).
+ *   - **De-duplicated, first occurrence wins.** The pre-existing sites did NOT de-duplicate, so
+ *     this is the one deliberate behaviour change of the consolidation — and it is a real FIX,
+ *     not a no-op, because a duplicate IS reachable:
+ *       · `BlockManifestValidator.validate` ACCEPTS a duplicated scope. Measured:
+ *         `scopes: ['models:read:self','models:read:self']` returns `{valid:true}`, against a
+ *         negative control (`scopes:['models:read:all']` → `{valid:false}`) proving the
+ *         validator can reject. `block-manifest-validator.service.ts:478-496` is a per-element
+ *         loop with no uniqueness check, and `public/schemas/app-block/v1.json`
+ *         `properties.scopes` declares no `uniqueItems`.
+ *       · So pre-change `getInstallConfig` could return `['x','x']`, and that array reaches
+ *         `src/components/Apps/AppSettingsModal.tsx` (`declaredScopes = installConfig?.scopes`)
+ *         → `src/components/Apps/BlockScopeList.tsx`, which renders one `<Group key={scope}>`
+ *         per element — i.e. two siblings with the SAME React key.
+ *     Two consumers would have absorbed the duplicate anyway — `grantScopes` puts the result in
+ *     a `new Set` ceiling (`src/server/routers/blocks.router.ts:2786-2788`) and
+ *     `recordScopeGrant` de-dups its own input
+ *     (`src/server/services/blocks/scope-grant.service.ts:221-223`) — but the RENDER path had no
+ *     such absorber, which is what makes de-duplicating here load-bearing rather than cosmetic.
  *
  * Both arguments are treated as untrusted JSON/DB values: a non-array on either side yields
- * `[]` rather than throwing, and non-string elements are dropped. That is deliberate even
- * though Prisma types `approvedScopes` as `string[]` — the approve paths write
+ * `[]` rather than throwing, and a non-string element never reaches the output. That is
+ * deliberate even though Prisma types `approvedScopes` as `string[]` — the approve paths write
  * `manifest.scopes as string[]`, a bare cast with no per-element check, so a malformed
  * manifest can put a non-string into the column.
+ *
+ * 🔴 THERE IS EXACTLY ONE NON-STRING GUARD, AND THAT IS A DELIBERATE REDUCTION FROM TWO.
+ * An earlier revision also filtered the APPROVED side to strings before building the Set. That
+ * filter could not change this function's output for ANY input, and the test titled "drops
+ * non-string elements on the APPROVED side" could not reach it. Measured, with the fixture
+ * `effectiveBlockScopes({scopes:[42,'buzz:read:self']}, [42,'buzz:read:self'])`:
+ *
+ *   | variant                                   | result                      |
+ *   | both guards present                       | `['buzz:read:self']`        |
+ *   | approved-side filter deleted only         | `['buzz:read:self']`        |
+ *   | manifest-side `typeof` guard deleted only | `['buzz:read:self']`        |
+ *   | BOTH deleted                              | `[42,'buzz:read:self']` ← leak |
+ *
+ * The two were MUTUALLY REDUNDANT: a non-string in the approved Set is unmatchable because the
+ * only values tested against it are strings, and a non-string manifest entry is unmatchable
+ * because the Set held only strings. So neither could be killed alone and each made the other
+ * untestable. Keeping the loop guard (it is the one standing between the column and `out.push`)
+ * and dropping the filter leaves a SINGLE guard that the fixture above kills on its own — i.e. a
+ * guard proven reachable, not merely breakable. Do not re-add the approved-side filter without a
+ * fixture that fails when ONLY that filter is removed; there is no such input.
  *
  * NOT filtered to the known scope vocabulary (`isKnownBlockScope`). None of the call sites
  * did that, and adding it here would silently change what they enforce and disclose; the
@@ -90,10 +144,16 @@ export function effectiveBlockScopes(
 ): string[] {
   const declared = (manifest ?? {}).scopes;
   if (!Array.isArray(declared) || !Array.isArray(approvedScopes)) return [];
-  const approved = new Set(approvedScopes.filter((s): s is string => typeof s === 'string'));
+  // NOT filtered to strings — see "EXACTLY ONE NON-STRING GUARD" above. A non-string in this
+  // Set is unmatchable, because the only values tested against it are the strings that clear
+  // the guard in the loop.
+  const approved = new Set<unknown>(approvedScopes);
   const seen = new Set<string>();
   const out: string[] = [];
   for (const scope of declared) {
+    // 🔴 THE non-string guard. Removing it leaks a non-string into `out` whenever the SAME
+    // non-string also sits in the column — pinned by the both-sides fixture in
+    // `block-effective-scopes.test.ts`. Do not delete on the strength of the `string[]` type.
     if (typeof scope !== 'string') continue;
     if (!approved.has(scope) || seen.has(scope)) continue;
     seen.add(scope);

--- a/src/shared/constants/block-effective-scopes.ts
+++ b/src/shared/constants/block-effective-scopes.ts
@@ -21,8 +21,11 @@
  * 🔴 THIS IS NOT "WHAT THE MINT WILL ISSUE A TOKEN FOR" — do not re-describe it that way, and
  * note that "THE mint" is itself the ambiguity that produced the false claim. There are THREE
  * scope-sourcing sites in `src/pages/api/v1/block-tokens/index.ts`, and none of them computes
- * this intersection. Each is named by its RESOLVER, because two of the three are author mints
- * and "the dev-tunnel mint" does not identify either one:
+ * this intersection. The two DEV-TUNNEL sites are each named by their RESOLVER, because both are
+ * author mints and "the dev-tunnel mint" does not identify either one. The production site is
+ * named by ROLE instead, because it has no single resolver: `BlockRegistry.resolvePageBlock`
+ * (`:835`, the page shape) and `BlockRegistry.resolveBlockInstance` (`:908`, the
+ * install/subscription shape) both converge on the one scope-sourcing line at `:1054`.
  *
  *   - `:1054` — the PRODUCTION run-token mint (the install/subscription/page path). Sources the
  *     MANIFEST: `requestedScopes = knownManifestScopes`, the manifest filtered to the known
@@ -49,10 +52,24 @@
  * of the column — `approvedScopes` non-empty ⟹ the app was moderator-approved at some point, so
  * `clampTunnelDeclaredScopes([])` cannot invent `ai:write:budgeted` for a never-approved app.
  * That argument is written at, and is about, `:650`. It CANNOT be carried over to `:469`, which
- * does not read the column at all. What `:469`'s own spend safety rests on is NOT established
- * here and was not measured — do not infer it from `:650`'s comment, and do not write one in.
- * Read `:455-480` (the resolver call passes `unsubmittedSpendAllowed`, and `resolveDevBuzzBudget`
- * is called on the clamp's output) if you need the answer.
+ * does not read the column at all — do not infer `:469`'s spend safety from `:650`'s comment.
+ *
+ * ⚠️ AN EARLIER REVISION ADDED "What `:469`'s own spend safety rests on is NOT established here",
+ * and a restatement of it dropped the "here" — which read as an open question and invited the next
+ * reader to answer it in. It IS established, in two places, both read rather than inferred:
+ *   - `src/pages/api/v1/block-tokens/index.ts:375-389` — the `resolveDevPageBlockForAuthor` branch's
+ *     own docblock. SPEND CONTAINMENT (`:375-382`): the token is self-bound (`sub` = the session
+ *     user), so `submitWorkflow` spends the AUTHOR's OWN Buzz, gated by
+ *     `assertViewerIsAppDeveloper(sub)` plus the per-call (`DEV_BUZZ_BUDGET_CAP`) / per-session /
+ *     per-day caps. SCOPE SOURCE (`:383-389`): real spend on a brand-new, never-reviewed app is
+ *     additionally gated by the `app-blocks-dev-tunnel-unsubmitted-spend` flag.
+ *   - `src/server/services/block-registry.service.ts:2117-2119` — where that flag gate actually
+ *     bites: `if (!opts?.unsubmittedSpendAllowed) ephemeralScopes = ephemeralScopes.filter((s) =>
+ *     s !== 'ai:write:budgeted')`. ⚠️ It sits in the `else` (BRAND-NEW) branch only. The PENDING
+ *     branch (`:2104-2114`) applies no such strip, so for an author's own pending submission the
+ *     caps-and-author-flag argument above is the whole of it.
+ * `:455-480` is the call side of the same thing (the resolver call at `:455-459` passes
+ * `unsubmittedSpendAllowed`; `resolveDevBuzzBudget` runs on the clamp's output at `:470`).
  *
  * The production signed set is narrower than this function's result in any case:
  * `manifest ∩ known-vocabulary ∩ approved ∩ per-user-grant ∩ anon/page rules`. This function
@@ -103,9 +120,9 @@ export type BlockScopeManifestInput = { scopes?: unknown } | null | undefined;
  *         → `src/components/Apps/BlockScopeList.tsx`, which renders one `<Group key={scope}>`
  *         per element — i.e. two siblings with the SAME React key.
  *     Two consumers would have absorbed the duplicate anyway — `grantScopes` puts the result in
- *     a `new Set` ceiling (`src/server/routers/blocks.router.ts:2786-2788`) and
+ *     a `new Set` ceiling (`src/server/routers/blocks.router.ts:2787-2789`) and
  *     `recordScopeGrant` de-dups its own input
- *     (`src/server/services/blocks/scope-grant.service.ts:221-223`) — but the RENDER path had no
+ *     (`src/server/services/blocks/scope-grant.service.ts:222-224`) — but the RENDER path had no
  *     such absorber, which is what makes de-duplicating here load-bearing rather than cosmetic.
  *
  * Both arguments are treated as untrusted JSON/DB values: a non-array on either side yields
@@ -132,7 +149,12 @@ export type BlockScopeManifestInput = { scopes?: unknown } | null | undefined;
  * untestable. Keeping the loop guard (it is the one standing between the column and `out.push`)
  * and dropping the filter leaves a SINGLE guard that the fixture above kills on its own — i.e. a
  * guard proven reachable, not merely breakable. Do not re-add the approved-side filter without a
- * fixture that fails when ONLY that filter is removed; there is no such input.
+ * fixture that fails when ONLY that filter is removed. ⚠️ An earlier revision said flatly "there
+ * is no such input"; that absolute is wrong. A hand-built `Proxy` whose reads differ between the
+ * `filter` pass and the `new Set` pass can make the filtered Set LACK a value the unfiltered one
+ * holds, so it distinguishes them — and it WIDENS rather than narrows. It is also unreachable from
+ * Prisma or `JSON.parse`, which only ever produce plain arrays, so the operative advice is
+ * unchanged: no plain-array input distinguishes them.
  *
  * NOT filtered to the known scope vocabulary (`isKnownBlockScope`). None of the call sites
  * did that, and adding it here would silently change what they enforce and disclose; the
@@ -143,6 +165,14 @@ export function effectiveBlockScopes(
   approvedScopes: unknown
 ): string[] {
   const declared = (manifest ?? {}).scopes;
+  // 🔴 EACH CLAUSE IS KILLED BY A DIFFERENT FIXTURE, AND NEITHER BY A STRING SCALAR. Measured:
+  // the `declared` clause fails "returns [] for a missing manifest.scopes, a null manifest, and an
+  // undefined manifest" (iterating `undefined` throws); the `approvedScopes` clause fails ONLY the
+  // NON-ITERABLE case, `effectiveBlockScopes({scopes:['buzz:read:self']}, 42)` → `TypeError: number
+  // 42 is not iterable`. A string scalar kills NEITHER — `new Set('buzz:read:self')` and
+  // `for (const s of 'buzz:read:self')` both iterate single CHARACTERS that match no scope id, so
+  // the result is `[]` with or without the clause. Both fixtures are in
+  // `src/shared/constants/__tests__/block-effective-scopes.test.ts`.
   if (!Array.isArray(declared) || !Array.isArray(approvedScopes)) return [];
   // NOT filtered to strings — see "EXACTLY ONE NON-STRING GUARD" above. A non-string in this
   // Set is unmatchable, because the only values tested against it are the strings that clear

--- a/src/shared/constants/block-effective-scopes.ts
+++ b/src/shared/constants/block-effective-scopes.ts
@@ -1,0 +1,103 @@
+/**
+ * The EFFECTIVE scope set of an App Block: `manifest.scopes ∩ approved_scopes`.
+ *
+ * 🔴 WHY AN INTERSECTION AND NOT EITHER COLUMN ALONE. The two columns diverge in BOTH
+ * directions, so neither one alone describes what the app can do:
+ *
+ *   - `manifest.scopes` is the developer's DECLARATION. It is replaced on every publisher
+ *     push — `src/pages/api/v1/developer/block-manifests.ts` updates `manifest` + `version`
+ *     and sets `status: 'pending'` WITHOUT touching `approved_scopes`.
+ *   - `approved_scopes` is the moderator-reviewed SNAPSHOT. The three approve paths in
+ *     `src/server/services/blocks/publish-request.service.ts` write it as
+ *     `approvedScopes = manifestScopes` — the manifest's own array, verbatim — and that
+ *     flow is the only writer.
+ *
+ * So a v2 manifest that ADDS a scope gives `manifest ⊋ approved` (the approval is stale and
+ * narrower), and a v2 manifest that DROPS one gives `manifest ⊊ approved` (the approval is
+ * stale and WIDER, naming a scope the current manifest no longer requests). Showing or
+ * enforcing either column alone is wrong in one of those two rows; the intersection is
+ * correct in both.
+ *
+ * 🔴 THIS IS NOT "WHAT THE MINT WILL ISSUE A TOKEN FOR" — do not re-describe it that way, and
+ * note that "THE mint" is itself the ambiguity that produced the false claim. There are TWO
+ * scope-sourcing paths in `src/pages/api/v1/block-tokens/index.ts`:
+ *
+ *   - The PRODUCTION run-token mint (the install/subscription/page path) derives the signed set
+ *     from the MANIFEST — `requestedScopes = knownManifestScopes`, the manifest filtered to the
+ *     known vocabulary — and uses `approved_scopes` as an ALL-OR-NOTHING VETO
+ *     (`outsideApproved.length > 0` → 403), never as a source. It also refuses outright unless
+ *     `status === 'approved'`.
+ *   - The DEV-TUNNEL author mint (`resolveDevPageBlockForAuthor`) DOES source from the column:
+ *     `clampTunnelDeclaredScopes(app.approvedScopes)`. `block-registry.service.ts`'s sentence
+ *     "The mint sources scopes from `approvedScopes` … NEVER the raw manifest" is TRUE, and is
+ *     about THIS path — it sits in that path's own docblock. Reading it as a statement about the
+ *     production mint is the error; the sentence itself is not wrong.
+ *
+ * The production signed set is narrower than this function's result in any case:
+ * `manifest ∩ known-vocabulary ∩ approved ∩ per-user-grant ∩ anon/page rules`. This function
+ * computes the first and third terms only, so the honest claim is "the scopes this app may be
+ * granted and exercised with", NOT "the scopes a token will carry".
+ *
+ * 🔴 THERE IS NO PER-SCOPE MODERATOR NARROWING MECHANISM. An earlier generation of comments
+ * at several call sites claimed `approved_scopes` was a moderator-narrowed subset of the
+ * manifest. It is not — see the verbatim write above. The only skew is the publisher-push
+ * path. `src/server/services/blocks/app-listing.service.ts` carries the same retraction for
+ * its own (deliberately NON-intersected) public pre-launch disclosure.
+ *
+ * 🔴 DEPENDENCY-FREE LEAF MODULE, DELIBERATELY. It must not live on a service module:
+ * `src/server/routers/blocks.router.ts` reaches
+ * `src/server/services/blocks/user-app-surface.service.ts` ONLY through `await import(...)`,
+ * never a static import, and a single eager import of that service would make every one of
+ * those call sites inert and break the one-key `vi.mock` factories in the router suites.
+ * (Deliberately no count here — a count in a comment goes stale; the call sites are asserted
+ * in `src/shared/constants/__tests__/block-effective-scopes.call-sites.test.ts`.) Keep this
+ * file free of runtime imports.
+ */
+
+/** A manifest as it comes off the JSON column — shape is not a runtime guarantee. */
+export type BlockScopeManifestInput = { scopes?: unknown } | null | undefined;
+
+/**
+ * `manifest.scopes ∩ approvedScopes`, de-duplicated, in MANIFEST ORDER.
+ *
+ * 🔴 ORDER AND DE-DUPLICATION ARE OBSERVABLE — the permissions tab and the install modal
+ * both render this array as a list of badges, so both are part of the contract and are
+ * pinned by tests rather than left to chance:
+ *
+ *   - **Manifest order.** It is what the two pre-existing open-coded sites already produced
+ *     (`getInstallConfig` and `recordInstallConsent` both `filter` the manifest array), and
+ *     what the mint uses (`requestedScopes = knownManifestScopes`). Adopting it is what makes
+ *     every site agree; sorting would have changed three sites to suit one.
+ *   - **De-duplicated, first occurrence wins.** A repeated scope would render a duplicate
+ *     React `key` on the same badge list. The pre-existing sites did NOT de-duplicate; this
+ *     is the one deliberate behaviour change of the consolidation, and it is a no-op for
+ *     every current consumer (a `Set` ceiling, a `recordScopeGrant` that unions, and a
+ *     manifest the validator already rejects duplicates in).
+ *
+ * Both arguments are treated as untrusted JSON/DB values: a non-array on either side yields
+ * `[]` rather than throwing, and non-string elements are dropped. That is deliberate even
+ * though Prisma types `approvedScopes` as `string[]` — the approve paths write
+ * `manifest.scopes as string[]`, a bare cast with no per-element check, so a malformed
+ * manifest can put a non-string into the column.
+ *
+ * NOT filtered to the known scope vocabulary (`isKnownBlockScope`). None of the call sites
+ * did that, and adding it here would silently change what they enforce and disclose; the
+ * mint applies that filter itself.
+ */
+export function effectiveBlockScopes(
+  manifest: BlockScopeManifestInput,
+  approvedScopes: unknown
+): string[] {
+  const declared = (manifest ?? {}).scopes;
+  if (!Array.isArray(declared) || !Array.isArray(approvedScopes)) return [];
+  const approved = new Set(approvedScopes.filter((s): s is string => typeof s === 'string'));
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const scope of declared) {
+    if (typeof scope !== 'string') continue;
+    if (!approved.has(scope) || seen.has(scope)) continue;
+    seen.add(scope);
+    out.push(scope);
+  }
+  return out;
+}


### PR DESCRIPTION
> ⚠️ **This body was last corrected at `1238337e3b` — the SECOND correction, and the second correction was needed because the first replaced a false claim with a differently-false one.** The behaviour changed (it displayed `approvedScopes`; it now displays the **intersection**). The rewrite at `a70b19fac2` fixed four false claims but introduced a mint table whose two dev-tunnel **resolvers were swapped**, and asserted the de-dup was a no-op because *"the validator rejects duplicates"* — which is false, measured. Both are corrected here, and the claim that three of four call sites had behavioural coverage is corrected to **two** (now three, after this round added the missing tests). Corrections are recorded in [the round-1 comment](https://github.com/civitai/civitai/pull/4790#issuecomment-5643739721) and the round-2 claims comment, so the timeline shows what a reviewer may already have read and believed. Do not review this body in isolation.

## What changed

`listMyScopeGrants` (`src/server/services/blocks/user-app-surface.service.ts`) displayed `manifest.scopes` — the dev's stated wishlist — falling back to `approvedScopes`. It now displays **`manifest.scopes ∩ approvedScopes`**, computed by a new shared helper that also replaces the three places this rule was already open-coded.

**Neither column alone is correct.** `src/pages/api/v1/developer/block-manifests.ts` replaces `manifest` + `version` and sets `status: 'pending'` **without touching `approved_scopes`**, and this query has **no status filter** — so a pending-v2 app still renders, and the two columns diverge in both directions:

| v2 manifest | relation | show `manifest` | show `approvedScopes` | show **∩** |
|---|---|---|---|---|
| **adds** a scope | `manifest ⊋ approved` | ❌ over-reports | ✅ | ✅ |
| **drops** a scope | `manifest ⊊ approved` | ✅ | ❌ over-reports a scope the manifest no longer requests | ✅ |

The intersection is the only set correct in both rows. Row 2 is why this PR's own earlier approach was wrong: it fixed row 1 and introduced row 2 — a **new** over-report in exactly the direction the PR exists to remove.

**Explicitly not `granted_scopes`.** That is only the consent-gated subset, so it **under-reports** by omitting every `CONSENT_EXEMPT_SCOPES` entry a token really carries.

### 🔴 What this set is NOT

It is **not** "what the mint will issue a token for." There are **three** scope-sourcing sites in `src/pages/api/v1/block-tokens/index.ts`, and none of them computes this intersection. Conflating them produced this PR's original false rationale — and the **previous revision of this very table had only two rows with the two dev-tunnel resolvers SWAPPED**, which is worse than vague, because the spend-safety invariant at `block-tokens/index.ts:640-650` belongs to exactly one of them:

| site | resolver | scope source |
|---|---|---|
| `:1054` **production run-token mint** (install / subscription / page) | — | `requestedScopes = knownManifestScopes` — the **MANIFEST**, filtered to the known vocabulary. `approvedScopes` is an **all-or-nothing veto** (`outsideApproved.length > 0` → 403), never a source. |
| `:469` **ephemeral dev-tunnel mint** | `resolveDevPageBlockForAuthor` | `clampTunnelDeclaredScopes(app.scopes)` — the **author's own declared manifest**. **NOT** `approvedScopes`: that app was never reviewed, so there is no approval to source. |
| `:650` **owned-non-approved dev-tunnel mint** | `resolveOwnedNonApprovedPageBlock` | `clampTunnelDeclaredScopes(app.approvedScopes)` — **the only one of the three that sources the column.** |

`block-registry.service.ts`'s *"The mint sources scopes from `approvedScopes` … NEVER the raw manifest"* is true of **`:650` only**. It sits at `src/server/services/block-registry.service.ts:329`, in the docblock of **`OwnedNonApprovedPageBlockResolution`** — that path's own type, not the ephemeral path's. **"The dev-tunnel author mint" does not identify it**, since `:469` and `:650` are both author mints; every corrected comment now names the resolver instead.

🔴 **Why the attribution is load-bearing.** `block-tokens/index.ts:640-650` states its spend safety in terms of the column — `approvedScopes` non-empty ⟹ the app was moderator-approved at some point, so `clampTunnelDeclaredScopes([])` cannot invent `ai:write:budgeted` for a never-approved app. That argument is written at, and is about, **`:650`**. A reader holding the two paths swapped attaches it to `:469`, which never reads the column at all. **What `:469`'s own spend safety rests on is NOT established by this PR and was not measured** — the comments say exactly that, and point at `:455-480`, rather than supplying a reason.

Apps on this tab use the production path, whose effective signed set is `manifest ∩ known-vocabulary ∩ approved ∩ per-user-grant ∩ anon/page rules` — and which refuses entirely unless `status === 'approved'`, something this unfiltered list does not require. So the honest claim, used throughout the new comments, is the narrower one: **the scopes the app may be granted and exercised with.**

## Consolidation, not a fourth variant

`manifest ∩ approvedScopes` was **already open-coded at three sites**. It now lives once, in a dependency-free leaf module `src/shared/constants/block-effective-scopes.ts`, with **four** call sites:

| call site | use |
|---|---|
| `blocks.router.ts` → `grantScopes` | the consent ceiling |
| `blocks.router.ts` → `getInstallConfig` | install-time disclosure |
| `block-registry.service.ts` → `BlockRegistry.recordInstallConsent` | which scopes to grant |
| `user-app-surface.service.ts` → `listMyScopeGrants` | **the permissions tab (new)** |

🔴 **A leaf module deliberately.** `blocks.router.ts` reaches `user-app-surface.service` only through `await import(...)`; exporting the helper from that service would have made every one of those lazy imports inert. The helper has **no runtime imports**.

**Order / de-duplication (observable — the tab renders this as a badge list): manifest order, de-duplicated, first occurrence wins.** Manifest order is what two of the three pre-existing sites already produced and what the production mint uses, so adopting it makes all four agree; sorting would have changed three sites to suit one. Both legs are pinned, and a sorted-output mutant confirms the order leg is pinned independently of membership.

🔴 **De-duplication is the one deliberate behaviour change, and the previous body's reason for calling it a no-op — *"a manifest whose validator rejects duplicates"* — is FALSE, measured.** `BlockManifestValidator.validate` **accepts** a duplicated scope: `scopes: ['models:read:self','models:read:self']` → `{"valid":true}`, against a negative control (`['models:read:all']` → `{"valid":false}`) proving the validator can reject. `block-manifest-validator.service.ts:478-496` is a per-element loop with no uniqueness check, and `public/schemas/app-block/v1.json` `properties.scopes` declares no `uniqueItems`. **So a duplicate is reachable and the de-dup is a real fix, not a no-op:** pre-change `getInstallConfig` could return `['x','x']`, which reaches `AppSettingsModal` (`declaredScopes = installConfig?.scopes`) → `BlockScopeList`, rendering two `<Group key={scope}>` siblings with the **same React key**. The two *other* consumers would have absorbed it (`grantScopes`' `new Set` ceiling; `recordScopeGrant` de-dups its own input) — the **render** path had no absorber, which is what makes this load-bearing rather than cosmetic.

### Three things the consolidation found

1. 🔴 **Three sites, not two** — the third was `recordInstallConsent`, now wired in.
2. 🔴 **`getInstallConfig`'s comment claimed `getAppDetail`/`scopesSummary` expose the same ceiling. They do not** — those and the app-listing detail DTO project **raw `approved_scopes`, no intersection**. That is deliberate for a *public* pre-launch disclosure (over-disclosing the stale approval is the safe direction; see `src/server/services/blocks/app-listing.service.ts`). Left alone; the comment now says so.
3. 🔴 **`BlockScopeList`'s *"so the two surfaces never drift"* could not be rescued, so it was deleted rather than rewritten.** Measured: **four** call sites fed from **three** sets — the two permissions surfaces (∩), `AppSettingsModal` (`installConfig?.scopes ?? manifest.scopes ?? []`, which **falls back to the raw manifest** on the Manage path before `getInstallConfig` resolves — pre-existing, unchanged), and `AppListingDetailBody` (raw `approved_scopes`, by design).

## False claims retracted, not reworded

Fixing false comments is part of this PR's purpose, and the PR itself shipped some. Each is stated as having **no** remaining justification rather than given a fresh one:

- **the mint-sourcing model — corrected TWICE.** §"What this set is NOT" now lists **three** sites named by **resolver**, because the round-1 replacement named only two and had them swapped. Corrected at four sites, not three: the helper docblock, `user-app-surface.service.ts`, `AppPermissionsActivityDrawer.tsx`, the orchestration test — **plus `blocks.router.getInstallConfig.test.ts`, which the round-1 sweep missed entirely** (it called the intersection *"the mint ceiling"* and claimed it *"mirrors … `getAppDetail`'s approved-only projection"*, the very claim §"Three things the consolidation found" item 2 had already retracted in the router);
- **the moderator-narrowing rationale — DELETED.** There is no per-scope narrowing mechanism: all three approve paths in `publish-request.service.ts` write `approvedScopes = manifestScopes` **verbatim**, and that file's own comment states those three are the only writers. The new comments **cross-reference the existing ⚠ retraction** in `app-listing.service.ts` rather than re-deriving it. 🔴 **The round-1 sweep left it alive in the suite cited as the intersection's own coverage**: `blocks.router.getInstallConfig.test.ts`'s test *title* read *"drops mod-narrowed/unapproved scopes"* and its fixture comment read *"The moderator narrowed approval to a subset"* — while the same commit wrote *"AN EARLIER REVISION … CALLED THE CEILING 'mod-narrowed'"* in the router, i.e. the exact phrase was in hand and never grepped for. Both are fixed, and a repo-wide sweep over **6313** files for `mod-narrow` / `mod_narrow` / `moderator narrow` / `moderator-narrow` / `mod narrowed` now returns **only the retractions themselves** plus the unrelated `contest-score` domain (positive control on the same pipeline: 33 files contain `approvedScopes`);
- **"`approvedScopes` is replaced exactly as `manifest` is"** — false on the publisher-push path;
- **all mintability claims** — dropped; the mint also requires `status === 'approved'`;
- **`src/pages/apps/activity.tsx`'s *"`spendScopeGranted` is the grant row, not the manifest"*** — the sibling the drawer's earlier correction missed. Found by grepping the field across consumers, not by hand-count; `activity.tsx:415`'s "a moderator narrows its approved set" was corrected in the same sweep.

## Tests

`src/shared/constants/__tests__/block-effective-scopes.test.ts` (new) pins the helper with **literal** expectations; the consuming sites are pinned against the **helper itself**. That split is the point of a consolidation — a "mirrors X" guard asserted against a hand-written copy on each side pins nothing.

- **Both divergence directions** as regression tests, plus a **partial-overlap** case (neither side contains the other), which is what separates a real intersection from "whichever column is shorter".
- **An order pin** whose fixture distinguishes manifest order from approval order *and* from sorted.
- **A helper-derived identity assertion** in the orchestration suite (expectation computed by calling the shared symbol, with a guard against it vacuously returning `[]`).
- **🔴 NEW: behavioural coverage for the `grantScopes` consent ceiling** — `blocks.router.getInstallConfig.test.ts` → *"the approved-scope consent ceiling"*. This is the one site that decides what a user can **consent to** and it had none (see §"Not verified"). Two cases under `manifest ⊋ approved`: a declared-but-unapproved scope is dropped from both the response **and** the persisted `grantedScopes`, and an all-unapproved request is refused with the call site's **literal** error message — a string that appeared in no test file before this round.
- **A growth-and-shrink call-site ledger** (`block-effective-scopes.call-sites.test.ts`) asserting the exact set of production importers — this half **is** structural — plus a re-open-coding tripwire, with **positive and negative controls**, since "0 offenders" from a probe wired to nothing is indistinguishable from a real pass.
  - 🔴 **The tripwire is a SPELLING check and its docstring now says so.** The old regex `/new Set\(\s*…approvedScopes/i` caught only the shape the three old sites used; `manifestScopes.filter((s) => block.approvedScopes.includes(s))` **walked straight past it** (verified: old regex `false`, on both the bare and the `?? []` form), while the docstring claimed it noticed "someone re-deriving the rule locally". The `.includes()` spelling is now a second pattern with **its own positive control**, and the docstring + test title are narrowed to the two spellings they actually pin, explicitly disclaiming structural coverage. Reachability proved through the real gate, not just the controls: planting the `.includes()` shape in a ledgered module fails the test and names the file.
- **🔴 The two non-string guards were UNKILLABLE, and one has been DELETED rather than re-certified.** The previous round added an approved-side `typeof` filter and pinned it with a test that could not reach it. Measured on the fixture `effectiveBlockScopes({scopes:[42,'buzz:read:self']}, [42,'buzz:read:self'])`:

  | variant | result |
  |---|---|
  | both guards present | `['buzz:read:self']` |
  | approved-side filter deleted **only** | `['buzz:read:self']` |
  | manifest-side `typeof` guard deleted **only** | `['buzz:read:self']` |
  | **both** deleted | `[42,'buzz:read:self']` ← leak |

  They were **mutually redundant** — a non-string in the approved `Set` is unmatchable because only strings are tested against it, and a non-string manifest entry is unmatchable because the `Set` held only strings — so neither could be killed alone and each made the other untestable (each deletion left the suite at 16/16, identical to HEAD; so did deleting both, because no fixture carried the same non-string on both sides). **The approved-side filter is removed and the loop guard kept** (it is the one standing between the column and `out.push`), leaving a **single** guard that one new fixture kills on its own — a guard proven *reachable*, not merely breakable. Verified: deleting it fails the new case on its own assertion, `expected [ 42, 'buzz:read:self' ] to deeply equal [ 'buzz:read:self' ]` (1 failed / 16 passed), and the same holds at the service seam in the orchestration suite (1 failed / 61 passed).
- **Re-labelled, not counted as regression coverage:** the one-sided malformed-array and non-array `approvedScopes` cases. Their earlier annotation claimed the first was *"attributable to the approved-side handling"*; it is not — a one-sided non-string passes whether or not any filtering happens. They now claim only the **output contract**, and the comments point at the both-columns case as the guard-level pin.

### 🔴 Mutation resistance — the old claim was measurably false

The previous body and test comment claimed *"values are pairwise distinct and distinct from the constant the assertion names, so a mutant hardcoding a literal cannot survive."* **False:** `'buzz:read:self'` was also a manifest element, so `const displayedScopes = ['buzz:read:self']` **passed**. The claim is unachievable for any single-row equality assertion.

It now rides on a **two-row fixture with disjoint expected intersections** — the set is computed per row in a loop, so no single literal satisfies both. **Measured** (each mutant confirmed to have executed — 61 tests, not an import cascade):

| mutant | failed | kills the two-row test |
|---|---|---|
| `['buzz:read:self']` *(used to survive)* | 8 | ✅ |
| `['models:read:self']` | 11 | ✅ |
| `['collections:read:private']` | 11 | ✅ |
| raw `approved_scopes` | 5 | ✅ |
| raw `manifest.scopes` | 7 | ✅ |
| sorted, same membership | 2 | — (kills the order pin, by design) |
| positive control `[]` | 8 | ✅ |

⚠️ `['buzz:read:self']` **still passes** the `manifest ⊋ approved` test, whose expected value *is* `['buzz:read:self']`. That is why the claim was moved rather than restated there.

### Red at base, green at HEAD — re-derived, the old matrix was stale

The earlier **`3 failed | 52 passed (55)`** was never re-run after the second commit added the two guard tests. Re-measured from scratch:

| tree | orchestration suite | all three suites |
|---|---|---|
| `origin/main`'s service | 7 failed \| 54 passed (61) | **10 failed \| 72 passed (82)** |
| **`3fce28aaeb`** (previous head) | 5 failed \| 56 passed (61) | **8 failed \| 74 passed (82)** |
| `a70b19fac2` (previous head) | 61 passed | **98 passed (98)** *(incl. `blocks.router.getInstallConfig`)* |
| **this round** | 62 passed | **102 passed (102)** *(+4: the both-columns guard case, its orchestration-seam mirror, and the two `grantScopes` ceiling cases)* |

🔴 **Red at `3fce28aaeb`, not merely at `origin/main`** — the new defect is one this PR introduced, so that is the matrix that matters. Failures there: `manifest ⊊ approved`, `partial overlap`, `two apps in one read`, `preserves MANIFEST order`, `agrees with effectiveBlockScopes`. `manifest ⊋ approved` is **green** at `3fce28aaeb` (the PR already handled that direction) and is labelled as such, not counted as a regression test against the old head. Full assertion output is in the [correction comment](https://github.com/civitai/civitai/pull/4790#issuecomment-5643739721).

## Verification

- **`253 files / 5682 tests passed`** across `src/server/routers/__tests__`, `src/server/services/blocks/__tests__`, `src/shared/constants/__tests__`, on the final tree — `5678` before this round, `+4` being the new cases. No collateral damage. ⚠️ **The first two runs of that sweep were COLD and lied**: run 1 reported `199 files failed | 2146 passed` with **0 tests failed** (the tell), run 2 `39 failed | 4051 passed`, run 3 `253 passed | 5682 passed`. Cause is the shared optimized-deps cache — this worktree's `node_modules` is a symlink into the primary clone, so a wide multi-directory run flaps until warm. Every decisive mutant below was therefore narrowed to single files and run **twice, warm**.
- **Typecheck: 0 errors** via `scripts/typecheck.mjs` (105 s, heap cap 8192 MB — not an OOM-134/missing-binary-127 false clean). Also run **with the `grantScopes` widening mutant applied**, 0 errors, confirming that mutant compiles and so is a legitimate mutation rather than a build failure.
- **Prettier clean** on all 10 PR files plus `blocks.router.getInstallConfig.test.ts`. Two files needed formatting this round (both newly-written test code, i.e. mine). **Instrument validated on the identical invocation:** the same command reported `2 files` before the fix and `All matched files…` after, so the green is a real verdict and not a zero-files glob match.
- **ESLint: unchanged from base, zero new findings — re-verified this round, not carried over.** `user-app-surface.service.ts` still crashes the linter (`@typescript-eslint/consistent-type-imports`, `TypeError: Cannot read properties of undefined (reading 'length')`) and the **same crash reproduces on `origin/main`** via `--stdin-filename`, same rule and same stack frame. The remaining files report exactly **7** `react/no-unescaped-entities` errors — 2 in `AppPermissionsActivityDrawer.tsx`, 5 in `activity.tsx` — and **all 7 reproduce at `origin/main`** (same rule, same columns; lines shifted only by this PR's comment inserts: 100→101, 160→200, 636→640, 861→865, 878→882, 879→883). 🔴 **Left for a decision:** fixing them means editing user-facing JSX copy in two large files for a comments-and-tests PR.

### 🔴 Not verified

- **The production figures below are carried over from the earlier body, NOT re-derived** — no DB access in this round. Re-measure before relying on the "no-op today" framing.
- **`recordInstallConsent` has no dedicated behavioural test**; its consolidation is covered structurally (ledger + typecheck). 🔴 **The earlier claim that "the other three sites have behavioural coverage" was FALSE — measured it was TWO of four.** `grantScopes`, the one site that decides what a user can **consent to**, had none: replacing its ceiling with the raw manifest (the *widening* direction, ignoring `approvedScopes` entirely) left `blocks.router.getInstallConfig.test.ts` at **16/16 passed, byte-identical to HEAD**, and the ceiling's own error string `none of the requested scopes are within the app’s approved manifest` appeared in **0 of 1994 test files** (positive control on the same pipeline: `grantScopes` → 5 files). Cause was fixture shape — every `grantScopes` fixture used a manifest and an approval that overlap on the scope under test. **Now three of four**: this round adds two behavioural cases under `manifest ⊋ approved`, and both fail under that widening mutant on **their own** assertions (`expected [ 'models:read:self', …(1) ] to deeply equal [ 'models:read:self' ]`; `promise resolved "{ ok: true, …(2) }" instead of rejecting`), with the mutant confirmed to **compile** (typecheck 0 errors).
- `*.browser.test.tsx` cannot run locally (no Playwright binary): `BlockConsentModal.browser.test.tsx` and `AppActivityPage.browser.test.tsx` touch these paths and were **not** executed.
- `preview / smoke-tests` is red platform-wide (`#4787`), unrelated.

## Carried-over production measurements (unverified this round)

From the original body, measured before the first commit:

- For **all 14 apps** then rendering on any permissions tab, `manifest.scopes` and `approved_scopes` were **byte-identical sets** (set difference both directions).
- **4 of 24** `app_blocks` had empty `approved_scopes`; **all 4 also had empty `manifest.scopes`**.
- The audit additionally found **8 of those 14 are `status: 'suspended'`** — which is what makes the dropped mintability claim substantive rather than pedantic, since the mint refuses a non-`approved` app outright.

On those numbers this remains a **correctness / defence-in-depth** change with no user-visible diff today. No user-visible fix is claimed.

## Still not changed, deliberately

- **The granted-vs-declared open decision survives, unresolved.** The real fix is adding `grantedScopes` to `ScopeGrantSurface` plus a per-row choice of which set to show — *"a new field plus a per-row choice, not a swap"*. This change was taken on a different axis (which **app-side** set to display) and does not settle it. The intersection does **not** fix the *under*-report direction either: a scope the viewer still holds but a v2 dropped is absent from the manifest too.
- **`src/pages/apps/activity.tsx:597` still passes no `emptyLabel`**, so an empty list gets the component default — *"This app doesn't request any permissions…"* — which an approval-or-manifest-empty app could make false. Unreachable on the carried-over data (all 4 empty-approval apps also have empty manifests). Changing user-facing copy is a separate product decision.

Refs clawgate #532

