### PR TITLE
docs(training-studio): tie the two orchestrator-hostname literals together, and assert the coupling

### DIFF
--- a/src/__tests__/pages/training-studio-embed-orchestrator-origin.test.ts
+++ b/src/__tests__/pages/training-studio-embed-orchestrator-origin.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 
+import { CIVITAI_IMAGE_HOSTS } from '~/components/AppBlocks/saveImageDownload';
 import { clientSchema } from '~/env/client-schema';
 
 /**
@@ -83,5 +84,28 @@ describe('training-studio embed: browser gets the public orchestrator origin', (
     expect(value).not.toContain('localhost');
     // An explicit port is the tell of an in-cluster service address; a public origin needs none.
     expect(value.replace('https://', '')).not.toContain(':');
+  });
+
+  /**
+   * 🔴 INVARIANT GUARD, not regression coverage — this relationship has never been broken; the guard
+   * exists so it cannot break silently. Labelled explicitly so nobody counts it as a test for a bug
+   * that happened.
+   *
+   * The coupling: the App Blocks download bridge will only fetch from `CIVITAI_IMAGE_HOSTS`, and the
+   * blob URLs it is handed are minted by the orchestrator origin below. So the origin's host must be
+   * an allowed fetch host, or saving a block-generated image breaks — in the bridge, far from either
+   * of these two files, which is why prose cross-references on both sides are not enough.
+   *
+   * Deliberately one-directional: the allowlist may hold MORE hosts than this origin (the image CDN;
+   * a previous host kept fetchable across a migration). It may not hold fewer.
+   */
+  it('the public orchestrator host is a host the download bridge may fetch from', () => {
+    const host = new URL(clientSchema.shape[PUBLIC_KEY].parse(undefined)).host;
+
+    // Control: the assertion can fail. Without this, a bad `host` (or an accidentally permissive
+    // allowlist) would let the check pass while proving nothing.
+    expect(CIVITAI_IMAGE_HOSTS).not.toContain('not-a-civitai-host.example.com');
+
+    expect(CIVITAI_IMAGE_HOSTS).toContain(host);
   });
 });

--- a/src/components/AppBlocks/saveImageDownload.ts
+++ b/src/components/AppBlocks/saveImageDownload.ts
@@ -30,6 +30,13 @@
  */
 export const CIVITAI_IMAGE_HOSTS: readonly string[] = [
   'image.civitai.com',
+  // Same hostname as the default of `NEXT_PUBLIC_ORCHESTRATOR_ENDPOINT` (src/env/client-schema.ts),
+  // for a different reason: there it is the base URL the browser CALLS, here it is a host this
+  // bridge may FETCH from. Keep them separate — but a blob URL minted by that origin must be
+  // fetchable here, so if the public orchestrator host changes, this entry changes with it. Asserted
+  // in src/__tests__/pages/training-studio-embed-orchestrator-origin.test.ts. This list may legally
+  // hold MORE hosts than that one origin (an old host kept fetchable across a migration, the image
+  // CDN); it may not hold fewer.
   'orchestration.civitai.com',
 ];
 

--- a/src/env/client-schema.ts
+++ b/src/env/client-schema.ts
@@ -25,6 +25,14 @@ export const clientSchema = z.object({
   // Studio did until this existed. The web component calls the orchestrator DIRECTLY from the
   // browser (docs/training-studio-web-component.md), so it needs the public origin. Keep the two
   // separate: server code keeps using `ORCHESTRATOR_ENDPOINT`, browser code uses this.
+  //
+  // This default's HOST also appears in `CIVITAI_IMAGE_HOSTS`
+  // (src/components/AppBlocks/saveImageDownload.ts) — same hostname, different job: that one is the
+  // allowlist of hosts the App Blocks download bridge may FETCH from, this one is the base URL the
+  // browser CALLS. They are not interchangeable and must not be merged, but they are coupled: a
+  // blob URL minted by this origin has to be fetchable by that bridge, so changing the public
+  // orchestrator host means changing both. The coupling is asserted, not just described, in
+  // src/__tests__/pages/training-studio-embed-orchestrator-origin.test.ts.
   NEXT_PUBLIC_ORCHESTRATOR_ENDPOINT: z.url().default('https://orchestration.civitai.com'),
   NEXT_PUBLIC_GPTT_UUID: z.string().optional(),
   NEXT_PUBLIC_GPTT_UUID_ALT: z.string().optional(),


### PR DESCRIPTION
Follow-up to #4789, which prompted a fair question: is that new env var redundant? It isn't — there was no prior client-side orchestrator URL, and it can't reuse the server-side `ORCHESTRATOR_ENDPOINT` because that value must stay in-cluster. But the review did surface a real duplication.

`orchestration.civitai.com` now appears **twice** in client-reachable code, with nothing linking them:

| Where | What it is |
|---|---|
| `src/env/client-schema.ts` — `NEXT_PUBLIC_ORCHESTRATOR_ENDPOINT` default | the base URL the browser **calls** |
| `src/components/AppBlocks/saveImageDownload.ts` — `CIVITAI_IMAGE_HOSTS` | hosts the download bridge may **fetch from** |

Different jobs, so merging them would be wrong. But they **are** coupled: blob URLs minted by that origin are exactly what the bridge is handed. If the public orchestrator host changes and the allowlist doesn't, saving a block-generated image breaks — in the bridge, far from either of these files.

## What this adds

- Cross-reference comments on both sides, each saying why the two are separate *and* why they move together.
- The coupling **asserted**, not merely described. A prose cross-reference rots silently, and this one spans two directories — exactly the case where nobody notices.

The assertion is deliberately one-directional: the allowlist may hold **more** hosts than this origin (the image CDN; a previous host kept fetchable across a migration). It may not hold fewer.

## 🔴 It's an invariant guard, not regression coverage

Labelled that way in the test, because this relationship has never been broken — the guard exists so it can't break silently. Calling it a regression test would overstate what it earns.

Checked by reading the **real literals out of both files** rather than restating them: the invariant holds, and a mutated origin host is rejected, so the guard can go red rather than passing vacuously. The harvester strips comments first — otherwise a hostname named in the new prose would be counted as a list entry and the guard would pass on its own documentation.

No behaviour change: comments plus one test case.
