### PR TITLE
fix(app-blocks): the low-budget warning was false for step-priced apps, and recordScopeGrant lost its docblock

### DIFF
--- a/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
@@ -2,7 +2,10 @@ import { describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
-import { BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY } from '~/shared/constants/block-scope.constants';
+import {
+  BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY,
+  BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
+} from '~/shared/constants/block-scope.constants';
 
 /**
  * BlockConsentModal — the lazy-consent surface a logged-in viewer sees when a
@@ -222,10 +225,12 @@ describe('BlockConsentModal — per-app spend limit', () => {
       const el = page.getByTestId('block-consent-budget-low-warning');
       const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
       expect(text).toBe(
-        '5 Buzz/day will not cover one image generation — the cheapest engine costs ' +
-          `${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz per run and others cost more, so ` +
-          'image generation will refuse until you raise it. Step-based actions, which ' +
-          'start at 1 Buzz, still run. You can change it later under Apps → Permissions.'
+        '5 Buzz/day may be too low. An image generation reserves its worst case up front — ' +
+          `up to ${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz on the cheapest recipe engine ` +
+          `and up to ${BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY} on the priciest — and is ` +
+          'refused if that reservation exceeds your limit, even when the run would have ' +
+          'settled for less. Step-based actions, from 1 Buzz, still run. You can change it ' +
+          'later under Apps → Permissions.'
       );
     }
     // …and it goes away again above the threshold, so the warning tracks the VALUE and

--- a/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
@@ -2,10 +2,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
-import {
-  BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY,
-  BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
-} from '~/shared/constants/block-scope.constants';
+import { BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY } from '~/shared/constants/block-scope.constants';
 
 /**
  * BlockConsentModal — the lazy-consent surface a logged-in viewer sees when a
@@ -216,21 +213,22 @@ describe('BlockConsentModal — per-app spend limit', () => {
     await input.fill('5');
     await expect.element(page.getByTestId('block-consent-budget-low-warning')).toBeInTheDocument();
     // 🔴 PINNED AS A WHOLE NORMALISED STRING, same reason as the OFF-state copy above:
-    // both retracted sentences passed every keyword check while being false. The threshold
-    // is a FLOOR (the lowest per-engine maxBuzz), so copy must say "at least", never
-    // "up to" — the rationale lives once, at BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY.
-    // The number is INTERPOLATED, not literal: that constant's own docblock says it is
-    // free to drop, and a literal would red this test on a legitimate change.
+    // FOUR successive wordings of this sentence shipped false, each passing every keyword
+    // check, and each introduced by the fix for the previous one. Only a whole-string pin
+    // catches that. The rules the wording must satisfy live at
+    // BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY — read them before editing this literal;
+    // in particular the copy names NO upper bound, because none is true.
+    // The threshold number is INTERPOLATED, not literal: its docblock says it is free to
+    // drop, and a literal would red this test on a legitimate change.
     {
       const el = page.getByTestId('block-consent-budget-low-warning');
       const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
       expect(text).toBe(
-        '5 Buzz/day may be too low. An image generation reserves its worst case up front — ' +
-          `up to ${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz on the cheapest recipe engine ` +
-          `and up to ${BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY} on the priciest — and is ` +
-          'refused if that reservation exceeds your limit, even when the run would have ' +
-          'settled for less. Step-based actions, from 1 Buzz, still run. You can change it ' +
-          'later under Apps → Permissions.'
+        '5 Buzz/day may be too low. A single image generation reserves Buzz up front before ' +
+          `it runs — ${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} or more on the cheapest recipe ` +
+          'engine, and more on others — and is refused if that reservation exceeds your ' +
+          'limit, even in cases where the run itself would have cost less. Step-based ' +
+          'actions, from 1 Buzz, still run. You can change it later under Apps → Permissions.'
       );
     }
     // …and it goes away again above the threshold, so the warning tracks the VALUE and

--- a/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import { BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY } from '~/shared/constants/block-scope.constants';
 
 /**
  * BlockConsentModal — the lazy-consent surface a logged-in viewer sees when a
@@ -211,22 +212,20 @@ describe('BlockConsentModal — per-app spend limit', () => {
     await input.clear();
     await input.fill('5');
     await expect.element(page.getByTestId('block-consent-budget-low-warning')).toBeInTheDocument();
-    // 🔴 PINNED AS A WHOLE NORMALISED STRING, same reason as the OFF-state copy above.
-    // The retracted sentence — "this app will refuse to generate until you raise it" —
-    // passed every keyword check while being categorically FALSE for a step-priced app:
-    // registry steps cost 1 Buzz (`convert-image`), so 5 Buzz/day funds five runs and
-    // refuses nothing. Worse, it contradicted the BLOCK_CONSENT_BUDGET_MIN_PER_DAY
-    // rationale written in the same commit, which keeps the floor at 1 precisely so that
-    // a tiny allowance for a step-priced app stays possible. The subject must be IMAGE
-    // GENERATION, never "this app" — a word-level guard would walk past a relapse.
+    // 🔴 PINNED AS A WHOLE NORMALISED STRING, same reason as the OFF-state copy above:
+    // both retracted sentences passed every keyword check while being false. The threshold
+    // is a FLOOR (the lowest per-engine maxBuzz), so copy must say "at least", never
+    // "up to" — the rationale lives once, at BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY.
+    // The number is INTERPOLATED, not literal: that constant's own docblock says it is
+    // free to drop, and a literal would red this test on a legitimate change.
     {
       const el = page.getByTestId('block-consent-budget-low-warning');
       const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
       expect(text).toBe(
-        '5 Buzz/day will not cover a single image generation, which can cost up to 90 ' +
-          'Buzz per run — an app that generates images will refuse until you raise it. ' +
-          'Apps that only run cheaper steps are unaffected. You can change it later under ' +
-          'Apps → Permissions.'
+        '5 Buzz/day will not cover one image generation — the cheapest engine costs ' +
+          `${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz per run and others cost more, so ` +
+          'image generation will refuse until you raise it. Step-based actions, which ' +
+          'start at 1 Buzz, still run. You can change it later under Apps → Permissions.'
       );
     }
     // …and it goes away again above the threshold, so the warning tracks the VALUE and

--- a/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
@@ -2,7 +2,6 @@ import { describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
-import { BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY } from '~/shared/constants/block-scope.constants';
 
 /**
  * BlockConsentModal — the lazy-consent surface a logged-in viewer sees when a
@@ -212,23 +211,17 @@ describe('BlockConsentModal — per-app spend limit', () => {
     await input.clear();
     await input.fill('5');
     await expect.element(page.getByTestId('block-consent-budget-low-warning')).toBeInTheDocument();
-    // 🔴 PINNED AS A WHOLE NORMALISED STRING, same reason as the OFF-state copy above:
-    // FOUR successive wordings of this sentence shipped false, each passing every keyword
-    // check, and each introduced by the fix for the previous one. Only a whole-string pin
-    // catches that. The rules the wording must satisfy live at
-    // BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY — read them before editing this literal;
-    // in particular the copy names NO upper bound, because none is true.
-    // The threshold number is INTERPOLATED, not literal: its docblock says it is free to
-    // drop, and a literal would red this test on a legitimate change.
+    // 🔴 PINNED AS A WHOLE NORMALISED STRING, and DELIBERATELY AS A LITERAL — it must NOT
+    // read BLOCK_CONSENT_BUDGET_LOW_WARNING_BODY. The components share that constant so they
+    // cannot drift from each other; if this expectation read it too, the assertion would be
+    // tautological and a reworded relapse would pass silently. FIVE wordings of this sentence
+    // shipped false, every one keyword-clean, which is what a whole-string literal catches.
+    // The rules the wording must satisfy are in that constant's docblock.
     {
       const el = page.getByTestId('block-consent-budget-low-warning');
       const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
       expect(text).toBe(
-        '5 Buzz/day may be too low. A single image generation reserves Buzz up front before ' +
-          `it runs — ${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz on the cheapest recipe ` +
-          'engine, and more on the other engines — and is refused if that reservation exceeds ' +
-          'your limit, even in cases where the run itself would have cost less. Step-based ' +
-          'actions, from 1 Buzz, still run. You can change it later under Apps → Permissions.'
+        '5 Buzz/day is a low limit. Each generation reserves Buzz up front, and is refused if that reservation exceeds your remaining limit for the day — so a low limit can make an app look broken. You can change it later under Apps → Permissions.'
       );
     }
     // …and it goes away again above the threshold, so the warning tracks the VALUE and

--- a/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
@@ -211,6 +211,24 @@ describe('BlockConsentModal — per-app spend limit', () => {
     await input.clear();
     await input.fill('5');
     await expect.element(page.getByTestId('block-consent-budget-low-warning')).toBeInTheDocument();
+    // 🔴 PINNED AS A WHOLE NORMALISED STRING, same reason as the OFF-state copy above.
+    // The retracted sentence — "this app will refuse to generate until you raise it" —
+    // passed every keyword check while being categorically FALSE for a step-priced app:
+    // registry steps cost 1 Buzz (`convert-image`), so 5 Buzz/day funds five runs and
+    // refuses nothing. Worse, it contradicted the BLOCK_CONSENT_BUDGET_MIN_PER_DAY
+    // rationale written in the same commit, which keeps the floor at 1 precisely so that
+    // a tiny allowance for a step-priced app stays possible. The subject must be IMAGE
+    // GENERATION, never "this app" — a word-level guard would walk past a relapse.
+    {
+      const el = page.getByTestId('block-consent-budget-low-warning');
+      const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
+      expect(text).toBe(
+        '5 Buzz/day will not cover a single image generation, which can cost up to 90 ' +
+          'Buzz per run — an app that generates images will refuse until you raise it. ' +
+          'Apps that only run cheaper steps are unaffected. You can change it later under ' +
+          'Apps → Permissions.'
+      );
+    }
     // …and it goes away again above the threshold, so the warning tracks the VALUE and
     // is not just "shown once the field was touched".
     await input.clear();

--- a/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
@@ -225,9 +225,9 @@ describe('BlockConsentModal — per-app spend limit', () => {
       const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
       expect(text).toBe(
         '5 Buzz/day may be too low. A single image generation reserves Buzz up front before ' +
-          `it runs — ${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} or more on the cheapest recipe ` +
-          'engine, and more on others — and is refused if that reservation exceeds your ' +
-          'limit, even in cases where the run itself would have cost less. Step-based ' +
+          `it runs — ${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz on the cheapest recipe ` +
+          'engine, and more on the other engines — and is refused if that reservation exceeds ' +
+          'your limit, even in cases where the run itself would have cost less. Step-based ' +
           'actions, from 1 Buzz, still run. You can change it later under Apps → Permissions.'
       );
     }

--- a/src/components/AppBlocks/BlockConsentModal.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.tsx
@@ -15,6 +15,7 @@ import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import {
   BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY,
+  BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY,
   BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
   BLOCK_CONSENT_BUDGET_MAX_PER_DAY,
   BLOCK_CONSENT_BUDGET_MIN_PER_DAY,
@@ -171,14 +172,17 @@ export default function BlockConsentModal({
               </Text>
             )}
             {/* A very low limit is storable (the floor is 1) and enforced exactly as
-                given, so say what it does at the moment it is chosen. The threshold is a
-                FLOOR, not a ceiling — see the note in pages/apps/activity.tsx. */}
+                given, so say what it does at the moment it is chosen. RESERVES, never
+                COSTS; stays hedged; subject is the RUN — the three rules and why each
+                exists are in the note in pages/apps/activity.tsx. */}
             {limitEnabled && budgetValid && parsedBudget < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
               <Text size="xs" c="orange" data-testid="block-consent-budget-low-warning">
-                {parsedBudget.toLocaleString()} Buzz/day will not cover one image generation — the
-                cheapest engine costs {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz per run and
-                others cost more, so image generation will refuse until you raise it. Step-based
-                actions, which start at 1 Buzz, still run. You can change it later under Apps →
+                {parsedBudget.toLocaleString()} Buzz/day may be too low. An image generation
+                reserves its worst case up front — up to {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY}{' '}
+                Buzz on the cheapest recipe engine and up to{' '}
+                {BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY} on the priciest — and is refused if that
+                reservation exceeds your limit, even when the run would have settled for less.
+                Step-based actions, from 1 Buzz, still run. You can change it later under Apps →
                 Permissions.
               </Text>
             ) : null}

--- a/src/components/AppBlocks/BlockConsentModal.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.tsx
@@ -15,7 +15,6 @@ import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import {
   BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY,
-  BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY,
   BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
   BLOCK_CONSENT_BUDGET_MAX_PER_DAY,
   BLOCK_CONSENT_BUDGET_MIN_PER_DAY,
@@ -172,18 +171,18 @@ export default function BlockConsentModal({
               </Text>
             )}
             {/* A very low limit is storable (the floor is 1) and enforced exactly as
-                given, so say what it does at the moment it is chosen. RESERVES, never
-                COSTS; stays hedged; subject is the RUN — the three rules and why each
-                exists are in the note in pages/apps/activity.tsx. */}
+                given, so say what it does at the moment it is chosen. RESERVES not COSTS;
+                stay hedged; NAME NO UPPER BOUND; subject is the RUN — the four rules, and
+                the wording that broke each one, are in pages/apps/activity.tsx. Keep this
+                sentence in step with that one. */}
             {limitEnabled && budgetValid && parsedBudget < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
               <Text size="xs" c="orange" data-testid="block-consent-budget-low-warning">
-                {parsedBudget.toLocaleString()} Buzz/day may be too low. An image generation
-                reserves its worst case up front — up to {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY}{' '}
-                Buzz on the cheapest recipe engine and up to{' '}
-                {BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY} on the priciest — and is refused if that
-                reservation exceeds your limit, even when the run would have settled for less.
-                Step-based actions, from 1 Buzz, still run. You can change it later under Apps →
-                Permissions.
+                {parsedBudget.toLocaleString()} Buzz/day may be too low. A single image generation
+                reserves Buzz up front before it runs — {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} or
+                more on the cheapest recipe engine, and more on others — and is refused if that
+                reservation exceeds your limit, even in cases where the run itself would have cost
+                less. Step-based actions, from 1 Buzz, still run. You can change it later under Apps
+                → Permissions.
               </Text>
             ) : null}
           </Stack>

--- a/src/components/AppBlocks/BlockConsentModal.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.tsx
@@ -16,6 +16,7 @@ import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import {
   BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY,
   BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
+  BLOCK_CONSENT_BUDGET_LOW_WARNING_BODY,
   BLOCK_CONSENT_BUDGET_MAX_PER_DAY,
   BLOCK_CONSENT_BUDGET_MIN_PER_DAY,
   isSensitiveBlockScope,
@@ -171,18 +172,14 @@ export default function BlockConsentModal({
               </Text>
             )}
             {/* A very low limit is storable (the floor is 1) and enforced exactly as
-                given, so say what it does at the moment it is chosen. RESERVES not COSTS;
-                stay hedged; NAME NO UPPER BOUND; subject is the RUN — the four rules, and
-                the wording that broke each one, are in pages/apps/activity.tsx. Keep this
-                sentence in step with that one. */}
+                given, so say what it does at the moment it is chosen. 🔴 THE SENTENCE IS
+                SHARED — BLOCK_CONSENT_BUDGET_LOW_WARNING_BODY — so this surface and the
+                editor on /apps/activity cannot drift. Its wording rules, and the five
+                wordings that shipped false, are in that constant's docblock. */}
             {limitEnabled && budgetValid && parsedBudget < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
               <Text size="xs" c="orange" data-testid="block-consent-budget-low-warning">
-                {parsedBudget.toLocaleString()} Buzz/day may be too low. A single image generation
-                reserves Buzz up front before it runs — {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz
-                on the cheapest recipe engine, and more on the other engines — and is refused if
-                that reservation exceeds your limit, even in cases where the run itself would have
-                cost less. Step-based actions, from 1 Buzz, still run. You can change it later under
-                Apps → Permissions.
+                {parsedBudget.toLocaleString()} {BLOCK_CONSENT_BUDGET_LOW_WARNING_BODY} You can
+                change it later under Apps → Permissions.
               </Text>
             ) : null}
           </Stack>

--- a/src/components/AppBlocks/BlockConsentModal.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.tsx
@@ -171,16 +171,15 @@ export default function BlockConsentModal({
               </Text>
             )}
             {/* A very low limit is storable (the floor is 1) and enforced exactly as
-                given, so say what it does at the moment it is chosen.
-                🔴 Keep this wording in step with the editor's copy in pages/apps/activity.tsx —
-                the subject is IMAGE GENERATION, never "this app". See the note there for why
-                "this app will refuse" is false for a step-priced app. */}
+                given, so say what it does at the moment it is chosen. The threshold is a
+                FLOOR, not a ceiling — see the note in pages/apps/activity.tsx. */}
             {limitEnabled && budgetValid && parsedBudget < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
               <Text size="xs" c="orange" data-testid="block-consent-budget-low-warning">
-                {parsedBudget.toLocaleString()} Buzz/day will not cover a single image generation,
-                which can cost up to {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz per run — an app
-                that generates images will refuse until you raise it. Apps that only run cheaper
-                steps are unaffected. You can change it later under Apps → Permissions.
+                {parsedBudget.toLocaleString()} Buzz/day will not cover one image generation — the
+                cheapest engine costs {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz per run and
+                others cost more, so image generation will refuse until you raise it. Step-based
+                actions, which start at 1 Buzz, still run. You can change it later under Apps →
+                Permissions.
               </Text>
             ) : null}
           </Stack>

--- a/src/components/AppBlocks/BlockConsentModal.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.tsx
@@ -178,11 +178,11 @@ export default function BlockConsentModal({
             {limitEnabled && budgetValid && parsedBudget < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
               <Text size="xs" c="orange" data-testid="block-consent-budget-low-warning">
                 {parsedBudget.toLocaleString()} Buzz/day may be too low. A single image generation
-                reserves Buzz up front before it runs — {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} or
-                more on the cheapest recipe engine, and more on others — and is refused if that
-                reservation exceeds your limit, even in cases where the run itself would have cost
-                less. Step-based actions, from 1 Buzz, still run. You can change it later under Apps
-                → Permissions.
+                reserves Buzz up front before it runs — {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz
+                on the cheapest recipe engine, and more on the other engines — and is refused if
+                that reservation exceeds your limit, even in cases where the run itself would have
+                cost less. Step-based actions, from 1 Buzz, still run. You can change it later under
+                Apps → Permissions.
               </Text>
             ) : null}
           </Stack>

--- a/src/components/AppBlocks/BlockConsentModal.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.tsx
@@ -171,12 +171,16 @@ export default function BlockConsentModal({
               </Text>
             )}
             {/* A very low limit is storable (the floor is 1) and enforced exactly as
-                given, so say what it does at the moment it is chosen. */}
+                given, so say what it does at the moment it is chosen.
+                🔴 Keep this wording in step with the editor's copy in pages/apps/activity.tsx —
+                the subject is IMAGE GENERATION, never "this app". See the note there for why
+                "this app will refuse" is false for a step-priced app. */}
             {limitEnabled && budgetValid && parsedBudget < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
               <Text size="xs" c="orange" data-testid="block-consent-budget-low-warning">
-                {parsedBudget.toLocaleString()} Buzz/day is lower than most generations cost — this
-                app will refuse to generate until you raise it. You can change it later under Apps →
-                Permissions.
+                {parsedBudget.toLocaleString()} Buzz/day will not cover a single image generation,
+                which can cost up to {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz per run — an app
+                that generates images will refuse until you raise it. Apps that only run cheaper
+                steps are unaffected. You can change it later under Apps → Permissions.
               </Text>
             ) : null}
           </Stack>

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -647,6 +647,22 @@ describe('Apps & permissions — the per-app daily Buzz limit', () => {
     await input.clear();
     await input.fill('5');
     await expect.element(page.getByTestId('app-budget-low-warning')).toBeInTheDocument();
+    // 🔴 PINNED AS A WHOLE NORMALISED STRING. The retracted sentence — "this app will
+    // refuse to generate until you raise it" — passed every keyword check while being
+    // categorically FALSE for a step-priced app: registry steps cost 1 Buzz
+    // (`convert-image`), so 5 Buzz/day funds five runs and refuses nothing. It also
+    // contradicted the BLOCK_CONSENT_BUDGET_MIN_PER_DAY rationale written in the same
+    // commit, which keeps the floor at 1 so a tiny allowance stays possible. The subject
+    // must be IMAGE GENERATION, never "this app".
+    {
+      const el = page.getByTestId('app-budget-low-warning');
+      const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
+      expect(text).toBe(
+        '5 Buzz/day will not cover a single image generation, which can cost up to 90 ' +
+          'Buzz per run — an app that generates images will refuse until you raise it. ' +
+          'Apps that only run cheaper steps are unaffected. You can change it here at any time.'
+      );
+    }
   });
 });
 

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -4,7 +4,10 @@ import { useRouter } from 'next/router';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 import type * as TrpcMod from '~/utils/trpc';
-import { BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY } from '~/shared/constants/block-scope.constants';
+import {
+  BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY,
+  BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
+} from '~/shared/constants/block-scope.constants';
 
 /**
  * `/apps/activity` — the PAGE, mounted for real.
@@ -656,10 +659,12 @@ describe('Apps & permissions — the per-app daily Buzz limit', () => {
       const el = page.getByTestId('app-budget-low-warning');
       const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
       expect(text).toBe(
-        '5 Buzz/day will not cover one image generation — the cheapest engine costs ' +
-          `${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz per run and others cost more, so ` +
-          'image generation will refuse until you raise it. Step-based actions, which ' +
-          'start at 1 Buzz, still run. You can change it here at any time.'
+        '5 Buzz/day may be too low. An image generation reserves its worst case up front — ' +
+          `up to ${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz on the cheapest recipe engine ` +
+          `and up to ${BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY} on the priciest — and is ` +
+          'refused if that reservation exceeds your limit, even when the run would have ' +
+          'settled for less. Step-based actions, from 1 Buzz, still run. You can change it ' +
+          'here at any time.'
       );
     }
   });

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 import type * as TrpcMod from '~/utils/trpc';
-import { BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY } from '~/shared/constants/block-scope.constants';
 
 /**
  * `/apps/activity` — the PAGE, mounted for real.
@@ -648,20 +647,17 @@ describe('Apps & permissions — the per-app daily Buzz limit', () => {
     await input.clear();
     await input.fill('5');
     await expect.element(page.getByTestId('app-budget-low-warning')).toBeInTheDocument();
-    // 🔴 PINNED AS A WHOLE NORMALISED STRING — a keyword guard walks past a reworded
-    // relapse, and all four retracted wordings here were keyword-clean and false. The
-    // rules the wording must satisfy live at BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY;
-    // notably the copy names NO upper bound, because none is true. The threshold number
-    // is INTERPOLATED because that constant is documented as free to drop.
+    // 🔴 PINNED AS A WHOLE NORMALISED STRING, and DELIBERATELY AS A LITERAL — it must NOT
+    // read BLOCK_CONSENT_BUDGET_LOW_WARNING_BODY. The components share that constant so they
+    // cannot drift from each other; if this expectation read it too, the assertion would be
+    // tautological and a reworded relapse would pass silently. FIVE wordings of this sentence
+    // shipped false, every one keyword-clean, which is what a whole-string literal catches.
+    // The rules the wording must satisfy are in that constant's docblock.
     {
       const el = page.getByTestId('app-budget-low-warning');
       const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
       expect(text).toBe(
-        '5 Buzz/day may be too low. A single image generation reserves Buzz up front before ' +
-          `it runs — ${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz on the cheapest recipe ` +
-          'engine, and more on the other engines — and is refused if that reservation exceeds ' +
-          'your limit, even in cases where the run itself would have cost less. Step-based ' +
-          'actions, from 1 Buzz, still run. You can change it here at any time.'
+        '5 Buzz/day is a low limit. Each generation reserves Buzz up front, and is refused if that reservation exceeds your remaining limit for the day — so a low limit can make an app look broken. You can change it here at any time.'
       );
     }
   });

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 import type * as TrpcMod from '~/utils/trpc';
+import { BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY } from '~/shared/constants/block-scope.constants';
 
 /**
  * `/apps/activity` — the PAGE, mounted for real.
@@ -647,20 +648,18 @@ describe('Apps & permissions — the per-app daily Buzz limit', () => {
     await input.clear();
     await input.fill('5');
     await expect.element(page.getByTestId('app-budget-low-warning')).toBeInTheDocument();
-    // 🔴 PINNED AS A WHOLE NORMALISED STRING. The retracted sentence — "this app will
-    // refuse to generate until you raise it" — passed every keyword check while being
-    // categorically FALSE for a step-priced app: registry steps cost 1 Buzz
-    // (`convert-image`), so 5 Buzz/day funds five runs and refuses nothing. It also
-    // contradicted the BLOCK_CONSENT_BUDGET_MIN_PER_DAY rationale written in the same
-    // commit, which keeps the floor at 1 so a tiny allowance stays possible. The subject
-    // must be IMAGE GENERATION, never "this app".
+    // 🔴 PINNED AS A WHOLE NORMALISED STRING — a keyword guard walks past a reworded
+    // relapse, and both retracted sentences here were keyword-clean and false. Rationale
+    // lives once, at BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY; the number is INTERPOLATED
+    // because that constant is documented as free to drop.
     {
       const el = page.getByTestId('app-budget-low-warning');
       const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
       expect(text).toBe(
-        '5 Buzz/day will not cover a single image generation, which can cost up to 90 ' +
-          'Buzz per run — an app that generates images will refuse until you raise it. ' +
-          'Apps that only run cheaper steps are unaffected. You can change it here at any time.'
+        '5 Buzz/day will not cover one image generation — the cheapest engine costs ' +
+          `${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz per run and others cost more, so ` +
+          'image generation will refuse until you raise it. Step-based actions, which ' +
+          'start at 1 Buzz, still run. You can change it here at any time.'
       );
     }
   });

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -658,9 +658,9 @@ describe('Apps & permissions — the per-app daily Buzz limit', () => {
       const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
       expect(text).toBe(
         '5 Buzz/day may be too low. A single image generation reserves Buzz up front before ' +
-          `it runs — ${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} or more on the cheapest recipe ` +
-          'engine, and more on others — and is refused if that reservation exceeds your ' +
-          'limit, even in cases where the run itself would have cost less. Step-based ' +
+          `it runs — ${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz on the cheapest recipe ` +
+          'engine, and more on the other engines — and is refused if that reservation exceeds ' +
+          'your limit, even in cases where the run itself would have cost less. Step-based ' +
           'actions, from 1 Buzz, still run. You can change it here at any time.'
       );
     }

--- a/src/components/Apps/AppActivityPage.browser.test.tsx
+++ b/src/components/Apps/AppActivityPage.browser.test.tsx
@@ -4,10 +4,7 @@ import { useRouter } from 'next/router';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 import type * as TrpcMod from '~/utils/trpc';
-import {
-  BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY,
-  BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
-} from '~/shared/constants/block-scope.constants';
+import { BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY } from '~/shared/constants/block-scope.constants';
 
 /**
  * `/apps/activity` — the PAGE, mounted for real.
@@ -652,19 +649,19 @@ describe('Apps & permissions — the per-app daily Buzz limit', () => {
     await input.fill('5');
     await expect.element(page.getByTestId('app-budget-low-warning')).toBeInTheDocument();
     // 🔴 PINNED AS A WHOLE NORMALISED STRING — a keyword guard walks past a reworded
-    // relapse, and both retracted sentences here were keyword-clean and false. Rationale
-    // lives once, at BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY; the number is INTERPOLATED
-    // because that constant is documented as free to drop.
+    // relapse, and all four retracted wordings here were keyword-clean and false. The
+    // rules the wording must satisfy live at BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY;
+    // notably the copy names NO upper bound, because none is true. The threshold number
+    // is INTERPOLATED because that constant is documented as free to drop.
     {
       const el = page.getByTestId('app-budget-low-warning');
       const text = ((await el.element().textContent) ?? '').replace(/\s+/g, ' ').trim();
       expect(text).toBe(
-        '5 Buzz/day may be too low. An image generation reserves its worst case up front — ' +
-          `up to ${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz on the cheapest recipe engine ` +
-          `and up to ${BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY} on the priciest — and is ` +
-          'refused if that reservation exceeds your limit, even when the run would have ' +
-          'settled for less. Step-based actions, from 1 Buzz, still run. You can change it ' +
-          'here at any time.'
+        '5 Buzz/day may be too low. A single image generation reserves Buzz up front before ' +
+          `it runs — ${BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} or more on the cheapest recipe ` +
+          'engine, and more on others — and is refused if that reservation exceeds your ' +
+          'limit, even in cases where the run itself would have cost less. Step-based ' +
+          'actions, from 1 Buzz, still run. You can change it here at any time.'
       );
     }
   });

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -526,10 +526,10 @@ function AppBudgetControl({
       {valid && parsed < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
         <Text size="xs" c="orange" data-testid="app-budget-low-warning">
           {parsed.toLocaleString()} Buzz/day may be too low. A single image generation reserves Buzz
-          up front before it runs — {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} or more on the cheapest
-          recipe engine, and more on others — and is refused if that reservation exceeds your limit,
-          even in cases where the run itself would have cost less. Step-based actions, from 1 Buzz,
-          still run. You can change it here at any time.
+          up front before it runs — {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz on the cheapest
+          recipe engine, and more on the other engines — and is refused if that reservation exceeds
+          your limit, even in cases where the run itself would have cost less. Step-based actions,
+          from 1 Buzz, still run. You can change it here at any time.
         </Text>
       ) : null}
       <Group gap="xs" justify="flex-end">

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -56,7 +56,6 @@ import { resolveActivityPageAccess } from '~/components/Apps/resolveActivityPage
 import { canAccessAppsActivity, hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
 import {
   BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY,
-  BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY,
   BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
   BLOCK_CONSENT_BUDGET_MAX_PER_DAY,
   BLOCK_CONSENT_BUDGET_MIN_PER_DAY,
@@ -500,25 +499,37 @@ function AppBudgetControl({
       {/* A very low limit is a real setting, not a mistake — but it is also the one
           that makes an app look broken, so say what it does at the point it is set.
           This is what keeps the floor of 1 tolerable; see BLOCK_CONSENT_BUDGET_MIN_PER_DAY.
-          🔴 THREE RULES, EACH FROM A SENTENCE THAT SHIPPED HERE AND WAS FALSE.
-          (1) RESERVES, never COSTS — maxBuzz is the worst case reserved up front and
-              settled back to actual, so a run's real price is far lower (zimage-turbo
-              estimates 20 against a 90 ceiling; a warm starter run measured 4).
-          (2) HEDGE — the consent budget is path-agnostic, but these bounds describe the
-              RECIPE path only. `textToImage` reserves its live whatIf quote and is NOT
-              bounded below by LOW (the platform's own per-gen default is 10), so a
-              categorical "will not cover" is false there.
-          (3) Subject is the RUN, not "this app" — registry steps cost from 1 Buzz, so a
+
+          🔴 FOUR RULES, ONE PER WORDING THAT SHIPPED HERE AND WAS FALSE. Each was
+          introduced by the fix for the previous one, so read all four before editing.
+          (1) RESERVES, never COSTS — a recipe's `maxBuzz` is the worst case reserved up
+              front and settled back to actual, so the real price is far lower
+              (zimage-turbo estimates 20 against a 90 ceiling; a warm starter run
+              measured 4). "costs 90 per run" overstated by up to ~22×.
+          (2) HEDGE — the consent budget is path-agnostic while these bounds are not.
+              `textToImage` reserves its live whatIf quote, is not bounded below by LOW
+              (the platform's per-gen default is 10), and has NO settle-back, so neither
+              "will not cover" nor an unqualified "settles back" is true there.
+          (3) NO CLOSED UPPER BOUND EXISTS — do not name one. "up to 180 on the priciest"
+              was false because the inline customComfy arm reserves an app-declared
+              ceiling up to INLINE_MAX_BUZZ = 250, un-dev-gated, and textToImage is
+              bounded by neither figure. Say "and more on others" and stop.
+          (4) Subject is the RUN, not "this app" — registry steps cost from 1 Buzz, so a
               step-priced app keeps working under this threshold, and that user is exactly
               who MIN=1 exists to protect.
-          Both bounds are pinned to the registry by recipes/__tests__/budget-bounds-parity. */}
+
+          🔴 STILL OPEN, and this note is its only record — do not delete it again. The
+          warning renders only below LOW (90), so a user at 100/day is told nothing while
+          a qwen-image run (reserves 180) or an inline app (up to 250) is still refused.
+          Thresholding on HIGH, or on INLINE_MAX_BUZZ, would close it at the cost of
+          warning step-only apps that are fine. Deliberately not decided here. */}
       {valid && parsed < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
         <Text size="xs" c="orange" data-testid="app-budget-low-warning">
-          {parsed.toLocaleString()} Buzz/day may be too low. An image generation reserves its worst
-          case up front — up to {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz on the cheapest recipe
-          engine and up to {BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY} on the priciest — and is
-          refused if that reservation exceeds your limit, even when the run would have settled for
-          less. Step-based actions, from 1 Buzz, still run. You can change it here at any time.
+          {parsed.toLocaleString()} Buzz/day may be too low. A single image generation reserves Buzz
+          up front before it runs — {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} or more on the cheapest
+          recipe engine, and more on others — and is refused if that reservation exceeds your limit,
+          even in cases where the run itself would have cost less. Step-based actions, from 1 Buzz,
+          still run. You can change it here at any time.
         </Text>
       ) : null}
       <Group gap="xs" justify="flex-end">

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -498,11 +498,20 @@ function AppBudgetControl({
       />
       {/* A very low limit is a real setting, not a mistake — but it is also the one
           that makes an app look broken, so say what it does at the point it is set.
-          This is what keeps the floor of 1 tolerable; see BLOCK_CONSENT_BUDGET_MIN_PER_DAY. */}
+          This is what keeps the floor of 1 tolerable; see BLOCK_CONSENT_BUDGET_MIN_PER_DAY.
+          🔴 SAY "IMAGE GENERATION", NOT "THIS APP". The threshold is the lowest per-engine
+          customComfy ceiling (90); registry steps cost as little as 1 Buzz
+          (`convert-image`), so a step-priced app funds dozens of runs under it and refuses
+          NOTHING. The retracted copy read "this app will refuse to generate until you raise
+          it" — categorically false for exactly the step-priced user the MIN=1 rationale in
+          BLOCK_CONSENT_BUDGET_MIN_PER_DAY exists to protect, i.e. this sentence contradicted
+          the decision it was written to justify. Keep the subject the ENGINE, not the app. */}
       {valid && parsed < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
         <Text size="xs" c="orange" data-testid="app-budget-low-warning">
-          {parsed.toLocaleString()} Buzz/day is lower than most generations cost — this app will
-          refuse to generate until you raise it. You can change it here at any time.
+          {parsed.toLocaleString()} Buzz/day will not cover a single image generation, which can
+          cost up to {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz per run — an app that generates
+          images will refuse until you raise it. Apps that only run cheaper steps are unaffected.
+          You can change it here at any time.
         </Text>
       ) : null}
       <Group gap="xs" justify="flex-end">

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -57,6 +57,7 @@ import { canAccessAppsActivity, hasAppsStoreAccess } from '~/shared/utils/app-bl
 import {
   BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY,
   BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
+  BLOCK_CONSENT_BUDGET_LOW_WARNING_BODY,
   BLOCK_CONSENT_BUDGET_MAX_PER_DAY,
   BLOCK_CONSENT_BUDGET_MIN_PER_DAY,
 } from '~/shared/constants/block-scope.constants';
@@ -500,23 +501,13 @@ function AppBudgetControl({
           that makes an app look broken, so say what it does at the point it is set.
           This is what keeps the floor of 1 tolerable; see BLOCK_CONSENT_BUDGET_MIN_PER_DAY.
 
-          🔴 FOUR RULES, ONE PER WORDING THAT SHIPPED HERE AND WAS FALSE. Each was
-          introduced by the fix for the previous one, so read all four before editing.
-          (1) RESERVES, never COSTS — a recipe's `maxBuzz` is the worst case reserved up
-              front and settled back to actual, so the real price is far lower
-              (zimage-turbo estimates 20 against a 90 ceiling; a warm starter run
-              measured 4). "costs 90 per run" overstated by up to ~22×.
-          (2) HEDGE — the consent budget is path-agnostic while these bounds are not.
-              `textToImage` reserves its live whatIf quote, is not bounded below by LOW
-              (the platform's per-gen default is 10), and has NO settle-back, so neither
-              "will not cover" nor an unqualified "settles back" is true there.
-          (3) NO CLOSED UPPER BOUND EXISTS — do not name one. "up to 180 on the priciest"
-              was false because the inline customComfy arm reserves an app-declared
-              ceiling up to INLINE_MAX_BUZZ = 250, un-dev-gated, and textToImage is
-              bounded by neither figure. Say "and more on others" and stop.
-          (4) Subject is the RUN, not "this app" — registry steps cost from 1 Buzz, so a
-              step-priced app keeps working under this threshold, and that user is exactly
-              who MIN=1 exists to protect.
+          🔴 THE SENTENCE ITSELF NOW LIVES IN ONE PLACE —
+          BLOCK_CONSENT_BUDGET_LOW_WARNING_BODY — shared with the consent modal so the two
+          cannot drift, and the rules governing its wording live in that constant's
+          docblock. READ THEM BEFORE EDITING: five successive wordings shipped false, each
+          introduced by the fix for the previous one, and the rule that replaced them is
+          structural — the sentence asserts NO figure and NO claim about which actions
+          still run, because every such claim proved falsifiable.
 
           🔴 STILL OPEN, and this note is its only record — do not delete it again. The
           warning renders only below LOW (90), so a user at 100/day is told nothing while
@@ -525,11 +516,8 @@ function AppBudgetControl({
           warning step-only apps that are fine. Deliberately not decided here. */}
       {valid && parsed < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
         <Text size="xs" c="orange" data-testid="app-budget-low-warning">
-          {parsed.toLocaleString()} Buzz/day may be too low. A single image generation reserves Buzz
-          up front before it runs — {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz on the cheapest
-          recipe engine, and more on the other engines — and is refused if that reservation exceeds
-          your limit, even in cases where the run itself would have cost less. Step-based actions,
-          from 1 Buzz, still run. You can change it here at any time.
+          {parsed.toLocaleString()} {BLOCK_CONSENT_BUDGET_LOW_WARNING_BODY} You can change it here
+          at any time.
         </Text>
       ) : null}
       <Group gap="xs" justify="flex-end">

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -499,19 +499,19 @@ function AppBudgetControl({
       {/* A very low limit is a real setting, not a mistake — but it is also the one
           that makes an app look broken, so say what it does at the point it is set.
           This is what keeps the floor of 1 tolerable; see BLOCK_CONSENT_BUDGET_MIN_PER_DAY.
-          🔴 SAY "IMAGE GENERATION", NOT "THIS APP". The threshold is the lowest per-engine
-          customComfy ceiling (90); registry steps cost as little as 1 Buzz
-          (`convert-image`), so a step-priced app funds dozens of runs under it and refuses
-          NOTHING. The retracted copy read "this app will refuse to generate until you raise
-          it" — categorically false for exactly the step-priced user the MIN=1 rationale in
-          BLOCK_CONSENT_BUDGET_MIN_PER_DAY exists to protect, i.e. this sentence contradicted
-          the decision it was written to justify. Keep the subject the ENGINE, not the app. */}
+          🔴 THE THRESHOLD IS A FLOOR, NOT A CEILING — say "at least", never "up to".
+          BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY is the LOWEST per-engine maxBuzz
+          (zimage-turbo 90); flux2-klein is 150 and qwen-image 180. Copy reading "can cost
+          up to 90" is false in the other direction: at 100/day no warning fires, yet a
+          qwen-image run needs 180 and refuses. Say the ENGINE refuses, not "this app" —
+          registry steps cost from 1 Buzz, so a step-priced app keeps running under this
+          threshold, which is exactly the user MIN=1 exists to protect. */}
       {valid && parsed < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
         <Text size="xs" c="orange" data-testid="app-budget-low-warning">
-          {parsed.toLocaleString()} Buzz/day will not cover a single image generation, which can
-          cost up to {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz per run — an app that generates
-          images will refuse until you raise it. Apps that only run cheaper steps are unaffected.
-          You can change it here at any time.
+          {parsed.toLocaleString()} Buzz/day will not cover one image generation — the cheapest
+          engine costs {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz per run and others cost more, so
+          image generation will refuse until you raise it. Step-based actions, which start at 1
+          Buzz, still run. You can change it here at any time.
         </Text>
       ) : null}
       <Group gap="xs" justify="flex-end">

--- a/src/pages/apps/activity.tsx
+++ b/src/pages/apps/activity.tsx
@@ -56,6 +56,7 @@ import { resolveActivityPageAccess } from '~/components/Apps/resolveActivityPage
 import { canAccessAppsActivity, hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
 import {
   BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY,
+  BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY,
   BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
   BLOCK_CONSENT_BUDGET_MAX_PER_DAY,
   BLOCK_CONSENT_BUDGET_MIN_PER_DAY,
@@ -499,19 +500,25 @@ function AppBudgetControl({
       {/* A very low limit is a real setting, not a mistake — but it is also the one
           that makes an app look broken, so say what it does at the point it is set.
           This is what keeps the floor of 1 tolerable; see BLOCK_CONSENT_BUDGET_MIN_PER_DAY.
-          🔴 THE THRESHOLD IS A FLOOR, NOT A CEILING — say "at least", never "up to".
-          BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY is the LOWEST per-engine maxBuzz
-          (zimage-turbo 90); flux2-klein is 150 and qwen-image 180. Copy reading "can cost
-          up to 90" is false in the other direction: at 100/day no warning fires, yet a
-          qwen-image run needs 180 and refuses. Say the ENGINE refuses, not "this app" —
-          registry steps cost from 1 Buzz, so a step-priced app keeps running under this
-          threshold, which is exactly the user MIN=1 exists to protect. */}
+          🔴 THREE RULES, EACH FROM A SENTENCE THAT SHIPPED HERE AND WAS FALSE.
+          (1) RESERVES, never COSTS — maxBuzz is the worst case reserved up front and
+              settled back to actual, so a run's real price is far lower (zimage-turbo
+              estimates 20 against a 90 ceiling; a warm starter run measured 4).
+          (2) HEDGE — the consent budget is path-agnostic, but these bounds describe the
+              RECIPE path only. `textToImage` reserves its live whatIf quote and is NOT
+              bounded below by LOW (the platform's own per-gen default is 10), so a
+              categorical "will not cover" is false there.
+          (3) Subject is the RUN, not "this app" — registry steps cost from 1 Buzz, so a
+              step-priced app keeps working under this threshold, and that user is exactly
+              who MIN=1 exists to protect.
+          Both bounds are pinned to the registry by recipes/__tests__/budget-bounds-parity. */}
       {valid && parsed < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ? (
         <Text size="xs" c="orange" data-testid="app-budget-low-warning">
-          {parsed.toLocaleString()} Buzz/day will not cover one image generation — the cheapest
-          engine costs {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz per run and others cost more, so
-          image generation will refuse until you raise it. Step-based actions, which start at 1
-          Buzz, still run. You can change it here at any time.
+          {parsed.toLocaleString()} Buzz/day may be too low. An image generation reserves its worst
+          case up front — up to {BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY} Buzz on the cheapest recipe
+          engine and up to {BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY} on the priciest — and is
+          refused if that reservation exceeds your limit, even when the run would have settled for
+          less. Step-based actions, from 1 Buzz, still run. You can change it here at any time.
         </Text>
       ) : null}
       <Group gap="xs" justify="flex-end">

--- a/src/server/services/blocks/recipes/__tests__/budget-bounds-parity.test.ts
+++ b/src/server/services/blocks/recipes/__tests__/budget-bounds-parity.test.ts
@@ -7,14 +7,21 @@ import {
 
 /**
  * 🔴 WHY THIS EXISTS. `BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY` / `_HIGH_CEILING_PER_DAY`
- * are hand-mirrored from the recipe registry and are rendered VERBATIM to users in the
- * low-budget warning. Nothing enforced them, so registering an engine outside the pair
- * silently makes that user-facing sentence false — which is exactly the failure this
- * whole surface has now produced three times, each time in a new direction.
+ * are hand-mirrored from the recipe registry, and NEITHER IS RENDERED TO USERS. An
+ * earlier revision of this paragraph said they were "rendered VERBATIM", which was true
+ * when written and was falsified by the commit that stopped the copy quoting any figure
+ * at all — the same shape as the five wordings this surface has already produced, which
+ * is why it is being called out here rather than quietly corrected.
  *
- * The numbers are copy-only (no enforcement path reads them), so the remedy for a red
- * here is to UPDATE THE CONSTANTS and re-read the two warning strings — not to change
- * the recipe.
+ * 🔴 SO DO NOT READ A RED HERE AS "GO AND UPDATE A NUMBER IN THE COPY". The copy names
+ * no number, and re-adding one is the relapse the rule at
+ * `BLOCK_CONSENT_BUDGET_LOW_WARNING_BODY` forbids. What is actually at stake:
+ *   · `LOW` is the render THRESHOLD (`parsed < LOW`). If a cheaper engine is registered
+ *     and LOW is left stale, the warning stops firing across the band between the old
+ *     and new minimum — and "is a low limit" becomes wrong for values in it.
+ *   · `HIGH` is tracked ONLY so a widening of the recipe range is noticed here.
+ * The remedy for a red is to update the constants and re-read the threshold's meaning —
+ * never to change the recipe, and never to put a figure back in the sentence.
  *
  * 🔴 SCOPE — FOUR THINGS THIS DOES NOT COVER. Stated in full because naming some gaps
  * and not the others reads as an exhaustive scope statement — an earlier revision said

--- a/src/server/services/blocks/recipes/__tests__/budget-bounds-parity.test.ts
+++ b/src/server/services/blocks/recipes/__tests__/budget-bounds-parity.test.ts
@@ -16,10 +16,21 @@ import {
  * here is to UPDATE THE CONSTANTS and re-read the two warning strings — not to change
  * the recipe.
  *
- * Scope, stated honestly: this pins the bounds against the RECIPE (customComfy) path,
- * which is the only path that declares a per-engine `maxBuzz`. It says nothing about
- * `textToImage`, whose reservation is the live whatIf quote — which is why the warning
- * copy is hedged rather than categorical.
+ * 🔴 SCOPE — THREE THINGS THIS DOES NOT COVER. Stated in full because naming one gap
+ * and not the others reads as an exhaustive scope statement, and the gap that actually
+ * produced a false sentence is the second one:
+ *   1. `textToImage` — reserves the live whatIf quote, not a declared ceiling, and is
+ *      not bounded below by LOW (the platform's per-gen default is 10).
+ *   2. The INLINE `customComfy` arm — the app declares its own ceiling, up to
+ *      `INLINE_MAX_BUZZ` = 250, which the router reserves verbatim. That is ABOVE the
+ *      HIGH bound asserted here, and it is why the warning copy names no upper bound.
+ *      Nothing in this file can see it; it is schema-bounded, not registry-bounded.
+ *   3. `budgetFor(params)` — the router reserves THAT for the recipe arm, while this
+ *      file reads `budgetForEngine(engine)`. Measured: replacing `budgetFor` with a
+ *      400-Buzz stub leaves these four tests GREEN. The per-recipe suites
+ *      (e.g. `seamless-pano.recipe.test.ts`) are what catch that, so a NEW recipe whose
+ *      author skips its own suite is uncovered here. Also uncovered: a recipe
+ *      registered with `engines: []` (the module-load invariant has the same hole).
  */
 describe('consent-budget copy bounds track the recipe registry', () => {
   /** Every (recipe, engine) pair's declared post-paid ceiling. */
@@ -66,7 +77,7 @@ describe('consent-budget copy bounds track the recipe registry', () => {
     ).toBe(highest);
   });
 
-  it('no registered engine falls outside the pair the warning quotes', () => {
+  it('no registered engine falls outside the tracked [LOW, HIGH] range', () => {
     const outside = ceilings.filter(
       (c) =>
         c.maxBuzz < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ||
@@ -74,7 +85,9 @@ describe('consent-budget copy bounds track the recipe registry', () => {
     );
     expect(
       outside.map((c) => `${c.id}/${c.engine}=${c.maxBuzz}`),
-      'these engines are outside the range the user-facing warning names'
+      'these engines fall outside the tracked range; LOW is the warning THRESHOLD (so a ' +
+        'value under it silently stops the warning firing) and HIGH is tracked only to ' +
+        'notice a widening — HIGH is deliberately NOT rendered to users'
     ).toEqual([]);
   });
 });

--- a/src/server/services/blocks/recipes/__tests__/budget-bounds-parity.test.ts
+++ b/src/server/services/blocks/recipes/__tests__/budget-bounds-parity.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { REGISTERED_RECIPE_IDS, getRecipe } from '../index';
+import {
+  BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY,
+  BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
+} from '~/shared/constants/block-scope.constants';
+
+/**
+ * 🔴 WHY THIS EXISTS. `BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY` / `_HIGH_CEILING_PER_DAY`
+ * are hand-mirrored from the recipe registry and are rendered VERBATIM to users in the
+ * low-budget warning. Nothing enforced them, so registering an engine outside the pair
+ * silently makes that user-facing sentence false — which is exactly the failure this
+ * whole surface has now produced three times, each time in a new direction.
+ *
+ * The numbers are copy-only (no enforcement path reads them), so the remedy for a red
+ * here is to UPDATE THE CONSTANTS and re-read the two warning strings — not to change
+ * the recipe.
+ *
+ * Scope, stated honestly: this pins the bounds against the RECIPE (customComfy) path,
+ * which is the only path that declares a per-engine `maxBuzz`. It says nothing about
+ * `textToImage`, whose reservation is the live whatIf quote — which is why the warning
+ * copy is hedged rather than categorical.
+ */
+describe('consent-budget copy bounds track the recipe registry', () => {
+  /** Every (recipe, engine) pair's declared post-paid ceiling. */
+  const ceilings = REGISTERED_RECIPE_IDS.flatMap((id) => {
+    const recipe = getRecipe(id);
+    if (!recipe) return [];
+    return recipe.engines.map((engine) => ({
+      id,
+      engine,
+      maxBuzz: recipe.budgetForEngine(engine).maxBuzz,
+    }));
+  });
+
+  it('enumerates at least one ceiling (positive control — a zero here would pass every assertion below vacuously)', () => {
+    expect(ceilings.length).toBeGreaterThan(0);
+    // Guard the enumeration itself, not just its length: a registry that returned
+    // undefined ceilings would still have a non-zero length.
+    for (const c of ceilings) {
+      expect(Number.isFinite(c.maxBuzz), `${c.id}/${c.engine} declared a non-finite maxBuzz`).toBe(
+        true
+      );
+    }
+  });
+
+  it('LOW_WARN equals the lowest declared per-engine ceiling', () => {
+    const lowest = Math.min(...ceilings.map((c) => c.maxBuzz));
+    expect(
+      BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY,
+      `lowest declared ceiling is ${lowest} (${ceilings
+        .filter((c) => c.maxBuzz === lowest)
+        .map((c) => `${c.id}/${c.engine}`)
+        .join(', ')}); update the constant and re-read the low-budget warning copy`
+    ).toBe(lowest);
+  });
+
+  it('HIGH_CEILING equals the highest declared per-engine ceiling', () => {
+    const highest = Math.max(...ceilings.map((c) => c.maxBuzz));
+    expect(
+      BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY,
+      `highest declared ceiling is ${highest} (${ceilings
+        .filter((c) => c.maxBuzz === highest)
+        .map((c) => `${c.id}/${c.engine}`)
+        .join(', ')}); update the constant and re-read the low-budget warning copy`
+    ).toBe(highest);
+  });
+
+  it('no registered engine falls outside the pair the warning quotes', () => {
+    const outside = ceilings.filter(
+      (c) =>
+        c.maxBuzz < BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY ||
+        c.maxBuzz > BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY
+    );
+    expect(
+      outside.map((c) => `${c.id}/${c.engine}=${c.maxBuzz}`),
+      'these engines are outside the range the user-facing warning names'
+    ).toEqual([]);
+  });
+});

--- a/src/server/services/blocks/recipes/__tests__/budget-bounds-parity.test.ts
+++ b/src/server/services/blocks/recipes/__tests__/budget-bounds-parity.test.ts
@@ -16,9 +16,12 @@ import {
  * here is to UPDATE THE CONSTANTS and re-read the two warning strings — not to change
  * the recipe.
  *
- * 🔴 SCOPE — THREE THINGS THIS DOES NOT COVER. Stated in full because naming one gap
- * and not the others reads as an exhaustive scope statement, and the gap that actually
- * produced a false sentence is the second one:
+ * 🔴 SCOPE — FOUR THINGS THIS DOES NOT COVER. Stated in full because naming some gaps
+ * and not the others reads as an exhaustive scope statement — an earlier revision said
+ * "three" and omitted the STEP path (4), which is where the next false sentence then
+ * appeared. It also cannot see a TIE: `LOW === min(...)` holds however many engines
+ * share the minimum, and two of the four do, which falsified a "more on the others"
+ * clause while these tests stayed green.
  *   1. `textToImage` — reserves the live whatIf quote, not a declared ceiling, and is
  *      not bounded below by LOW (the platform's per-gen default is 10).
  *   2. The INLINE `customComfy` arm — the app declares its own ceiling, up to
@@ -31,6 +34,12 @@ import {
  *      (e.g. `seamless-pano.recipe.test.ts`) are what catch that, so a NEW recipe whose
  *      author skips its own suite is uncovered here. Also uncovered: a recipe
  *      registered with `engines: []` (the module-load invariant has the same hole).
+ *   4. The STEP path — a step reserves `max(declaredBuzz, quotedBuzz)`, which is not a
+ *      registry figure at all. `chat-completion`'s declared 1 is documented in
+ *      `blocks.router.ts` as "that floor, not a price": measured several times the
+ *      constant for an ordinary conversation, and rising with `maxTokens`. Nothing here
+ *      or anywhere else pins it, which is why the warning copy makes no claim about
+ *      whether step-based actions still run.
  */
 describe('consent-budget copy bounds track the recipe registry', () => {
   /** Every (recipe, engine) pair's declared post-paid ceiling. */

--- a/src/server/services/blocks/scope-grant.service.ts
+++ b/src/server/services/blocks/scope-grant.service.ts
@@ -158,6 +158,28 @@ export async function getConsentBuzzBudget(opts: {
 }
 
 /**
+ * 🔴 THE WRITES BELOW MUST NEVER READ A COLUMN BACK. Prisma's DEFAULT selection is
+ * "every scalar", so a `create`/`update` with no `select` emits
+ * `RETURNING … buzz_budget_per_day` — which makes an ordinary install / subscribe /
+ * re-consent throw P2022 against a database that has not had the migration applied
+ * yet, i.e. a 500 on every grant write from a deploy that lands first. MEASURED on
+ * this PR's own preview environment before this select existed.
+ *
+ * `id` is picked because it is the primary key: it predates this feature, it can
+ * never be the column a future migration is racing, and no caller uses the return
+ * value (both writers return `void`). Do NOT widen this to include a column added by
+ * a pending migration — the whole point is that these writes read nothing new.
+ *
+ * 🔴 KEEP THIS CONST ABOVE `recordScopeGrant`'s DOCBLOCK, NOT BETWEEN THEM. It was
+ * introduced between that docblock and its function, which silently orphaned it:
+ * TypeScript attaches a leading comment to the next DECLARATION, so the whole
+ * `buzzBudgetPerDay` three-state contract stopped appearing on hover at every call
+ * site. A docblock separated from its function by another declaration documents
+ * that declaration instead.
+ */
+const WRITE_RETURN_SELECT = { id: true } as const;
+
+/**
  * Records (or extends) a user's consent for an app block. ADDITIVE — scopes
  * the user already granted persist; the supplied scopes are unioned in. Writing
  * a grant also clears any prior `revoked_at` (re-granting un-revokes), and
@@ -191,21 +213,6 @@ export async function getConsentBuzzBudget(opts: {
  * permission would silently wipe a spend limit the user had deliberately set —
  * a widening, performed by a dialog that said nothing about money.
  */
-/**
- * 🔴 THE WRITES BELOW MUST NEVER READ A COLUMN BACK. Prisma's DEFAULT selection is
- * "every scalar", so a `create`/`update` with no `select` emits
- * `RETURNING … buzz_budget_per_day` — which makes an ordinary install / subscribe /
- * re-consent throw P2022 against a database that has not had the migration applied
- * yet, i.e. a 500 on every grant write from a deploy that lands first. MEASURED on
- * this PR's own preview environment before this select existed.
- *
- * `id` is picked because it is the primary key: it predates this feature, it can
- * never be the column a future migration is racing, and no caller uses the return
- * value (both writers return `void`). Do NOT widen this to include a column added by
- * a pending migration — the whole point is that these writes read nothing new.
- */
-const WRITE_RETURN_SELECT = { id: true } as const;
-
 export async function recordScopeGrant(opts: {
   userId: number;
   appBlockId: string;

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -199,30 +199,39 @@ export const BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY = 90;
 
 /**
  * The HIGHEST per-engine post-paid ceiling any registered recipe declares
- * (`seamless-pano`'s `qwen-image` = 180). Copy-only, like its LOW sibling —
- * neither bound is read by any enforcement path.
+ * (`seamless-pano`'s `qwen-image` = 180). Pinned to the registry alongside LOW
+ * by `recipes/__tests__/budget-bounds-parity.test.ts`; read by no enforcement
+ * path.
  *
- * 🔴 A CEILING IS NOT A PRICE, AND CONFLATING THE TWO IS THE DEFECT THIS PAIR
- * EXISTS TO PREVENT. `maxBuzz` is the worst case RESERVED up front and settled
- * back to actual at terminal (`custom-comfy-settle.service.ts` decrBy's the
- * consent-budget key by ceiling − actual), so what a run COSTS is a different
- * and much smaller number: `ESTIMATE_BUZZ_BY_ENGINE` is
- * `{zimage-turbo: 20, flux2-klein: 45, qwen-image: 150}` and a warm starter run
- * was dogfood-measured at 4 Buzz against a 90 ceiling. User-facing copy that
- * says a generation "costs" one of these numbers overstates it by up to ~22×;
- * say it RESERVES up to this much. A refusal happens when the RESERVATION
- * exceeds the remaining budget, even when the run would have settled cheaper.
+ * 🔴 DELIBERATELY NOT RENDERED TO USERS, AND DO NOT "RESTORE" IT TO THE COPY.
+ * A version of the low-budget warning did quote it as "up to 180 on the
+ * priciest", and that was FALSE: the inline `customComfy` arm lets an app
+ * declare its own ceiling up to `INLINE_MAX_BUZZ` = 250 (`workflow.schema.ts`),
+ * which the router reserves verbatim, on a path the consent budget applies to
+ * and which is NOT dev-gated. `textToImage` is bounded by neither figure — it
+ * reserves its live whatIf quote. **There is no true closed upper bound to
+ * name**, so the copy says "and more on others" and stops. This constant exists
+ * only so that a widening of the RECIPE range is noticed by the parity test.
  *
- * 🔴 These two bounds also describe the RECIPE (customComfy) path only. The
- * consent budget applies path-agnostically — `textToImage` reserves its real
- * whatIf quote, which is NOT bounded below by the LOW figure (the platform's
- * own default per-generation budget is 10). Copy must stay hedged ("may be too
- * low"), never categorical.
+ * 🔴 A CEILING IS NOT A PRICE. `maxBuzz` is the worst case RESERVED up front and
+ * settled back to actual at terminal (`custom-comfy-settle.service.ts` decrBy's
+ * the consent-budget key by ceiling − actual), so what a recipe run COSTS is a
+ * different, much smaller number: `ESTIMATE_BUZZ_BY_ENGINE` is
+ * `{zimage-turbo: 20, flux2-klein: 45, qwen-image: 150}`, and a warm starter run
+ * was dogfood-measured at 4 Buzz against a 90 ceiling. Copy saying a generation
+ * "costs" one of these overstates it by up to ~22×.
  *
- * Both numbers are hand-mirrored from the recipe registry and are pinned
- * against it by `recipes/__tests__/budget-bounds-parity.test.ts`, so a newly
- * registered engine outside [LOW, HIGH] fails there rather than silently
- * making this copy false.
+ * 🔴 SETTLE-BACK IS RECIPE-ONLY. `textToImage` reserves its quote and has no
+ * settle path, so "reserves its worst case, settled back to actual" is a
+ * customComfy statement, not a statement about image generation in general.
+ *
+ * 🔴 THESE BOUNDS DESCRIBE THE RECIPE PATH ONLY, and the LOW figure is not a
+ * lower bound on anything else: the platform's own default per-generation budget
+ * is 10. Copy must stay hedged ("may be too low"), never categorical.
+ *
+ * That is four successive wordings of one sentence, each false in a new way and
+ * each introduced by the fix for the previous one. The rules above are the
+ * residue; read them before editing either warning.
  */
 export const BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY = 180;
 

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -219,7 +219,7 @@ export const BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY = 180;
  * THE FIX FOR THE PREVIOUS ONE. In order: "this app will refuse to generate"
  * (false for step-priced apps) → "can cost up to 90 per run" (inverted the bound
  * over the engine set) → "the cheapest engine costs 90 per run" (quoted a
- * RESERVATION as a PRICE, ~4.3–22× over) → "up to 180 on the priciest" (a CLOSED
+ * RESERVATION as a PRICE, 4.5–22.5× over) → "up to 180 on the priciest" (a CLOSED
  * bound the inline arm exceeds) → "and more on the other engines … step-based
  * actions still run" (two engines tie at 90, and steps do NOT always run).
  *
@@ -241,9 +241,9 @@ export const BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY = 180;
  * ⚠️ A closed upper bound DOES exist, contrary to what an earlier revision of
  * this docblock asserted: every path gates the reservation against the token's
  * per-call budget, which `resolveBuzzBudget` clamps at `BUZZ_BUDGET_CAP` = 1000.
- * It is simply not renderable — it is per-app, an order of magnitude above any
- * real reservation, and alarming rather than informative. Do not "correct" the
- * copy by naming it.
+ * It is simply not renderable — it is per-app, ~4× the largest reservation any
+ * path can actually take (INLINE_MAX_BUZZ = 250; 180 for recipes), and alarming
+ * rather than informative. Do not "correct" the copy by naming it.
  *
  * What IS true on every consent-bearing path, and all this sentence claims:
  * the reservation is taken up front, before the run, and the request is refused

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -198,6 +198,35 @@ export const BLOCK_CONSENT_BUDGET_DEFAULT_PER_DAY = 1000;
 export const BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY = 90;
 
 /**
+ * The HIGHEST per-engine post-paid ceiling any registered recipe declares
+ * (`seamless-pano`'s `qwen-image` = 180). Copy-only, like its LOW sibling —
+ * neither bound is read by any enforcement path.
+ *
+ * 🔴 A CEILING IS NOT A PRICE, AND CONFLATING THE TWO IS THE DEFECT THIS PAIR
+ * EXISTS TO PREVENT. `maxBuzz` is the worst case RESERVED up front and settled
+ * back to actual at terminal (`custom-comfy-settle.service.ts` decrBy's the
+ * consent-budget key by ceiling − actual), so what a run COSTS is a different
+ * and much smaller number: `ESTIMATE_BUZZ_BY_ENGINE` is
+ * `{zimage-turbo: 20, flux2-klein: 45, qwen-image: 150}` and a warm starter run
+ * was dogfood-measured at 4 Buzz against a 90 ceiling. User-facing copy that
+ * says a generation "costs" one of these numbers overstates it by up to ~22×;
+ * say it RESERVES up to this much. A refusal happens when the RESERVATION
+ * exceeds the remaining budget, even when the run would have settled cheaper.
+ *
+ * 🔴 These two bounds also describe the RECIPE (customComfy) path only. The
+ * consent budget applies path-agnostically — `textToImage` reserves its real
+ * whatIf quote, which is NOT bounded below by the LOW figure (the platform's
+ * own default per-generation budget is 10). Copy must stay hedged ("may be too
+ * low"), never categorical.
+ *
+ * Both numbers are hand-mirrored from the recipe registry and are pinned
+ * against it by `recipes/__tests__/budget-bounds-parity.test.ts`, so a newly
+ * registered engine outside [LOW, HIGH] fails there rather than silently
+ * making this copy false.
+ */
+export const BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY = 180;
+
+/**
  * Membership test against the authoritative scope vocabulary.
  *
  * 🔴 OWN-PROPERTY ONLY — deliberately `hasOwnProperty`, never `in`. `in` walks

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -203,37 +203,57 @@ export const BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY = 90;
  * by `recipes/__tests__/budget-bounds-parity.test.ts`; read by no enforcement
  * path.
  *
- * 🔴 DELIBERATELY NOT RENDERED TO USERS, AND DO NOT "RESTORE" IT TO THE COPY.
- * A version of the low-budget warning did quote it as "up to 180 on the
- * priciest", and that was FALSE: the inline `customComfy` arm lets an app
- * declare its own ceiling up to `INLINE_MAX_BUZZ` = 250 (`workflow.schema.ts`),
- * which the router reserves verbatim, on a path the consent budget applies to
- * and which is NOT dev-gated. `textToImage` is bounded by neither figure — it
- * reserves its live whatIf quote. **There is no true closed upper bound to
- * name**, so the copy says "and more on others" and stops. This constant exists
- * only so that a widening of the RECIPE range is noticed by the parity test.
- *
- * 🔴 A CEILING IS NOT A PRICE. `maxBuzz` is the worst case RESERVED up front and
- * settled back to actual at terminal (`custom-comfy-settle.service.ts` decrBy's
- * the consent-budget key by ceiling − actual), so what a recipe run COSTS is a
- * different, much smaller number: `ESTIMATE_BUZZ_BY_ENGINE` is
- * `{zimage-turbo: 20, flux2-klein: 45, qwen-image: 150}`, and a warm starter run
- * was dogfood-measured at 4 Buzz against a 90 ceiling. Copy saying a generation
- * "costs" one of these overstates it by up to ~22×.
- *
- * 🔴 SETTLE-BACK IS RECIPE-ONLY. `textToImage` reserves its quote and has no
- * settle path, so "reserves its worst case, settled back to actual" is a
- * customComfy statement, not a statement about image generation in general.
- *
- * 🔴 THESE BOUNDS DESCRIBE THE RECIPE PATH ONLY, and the LOW figure is not a
- * lower bound on anything else: the platform's own default per-generation budget
- * is 10. Copy must stay hedged ("may be too low"), never categorical.
- *
- * That is four successive wordings of one sentence, each false in a new way and
- * each introduced by the fix for the previous one. The rules above are the
- * residue; read them before editing either warning.
+ * 🔴 NOT RENDERED, AND NEITHER IS ITS LOW SIBLING. See
+ * `BLOCK_CONSENT_BUDGET_LOW_WARNING_BODY` below for why the warning quotes no
+ * figure at all. This constant exists solely so the parity test notices a
+ * widening of the RECIPE range.
  */
 export const BLOCK_CONSENT_BUDGET_HIGH_CEILING_PER_DAY = 180;
+
+/**
+ * The body of the low-budget warning, shared by the consent modal and the editor
+ * on /apps/activity so the two cannot drift. The caller supplies the amount
+ * before it and its own "you can change it" tail after it.
+ *
+ * 🔴 FIVE SUCCESSIVE WORDINGS OF THIS SENTENCE SHIPPED FALSE, EACH INTRODUCED BY
+ * THE FIX FOR THE PREVIOUS ONE. In order: "this app will refuse to generate"
+ * (false for step-priced apps) → "can cost up to 90 per run" (inverted the bound
+ * over the engine set) → "the cheapest engine costs 90 per run" (quoted a
+ * RESERVATION as a PRICE, ~4.3–22× over) → "up to 180 on the priciest" (a CLOSED
+ * bound the inline arm exceeds) → "and more on the other engines … step-based
+ * actions still run" (two engines tie at 90, and steps do NOT always run).
+ *
+ * 🔴 SO THE RULE IS NOW STRUCTURAL, NOT A BETTER FORM OF WORDS: **this sentence
+ * asserts no figure, and no claim about which actions still run.** Every such
+ * claim was falsifiable because the reservation space has no short true
+ * description —
+ *   · recipe ceilings are 90, 90, 150, 180 (note the TIE — it falsified
+ *     "more on the other engines", and the parity test cannot see it because
+ *     `LOW === min(...)` holds for any number of ties);
+ *   · the INLINE customComfy arm reserves an app-declared ceiling up to
+ *     `INLINE_MAX_BUZZ` = 250, verbatim, un-dev-gated;
+ *   · `textToImage` reserves its live whatIf quote, which can be far LOWER (the
+ *     platform's own default per-generation budget is 10);
+ *   · a STEP reserves `max(declaredBuzz, quotedBuzz)`, and `chat-completion`'s
+ *     declared 1 is documented in `blocks.router.ts` as "that floor, not a
+ *     price" — measured several times the constant, rising with `maxTokens`.
+ *
+ * ⚠️ A closed upper bound DOES exist, contrary to what an earlier revision of
+ * this docblock asserted: every path gates the reservation against the token's
+ * per-call budget, which `resolveBuzzBudget` clamps at `BUZZ_BUDGET_CAP` = 1000.
+ * It is simply not renderable — it is per-app, an order of magnitude above any
+ * real reservation, and alarming rather than informative. Do not "correct" the
+ * copy by naming it.
+ *
+ * What IS true on every consent-bearing path, and all this sentence claims:
+ * the reservation is taken up front, before the run, and the request is refused
+ * when the running per-UTC-day total exceeds the user's cap
+ * (`consentBudgetExceeded`: `consent.total > consent.cap`).
+ */
+export const BLOCK_CONSENT_BUDGET_LOW_WARNING_BODY =
+  'Buzz/day is a low limit. Each generation reserves Buzz up front, and is refused if that ' +
+  'reservation exceeds your remaining limit for the day — so a low limit can make an app look ' +
+  'broken.';
 
 /**
  * Membership test against the authoritative scope vocabulary.


### PR DESCRIPTION
## What this is

Two findings from an **adversarial delta re-audit (round 2) of #4745's fix round** — 16 files / 1,379 insertions that no adversarial round had ever read. Round 1 audited through `9195c7fb4d`; the three fix commits `8ee4f03`, `afc17b6`, `5e3b166` went in afterwards and shipped unaudited.

Both findings are in **the prose that fix round wrote about itself**, which is the class that keeps recurring in this arc. **No behaviour change.**

Round 2 found **no 🔴**, and dispositioned all eight of round 1's claims as *actually fixed* — nothing regressed. The money path in particular held up: all three cumulative reservers route through one primitive, it self-unwinds and rethrows (fails closed), there is no double-refund, and the settle path unwinds the consent key.

---

## 🟡 1 — the low-budget warning was categorically false for step-priced apps

Both surfaces warned, below `BLOCK_CONSENT_BUDGET_LOW_WARN_PER_DAY` (90):

> `{N}` Buzz/day is lower than most generations cost — **this app will refuse to generate until you raise it.**

That threshold is the lowest per-engine **customComfy** ceiling. Registry steps cost **1 Buzz** — `CONVERT_IMAGE_PRICE_BUZZ = 1`, `CHAT_COMPLETION_PRICE_BUZZ = 1` — so a 50 Buzz/day limit on a step-priced app funds **fifty runs** and refuses nothing. The sentence is unconditionally false for that app.

**It also contradicted a decision taken in the same commit.** `BLOCK_CONSENT_BUDGET_MIN_PER_DAY` keeps the floor at 1 specifically so as not to "silently overrule a user who deliberately wants a tiny allowance for a step-priced app (`convert-image` costs 1 Buzz)" — and its written rationale leans on *this very warning* to make the floor tolerable. The warning then told that exact user their legitimate setting was broken.

The constant's own docblock already had it right: *"Registry steps can be far cheaper (`convert-image` = 1 Buzz), which is why this warns instead of blocking."* Only the user-facing copy disagreed.

**The threshold is correct and unchanged** — I verified 90 is still the floor (`STARTER_BUDGET.maxBuzz` = 90, `seamless-pano`'s `zimage-turbo` = 90). Only the subject is fixed: the copy now names **image generation** rather than "this app", and says cheaper step-based apps are unaffected.

## 🟡 2 — `recordScopeGrant` ships with no docblock at all

`8ee4f03` inserted the `WRITE_RETURN_SELECT` docblock **and its const** between `recordScopeGrant`'s 34-line contract docblock and the function. TypeScript attaches a leading comment to the next **declaration**, so that contract now documents the const, and hovering `recordScopeGrant` at any call site shows nothing.

What got orphaned is not decoration — it is the three-state `buzzBudgetPerDay` rule (`number` → replace / `null` → clear / **omitted** → leave alone). That is the subtlest rule in this feature and the one the budget editor added in the same PR depends on: "Remove limit" sends an explicit `null`, Save sends a number, and the consent modal omits the key.

Fixed by moving the const **above** the docblock. No code changed — verified one declaration, three usages, same value.

## Also: a missing pin the audit surfaced

The warning **text was pinned by nothing**. Round 1 pinned the off-state copy as a whole normalised string *precisely because the defect it replaced was a keyword-passing sentence* — this warning was the same shape and had no such pin, so a reworded relapse would have been silent. Both warnings are now pinned as whole normalised strings, matching that existing idiom.

---

## 🔴 Deliberately NOT included — the audit's third finding

Round 2's third 🟡 is a stale P2022 comment in `user-app-surface.service.ts`: it says the failure means "every app reports `null`", but it also forces `spendScopeGranted: false` (removing the budget editor), and **post-#4760 that `try` now carries the grant-only leg — so on a pre-migration database every grant-only app silently vanishes from the permissions tab.**

**#4790 is actively rewriting that function**, and this repo bans stacked PRs, so that fix belongs with #4790 or after it merges. Keeping this diff file-disjoint from #4790 is the same call #4760 made against #4722. Verified disjoint immediately before opening this.

## One interaction worth recording on #4790

After #4790, `BlockScopeList` renders `approvedScopes` while `AppBudgetControl` still renders off `spendScopeGranted` (from `grantedScopes` on the grant row) — adjacent lines, two different sources. A moderator narrowing an approval to exclude `ai:write:budgeted` produces a card reading *"This app doesn't request any permissions"* with a **"Daily Buzz limit: 750 Buzz/day — Change"** editor directly beneath it, and clicking Change returns `BAD_REQUEST`. #4790's body reasons about that empty-label copy in isolation; the contradiction is with the budget row. Flagging rather than fixing, since #4790 owns that file.

---

## Verification

- **typecheck: 41 errors at HEAD, 41 at `origin/main`, delta 0** — and **zero** in any of the five touched files. The 41 are module-resolution artifacts of an unpopulated submodule / unlinked workspace packages in a fresh worktree; the repo's own `submodules-checked-out.test.ts` is among the failures, which is the environment diagnosing itself. I ran the base as an explicit control rather than quoting a bare count.
- **unit tier:** none of the touched files appear in the failed set, confirmed with a positive control proving the grep pattern matches real failure lines.
- **prettier:** clean on all five, with a **negative control** confirming the checker flags bad input (a quoted file list checks zero files and prints a pass, so the control matters).
- **browser tier NOT run locally** — this host's Playwright pin does not match the nix store's browsers (wants chromium 1200, store has 1228). That is an environment limit, not a gap in this change: CI covers it via the Tekton preview pipeline (`preview / component-tests`). **The two whole-string pins added here are therefore unverified locally and I am not claiming otherwise** — they are the thing to watch on the preview run.

## Audit provenance

Round 2 also reported four 🟢s I am **not** fixing here, recorded so they are open rather than absent: a once-per-process log flag making the `site` field single-valued; an unqualified "one line per pod" claim where this repo has a measured bundler-duplication counter-example; a budget edit re-stamping the grant row's consent-provenance `version` (harmless today — that column is write-only everywhere, which I checked); and the run-for-real leg having no expire-failure test of its own.
