### PR TITLE
feat(apps): a bounded recent-reviews block below the listing description

### DIFF
--- a/src/components/Apps/AppListingDetailBody.affordances.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.affordances.browser.test.tsx
@@ -51,6 +51,13 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof TrpcMod>()),
   trpc: {
     appListings: {
+      // The inline recent-reviews block's BOUNDED read. Empty here: this file is
+      // about other surfaces, and an empty page makes the block render nothing —
+      // the shape those assertions were written against. Without the key, the real
+      // `trpc.appListings.listReviews` is undefined and the component THROWS.
+      listReviews: {
+        useQuery: () => ({ data: { items: [], nextCursor: null }, isLoading: false }),
+      },
       listAvailable: { useQuery: () => ({ data: { items: [] }, isLoading: false }) },
       getMyReview: { useQuery: () => ({ data: null, isLoading: false }) },
       upsertReview: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -124,6 +124,13 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof TrpcMod>()),
   trpc: {
     appListings: {
+      // The inline recent-reviews block's BOUNDED read. Empty here: this file is
+      // about other surfaces, and an empty page makes the block render nothing —
+      // the shape those assertions were written against. Without the key, the real
+      // `trpc.appListings.listReviews` is undefined and the component THROWS.
+      listReviews: {
+        useQuery: () => ({ data: { items: [], nextCursor: null }, isLoading: false }),
+      },
       listAvailable: {
         useQuery: (_input: unknown, opts?: { enabled?: boolean }) => ({
           data: opts?.enabled === false ? undefined : { items: mocks.relatedItems },

--- a/src/components/Apps/AppListingDetailBody.gallery.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.gallery.browser.test.tsx
@@ -94,6 +94,13 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
     appListings: {
       // The discovery rail sits BELOW the two-column grid, so what it returns cannot
       // move a tile. Empty anyway, to keep the suite network-free.
+      // The inline recent-reviews block's BOUNDED read. Empty here: this file is
+      // about other surfaces, and an empty page makes the block render nothing —
+      // the shape those assertions were written against. Without the key, the real
+      // `trpc.appListings.listReviews` is undefined and the component THROWS.
+      listReviews: {
+        useQuery: () => ({ data: { items: [], nextCursor: null }, isLoading: false }),
+      },
       listAvailable: { useQuery: () => ({ data: { items: [] }, isLoading: false }) },
       getMyReview: { useQuery: () => ({ data: null, isLoading: false }) },
       upsertReview: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },

--- a/src/components/Apps/AppListingDetailBody.permissions.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.permissions.browser.test.tsx
@@ -76,6 +76,13 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof TrpcMod>()),
   trpc: {
     appListings: {
+      // The inline recent-reviews block's BOUNDED read. Empty here: this file is
+      // about other surfaces, and an empty page makes the block render nothing —
+      // the shape those assertions were written against. Without the key, the real
+      // `trpc.appListings.listReviews` is undefined and the component THROWS.
+      listReviews: {
+        useQuery: () => ({ data: { items: [], nextCursor: null }, isLoading: false }),
+      },
       listAvailable: { useQuery: () => ({ data: { items: [] }, isLoading: false }) },
       getMyReview: { useQuery: () => ({ data: null, isLoading: false }) },
       upsertReview: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },

--- a/src/components/Apps/AppListingDetailBody.recentReviews.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.recentReviews.browser.test.tsx
@@ -1,0 +1,331 @@
+import React from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
+import type * as FeatureFlagsMod from '~/providers/FeatureFlagsProvider';
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+import type { AppListingReviewListItem } from '~/server/schema/blocks/app-listing-review.schema';
+
+/**
+ * App-listing detail — the BOUNDED INLINE RECENT-REVIEWS BLOCK, and the DOM ORDER
+ * it was introduced into.
+ *
+ * A tester asked for reviews "right below description, show 3-4 recent + a 'See
+ * more reviews' link", and separately for "More in category" to move to the very
+ * bottom. The operator ruled: add a BOUNDED block; do NOT move the discovery rail
+ * and do NOT move the full reviews section or change its anchor id. The bounded
+ * shape is what makes those compatible — a fixed-height block cannot bury what
+ * follows it, whereas hoisting the unbounded list would push the rail down by an
+ * arbitrary amount.
+ *
+ * 🔴 READ BEFORE TREATING ANY RESULT HERE AS A GATE: IT IS NOT ONE. This file is
+ * in the Vitest browser-mode `component` project, which CI runs only as the
+ * preview pipeline's `preview / component-tests` — report-only and non-blocking.
+ * The BOUND itself is pinned in the blocking node `unit` tier by
+ * `__tests__/recentReviews.test.ts`. What only this tier can see is DOM ORDER and
+ * the rendered `href`, and those are what it is here for.
+ *
+ * 🔴 ORDER IS ASSERTED ON DOCUMENT POSITION, NOT ON SOURCE TEXT AND NOT ON MERE
+ * PRESENCE. "Both nodes exist" passes in either order, which is exactly the
+ * regression this file is meant to catch: a future change that hoists the full
+ * reviews list, or drops the rail to the bottom, would leave every presence
+ * assertion green.
+ *
+ * 🔴 NO NEW-MODULE IMPORT AT THE TOP OF THIS FILE, DELIBERATELY. Everything it
+ * imports exists on `main` too, so the whole file COLLECTS AND RUNS against the
+ * pre-change tree and produces real red assertions there — rather than failing to
+ * import and reporting `Tests no tests`, which is indistinguishable from a pass.
+ * That is why the cap is asserted as a BAND (the operator's "3-4") against an
+ * over-long fixture instead of against the constant; the constant-vs-render
+ * agreement is the node tier's job, and it holds by construction because the
+ * component reads one constant for both its query `limit` and its render.
+ */
+
+const WIDE: [number, number] = [1440, 900];
+
+/** How many reviews the fake query returns — MUCH more than the cap. */
+const FED = 9;
+
+const mocks = vi.hoisted(() => ({
+  /** Rows `appListings.listReviews` resolves with for the test at hand. */
+  reviews: [] as unknown[],
+  /** Whether that query is still loading. */
+  loading: false,
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// `importOriginal` SPREAD, not a wholesale replacement (local-rules/
+// no-wholesale-module-mock): a hand-written factory silently breaks every importer
+// the day the real module grows an export it omits, and here that surfaces as
+// `Tests no tests` — nothing to see rather than a failure.
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => {
+  const flags = { appBlocks: true, appListings: true, appBlocksPages: false };
+  return {
+    ...(await importOriginal<typeof FeatureFlagsMod>()),
+    useFeatureFlags: () => flags,
+    useOptionalFeatureFlags: () => flags,
+  };
+});
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    appListings: {
+      listAvailable: { useQuery: () => ({ data: { items: [] }, isLoading: false }) },
+      // The INLINE block's bounded read. Non-infinite by design — this block has
+      // no "load more".
+      listReviews: {
+        useQuery: () => ({
+          data: mocks.loading ? undefined : { items: mocks.reviews, nextCursor: null },
+          isLoading: mocks.loading,
+        }),
+      },
+      getMyReview: { useQuery: () => ({ data: null, isLoading: false }) },
+      upsertReview: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      reportListing: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
+    user: {
+      getCreator: { useQuery: () => ({ data: null }) },
+      getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) },
+    },
+    useUtils: () => ({
+      appListings: {
+        getMyReview: { invalidate: async () => undefined },
+        listReviews: { invalidate: async () => undefined },
+        getAppDetail: { invalidate: async () => undefined },
+      },
+    }),
+  },
+}));
+// The FULL list is stubbed — it is the bottom-of-page infinite list, not the unit
+// under test. Its wrapping `Stack` (and the anchor id on it) lives in
+// AppListingDetailBody itself, so the jump target is still real here.
+vi.mock('~/components/Apps/AppListingReviews', () => ({
+  AppListingReviews: () => <div data-testid="mock-reviews" />,
+}));
+vi.mock('~/components/Apps/AppListingComments', () => ({
+  AppListingComments: () => <div data-testid="mock-comments" />,
+}));
+// Two LEAF components inside a review row that reach for app-wide contexts this
+// harness does not mount (`ContentSettingsProvider`, `IsClientContext`). Stubbed so
+// the row itself stays REAL — the assertions here count rows and compare document
+// positions, neither of which is about an avatar or a timestamp. Same stub shape the
+// sibling `AppListingDetailBody.browser.test.tsx` already uses for UserAvatar.
+vi.mock('~/components/UserAvatar/UserAvatar', () => ({
+  UserAvatar: ({ userId }: { userId?: number }) => (
+    <div data-testid="mock-user-avatar">{userId ?? ''}</div>
+  ),
+  UserProfileLink: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('~/components/Dates/DaysFromNow', () => ({
+  DaysFromNow: () => <span data-testid="mock-days-from-now">some time ago</span>,
+}));
+
+// 🔴 Imported AFTER the mocks, like the component itself. A top-level VALUE import
+// from the app graph pulls part of that graph in before `vi.mock` hoisting settles,
+// which resolves a SECOND copy of React and produces 'Invalid hook call' on every
+// test in the file. An `import type` is fine (erased); a value import is not.
+const { AppListingDetailBody } = await import('./AppListingDetailBody');
+const { LISTING_REVIEWS_ANCHOR_ID } = await import('~/components/Apps/listingKindLabels');
+
+const BLOCK = '[data-testid="apps-listing-recent-reviews"]';
+const ROW = '[data-testid="apps-listing-review-row"]';
+const SEE_MORE = '[data-testid="apps-listing-see-more-reviews"]';
+const RAIL = '[data-testid="apps-related-rail"]';
+
+function reviewFixture(id: number): AppListingReviewListItem {
+  return {
+    id,
+    recommended: id % 2 === 0,
+    details: `Review body number ${id}`,
+    createdAt: new Date('2026-03-04T05:06:07.000Z'),
+    user: { id: id * 10, username: `user${id}`, image: null },
+  };
+}
+
+function base(over: Partial<ListingDetail> = {}): ListingDetail {
+  return {
+    id: 'l1',
+    serialId: 1,
+    slug: 'my-app',
+    kind: 'onsite',
+    collaborators: [],
+    name: 'My App',
+    tagline: 'A handy app',
+    description: 'What this app does.',
+    category: 'utility',
+    contentRating: null,
+    isBeta: false,
+    betaMessage: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: { recommendedCount: 7, notRecommendedCount: 1, recommendPct: 0.875 },
+    reviewCount: 8,
+    installCount: 4213,
+    sourceRepoUrl: null,
+    updatedAt: '2026-03-04T05:06:07.000Z',
+    screenshots: [],
+    scopes: [],
+    kindData: {
+      kind: 'onsite',
+      appBlockId: 'blk-1',
+      hasPage: true,
+      liveUrl: 'https://my-app.civit.ai',
+    },
+    ...over,
+  };
+}
+
+async function renderBody(detail: ListingDetail, preview = false) {
+  const { container } = await renderWithProviders(
+    <AppListingDetailBody detail={detail} preview={preview} />
+  );
+  const within = page.elementLocator(container);
+  await expect.element(within.getByText('My App')).toBeInTheDocument();
+  return { container };
+}
+
+/** True when `a` comes BEFORE `b` in document order. */
+function precedes(a: Element | null, b: Element | null): boolean {
+  expect(a, 'the earlier node must exist for an order claim to mean anything').not.toBeNull();
+  expect(b, 'the later node must exist for an order claim to mean anything').not.toBeNull();
+  return Boolean(
+    a!.compareDocumentPosition(b!) & Node.DOCUMENT_POSITION_FOLLOWING // eslint-disable-line no-bitwise
+  );
+}
+
+beforeEach(async () => {
+  mocks.reviews = Array.from({ length: FED }, (_, i) => reviewFixture(i + 1));
+  mocks.loading = false;
+  await page.viewport(...WIDE);
+});
+
+describe('inline recent reviews — the bounded block', () => {
+  test('🔴 renders below the description when the listing HAS reviews', async () => {
+    // The POSITIVE CONTROL for every "it is absent" assertion further down. Without
+    // it, a probe wired to nothing would satisfy all of them.
+    const { container } = await renderBody(base());
+    const block = container.querySelector(BLOCK);
+    expect(block, 'the inline recent-reviews block must render').not.toBeNull();
+    expect(container.querySelector('[data-testid="apps-listing-description"]')).not.toBeNull();
+    expect(
+      precedes(container.querySelector('[data-testid="apps-listing-description"]'), block)
+    ).toBe(true);
+  });
+
+  test('🔴 renders AT MOST the cap even when far more reviews exist', async () => {
+    // THE ASSERTION THAT PROTECTS THE BOUND. The query is fed 9 rows; a block that
+    // renders all 9 is the unbounded shape the design rejected, and it would pass a
+    // bare "the block rendered" check. The band is the operator's decision ("3-4"),
+    // asserted here rather than the constant so this file still collects and runs
+    // against the pre-change tree.
+    const { container } = await renderBody(base());
+    const rows = container.querySelectorAll(`${BLOCK} ${ROW}`);
+    expect(rows.length).toBeLessThan(FED);
+    expect(rows.length).toBeGreaterThanOrEqual(3);
+    expect(rows.length).toBeLessThanOrEqual(4);
+  });
+
+  test('🔴 renders NOTHING when the listing has no reviews', async () => {
+    // No empty section, no placeholder heading, no "be the first to review" box —
+    // the #4761 convention. The sibling above is the control that proves this
+    // selector can see the block when it IS there.
+    mocks.reviews = [];
+    const { container } = await renderBody(base({ reviewCount: 0 }));
+    expect(container.querySelector(BLOCK)).toBeNull();
+    expect(container.querySelector(SEE_MORE)).toBeNull();
+    expect(container.textContent).not.toContain('Recent reviews');
+    // …and the page still gets its discovery rail and its full reviews section.
+    expect(container.querySelector(RAIL)).not.toBeNull();
+    expect(container.querySelector(`#${LISTING_REVIEWS_ANCHOR_ID}`)).not.toBeNull();
+  });
+
+  test('renders nothing while the bounded query is still loading', async () => {
+    // A skeleton here would reserve height above the discovery rail for a block
+    // that may never appear — the exact reflow the fixed-height shape avoids.
+    mocks.loading = true;
+    const { container } = await renderBody(base());
+    expect(container.querySelector(BLOCK)).toBeNull();
+  });
+
+  test('🔴 the "See more reviews" href is DERIVED from the anchor constant', async () => {
+    // Both ends must read one value. A second `'app-listing-reviews'` literal here
+    // would re-open a seam that fails SILENTLY: a fragment link to a missing id
+    // produces no error and no visual difference. Renaming the constant must move
+    // this assertion and the link together.
+    const { container } = await renderBody(base());
+    const link = container.querySelector<HTMLAnchorElement>(SEE_MORE);
+    expect(link, 'the block must offer a way to the full list').not.toBeNull();
+    expect(link!.tagName).toBe('A');
+    expect(link!.getAttribute('href')).toBe(`#${LISTING_REVIEWS_ANCHOR_ID}`);
+    // 🔴 A same-page jump must not open a new tab.
+    expect(link!.getAttribute('target')).toBeNull();
+  });
+
+  test('🔴 the target that link points at EXISTS in the rendered document', async () => {
+    const { container } = await renderBody(base());
+    expect(container.querySelector(`#${LISTING_REVIEWS_ANCHOR_ID}`)).not.toBeNull();
+  });
+});
+
+describe('inline recent reviews — REGRESSION: what must NOT have moved', () => {
+  test('🔴 the full reviews section and its id still render', async () => {
+    // The Details rail's "Reviews" row links here. The inline block is additive;
+    // it must not have replaced or relocated the jump target.
+    const { container } = await renderBody(base());
+    const section = container.querySelector(`#${LISTING_REVIEWS_ANCHOR_ID}`);
+    expect(section).not.toBeNull();
+    expect(container.querySelector('[data-testid="mock-reviews"]')).not.toBeNull();
+    expect(section!.contains(container.querySelector('[data-testid="mock-reviews"]'))).toBe(true);
+  });
+
+  test('🔴 DOM ORDER: inline block → discovery rail → full reviews section', async () => {
+    // THE OPERATOR'S DECISION, PINNED. Three separate claims, because a single
+    // "first precedes last" test passes with the middle node anywhere:
+    //   1. the bounded block is above the rail (the tester's request, honoured);
+    //   2. the rail is still ABOVE the unbounded threads (the decision NOT to move
+    //      it to the bottom — the rail exists for viewers who read the listing and
+    //      didn't convert, and below the threads it is buried);
+    //   3. the full list is still last (not hoisted).
+    const { container } = await renderBody(base());
+    const block = container.querySelector(BLOCK);
+    const rail = container.querySelector(RAIL);
+    const section = container.querySelector(`#${LISTING_REVIEWS_ANCHOR_ID}`);
+
+    expect(precedes(block, rail), 'the inline block must sit ABOVE "More in category"').toBe(true);
+    expect(precedes(rail, section), '"More in category" must stay ABOVE the full reviews').toBe(
+      true
+    );
+    expect(precedes(block, section), 'the inline block must sit above the full list').toBe(true);
+  });
+
+  test('🔴 the discovery rail keeps its place even with NO inline block to displace it', async () => {
+    // The rail's placement is not contingent on the new block existing. Without
+    // this, deleting the block would be indistinguishable from moving the rail.
+    mocks.reviews = [];
+    const { container } = await renderBody(base({ reviewCount: 0 }));
+    expect(
+      precedes(
+        container.querySelector(RAIL),
+        container.querySelector(`#${LISTING_REVIEWS_ANCHOR_ID}`)
+      )
+    ).toBe(true);
+  });
+});
+
+describe('inline recent reviews — preview posture', () => {
+  test('🔴 in PREVIEW neither the inline block nor the full section renders', async () => {
+    // A shadow listing has no review rows and must not be queried. The block is
+    // gated `!preview` exactly like both of its neighbours; emitting it here would
+    // also emit a "See more reviews" link pointing at an id that does not exist on
+    // the page, which is a dead link that fails silently.
+    const { container } = await renderBody(base(), true);
+    expect(container.querySelector(BLOCK)).toBeNull();
+    expect(container.querySelector(SEE_MORE)).toBeNull();
+    expect(container.querySelector(`#${LISTING_REVIEWS_ANCHOR_ID}`)).toBeNull();
+    expect(container.querySelector(RAIL)).toBeNull();
+  });
+});

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -62,6 +62,7 @@ import { ListingCollaboratorByline } from '~/components/Apps/ListingCollaborator
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { AppListingComments } from '~/components/Apps/AppListingComments';
 import { AppListingDescription } from '~/components/Apps/AppListingDescription';
+import { AppListingRecentReviews } from '~/components/Apps/AppListingRecentReviews';
 import { AppListingReviews } from '~/components/Apps/AppListingReviews';
 import { CATEGORY_ICONS, FALLBACK_CATEGORY_ICON } from '~/components/Apps/marketplaceCategoryIcons';
 import { ContainerGrid2 } from '~/components/ContainerGrid/ContainerGrid';
@@ -1303,6 +1304,28 @@ export function AppListingDetailBody({
           </Stack>
         </ContainerGrid2.Col>
       </ContainerGrid2>
+
+      {/* RECENT REVIEWS — a BOUNDED taste of the reviews, full-width directly
+          below the description column and ABOVE the discovery rail.
+          🔴 THE BOUND IS THE DESIGN. A tester asked for the reviews section to be
+          MOVED up whole and for the discovery rail to move to the very bottom.
+          Neither was done: the full list below is unbounded, so hoisting it would
+          bury the rail (and the discussion) behind an arbitrary amount of
+          scrolling — the same reasoning the rail's own placement comment records,
+          which still holds. What went up instead is a block that CANNOT grow: at
+          most `INLINE_RECENT_REVIEWS_LIMIT` rows plus a "See more reviews" link
+          down to the full list, which stays where it is and keeps its anchor id.
+          A future change that lets this block grow without limit defeats the
+          entire reason this shape was chosen over the literal request.
+          🔴 The DOM order Description → this block → RelatedListings →
+          `#LISTING_REVIEWS_ANCHOR_ID` is the decision, and it is pinned by a test
+          that asserts relative document position (not source text, and not mere
+          presence — both nodes present passes in either order, which is exactly
+          the defect). See `AppListingDetailBody.recentReviews.browser.test.tsx`.
+          Renders NOTHING at zero reviews (no heading, no placeholder) and is
+          omitted in preview for the same reason as its two neighbours: a shadow
+          listing has no review rows and must not be queried. */}
+      {!preview && <AppListingRecentReviews appListingId={detail.id} />}
 
       {/* DISCOVERY — "More in <category>" + a persistent "Browse all apps" link.
           Placed AFTER the two-column body but BEFORE the reviews/comments: those

--- a/src/components/Apps/AppListingDetailBody.viewer.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.viewer.browser.test.tsx
@@ -74,6 +74,13 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof TrpcMod>()),
   trpc: {
     appListings: {
+      // The inline recent-reviews block's BOUNDED read. Empty here: this file is
+      // about other surfaces, and an empty page makes the block render nothing —
+      // the shape those assertions were written against. Without the key, the real
+      // `trpc.appListings.listReviews` is undefined and the component THROWS.
+      listReviews: {
+        useQuery: () => ({ data: { items: [], nextCursor: null }, isLoading: false }),
+      },
       listAvailable: { useQuery: () => ({ data: { items: [] }, isLoading: false }) },
       getMyReview: { useQuery: () => ({ data: null, isLoading: false }) },
       upsertReview: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },

--- a/src/components/Apps/AppListingRecentReviews.tsx
+++ b/src/components/Apps/AppListingRecentReviews.tsx
@@ -1,0 +1,107 @@
+import { Anchor, Divider, Group, Stack, Title } from '@mantine/core';
+import { IconArrowDown } from '@tabler/icons-react';
+
+import { AppListingReviewRow } from '~/components/Apps/AppListingReviewRow';
+import { LISTING_REVIEWS_ANCHOR_ID } from '~/components/Apps/listingKindLabels';
+import { INLINE_RECENT_REVIEWS_LIMIT, selectRecentReviews } from '~/components/Apps/recent-reviews';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * App Store Listings (W13) — the BOUNDED inline recent-reviews block, rendered
+ * full-width between the listing description and the "More in <category>"
+ * discovery rail.
+ *
+ * ## What this is, and what it deliberately is not
+ *
+ * A tester asked for reviews "right below description, show 3-4 recent + a 'See
+ * more reviews' link", and separately for the discovery rail to move to the very
+ * bottom. The rail did NOT move: its placement comment in
+ * `AppListingDetailBody.tsx` explains that it sits above the unbounded threads
+ * precisely so it is not buried, and that reasoning still holds. This block is
+ * what made honouring the first request compatible with keeping the second
+ * unchanged — it is FIXED-HEIGHT, so it cannot push the rail down by an
+ * arbitrary amount the way hoisting the full list would have.
+ *
+ * 🔴 THAT BOUND IS THE DESIGN. The cap lives in `recent-reviews.ts` and is
+ * applied to the RENDER as well as to the query `limit`, so neither a server
+ * that returns more nor a future edit that asks for more can quietly widen the
+ * block. `recentReviews.test.ts` (node `unit` tier — blocking) asserts it
+ * against an over-long input.
+ *
+ * ## Reuse, not a second renderer
+ *
+ * Rows go through the shared `AppListingReviewRow`, the same component the full
+ * `AppListingReviews` list uses, so the two surfaces cannot drift in how a
+ * review is presented or — the part that matters — in `details` being rendered
+ * as ESCAPED PLAIN TEXT. The only difference is the query: a plain bounded
+ * `useQuery` here versus the full list's `useInfiniteQuery`, because this block
+ * has no "load more" by construction. `appListings.listReviews` already accepts
+ * a `limit`, so this needed no server change.
+ *
+ * ## Nothing to show ⇒ nothing rendered
+ *
+ * 🔴 Returns `null` while loading AND when there are no reviews — no heading, no
+ * skeleton, no "be the first to review" placeholder. The full list at the bottom
+ * of the page still says that; saying it twice on one page, once in a box that
+ * pushed the rail down, is worse than not having the block. Convention per
+ * #4761 and the neighbouring permissions/disclosure sections.
+ */
+export function AppListingRecentReviews({ appListingId }: { appListingId: string }) {
+  const currentUser = useCurrentUser();
+
+  // Bounded, NON-infinite. The same procedure the full list pages through; the
+  // `limit` is the shared constant, so the network ask and the render bound are
+  // one number.
+  const { data, isLoading } = trpc.appListings.listReviews.useQuery({
+    appListingId,
+    limit: INLINE_RECENT_REVIEWS_LIMIT,
+  });
+
+  const reviews = selectRecentReviews(data?.items);
+
+  // 🔴 Loading renders NOTHING rather than a skeleton: a placeholder here would
+  // reserve height above the discovery rail for a block that may never appear,
+  // which is the exact reflow this shape exists to avoid.
+  if (isLoading || reviews.length === 0) return null;
+
+  return (
+    <>
+      <Divider />
+      <Stack
+        gap="md"
+        component="section"
+        aria-label="Recent reviews"
+        data-testid="apps-listing-recent-reviews"
+      >
+        <Group justify="space-between" align="center">
+          <Title order={4}>Recent reviews</Title>
+          {/* 🔴 The SAME constant the full section's `id` is built from — never a
+              second `'app-listing-reviews'` literal. A fragment link to a missing
+              id is inert with no error, so the only thing keeping this honest is
+              that both ends read one value. Pinned by
+              `AppListingDetailBody.recentReviews.browser.test.tsx`. */}
+          <Anchor
+            href={`#${LISTING_REVIEWS_ANCHOR_ID}`}
+            size="sm"
+            underline="always"
+            data-testid="apps-listing-see-more-reviews"
+          >
+            <Group gap={4}>
+              <IconArrowDown size={14} />
+              See more reviews
+            </Group>
+          </Anchor>
+        </Group>
+
+        {reviews.map((review) => (
+          <AppListingReviewRow
+            key={review.id}
+            review={review}
+            isViewer={review.user?.id === currentUser?.id}
+          />
+        ))}
+      </Stack>
+    </>
+  );
+}

--- a/src/components/Apps/AppListingRecentReviews.tsx
+++ b/src/components/Apps/AppListingRecentReviews.tsx
@@ -60,9 +60,26 @@ export function AppListingRecentReviews({ appListingId }: { appListingId: string
 
   const reviews = selectRecentReviews(data?.items);
 
-  // 🔴 Loading renders NOTHING rather than a skeleton: a placeholder here would
-  // reserve height above the discovery rail for a block that may never appear,
-  // which is the exact reflow this shape exists to avoid.
+  // 🔴 THE WHOLE RENDER-OR-NOT POLICY, both clauses, and it lives HERE — with the
+  // thing that renders — rather than in a predicate in `recent-reviews.ts`. One
+  // such predicate existed and was deleted before merge for being unreachable and
+  // for being unable to express the loading half; that file records why.
+  //
+  // EMPTY renders NOTHING, not an empty section — no heading, no "be the first to
+  // review" placeholder, no bordered empty box. A listing with no reviews shows the
+  // description and then goes straight to the discovery rail. This matches the
+  // convention #4761 established for this page: a section with nothing in it is said
+  // better by its absence than by a sentence nobody reads (the permissions section
+  // and the off-site disclosure both work this way).
+  //
+  // LOADING renders NOTHING rather than a skeleton: a placeholder here would reserve
+  // height above the discovery rail for a block that may never appear, which is the
+  // exact reflow this shape exists to avoid.
+  //
+  // ⚠ Covered by the COMPONENT tier (`preview / component-tests`), not the node
+  // tier — a source-text assertion cannot observe a render decision. Note also that
+  // this repo declares NO required status checks, so "blocking tier" is a convention
+  // here, not an enforced gate.
   if (isLoading || reviews.length === 0) return null;
 
   return (

--- a/src/components/Apps/AppListingReviewRow.tsx
+++ b/src/components/Apps/AppListingReviewRow.tsx
@@ -1,0 +1,83 @@
+import { Badge, Group, Stack, Text, ThemeIcon } from '@mantine/core';
+import { IconThumbDown, IconThumbUp } from '@tabler/icons-react';
+
+import { DaysFromNow } from '~/components/Dates/DaysFromNow';
+import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
+import type { AppListingReviewListItem } from '~/server/schema/blocks/app-listing-review.schema';
+
+/**
+ * App Store Listings (W13) — the ONE review row renderer.
+ *
+ * Extracted from `AppListingReviews` so the bounded inline block
+ * (`AppListingRecentReviews`, below the description) and the full paginated list
+ * (`AppListingReviews`, at the bottom of the page) render a review IDENTICALLY.
+ * They differ only in how many rows they ask for and what surrounds them; a
+ * second renderer would let the two drift — one gaining a moderation affordance
+ * or a truncation the other lacks — with nothing observing the divergence.
+ *
+ * 🔴 `details` is ESCAPED PLAIN TEXT via React's default escaping — NEVER
+ * `dangerouslySetInnerHTML`. `details` is only length-capped/trimmed server-side
+ * (`LISTING_REVIEW_DETAILS_MAX`), so the escaping IS the XSS control, and it now
+ * lives in exactly one place rather than one per list surface.
+ *
+ * 🔴 Its OWN module, not an export of `AppListingReviews`. Component tests mock
+ * `~/components/Apps/AppListingReviews` wholesale to keep the infinite query out
+ * of unrelated trees; a row exported from there would vanish under that mock and
+ * take the inline block down with it.
+ */
+export function AppListingReviewRow({
+  review,
+  isViewer,
+}: {
+  review: AppListingReviewListItem;
+  isViewer: boolean;
+}) {
+  return (
+    <Group align="flex-start" wrap="nowrap" gap="sm" data-testid="apps-listing-review-row">
+      <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
+        <Group gap="xs" align="center" wrap="wrap">
+          {review.user ? (
+            <UserAvatar userId={review.user.id} size="sm" withUsername linkToProfile />
+          ) : (
+            <Text size="sm" c="dimmed">
+              [deleted]
+            </Text>
+          )}
+          {isViewer && (
+            <Badge size="xs" variant="light" color="blue">
+              Your review
+            </Badge>
+          )}
+          <Text c="dimmed" size="xs">
+            <DaysFromNow date={review.createdAt} />
+          </Text>
+        </Group>
+        {review.recommended ? (
+          <Group gap={4} align="center">
+            <ThemeIcon variant="light" color="green" size="sm" radius="xl">
+              <IconThumbUp size={12} />
+            </ThemeIcon>
+            <Text size="xs" c="green">
+              Recommends
+            </Text>
+          </Group>
+        ) : (
+          <Group gap={4} align="center">
+            <ThemeIcon variant="light" color="red" size="sm" radius="xl">
+              <IconThumbDown size={12} />
+            </ThemeIcon>
+            <Text size="xs" c="red">
+              Doesn&apos;t recommend
+            </Text>
+          </Group>
+        )}
+        {/* PLAIN TEXT ONLY — React escapes this. NEVER dangerouslySetInnerHTML. */}
+        {review.details && (
+          <Text size="sm" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+            {review.details}
+          </Text>
+        )}
+      </Stack>
+    </Group>
+  );
+}

--- a/src/components/Apps/AppListingReviews.tsx
+++ b/src/components/Apps/AppListingReviews.tsx
@@ -1,21 +1,23 @@
-import { Badge, Button, Divider, Group, Loader, Stack, Text, ThemeIcon } from '@mantine/core';
-import { IconThumbDown, IconThumbUp } from '@tabler/icons-react';
+import { Button, Divider, Group, Loader, Stack, Text } from '@mantine/core';
 import { useMemo } from 'react';
 
-import { DaysFromNow } from '~/components/Dates/DaysFromNow';
-import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
+import { AppListingReviewRow } from '~/components/Apps/AppListingReviewRow';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import type { AppListingReviewListItem } from '~/server/schema/blocks/app-listing-review.schema';
 import { trpc } from '~/utils/trpc';
 
 /**
- * App Store Listings (W13) — the recent-reviews LIST for a store listing (thumbs
- * / recommend). Keyset/infinite over `appListings.listReviews` (which already
- * filters mod-excluded / tos-violation rows). Renders `details` as ESCAPED PLAIN
- * TEXT via React's default escaping — NEVER dangerouslySetInnerHTML (`details` is
- * only length-capped/trimmed server-side, so the escaping is the XSS control).
+ * App Store Listings (W13) — the FULL reviews list for a store listing (thumbs /
+ * recommend). Keyset/infinite over `appListings.listReviews` (which already
+ * filters mod-excluded / tos-violation rows).
  *
- * DARK: mounted only under the mod-only store-preview detail body today.
+ * 🔴 Rows render through the SHARED `AppListingReviewRow`, which the bounded
+ * inline block (`AppListingRecentReviews`, below the description) also uses — so
+ * the two surfaces cannot drift, and in particular `details` is escaped plain
+ * text in exactly one place. NEVER dangerouslySetInnerHTML: `details` is only
+ * length-capped/trimmed server-side, so the escaping is the XSS control.
+ *
+ * This is the list the page's `LISTING_REVIEWS_ANCHOR_ID` section wraps, and it
+ * stays at the BOTTOM of the detail page — the inline block links down to it.
  */
 export function AppListingReviews({ appListingId }: { appListingId: string }) {
   const currentUser = useCurrentUser();
@@ -47,7 +49,7 @@ export function AppListingReviews({ appListingId }: { appListingId: string }) {
     <Stack gap="md">
       {items.map((review) => (
         <div key={review.id}>
-          <ReviewRow review={review} isViewer={review.user?.id === currentUser?.id} />
+          <AppListingReviewRow review={review} isViewer={review.user?.id === currentUser?.id} />
           <Divider mt="md" />
         </div>
       ))}
@@ -59,62 +61,5 @@ export function AppListingReviews({ appListingId }: { appListingId: string }) {
         </Group>
       )}
     </Stack>
-  );
-}
-
-function ReviewRow({
-  review,
-  isViewer,
-}: {
-  review: AppListingReviewListItem;
-  isViewer: boolean;
-}) {
-  return (
-    <Group align="flex-start" wrap="nowrap" gap="sm">
-      <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
-        <Group gap="xs" align="center" wrap="wrap">
-          {review.user ? (
-            <UserAvatar userId={review.user.id} size="sm" withUsername linkToProfile />
-          ) : (
-            <Text size="sm" c="dimmed">
-              [deleted]
-            </Text>
-          )}
-          {isViewer && (
-            <Badge size="xs" variant="light" color="blue">
-              Your review
-            </Badge>
-          )}
-          <Text c="dimmed" size="xs">
-            <DaysFromNow date={review.createdAt} />
-          </Text>
-        </Group>
-        {review.recommended ? (
-          <Group gap={4} align="center">
-            <ThemeIcon variant="light" color="green" size="sm" radius="xl">
-              <IconThumbUp size={12} />
-            </ThemeIcon>
-            <Text size="xs" c="green">
-              Recommends
-            </Text>
-          </Group>
-        ) : (
-          <Group gap={4} align="center">
-            <ThemeIcon variant="light" color="red" size="sm" radius="xl">
-              <IconThumbDown size={12} />
-            </ThemeIcon>
-            <Text size="xs" c="red">
-              Doesn&apos;t recommend
-            </Text>
-          </Group>
-        )}
-        {/* PLAIN TEXT ONLY — React escapes this. NEVER dangerouslySetInnerHTML. */}
-        {review.details && (
-          <Text size="sm" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-            {review.details}
-          </Text>
-        )}
-      </Stack>
-    </Group>
   );
 }

--- a/src/components/Apps/__tests__/recentReviews.test.ts
+++ b/src/components/Apps/__tests__/recentReviews.test.ts
@@ -1,0 +1,165 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { LISTING_REVIEWS_ANCHOR_ID } from '~/components/Apps/listingKindLabels';
+import {
+  INLINE_RECENT_REVIEWS_LIMIT,
+  selectRecentReviews,
+  shouldRenderRecentReviews,
+} from '~/components/Apps/recent-reviews';
+import type { AppListingReviewListItem } from '~/server/schema/blocks/app-listing-review.schema';
+
+/**
+ * Inline recent-reviews block — THE BOUND.
+ *
+ * 🔴 Node `unit` tier, deliberately. The browser sibling
+ * (`AppListingDetailBody.recentReviews.browser.test.tsx`) can see the rendered
+ * DOM, which is the only place DOM ORDER and the anchor's href can be observed —
+ * but that tier is report-only in CI, so a regression there blocks nothing. The
+ * bound itself is pure, so it is pinned HERE, in the tier that gates a merge.
+ *
+ * 🔴 EVERY CAP ASSERTION FEEDS MORE ITEMS THAN THE CAP. A fixture with three
+ * reviews cannot distinguish "capped at 3" from "renders everything it is
+ * given" — the assertion would be green against code with no cap at all, which
+ * is precisely the regression this file exists to catch. So the inputs here
+ * overshoot the limit rather than landing on it.
+ */
+
+function review(
+  id: number,
+  over: Partial<AppListingReviewListItem> = {}
+): AppListingReviewListItem {
+  return {
+    id,
+    recommended: true,
+    details: `review ${id}`,
+    createdAt: new Date(`2026-0${(id % 9) + 1}-01T00:00:00.000Z`),
+    user: { id: id * 10, username: `user${id}`, image: null },
+    ...over,
+  };
+}
+
+/** `n` reviews, newest-first, exactly as `listReviews` returns them. */
+const page = (n: number) => Array.from({ length: n }, (_, i) => review(i + 1));
+
+describe('inline recent-reviews — the cap', () => {
+  it('🔴 the limit is a NAMED CONSTANT in the requested 3-4 band', () => {
+    // The operator's decision was "at most 3-4". Pinning the band (rather than
+    // the exact number) lets the value be tuned inside the decision without a
+    // test edit, while a change that walks OUT of the decision fails here.
+    expect(Number.isInteger(INLINE_RECENT_REVIEWS_LIMIT)).toBe(true);
+    expect(INLINE_RECENT_REVIEWS_LIMIT).toBeGreaterThanOrEqual(3);
+    expect(INLINE_RECENT_REVIEWS_LIMIT).toBeLessThanOrEqual(4);
+  });
+
+  it('🔴 caps at the limit when MORE reviews exist than the bound', () => {
+    // The load-bearing assertion. Overshoot by a wide margin: a block fed 20 and
+    // rendering 20 is exactly the unbounded shape the design rejected.
+    const picked = selectRecentReviews(page(20));
+    expect(picked).toHaveLength(INLINE_RECENT_REVIEWS_LIMIT);
+  });
+
+  it('🔴 keeps the FIRST (newest) reviews, not an arbitrary slice', () => {
+    // `listReviews` is keyset-paginated NEWEST-first, so "recent" is the head of
+    // the page. A cap that took the tail would still be a cap and would still
+    // pass a bare length assertion.
+    const picked = selectRecentReviews(page(20));
+    expect(picked.map((r) => r.id)).toEqual(
+      Array.from({ length: INLINE_RECENT_REVIEWS_LIMIT }, (_, i) => i + 1)
+    );
+  });
+
+  it('does not re-order what the server returned', () => {
+    // The server owns recency. A second opinion here would drift from the query.
+    const shuffled = [review(9), review(2), review(7), review(4), review(1)];
+    const picked = selectRecentReviews(shuffled);
+    expect(picked.map((r) => r.id)).toEqual(
+      shuffled.slice(0, INLINE_RECENT_REVIEWS_LIMIT).map((r) => r.id)
+    );
+  });
+
+  it('returns everything when FEWER reviews exist than the bound', () => {
+    // The complement of the cap case — without it, `() => []` would pass the
+    // cap assertion above for entirely the wrong reason.
+    const picked = selectRecentReviews(page(2));
+    expect(picked.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('an explicit limit overrides the default, in both directions', () => {
+    // The parameter is what makes the constant testable at a value it does not
+    // hold, so a mutant that hardcodes the default inside the function dies.
+    expect(selectRecentReviews(page(20), 1)).toHaveLength(1);
+    expect(selectRecentReviews(page(20), 7)).toHaveLength(7);
+    expect(selectRecentReviews(page(20), 0)).toHaveLength(0);
+    expect(selectRecentReviews(page(20), -3)).toHaveLength(0);
+  });
+
+  it('tolerates the query’s pre-data states and holes without throwing', () => {
+    expect(selectRecentReviews(undefined)).toEqual([]);
+    expect(selectRecentReviews(null)).toEqual([]);
+    expect(selectRecentReviews([null, review(1), undefined, review(2)]).map((r) => r.id)).toEqual([
+      1, 2,
+    ]);
+  });
+});
+
+describe('inline recent-reviews — nothing to show means nothing rendered', () => {
+  it('🔴 does NOT render at zero reviews', () => {
+    // No heading, no placeholder, no empty box — the #4761 convention. The
+    // caller returns `null` on this.
+    expect(shouldRenderRecentReviews([])).toBe(false);
+    expect(shouldRenderRecentReviews(undefined)).toBe(false);
+    expect(shouldRenderRecentReviews(null)).toBe(false);
+    expect(shouldRenderRecentReviews([null, undefined])).toBe(false);
+  });
+
+  it('DOES render with at least one review — the positive control', () => {
+    // Without this, `() => false` passes every assertion above.
+    expect(shouldRenderRecentReviews(page(1))).toBe(true);
+    expect(shouldRenderRecentReviews(page(20))).toBe(true);
+  });
+});
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+const blockSource = () =>
+  fs.readFileSync(path.join(REPO_ROOT, 'src/components/Apps/AppListingRecentReviews.tsx'), 'utf8');
+
+/** Source with comments stripped — a constant NAMED in prose is not a call site. */
+const codeOnly = (src: string) => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+describe('inline recent-reviews — one constant, two ends', () => {
+  it('🔴 the "See more reviews" href is built from LISTING_REVIEWS_ANCHOR_ID, not a 2nd literal', () => {
+    // The browser sibling asserts the RENDERED href equals `#${constant}` — but it
+    // is in the report-only tier, and it would stay green against a hardcoded
+    // literal that happens to match today. This is the half that survives a rename:
+    // a literal here silently outlives a change to the constant, and a fragment
+    // link to a missing id is inert with NO error.
+    //
+    // 🔴 THE ASSERTION IS ON THE ID's TEXT ANYWHERE IN CODE, NOT ON A QUOTED
+    // SPELLING OF IT. An earlier version of this guard enumerated the quoting
+    // forms it imagined (`'app-listing-reviews'`, `"..."`, `` `#...` ``) and a
+    // mutation sweep walked straight through it: the mutant wrote
+    // `href={'#app-listing-reviews'}` — the `#` inside the quotes — and the guard
+    // reported GREEN over a hardcoded literal, which is exactly the drift it
+    // claims to close. The id can only reach this file through the constant, so
+    // its characters must not appear in code at all, however they are punctuated.
+    const src = codeOnly(blockSource());
+    expect(src).toContain('LISTING_REVIEWS_ANCHOR_ID');
+    expect(src).not.toContain(LISTING_REVIEWS_ANCHOR_ID);
+  });
+
+  it('🔴 the query limit and the render bound read the SAME named constant', () => {
+    // The bound is only a bound if the render enforces it. Asking the server for
+    // `INLINE_RECENT_REVIEWS_LIMIT` while rendering `data.items` unsliced would
+    // leave a server that returns more free to widen the block, and would leave
+    // every assertion in this file green (they test the pure selector, which the
+    // component would no longer be calling).
+    const src = codeOnly(blockSource());
+    expect(src).toContain('INLINE_RECENT_REVIEWS_LIMIT');
+    expect(src).toContain('selectRecentReviews(');
+    // No bare numeric `limit:` — that is the shape that decouples the two ends.
+    expect(src).not.toMatch(/limit:\s*\d/);
+  });
+});

--- a/src/components/Apps/__tests__/recentReviews.test.ts
+++ b/src/components/Apps/__tests__/recentReviews.test.ts
@@ -6,7 +6,6 @@ import { LISTING_REVIEWS_ANCHOR_ID } from '~/components/Apps/listingKindLabels';
 import {
   INLINE_RECENT_REVIEWS_LIMIT,
   selectRecentReviews,
-  shouldRenderRecentReviews,
 } from '~/components/Apps/recent-reviews';
 import type { AppListingReviewListItem } from '~/server/schema/blocks/app-listing-review.schema';
 
@@ -104,22 +103,17 @@ describe('inline recent-reviews — the cap', () => {
   });
 });
 
-describe('inline recent-reviews — nothing to show means nothing rendered', () => {
-  it('🔴 does NOT render at zero reviews', () => {
-    // No heading, no placeholder, no empty box — the #4761 convention. The
-    // caller returns `null` on this.
-    expect(shouldRenderRecentReviews([])).toBe(false);
-    expect(shouldRenderRecentReviews(undefined)).toBe(false);
-    expect(shouldRenderRecentReviews(null)).toBe(false);
-    expect(shouldRenderRecentReviews([null, undefined])).toBe(false);
-  });
-
-  it('DOES render with at least one review — the positive control', () => {
-    // Without this, `() => false` passes every assertion above.
-    expect(shouldRenderRecentReviews(page(1))).toBe(true);
-    expect(shouldRenderRecentReviews(page(20))).toBe(true);
-  });
-});
+// 🔴 TWO TESTS WERE DELETED HERE, AND THE DELETION IS THE POINT — they were named
+// "🔴 does NOT render at zero reviews" and "DOES render … the positive control",
+// and they asserted on `shouldRenderRecentReviews`, a function NOTHING in production
+// called. In this tier they read as coverage of the render-or-not policy while
+// touching none of it: the page's actual decision is two clauses (empty AND loading)
+// in `AppListingRecentReviews.tsx`, and a node-tier test cannot observe a render.
+//
+// Do not re-add an equivalent here. A test whose name describes a rendering outcome,
+// in a tier that cannot render, is worse than no test — it stops the next reader
+// looking. That policy is covered by the COMPONENT tier; `recent-reviews.ts` records
+// why the predicate itself is gone.
 
 const REPO_ROOT = path.resolve(__dirname, '../../../..');
 

--- a/src/components/Apps/recent-reviews.ts
+++ b/src/components/Apps/recent-reviews.ts
@@ -64,19 +64,16 @@ export function selectRecentReviews(
   return picked;
 }
 
-/**
- * Does the inline block render at all?
- *
- * 🔴 NOTHING, not an empty section — no heading, no "be the first to review"
- * placeholder, no bordered empty box. A listing with no reviews shows the
- * description and then goes straight to the discovery rail. This matches the
- * convention #4761 established for this page: a section with nothing in it is
- * said better by its absence than by a sentence nobody reads (the permissions
- * section and the off-site disclosure both work this way).
- */
-export function shouldRenderRecentReviews(
-  items: (AppListingReviewListItem | null | undefined)[] | null | undefined,
-  limit: number = INLINE_RECENT_REVIEWS_LIMIT
-): boolean {
-  return selectRecentReviews(items, limit).length > 0;
-}
+// 🔴 THERE IS DELIBERATELY NO `shouldRenderRecentReviews` HERE. One existed and
+// was deleted before merge: it read `selectRecentReviews(items, limit).length > 0`,
+// which is an expression `AppListingRecentReviews` already computes — it needs the
+// array to render — so the only ways to "use" it were a redundant second pass or a
+// wrapper over `.length > 0`. It had ZERO production call sites and two tests in
+// the node tier, which together read as coverage of the render-or-not policy while
+// touching none of it: the mutant that killed them mutated unreachable code, and
+// the live guard was exercised only by the component tier.
+//
+// It also could not have covered that policy even fully wired, because the policy
+// has TWO clauses — empty AND loading — and this function could only ever see the
+// first. The render decision lives with the thing that renders; see the guard in
+// `AppListingRecentReviews.tsx` and the reasoning above it.

--- a/src/components/Apps/recent-reviews.ts
+++ b/src/components/Apps/recent-reviews.ts
@@ -1,0 +1,82 @@
+/**
+ * Inline RECENT-REVIEWS block — bounding policy (pure, React-free).
+ *
+ * Backs the fixed-height review block the unified listing detail renders BELOW
+ * the description and ABOVE the "More in <category>" discovery rail. Pure so the
+ * correctness coverage lands in the node `unit` project — the fast, blocking
+ * suite CI runs on every PR — rather than only in the report-only browser tier
+ * (same rationale as `related-listings.ts`).
+ *
+ * ## 🔴 THE BOUND IS THE DESIGN, NOT A PERFORMANCE DETAIL
+ *
+ * A tester asked for the reviews section to MOVE up, whole, under the
+ * description. It was deliberately NOT moved: the full list is unbounded, so
+ * hoisting it would push the discovery rail (and the discussion) down by an
+ * arbitrary amount for exactly the viewers most likely to want them — the ones
+ * who read the listing and didn't convert. That is the same reasoning the rail's
+ * own placement comment in `AppListingDetailBody.tsx` already records.
+ *
+ * What went up instead is a block that CANNOT grow: at most
+ * `INLINE_RECENT_REVIEWS_LIMIT` rows plus a "See more reviews" link to the full
+ * list, which stays at the bottom and remains the jump target for the Details
+ * rail's "Reviews" row. **A block that can grow without limit defeats the whole
+ * reason this shape was chosen**, so the cap is enforced here, centrally, and
+ * asserted against an over-long input rather than against a fixture that happens
+ * to be short.
+ */
+
+import type { AppListingReviewListItem } from '~/server/schema/blocks/app-listing-review.schema';
+
+/**
+ * How many reviews the inline block shows. 3 — the low end of the requested
+ * "3-4", because this block sits between the description and the discovery rail
+ * and its whole job is to be a taste of the reviews rather than the reviews.
+ *
+ * 🔴 Read this constant; never restate the number at a call site. It is also the
+ * `limit` handed to `appListings.listReviews`, so the query and the render agree
+ * by construction — a server that returned more could not widen the block, and a
+ * render that wanted more could not silently ask for it.
+ */
+export const INLINE_RECENT_REVIEWS_LIMIT = 3;
+
+/**
+ * Cap a newest-first review page to the inline block's bound.
+ *
+ * Order is the SERVER's (`listReviews` is keyset-paginated newest-first); this
+ * does not re-sort, because re-sorting here would be a second, divergent opinion
+ * about recency that nothing keeps in step with the query. It only bounds.
+ *
+ * Defensive against a `null`/`undefined` page (the query's pre-data state) and
+ * against holes in the array, so the caller never has to spell those two cases
+ * out beside the cap and get one of them wrong.
+ */
+export function selectRecentReviews(
+  items: (AppListingReviewListItem | null | undefined)[] | null | undefined,
+  limit: number = INLINE_RECENT_REVIEWS_LIMIT
+): AppListingReviewListItem[] {
+  if (limit <= 0) return [];
+  const picked: AppListingReviewListItem[] = [];
+  for (const item of items ?? []) {
+    if (picked.length >= limit) break;
+    if (!item) continue;
+    picked.push(item);
+  }
+  return picked;
+}
+
+/**
+ * Does the inline block render at all?
+ *
+ * 🔴 NOTHING, not an empty section — no heading, no "be the first to review"
+ * placeholder, no bordered empty box. A listing with no reviews shows the
+ * description and then goes straight to the discovery rail. This matches the
+ * convention #4761 established for this page: a section with nothing in it is
+ * said better by its absence than by a sentence nobody reads (the permissions
+ * section and the off-site disclosure both work this way).
+ */
+export function shouldRenderRecentReviews(
+  items: (AppListingReviewListItem | null | undefined)[] | null | undefined,
+  limit: number = INLINE_RECENT_REVIEWS_LIMIT
+): boolean {
+  return selectRecentReviews(items, limit).length > 0;
+}


### PR DESCRIPTION
## What this is

A tester asked for reviews **"right below description, show 3-4 recent + a 'See more reviews' link"**, and separately for **"More in category" to move to the very bottom**.

What ships is the first request in a **bounded** form, and deliberately **not** the second.

```
Description
  → [NEW] Recent reviews  (at most 3, + "See more reviews" ↓)
  → More in <category>     (unmoved)
  → Discussion             (unmoved)
  → Reviews                (unmoved, full list, still #app-listing-reviews)
```

### Why bounded, and why the discovery rail did not move

The rail's own placement comment already records the reason it sits above the unbounded threads: those threads have no length limit, so a rail below them is buried behind an arbitrary amount of scrolling — for exactly the viewers most likely to want it, the ones who read the listing and didn't convert. That reasoning still holds, so the rail stays.

Hoisting the *full* reviews list under the description would have reintroduced the same problem from the other side: an unbounded block above the rail pushes it down by however many reviews a listing happens to have. **A fixed-height block cannot.** That is what makes the tester's request and the existing decision compatible, so the bound is the design rather than a performance detail — and a future change that lets this block grow without limit defeats the whole point. It is enforced centrally and asserted against an over-long input, not against a fixture that happens to be short.

The full reviews section did not move and keeps `LISTING_REVIEWS_ANCHOR_ID`. It is still the jump target for the Details rail's "Reviews" row, and now also for the new block's "See more reviews" link.

## Changes

| File | |
|---|---|
| `src/components/Apps/recent-reviews.ts` | **new, pure.** `INLINE_RECENT_REVIEWS_LIMIT = 3`, `selectRecentReviews`, `shouldRenderRecentReviews`. Pure so the **blocking** node `unit` tier covers the bound. |
| `src/components/Apps/AppListingRecentReviews.tsx` | **new.** Bounded, non-infinite read of the existing `appListings.listReviews` (it already accepts `limit` — **no server change**). "See more reviews" `href` built from `LISTING_REVIEWS_ANCHOR_ID`. Returns `null` while loading and at zero reviews. |
| `src/components/Apps/AppListingReviewRow.tsx` | **new.** The review row lifted out of `AppListingReviews` so both surfaces render a review identically — in particular `details` stays escaped plain text in exactly one place. Its own module rather than an export of `AppListingReviews`, which component tests mock wholesale. |
| `src/components/Apps/AppListingReviews.tsx` | now renders the shared row; behaviour unchanged. |
| `src/components/Apps/AppListingDetailBody.tsx` | mounts the block full-width immediately after the two-column grid, before the discovery rail, gated `!preview` like both neighbours. |

**Reuse over a second renderer** (requirement 6): the row is shared; the only difference between the two surfaces is the query — a bounded `useQuery` here vs the full list's `useInfiniteQuery`, because this block has no "load more" by construction. No fork of the list component, no new tRPC procedure, no schema change.

**Nothing at zero reviews** (requirement 3): `null` — no heading, no skeleton, no "be the first to review" box. The full list at the bottom still says that; saying it twice, once in a box that displaces the rail, is worse than not having the block.

## Test coverage — red/green matrix

Two tiers, and they cover different halves. 🔴 **`pnpm test` is Playwright, not the unit suite.** Node tier = `--project 'unit*'` (**blocking** in CI); browser tier = `--project component` (**report-only**, so it cannot gate a merge).

### Browser tier — `AppListingDetailBody.recentReviews.browser.test.tsx` (`component`, report-only)

This file imports nothing that does not exist on `main`, so it **collects and runs against the pre-change tree** and produces real red assertions there, rather than failing to import and reporting `Tests no tests` (which is indistinguishable from a pass).

Measured: at `origin/main` **4 failed | 6 passed (10)**; at HEAD **10 passed (10)**.

| Test | at `origin/main` | at HEAD |
|---|---|---|
| renders below the description when the listing HAS reviews | 🔴 RED | ✅ |
| renders AT MOST the cap even when far more reviews exist (9 fed) | 🔴 RED | ✅ |
| the "See more reviews" href is DERIVED from the anchor constant | 🔴 RED | ✅ |
| DOM ORDER: inline block → discovery rail → full reviews section | 🔴 RED | ✅ |
| renders NOTHING when the listing has no reviews | green (vacuous — no block exists at base) | ✅ |
| renders nothing while the bounded query is still loading | green (vacuous) | ✅ |
| the target the link points at EXISTS in the rendered document | green (regression) | ✅ |
| the full reviews section and its `id` still render | green (regression) | ✅ |
| the discovery rail keeps its place with no block to displace it | green (regression) | ✅ |
| in PREVIEW neither the inline block nor the full section renders | green (half vacuous, half regression) | ✅ |

The four base-green-by-vacuity rows are labelled as such rather than counted as regression evidence. Their positive control is row 1 in the same file: it proves the selectors can see the block when it is there.

### Node tier — `__tests__/recentReviews.test.ts` (`unit`, **blocking**) — 11 tests

At `origin/main` this file **cannot run** — `Cannot find module '~/components/Apps/recent-reviews'`, i.e. `Tests no tests`. Per this repo's own gotcha that is **not** a meaningful red, so the evidence for these guards is a **mutation sweep at HEAD** instead. Every mutant was killed by a test that names the right thing:

| Mutant | Killed by |
|---|---|
| `M1` remove the cap | caps at the limit / keeps the FIRST / explicit-limit (4 tests) |
| `M2` `INLINE_RECENT_REVIEWS_LIMIT = 10` | the limit is a NAMED CONSTANT in the 3-4 band |
| `M3` `shouldRenderRecentReviews → true` | does NOT render at zero reviews |
| `M4` cap keeps the TAIL not the head | keeps the FIRST (newest) reviews |
| `M5` hardcode `href={'#app-listing-reviews'}` | href is built from the constant, not a 2nd literal |
| `M6` hardcode `limit: 3` in the query | query limit and render bound read the SAME constant |
| `M7` render `data.items` unsliced | *(browser)* renders AT MOST the cap |
| `M8` drop the `!preview` gate | *(browser)* in PREVIEW neither renders |
| `M9` drop `reviews.length === 0` from the guard | *(browser)* renders NOTHING at zero reviews |
| `M10` move the block below the discovery rail | *(browser)* DOM ORDER |

🔴 **`M5` SURVIVED the first sweep** and the guard was fixed because of it. The original assertion enumerated the quoting forms it imagined (`'app-listing-reviews'`, `"…"`, `` `#…` ``); the mutant wrote `'#app-listing-reviews'` — the `#` *inside* the quotes — and the guard reported green over a hardcoded literal, which is exactly the drift it claims to close. It now asserts the id's text appears nowhere in the component's code, however punctuated. Re-run after the fix: M5 dies with its own assertion; clean tree 11/11 green.

### Existing suites kept green

`appListingReviewsAnchor.test.ts` stays green (node tier). `src/components/Apps/__tests__/` node dir: **80 files / 1713 tests passed**.

🔴 **One real regression, found and fixed:** the new component calls `trpc.appListings.listReviews.useQuery`, and five existing `AppListingDetailBody.*.browser.test.tsx` suites mock `~/utils/trpc` without that key — so the hook read `undefined` and threw, taking **141 assertions** down across those files. They each gained a `listReviews.useQuery` stub returning an empty page. **Mock additions only; no assertion was changed or weakened.** Confirmed by a base-vs-head control: at `origin/main` the same `src/components/Apps/` run is 1288 passed / 4 failed (my new file's expected reds only), so those 141 were caused by this change and are not environmental.

### Full suites at HEAD

- **`component` (no filter, CI-equivalent): 240 files / 2628 tests — 0 failed.**
- `src/components/Apps/` node dir: 80 files / 1713 tests — 0 failed.
- `typecheck`: 0 errors, exit 0. Positive control: a deliberate `const __probe: number = appListingId` in the new component produced `AppListingRecentReviews.tsx(54,9): error TS2322`, proving the file is in the checked program and the zero is not a probe wired to nothing.
- `eslint` on all 12 changed files: clean. Positive control: a planted unused variable was reported, so the instrument can go red.
- `prettier --check` on all 12 changed files: clean.

## Not verified

Stated plainly rather than omitted.

- **The full node `unit*` tier could not be run cleanly in this worktree, so CI is the authority on it.** A whole-tier `vitest run --project 'unit*'` here reported *1568 failed files / 4 failed tests* — the file failures are two environmental causes, neither related to this change: the SvelteKit apps' generated `apps/*/.svelte-kit/tsconfig.json` does not exist in a fresh worktree (`TSConfckParseError: failed to resolve "extends"`), and the Vite `optimizeDeps` cache lives in the shared symlinked `node_modules` and was being rewritten concurrently (`Cannot find module .../deps_ssr/lodash-es.js`). The 4 real test failures are in `scripts/test-perf/` and a moderator-module loader, nowhere this PR touches. **What I did measure green:** the whole `src/components/` node tier — **269 files / 4160 tests, 0 failed** — plus the repo's structural lint-rule suites most likely to react to new files and new mocks (`no-wholesale-module-mock`, `no-direct-shared-module-mock`, `no-unguarded-user-text`, `no-module-scope-cache`, `no-server-infra-in-app-graph`, `featureFlagsMockCompleteness`): **6 files / 182 tests, 0 failed**. Nothing outside `src/components/` is touched by this change, but I have not proven the rest of the tier green.
- **No visual check.** Nothing here renders CSS — the component suite loads only `:root` custom properties, not the cascade — so "3 reviews plus a link is the right amount of vertical space between the description and the rail" is an assertion no test in this PR makes. It needs a human look at a listing that actually has reviews.
- **Not exercised against real data.** Every review row in these tests comes from a fixture. `appListings.listReviews` already accepted `limit` and already filtered mod-excluded / tos-violation rows before this PR, and no server code changed — but I did not run the bounded query against the real procedure.
- **Loading renders nothing, by choice.** On a slow query the block pops in rather than reserving space. That is deliberate (a reserved slot for a block that may never appear is the reflow the fixed-height shape avoids), but it is a judgement call, not a measured one.
- **The browser tier ran locally under a revision shim.** This host's nixpkgs Playwright bundle ships Chromium **1228** while the repo's playwright 1.57.0 wants **1200**, so the `component` project cannot start here at all (`Executable doesn't exist at …/chromium_headless_shell-1200/…`, which presents as `Tests no tests`). I pointed `PLAYWRIGHT_BROWSERS_PATH` at a directory symlinking `chromium_headless_shell-1200 → …-1228`. This is a **pre-existing host/repo skew**, not something this PR introduces — but it means every browser-tier number above was produced on Chromium 1228, not the pinned build. No assertion here is pixel- or layout-metric-based (they are DOM presence, counts, attributes and `compareDocumentPosition`), so the skew is unlikely to matter; it is disclosed because it is a departure from the pinned toolchain.
- **One unrelated flake seen.** `MySubmissionsList.browser.test.tsx > the History button opens the moderation timeline` failed once in a directory-wide run and passed 39/39 in isolation and in the full 240-file run. It touches nothing this PR changes.
- **`event-engine-common` had to be `submodule update --init`** in the worktree before `typecheck` was meaningful; without it the run reports 10 module-resolution errors that have nothing to do with this change. Noted so the next person does not read those as a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzFoPkexMtbyVbEpjTimq9
