### PR TITLE
feat(bot-detection): cluster on uploaded filenames inside content-templating

### DIFF
--- a/src/server/services/bot-account-detection/__tests__/evidence.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/evidence.test.ts
@@ -18,11 +18,25 @@ import {
   emptyCohortSignals,
   normalizeContent,
   registrationIpSql,
+  MAX_FILENAME_SAMPLES,
+  filenameFingerprint,
+  filenameSampleArgs,
+  normalizeFilename,
   type ContentSampleRow,
   type EvidenceClickhouse,
   type EvidenceReader,
+  type FilenameSampleRow,
   type RegistrationIpRow,
 } from '../evidence';
+import {
+  FILENAME_FINGERPRINT_PREFIX,
+  TEXT_FINGERPRINT_PREFIX,
+  unprefixFingerprint,
+} from '../fingerprint-keys';
+
+/** The NAMESPACED index key for a piece of text — what `membersPerFingerprint` is keyed by.
+ *  `contentFingerprint` itself still returns the bare normalised form. */
+const textKey = (raw: string) => `${TEXT_FINGERPRINT_PREFIX}${contentFingerprint(raw) as string}`;
 
 const surface = (partial: Partial<SurfaceCounts> = {}): SurfaceCounts => {
   const row = { comments: 0, models: 0, images: 0, ...partial };
@@ -188,6 +202,130 @@ describe('contentFingerprint', () => {
   });
 });
 
+// ---------------------------------------------------------------------------------------------
+// Filename normalisation and fingerprinting
+// ---------------------------------------------------------------------------------------------
+
+describe('normalizeFilename', () => {
+  it('🔴 lowercases, which is what folds two halves of one real cluster together', () => {
+    // Not cosmetic. In one production cohort `Logo.jpg` and `logo.jpg` were two separate clusters
+    // of ten — two groups sitting low on the ramp instead of one group of twenty.
+    expect(normalizeFilename('Logo.jpg')).toBe('logo.jpg');
+    expect(normalizeFilename('LOGO.JPG')).toBe('logo.jpg');
+    expect(normalizeFilename('logo.jpg')).toBe('logo.jpg');
+  });
+
+  it('trims and collapses whitespace', () => {
+    expect(normalizeFilename('  my   photo.png  ')).toBe('my photo.png');
+  });
+
+  it('🔴 does NOT mask digits — masking would collapse every numbered upload into one key', () => {
+    // The whole reason this is not `normalizeContent`. Under that function both of these become
+    // `nummask jpg jpeg`, so every `<digits>.jpg` on the site is ONE cluster and the largest group
+    // in any cohort becomes an artefact of camera naming rather than a ring.
+    expect(normalizeFilename('1900.jpg.jpeg')).toBe('1900.jpg.jpeg');
+    expect(normalizeFilename('2749.jpg.jpeg')).toBe('2749.jpg.jpeg');
+    expect(normalizeFilename('1900.jpg.jpeg')).not.toBe(normalizeFilename('2749.jpg.jpeg'));
+  });
+
+  it('🔴 does NOT strip punctuation — the dot and the extension are part of the identity', () => {
+    expect(normalizeFilename('my-file_v2.final.png')).toBe('my-file_v2.final.png');
+  });
+});
+
+describe('filenameFingerprint', () => {
+  it('namespaces the key, so a filename is never confused with a text fingerprint', () => {
+    expect(filenameFingerprint('logo.jpg')).toBe(`${FILENAME_FINGERPRINT_PREFIX}logo.jpg`);
+  });
+
+  it('🔴 THE REGRESSION THIS SOURCE EXISTS FOR: the PROSE floors are not applied to filenames', () => {
+    // 🔴 MEASURED BY EXECUTING THE SHIPPED NORMALISER, not by reading it. `contentFingerprint`
+    // rejects BOTH of these outright — `1900.jpg.jpeg` normalises to `"nummask jpg jpeg"` (16
+    // chars, 3 tokens) and `logo.jpg` to `"logo jpg"` (8 chars, 2 tokens), against floors of 24
+    // chars and 4 tokens. Both were filenames a confirmed ring actually shared, so reusing the
+    // prose floors here would have discarded the signal this whole change is about.
+    //
+    // The floors are right for prose and wrong for filenames: they exist because a SHORT SENTENCE
+    // is written independently by unrelated people, which is a fact about sentences.
+    expect(contentFingerprint('1900.jpg.jpeg')).toBeNull();
+    expect(contentFingerprint('logo.jpg')).toBeNull();
+    expect(filenameFingerprint('1900.jpg.jpeg')).not.toBeNull();
+    expect(filenameFingerprint('logo.jpg')).not.toBeNull();
+  });
+
+  it('🔴 folds case, so `Logo.jpg` and `logo.jpg` are ONE cluster key', () => {
+    expect(filenameFingerprint('Logo.jpg')).toBe(filenameFingerprint('logo.jpg'));
+  });
+
+  it('🔴 refuses a missing or blank name rather than keying on the empty string', () => {
+    // `Image.name` is nullable. An upload with no name is not a member of the empty-string
+    // cluster, and letting it become one would build the largest cluster in every cohort out of
+    // accounts that share nothing at all.
+    expect(filenameFingerprint(null)).toBeNull();
+    expect(filenameFingerprint(undefined)).toBeNull();
+    expect(filenameFingerprint('')).toBeNull();
+    expect(filenameFingerprint('   ')).toBeNull();
+  });
+});
+
+describe('unprefixFingerprint', () => {
+  it('strips either namespace and leaves an unprefixed key alone', () => {
+    expect(unprefixFingerprint(`${FILENAME_FINGERPRINT_PREFIX}logo.jpg`)).toBe('logo.jpg');
+    expect(unprefixFingerprint(`${TEXT_FINGERPRINT_PREFIX}free buzz linkmask`)).toBe(
+      'free buzz linkmask'
+    );
+    expect(unprefixFingerprint('no prefix here')).toBe('no prefix here');
+  });
+
+  it('🔴 does not truncate a normalised text at its first colon', () => {
+    // The naive implementation — slice at `indexOf(':')` — would eat the front of any text
+    // containing a colon, which every generation-parameter paste does.
+    expect(unprefixFingerprint('steps: 20, sampler: euler')).toBe('steps: 20, sampler: euler');
+  });
+});
+
+describe('filenameSampleArgs', () => {
+  it('reads the newest images of exactly these accounts, bounded, two columns', () => {
+    const args = filenameSampleArgs([1, 2], 50);
+    expect(args.where.userId).toEqual({ in: [1, 2] });
+    expect(args.select).toEqual({ userId: true, name: true });
+    expect(args.take).toBe(50);
+  });
+
+  it('🔴 orders by id, NOT createdAt — `Image` has no (userId, createdAt) index', () => {
+    // Verified against `schema.prisma`: the indexes on `Image` are `(userId, postId)` and
+    // `(userId, id)` (`image_userid_id_idx`). Ordering on `createdAt` would sort a user's whole
+    // image history outside any index. `id` is monotonic on an append-only table, so descending
+    // `id` is descending upload order — and the `take` means the ORDER decides which rows a
+    // bounded read keeps.
+    expect(filenameSampleArgs([1], 10).orderBy).toEqual({ id: 'desc' });
+  });
+
+  it('🔴 DOES NOT FILTER ON ingestion OR needsReview — the blocked rows ARE the signal', () => {
+    // 🔴 THE MOST LOAD-BEARING ABSENCE IN THIS MODULE, pinned as a ledger rather than as prose.
+    // There is a partial index covering `ingestion = 'Scanned' AND needsReview IS NULL`, so adding
+    // either predicate looks like free performance — and would delete exactly the population this
+    // heuristic reads, because the images a templated ring uploads are the ones the scanner blocks.
+    // An account surviving while its content is removed is the case the detector exists for.
+    //
+    // Asserted as the EXACT key set of `where`, so a new filter of ANY name fails here. A test
+    // naming only `ingestion` and `needsReview` would be walkable by a third predicate.
+    expect(Object.keys(filenameSampleArgs([1], 10).where).sort()).toEqual(['userId']);
+    expect(Object.keys(filenameSampleArgs([1], 10, new Date()).where).sort()).toEqual([
+      'createdAt',
+      'userId',
+    ]);
+  });
+
+  it('bounds on createdAt when given a window, and omits it when not', () => {
+    const before = new Date('2026-09-03T12:00:00.000Z');
+    expect(filenameSampleArgs([1], 10, before).where).toMatchObject({
+      createdAt: { lte: before },
+    });
+    expect(filenameSampleArgs([1], 10).where).not.toHaveProperty('createdAt');
+  });
+});
+
 describe('the module constants', () => {
   it('🔴 pins every bound a run is sized by, so moving one is a deliberate edit', () => {
     // 🔴 FOUR OF THESE WERE UNTESTED. A constant nothing asserts can be changed by a mutant — or by
@@ -196,6 +334,12 @@ describe('the module constants', () => {
     // width of every `IN (…)` list, and the truncation is what bounds both the memory a run holds
     // and what counts as "the same text".
     expect(MAX_CONTENT_SAMPLES).toBe(5_000);
+    // 🔴 A SEPARATE BUDGET, AND LARGER. Pinned so a later "tidy-up" that folds the filename read
+    // into the content allowance is a deliberate, visible edit rather than a silent one — the two
+    // populations are wildly unequal (a day's new accounts produce a handful of comments and
+    // thousands of images) and sharing one budget starves the half with the signal in it.
+    expect(MAX_FILENAME_SAMPLES).toBe(20_000);
+    expect(MAX_FILENAME_SAMPLES).toBeGreaterThan(MAX_CONTENT_SAMPLES);
     expect(EVIDENCE_CHUNK_SIZE).toBe(500);
     expect(MAX_CONTENT_CHARS).toBe(512);
     expect(MIN_FINGERPRINT_CHARS).toBe(24);
@@ -356,6 +500,9 @@ describe('buildCohortSignals', () => {
     contentSamples: true,
     contentBudgetExhausted: false,
     membersSampledForContent: 3,
+    filenameSamples: true,
+    filenameBudgetExhausted: false,
+    membersSampledForFilenames: 3,
   };
 
   it('🔴 counts DISTINCT accounts per IP, not rows', () => {
@@ -389,9 +536,113 @@ describe('buildCohortSignals', () => {
       ]),
       sources,
     });
-    const fp = contentFingerprint(text) as string;
+    // The INDEX key is namespaced; `contentFingerprint` itself still returns the bare normalised
+    // form, which is what the reason string quotes. See `fingerprint-keys.ts`.
+    const fp = textKey(text);
     expect(s.membersPerFingerprint.get(fp)).toBe(2);
     expect(s.fingerprintsByUser.get(1)).toEqual([fp]);
+  });
+
+  it('🔴 counts DISTINCT accounts per FILENAME, not uploads', () => {
+    // The same invariant in the filename axis, and the one that stops a single prolific account
+    // manufacturing a ring out of itself: account 1 uploads `logo.jpg` ninety times and is ONE
+    // member of that cluster. Without this a lone bulk uploader tops the run's distribution.
+    const s = buildCohortSignals({
+      members: [member(1), member(2)],
+      registrationIps: [],
+      contentSamples: [],
+      filenameSamples: Array.from({ length: 90 }, () => ({ userId: 1, name: 'logo.jpg' })).concat([
+        { userId: 2, name: 'logo.jpg' },
+      ]),
+      sources,
+    });
+    expect(s.membersPerFingerprint.get(filenameFingerprint('logo.jpg') as string)).toBe(2);
+    expect(s.fingerprintsByUser.get(1)).toEqual([filenameFingerprint('logo.jpg')]);
+  });
+
+  it('🔴 folds case across ACCOUNTS, so `Logo.jpg` and `logo.jpg` are one cluster of three', () => {
+    // The real cohort shape this was measured on: two spellings of one filename, each looking like
+    // a small group, that are one larger group once folded.
+    const s = buildCohortSignals({
+      members: [member(1), member(2), member(3)],
+      registrationIps: [],
+      contentSamples: [],
+      filenameSamples: [
+        { userId: 1, name: 'Logo.jpg' },
+        { userId: 2, name: 'logo.jpg' },
+        { userId: 3, name: 'LOGO.JPG' },
+      ],
+      sources,
+    });
+    expect(s.membersPerFingerprint.get(filenameFingerprint('logo.jpg') as string)).toBe(3);
+    // And exactly one key exists for them, rather than three that each fall below the floor.
+    expect([...s.membersPerFingerprint.keys()]).toEqual([filenameFingerprint('logo.jpg')]);
+  });
+
+  it('🔴 A FILENAME CANNOT COLLIDE WITH A TEXT FINGERPRINT OF THE SAME STRING', () => {
+    // 🔴 THE NAMESPACE GUARD, AND IT IS NOT HYPOTHETICAL. `normalizeContent` strips the dot out of
+    // `logo.jpg` and yields `logo jpg`; a comment saying "logo jpg" normalises to that too. Sharing
+    // one `Map<string, number>` without prefixes would merge uploaders and commenters into a single
+    // cluster — a ring of three assembled out of two unrelated behaviours.
+    //
+    // Built so the two WOULD collide without the prefixes: the text below is chosen to normalise to
+    // exactly the filename's own normalised form.
+    const text = 'logo jpg download free now';
+    const s = buildCohortSignals({
+      members: [member(1), member(2), member(3)],
+      registrationIps: [],
+      contentSamples: [
+        { userId: 1, content: text },
+        { userId: 2, content: text },
+      ],
+      filenameSamples: [
+        { userId: 3, name: normalizeContent(text) },
+        { userId: 4, name: normalizeContent(text) },
+      ],
+      sources,
+    });
+    // Two separate clusters of 2 — NOT one cluster of 3 (member 4 is outside the cohort).
+    expect(s.membersPerFingerprint.get(textKey(text))).toBe(2);
+    expect(s.membersPerFingerprint.get(filenameFingerprint(normalizeContent(text)) as string)).toBe(
+      1
+    );
+    // The two keys are different strings even though the underlying value is identical.
+    expect(textKey(text)).not.toBe(filenameFingerprint(normalizeContent(text)));
+    expect(unprefixFingerprint(textKey(text))).toBe(
+      unprefixFingerprint(filenameFingerprint(normalizeContent(text)) as string)
+    );
+  });
+
+  it('drops an upload with no filename rather than clustering on the empty string', () => {
+    const s = buildCohortSignals({
+      members: [member(1), member(2), member(3)],
+      registrationIps: [],
+      contentSamples: [],
+      filenameSamples: [
+        { userId: 1, name: null },
+        { userId: 2, name: null },
+        { userId: 3, name: '  ' },
+      ],
+      sources,
+    });
+    expect([...s.membersPerFingerprint.keys()]).toEqual([]);
+  });
+
+  it('🔴 ignores FILENAME rows for accounts outside the cohort', () => {
+    // The twin of the content/IP guard: a row for an id the run is not scoring must not inflate a
+    // cluster nobody is a member of.
+    const s = buildCohortSignals({
+      members: [member(1), member(2)],
+      registrationIps: [],
+      contentSamples: [],
+      filenameSamples: [
+        { userId: 1, name: 'logo.jpg' },
+        { userId: 2, name: 'logo.jpg' },
+        { userId: 999, name: 'logo.jpg' },
+      ],
+      sources,
+    });
+    expect(s.membersPerFingerprint.get(filenameFingerprint('logo.jpg') as string)).toBe(2);
   });
 
   it('🔴 ignores rows for accounts outside the cohort', () => {
@@ -455,6 +706,9 @@ describe('buildCohortSignals', () => {
         contentSamples: true,
         contentBudgetExhausted: true,
         membersSampledForContent: 7,
+        filenameSamples: true,
+        filenameBudgetExhausted: true,
+        membersSampledForFilenames: 4,
       },
     });
     expect(s.sources).toEqual({
@@ -462,6 +716,9 @@ describe('buildCohortSignals', () => {
       contentSamples: true,
       contentBudgetExhausted: true,
       membersSampledForContent: 7,
+      filenameSamples: true,
+      filenameBudgetExhausted: true,
+      membersSampledForFilenames: 4,
     });
   });
 });
@@ -476,6 +733,11 @@ describe('emptyCohortSignals', () => {
       contentSamples: false,
       contentBudgetExhausted: false,
       membersSampledForContent: 0,
+      // The filename source defaults the same way and for the same reason: a run with no evidence
+      // reader must not look like a cohort that shared no filenames.
+      filenameSamples: false,
+      filenameBudgetExhausted: false,
+      membersSampledForFilenames: 0,
     });
   });
 });
@@ -498,21 +760,26 @@ describe('chunk', () => {
 function fakeReader(opts: {
   ips?: RegistrationIpRow[];
   content?: ContentSampleRow[];
+  filenames?: FilenameSampleRow[];
   hasIps?: boolean;
   ipError?: Error;
   contentError?: Error;
+  filenameError?: Error;
 }): EvidenceReader & {
   ipCalls: number[][];
   ipWindows: Array<Date | undefined>;
   contentCalls: Array<{ ids: number[]; take: number }>;
+  filenameCalls: Array<{ ids: number[]; take: number; createdBefore: Date | undefined }>;
 } {
   const ipCalls: number[][] = [];
   const ipWindows: Array<Date | undefined> = [];
   const contentCalls: Array<{ ids: number[]; take: number }> = [];
+  const filenameCalls: Array<{ ids: number[]; take: number; createdBefore: Date | undefined }> = [];
   return {
     ipCalls,
     ipWindows,
     contentCalls,
+    filenameCalls,
     hasRegistrationIps: opts.hasIps ?? true,
     listRegistrationIps: async (ids, createdAfter) => {
       ipCalls.push(ids);
@@ -524,6 +791,11 @@ function fakeReader(opts: {
       contentCalls.push({ ids, take });
       if (opts.contentError) throw opts.contentError;
       return (opts.content ?? []).filter((r) => ids.includes(r.userId)).slice(0, take);
+    },
+    listFilenameSamples: async (ids, take, createdBefore) => {
+      filenameCalls.push({ ids, take, createdBefore });
+      if (opts.filenameError) throw opts.filenameError;
+      return (opts.filenames ?? []).filter((r) => ids.includes(r.userId)).slice(0, take);
     },
   };
 }
@@ -590,7 +862,7 @@ describe('collectCohortSignals', () => {
     });
     const s = await collectCohortSignals(reader, members, { chunkSize: 2 });
     expect(s.sources.registrationIps).toBe(false);
-    expect(s.membersPerFingerprint.get(contentFingerprint(text) as string)).toBe(3);
+    expect(s.membersPerFingerprint.get(textKey(text))).toBe(3);
   });
 
   it('🔴 a failing CONTENT read degrades the run instead of killing it', async () => {
@@ -627,6 +899,7 @@ describe('collectCohortSignals', () => {
     const reader: EvidenceReader = {
       hasRegistrationIps: false,
       listRegistrationIps: async () => [],
+      listFilenameSamples: async () => [],
       listContentSamples: async (ids) => {
         calls += 1;
         if (calls > 1) throw new Error('replica timeout');
@@ -647,6 +920,125 @@ describe('collectCohortSignals', () => {
     // free to be wrong.
     const s = await collectCohortSignals(fakeReader({ content: [] }), members, { chunkSize: 2 });
     expect(s.sources.contentSamples).toBe(true);
+  });
+
+  it('walks the cohort for filenames and indexes what comes back', async () => {
+    const reader = fakeReader({
+      filenames: [
+        { userId: 1, name: 'logo.jpg' },
+        { userId: 2, name: 'Logo.jpg' },
+        { userId: 3, name: 'logo.jpg' },
+      ],
+    });
+    const s = await collectCohortSignals(reader, members, { chunkSize: 2 });
+    expect(s.sources.filenameSamples).toBe(true);
+    expect(s.membersPerFingerprint.get(filenameFingerprint('logo.jpg') as string)).toBe(3);
+  });
+
+  it('🔴 a failing FILENAME read degrades the run instead of killing it, and says so', async () => {
+    // Same contract as the content read: the partial data is DISCARDED rather than scored, because
+    // a cluster count built from some of the chunks understates every ring that straddles the
+    // missing ones — and understating is the direction that produces a confident zero.
+    const text = 'Grab your 100 free credits at https://spam.example now';
+    const s = await collectCohortSignals(
+      fakeReader({
+        filenameError: new Error('replica timeout'),
+        content: [
+          { userId: 1, content: text },
+          { userId: 2, content: text },
+          { userId: 3, content: text },
+        ],
+      }),
+      members,
+      { chunkSize: 2 }
+    );
+    expect(s.sources.filenameSamples).toBe(false);
+    expect(s.sources.filenameBudgetExhausted).toBe(false);
+    expect(s.sources.membersSampledForFilenames).toBe(0);
+    // 🔴 THE OTHER SOURCE IS UNHARMED. The two reads fail independently, which is exactly why they
+    // carry separate flags rather than one shared one.
+    expect(s.sources.contentSamples).toBe(true);
+    expect(s.membersPerFingerprint.get(textKey(text))).toBe(3);
+  });
+
+  it('🔴 a failing CONTENT read does not take the filename read down with it', async () => {
+    // The mirror direction, asserted separately: a single flag covering both would let a live
+    // filename read vouch for a comment read that never happened, or vice versa.
+    const s = await collectCohortSignals(
+      fakeReader({
+        contentError: new Error('down'),
+        filenames: [
+          { userId: 1, name: 'logo.jpg' },
+          { userId: 2, name: 'logo.jpg' },
+          { userId: 3, name: 'logo.jpg' },
+        ],
+      }),
+      members,
+      { chunkSize: 2 }
+    );
+    expect(s.sources.contentSamples).toBe(false);
+    expect(s.sources.filenameSamples).toBe(true);
+    expect(s.membersPerFingerprint.get(filenameFingerprint('logo.jpg') as string)).toBe(3);
+  });
+
+  it('🔴 stops reading filenames once ITS OWN budget is spent, and records that it did', async () => {
+    const reader = fakeReader({
+      filenames: Array.from({ length: 5 }, (_, i) => ({ userId: i + 1, name: `f${i}.jpg` })),
+    });
+    const s = await collectCohortSignals(reader, members, {
+      chunkSize: 2,
+      maxFilenameSamples: 2,
+    });
+    expect(s.sources.filenameBudgetExhausted).toBe(true);
+    expect(s.sources.membersSampledForFilenames).toBeLessThan(members.length);
+  });
+
+  it('does not claim filename exhaustion when the whole cohort fit inside the budget', async () => {
+    const s = await collectCohortSignals(fakeReader({ filenames: [] }), members, { chunkSize: 2 });
+    expect(s.sources.filenameBudgetExhausted).toBe(false);
+    expect(s.sources.membersSampledForFilenames).toBe(members.length);
+  });
+
+  it('🔴 the two budgets are INDEPENDENT — a spent content budget does not starve filenames', async () => {
+    // 🔴 THE FAILURE THIS PREVENTS RUNS IN THE WORST DIRECTION. The comment read is cheap and finds
+    // almost nothing; the filename read is the one with the signal in it. A single shared budget
+    // spent in source order would let the empty half consume the allowance on a wave day and
+    // truncate the half being relied on — silently reproducing the defect this change fixes.
+    const reader = fakeReader({
+      content: Array.from({ length: 40 }, (_, i) => ({
+        userId: (i % 5) + 1,
+        content: 'Grab your 100 free credits at https://spam.example now',
+      })),
+      filenames: [
+        { userId: 1, name: 'logo.jpg' },
+        { userId: 2, name: 'logo.jpg' },
+        { userId: 3, name: 'logo.jpg' },
+      ],
+    });
+    const s = await collectCohortSignals(reader, members, {
+      chunkSize: 2,
+      maxContentSamples: 1,
+    });
+    expect(s.sources.contentBudgetExhausted).toBe(true);
+    // The filename walk covered the whole cohort regardless.
+    expect(s.sources.filenameBudgetExhausted).toBe(false);
+    expect(s.sources.membersSampledForFilenames).toBe(members.length);
+    expect(s.membersPerFingerprint.get(filenameFingerprint('logo.jpg') as string)).toBe(3);
+  });
+
+  it('hands the run clock down to the filename read as an upper bound', async () => {
+    const reader = fakeReader({});
+    const createdBefore = new Date('2026-09-03T12:00:00.000Z');
+    await collectCohortSignals(reader, members, { chunkSize: 5, createdBefore });
+    expect(reader.filenameCalls.map((c) => c.createdBefore)).toEqual([createdBefore]);
+  });
+
+  it('never asks for more filename rows than the budget has left', async () => {
+    const reader = fakeReader({
+      filenames: Array.from({ length: 5 }, (_, i) => ({ userId: i + 1, name: `f${i}.jpg` })),
+    });
+    await collectCohortSignals(reader, members, { chunkSize: 2, maxFilenameSamples: 3 });
+    for (const call of reader.filenameCalls) expect(call.take).toBeLessThanOrEqual(3);
   });
 
   it('hands the run window down to the registration-IP read', async () => {
@@ -713,6 +1105,7 @@ describe('createEvidenceReader', () => {
   const db = {
     comment: { findMany: vi.fn(async () => [{ userId: 1, content: 'a' }]) },
     commentV2: { findMany: vi.fn(async () => [{ userId: 2, content: 'b' }]) },
+    image: { findMany: vi.fn(async () => [{ userId: 3, name: 'logo.jpg' }]) },
   };
 
   it('🔴 reports the IP source as unavailable when there is no ClickHouse client', async () => {
@@ -730,6 +1123,24 @@ describe('createEvidenceReader', () => {
       { userId: 1, content: 'a' },
       { userId: 2, content: 'b' },
     ]);
+  });
+
+  it('reads the image surface for filenames, passing the bound through', async () => {
+    const reader = createEvidenceReader({ db, ch: null });
+    db.image.findMany.mockClear();
+    const before = new Date('2026-09-03T12:00:00.000Z');
+    expect(await reader.listFilenameSamples([1, 2], 10, before)).toEqual([
+      { userId: 3, name: 'logo.jpg' },
+    ]);
+    expect(db.image.findMany).toHaveBeenCalledWith(filenameSampleArgs([1, 2], 10, before));
+  });
+
+  it('issues no filename statement for an empty id list or a zero take', async () => {
+    const reader = createEvidenceReader({ db, ch: null });
+    db.image.findMany.mockClear();
+    expect(await reader.listFilenameSamples([], 10)).toEqual([]);
+    expect(await reader.listFilenameSamples([1], 0)).toEqual([]);
+    expect(db.image.findMany).not.toHaveBeenCalled();
   });
 
   it('issues no statement for an empty id list or a zero take', async () => {

--- a/src/server/services/bot-account-detection/__tests__/heuristics.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/heuristics.test.ts
@@ -20,8 +20,11 @@ import {
   CLUSTER_ONE_AT,
   CLUSTER_ZERO_AT,
   contentTemplatingHeuristic,
+  contentTemplatingSourceScore,
   largestContentCluster,
 } from '../heuristics/similarity';
+import { filenameFingerprint } from '../evidence';
+import { FILENAME_FINGERPRINT_PREFIX, TEXT_FINGERPRINT_PREFIX } from '../fingerprint-keys';
 import {
   MIN_AGE_HOURS,
   MIN_ITEMS,
@@ -494,6 +497,112 @@ describe('content-templating', () => {
     const note = contentTemplatingHeuristic.explain(evidence(member(), s), 0.5);
     expect(note).toContain('6 new accounts posted the same text');
     expect(note).toContain('check out my page at linkmask');
+  });
+
+  // -------------------------------------------------------------------------------------------
+  // The filename half
+  // -------------------------------------------------------------------------------------------
+
+  /** A signals index holding one filename cluster of `size`, owned by member 42. */
+  const filenameSignals = (name: string, size: number) => {
+    const key = filenameFingerprint(name) as string;
+    return signalsWith({ fingerprints: { 42: [key] }, membersPerFingerprint: { [key]: size } });
+  };
+
+  it('🔴 THE BOUNDARY, BOTH SIDES: two accounts sharing a filename score 0, three score', () => {
+    // 🔴 THREE DISTINCT MEMBERS IS THE SMALLEST SCORING GROUP, and — together with the fact that
+    // every member is an account under 24h old — it IS the innocent-collision defence. There is
+    // deliberately no stoplist of generic filenames: the measured rings share exactly the
+    // unremarkable names a stoplist would remove.
+    //
+    // LITERAL sizes and a LITERAL expected score, not expressions over the constants: a boundary
+    // case written in terms of `CLUSTER_ZERO_AT` is vacuous about its value.
+    expect(score(member(), filenameSignals('logo.jpg', 2))).toBe(0);
+    expect(score(member(), filenameSignals('logo.jpg', 3))).toBeCloseTo(0.125, 12);
+  });
+
+  it('a lone account is not a cluster', () => {
+    expect(score(member(), filenameSignals('logo.jpg', 1))).toBe(0);
+  });
+
+  it('saturates on a large filename ring', () => {
+    expect(score(member(), filenameSignals('logo.jpg', 26))).toBe(1);
+  });
+
+  it('🔴 REGRESSION: the PROSE floors do not reach filenames — both of these cluster', () => {
+    // 🔴 THE FILENAMES A CONFIRMED RING ACTUALLY SHARED. `contentFingerprint` rejects both outright
+    // (`1900.jpg.jpeg` → "nummask jpg jpeg", 16 chars / 3 tokens; `logo.jpg` → "logo jpg", 8 / 2,
+    // against floors of 24 and 4 — measured by executing the shipped normaliser). Had this source
+    // reused the prose fingerprint, the entire signal would have been discarded before scoring.
+    expect(score(member(), filenameSignals('1900.jpg.jpeg', 3))).toBeGreaterThan(0);
+    expect(score(member(), filenameSignals('logo.jpg', 3))).toBeGreaterThan(0);
+  });
+
+  it('🔴 explain() quotes the PLAIN filename, never the namespaced key', () => {
+    // The prefix is an implementation detail of the shared index. A moderator shown “file:logo.jpg”
+    // would reasonably conclude the account uploaded a file by that literal name.
+    const note = contentTemplatingHeuristic.explain(
+      evidence(member(), filenameSignals('logo.jpg', 8)),
+      0.75
+    );
+    expect(note).toContain('8 new accounts uploaded a file with the same name');
+    expect(note).toContain('logo.jpg');
+    expect(note).not.toContain(FILENAME_FINGERPRINT_PREFIX);
+    // And it is named as a FILENAME, not reported as posted text — the two call for different
+    // moderator actions and the wording is the only thing that distinguishes them.
+    expect(note).not.toContain('posted the same text');
+  });
+
+  it('🔴 explain() still says "text" for a TEXT cluster — the two are not merged', () => {
+    const s = signalsWith({
+      fingerprints: { 42: [`${TEXT_FINGERPRINT_PREFIX}free buzz at linkmask for nummask`] },
+      membersPerFingerprint: { [`${TEXT_FINGERPRINT_PREFIX}free buzz at linkmask for nummask`]: 5 },
+    });
+    const note = contentTemplatingHeuristic.explain(evidence(member(), s), 0.5);
+    expect(note).toContain('5 new accounts posted the same text');
+    expect(note).toContain('free buzz at linkmask');
+    expect(note).not.toContain(TEXT_FINGERPRINT_PREFIX);
+    expect(note).not.toContain('uploaded a file');
+  });
+
+  it('scores on the LARGEST cluster across both sources, whichever surface it is on', () => {
+    const textK = `${TEXT_FINGERPRINT_PREFIX}free buzz at linkmask for nummask`;
+    const fileK = filenameFingerprint('logo.jpg') as string;
+    const s = signalsWith({
+      fingerprints: { 42: [textK, fileK] },
+      membersPerFingerprint: { [textK]: 3, [fileK]: 9 },
+    });
+    expect(largestContentCluster(42, s)).toEqual({ size: 9, fingerprint: fileK });
+  });
+
+  it('🔴 contentTemplatingSourceScore isolates ONE source, so the two can be graded apart', () => {
+    // 🔴 WITHOUT THIS THE COUNTERS CANNOT SEE WHICH HALF FIRED — and an invisible zero-firing half
+    // is precisely how the comment-only version survived five production runs.
+    const textK = `${TEXT_FINGERPRINT_PREFIX}free buzz at linkmask for nummask`;
+    const fileK = filenameFingerprint('logo.jpg') as string;
+    const s = signalsWith({
+      fingerprints: { 42: [textK, fileK] },
+      // The text cluster is below the floor; the filename cluster is not.
+      membersPerFingerprint: { [textK]: 2, [fileK]: 9 },
+    });
+    expect(contentTemplatingSourceScore(42, s, TEXT_FINGERPRINT_PREFIX)).toBe(0);
+    expect(contentTemplatingSourceScore(42, s, FILENAME_FINGERPRINT_PREFIX)).toBeGreaterThan(0);
+    // The blended score is carried entirely by the filename half.
+    expect(score(member(), s)).toBe(
+      contentTemplatingSourceScore(42, s, FILENAME_FINGERPRINT_PREFIX)
+    );
+  });
+
+  it('🔴 a source score ignores the OTHER source entirely, even when it is larger', () => {
+    // The isolation has to hold in both directions, or the decomposition just re-reports the max.
+    const textK = `${TEXT_FINGERPRINT_PREFIX}free buzz at linkmask for nummask`;
+    const fileK = filenameFingerprint('logo.jpg') as string;
+    const s = signalsWith({
+      fingerprints: { 42: [textK, fileK] },
+      membersPerFingerprint: { [textK]: 9, [fileK]: 3 },
+    });
+    expect(contentTemplatingSourceScore(42, s, FILENAME_FINGERPRINT_PREFIX)).toBeCloseTo(0.125, 12);
+    expect(contentTemplatingSourceScore(42, s, TEXT_FINGERPRINT_PREFIX)).toBeCloseTo(0.875, 12);
   });
 
   it('bounds the quote, so one long text cannot truncate the whole finding', () => {

--- a/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
@@ -730,7 +730,7 @@ describe('the detector has no write surface', () => {
     expect(importSpecifiers(planted)).toEqual(['~/server/services/user-restriction.service']);
   });
 
-  it('performs exactly seven database operations, all of them reads', () => {
+  it('performs exactly eight database operations, all of them reads', () => {
     // 🔴 THE LEDGER. A write added anywhere in these files is an eighth member and fails here; a
     // read removed is a missing member and fails here too (dropping `commentV2` would silently turn
     // every newer-comment-only account into a false negative).
@@ -741,6 +741,16 @@ describe('the detector has no write surface', () => {
     // nothing (it reads counts the cohort already carried) and the clustering heuristic's email
     // half added nothing (a wider `select` on the existing `user.findMany` is not a new operation).
     //
+    // 🔴 THEN SEVEN TO EIGHT, AND `image.findMany` IS THE WHOLE COST OF THE FILENAME SOURCE. It is
+    // the second fingerprint surface for `content-templating` — uploaded `Image.name` values — and
+    // it is a `findMany` rather than the `image.groupBy` already on this list: the cohort's groupBy
+    // counts a member's images, this one reads their NAMES. A read of the same table is still a new
+    // operation and still a new member here, which is the property this ledger exists for.
+    //
+    // It is deliberately budgeted (`MAX_FILENAME_SAMPLES`) and deliberately UNFILTERED on
+    // `ingestion`/`needsReview` — see `filenameSampleArgs`, where dropping the blocked rows would
+    // remove exactly the population the heuristic reads.
+    //
     // 🔴 THIS LEDGER CANNOT SEE THE CLICKHOUSE READ — `DB_CALL` anchors on a `db` handle and the
     // ClickHouse client is not one. That is not a gap being tolerated; it is why the separate
     // ClickHouse ledger below exists. Adding a source that is not Prisma leaves this assertion
@@ -750,6 +760,7 @@ describe('the detector has no write surface', () => {
       'comment.groupBy',
       'commentV2.findMany',
       'commentV2.groupBy',
+      'image.findMany',
       'image.groupBy',
       'model.groupBy',
       'user.findMany',
@@ -771,10 +782,12 @@ describe('the detector has no write surface', () => {
     // specifier — that is the "which BINDING" gap named in the file header — so the ClickHouse
     // ledger below asserts the method set and the statement text separately.
     expect(importSpecifiers(detectorSources())).toEqual([
+      '../fingerprint-keys',
       '../scoring',
       './clustering',
       './cohort',
       './evidence',
+      './fingerprint-keys',
       './heuristics',
       './job',
       './ramp',

--- a/src/server/services/bot-account-detection/__tests__/run.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/run.test.ts
@@ -283,6 +283,7 @@ describe('🔴 the seam between the evidence and the scoring', () => {
       ids.map((userId) => ({ userId, ip: '203.0.113.9' })),
     listContentSamples: async (ids: number[]) =>
       ids.map((userId) => ({ userId, content: RING_TEXT })),
+    listFilenameSamples: async () => [],
   };
 
   it('🔴 the cohort-level evidence REACHES the scoring, and the finding proves it', async () => {
@@ -328,6 +329,70 @@ describe('🔴 the seam between the evidence and the scoring', () => {
     expect(finding?.reason).toContain('6 new accounts posted the same text');
   });
 
+  it('🔴 A SHARED FILENAME ALONE REACHES THE BOARD, with no comments anywhere in the run', async () => {
+    // 🔴 THE END-TO-END CASE THE WHOLE CHANGE EXISTS FOR, and the one no component test can make.
+    // `evidence.test.ts` covers the index and `heuristics.test.ts` covers the scorer over
+    // hand-built signals; neither ever builds the combined state, which is how a heuristic that
+    // fired ZERO times across five production runs kept looking healthy. This run has NO content
+    // rows at all — the exact production shape, where three consecutive daily cohorts totalling
+    // ~25,000 accounts produced 65 comments between them — and the finding still lands.
+    const scenario = ringRun({
+      hasRegistrationIps: false,
+      listRegistrationIps: async () => [],
+      listContentSamples: async () => [],
+      // Mixed case on purpose: these are ONE cluster, not two.
+      listFilenameSamples: async (ids: number[]) =>
+        ids.map((userId) => ({ userId, name: userId % 2 === 0 ? 'Logo.jpg' : 'logo.jpg' })),
+    });
+    const result = await scenario.result;
+
+    const finding = scenario.reports[0].findings.find((f) => f.userId === 1);
+    expect(finding).toBeDefined();
+    const sub = subScoresOf(finding as { reason: string });
+    expect(Object.keys(sub).sort()).toEqual([
+      'content-templating',
+      'posting-velocity',
+      'registration-cluster',
+    ]);
+
+    // The templating heuristic fired on filenames ALONE — its text half had nothing to read.
+    expect(sub['content-templating']).toBeGreaterThan(0);
+    // And the reason names it as a FILENAME and quotes the PLAIN name, not the namespaced key.
+    expect(finding?.reason).toContain('uploaded a file with the same name');
+    expect(finding?.reason).toContain('logo.jpg');
+    expect(finding?.reason).not.toContain('file:logo.jpg');
+
+    // 🔴 THE DECOMPOSITION. Without these two counters the shadow phase cannot grade the halves
+    // apart, which is precisely how the comment-only version survived five runs looking fine.
+    expect(result.counters['heuristic:content-templating:fired_filename']).toBeGreaterThan(0);
+    expect(result.counters['heuristic:content-templating:fired_text']).toBe(0);
+
+    // 🔴 THE EXISTING SERIES KEEPS ITS MEANING. `evidence_distinct_content_fingerprints` counts
+    // TEXT fingerprints only. Had it been left as `membersPerFingerprint.size` it would now include
+    // filenames, and the day this shipped would have read as an explosion of comment templating.
+    expect(result.counters.evidence_distinct_content_fingerprints).toBe(0);
+    expect(result.counters.evidence_distinct_filename_fingerprints).toBe(1);
+    expect(result.counters.evidence_filename_samples).toBe(1);
+  });
+
+  it('🔴 the filename source is reported UNAVAILABLE when the read fails, not as a quiet zero', async () => {
+    // A zero from a source that never ran is not a zero from a source that found nothing, and the
+    // counter plus the summary sentence are the only things that tell a reader which one this is.
+    const scenario = ringRun({
+      hasRegistrationIps: false,
+      listRegistrationIps: async () => [],
+      listContentSamples: async () => [],
+      listFilenameSamples: async () => {
+        throw new Error('replica timeout');
+      },
+    });
+    const result = await scenario.result;
+    expect(result.counters.evidence_filename_samples).toBe(0);
+    expect(scenario.reports[0].summary).toContain('UPLOADED-FILENAME DATA WAS UNAVAILABLE');
+    // The run still completed and still filed a report — a dead source degrades it, never kills it.
+    expect(result.reportsSent).toBeGreaterThan(0);
+  });
+
   it('the same cohort with NO evidence reader scores both ring heuristics 0 — the control', async () => {
     // The other arm. Without it the case above cannot attribute anything: a finding whose ring
     // sub-scores are non-zero proves the seam only if they are zero when the evidence is absent,
@@ -368,6 +433,7 @@ describe('the evidence sources are reported, not assumed', () => {
             { userId: 2, ip: 'x' },
           ],
           listContentSamples: async () => [],
+          listFilenameSamples: async () => [],
         },
         sendReport: out.sendReport,
         now: clock(),
@@ -403,6 +469,7 @@ describe('the evidence sources are reported, not assumed', () => {
           hasRegistrationIps: true,
           listRegistrationIps: async () => [],
           listContentSamples: async () => [],
+          listFilenameSamples: async () => [],
         },
         sendReport: out.sendReport,
         now: clock(),
@@ -432,6 +499,7 @@ describe('the evidence sources are reported, not assumed', () => {
           hasRegistrationIps: true,
           listRegistrationIps: async () => [{ userId: 1, ip: '203.0.113.4' }],
           listContentSamples: async () => [],
+          listFilenameSamples: async () => [],
         },
         sendReport: out.sendReport,
         now: clock(),
@@ -458,6 +526,7 @@ describe('the evidence sources are reported, not assumed', () => {
           listContentSamples: async () => {
             throw new Error('replica timeout');
           },
+          listFilenameSamples: async () => [],
         },
         sendReport: out.sendReport,
         now: clock(),
@@ -488,6 +557,7 @@ describe('the evidence sources are reported, not assumed', () => {
           hasRegistrationIps: false,
           listRegistrationIps: async () => [],
           listContentSamples: async () => [],
+          listFilenameSamples: async () => [],
         },
         sendReport: out.sendReport,
         now: clock(),
@@ -515,6 +585,7 @@ describe('the evidence sources are reported, not assumed', () => {
           // Two rows per chunk against a budget of 2: the first chunk spends it and the walk stops.
           listContentSamples: async (ids) =>
             ids.map((userId) => ({ userId, content: 'x'.repeat(30) })),
+          listFilenameSamples: async () => [],
         },
         sendReport: out.sendReport,
         now: clock(),
@@ -1178,6 +1249,7 @@ describe('🔴 the cluster key reaches the board', () => {
     hasRegistrationIps: false,
     listRegistrationIps: async () => [],
     listContentSamples: async () => [],
+    listFilenameSamples: async () => [],
   };
 
   const domainRun = (accounts: NewAccountRow[]) => {

--- a/src/server/services/bot-account-detection/evidence.ts
+++ b/src/server/services/bot-account-detection/evidence.ts
@@ -2,6 +2,7 @@ import { publicIpOnlySql } from '@civitai/shared/clickhouse-ip-filters';
 import { clickhouse } from '~/server/clickhouse/client';
 import { dbRead } from '~/server/db/client';
 import type { BotAccountCohortMember } from './cohort';
+import { FILENAME_FINGERPRINT_PREFIX, TEXT_FINGERPRINT_PREFIX } from './fingerprint-keys';
 
 /**
  * The COHORT-LEVEL evidence: the things that are only visible by looking at the whole day's signups
@@ -40,6 +41,22 @@ import type { BotAccountCohortMember } from './cohort';
  */
 export const MAX_CONTENT_SAMPLES = 5_000;
 
+/**
+ * The most image rows one run will read, across every account.
+ *
+ * 🔴 A SEPARATE BUDGET FROM `MAX_CONTENT_SAMPLES`, NOT A SHARE OF IT, and that is the whole reason
+ * the filename signal exists at all. The two sources are wildly unequal on this site — a day's new
+ * accounts produce a handful of comments and thousands of images — so a single shared budget spent
+ * in source order would let whichever read ran first consume everything. Worse, the direction that
+ * failure runs in is the one that reproduces the defect being fixed: the comment read is cheap and
+ * finds almost nothing, and it would leave the budget intact while the image read, which is the one
+ * with the signal in it, would be the half that gets truncated on a wave day.
+ *
+ * Sized larger than the content budget because the population is larger, and because one image row
+ * is two small columns against a comment's truncated body.
+ */
+export const MAX_FILENAME_SAMPLES = 20_000;
+
 /** How many accounts' ids go into one `IN (…)` list. Matches the cohort's own page size so the two
  *  walks put the same width of list in front of the planner. */
 export const EVIDENCE_CHUNK_SIZE = 500;
@@ -65,6 +82,17 @@ export type RegistrationIpRow = { userId: number; ip: string };
 export type ContentSampleRow = { userId: number; content: string };
 
 /**
+ * One filename an account uploaded under.
+ *
+ * 🔴 `name` IS NULLABLE IN THE SCHEMA (`Image.name String?`) and this type says so rather than
+ * lying about it. A `null` is not a filename that failed to cluster — it is an upload that carried
+ * no name at all — and the fold below drops it before it can become a key. Typing it as `string`
+ * and letting a `null` arrive would put the string `"null"` in front of the cluster counter, where
+ * it would look exactly like a wildly popular shared filename.
+ */
+export type FilenameSampleRow = { userId: number; name: string | null };
+
+/**
  * The Postgres slice this module is allowed to use: two reads, no write method, nothing to widen.
  *
  * Written structurally rather than as `typeof dbRead` for the reason `cohort.ts` gives at length —
@@ -78,6 +106,9 @@ export type EvidenceDb = {
   };
   commentV2: {
     findMany: (args: ReturnType<typeof contentSampleArgs>) => Promise<ContentSampleRow[]>;
+  };
+  image: {
+    findMany: (args: ReturnType<typeof filenameSampleArgs>) => Promise<FilenameSampleRow[]>;
   };
 };
 
@@ -111,6 +142,15 @@ export type EvidenceReader = {
   listRegistrationIps(userIds: number[], createdAfter?: Date): Promise<RegistrationIpRow[]>;
   /** Up to `take` recent comments across both comment surfaces, for exactly these accounts. */
   listContentSamples(userIds: number[], take: number): Promise<ContentSampleRow[]>;
+  /**
+   * Up to `take` recent uploaded filenames for exactly these accounts, uploaded at or before
+   * `createdBefore`.
+   */
+  listFilenameSamples(
+    userIds: number[],
+    take: number,
+    createdBefore?: Date
+  ): Promise<FilenameSampleRow[]>;
   /** Whether a registration-IP read can happen at all. `false` means the source is missing, NOT
    *  that the accounts share no IP. */
   hasRegistrationIps: boolean;
@@ -134,6 +174,46 @@ export function contentSampleArgs(userIds: number[], take: number) {
   return {
     where: { userId: { in: userIds } },
     select: { userId: true, content: true },
+    orderBy: { id: 'desc' },
+    take,
+  } as const;
+}
+
+/**
+ * The `findMany` arguments for one chunk of accounts' uploaded filenames.
+ *
+ * 🔴 IT DOES NOT FILTER ON `ingestion` OR `needsReview`, AND THAT OMISSION IS THE SIGNAL. There is a
+ * partial index on `Image` covering `ingestion = 'Scanned' AND needsReview IS NULL`, and adding
+ * either predicate here would make this read use it — at the cost of removing exactly the rows this
+ * heuristic depends on. The images a templated ring uploads are the ones the scanner blocks or holds
+ * for review; an account that survives while its content is removed is the case the whole detector
+ * exists to surface. A filter that reads as routine hygiene would delete the population under study
+ * and leave a heuristic that still runs, still reports a number, and can no longer see anything.
+ *
+ * 🔴 `orderBy: { id: 'desc' }`, NOT `createdAt`, AND THIS IS A CORRECTION TO THE OBVIOUS CHOICE.
+ * `Image` carries no `(userId, createdAt)` index — the ones it has are `(userId, postId)` and
+ * `(userId, id)` (`image_userid_id_idx`), verified against `schema.prisma` rather than assumed — so
+ * ordering on `createdAt` would sort a user's whole image history outside any index. `id` is a
+ * monotonic surrogate on an append-only table, so descending `id` IS descending upload order for
+ * every practical purpose, and it is the order `contentSampleArgs` already reads its own surface in
+ * for the same reason: the `take` bounds a chunk, so the order decides WHICH rows a bounded read
+ * keeps, and the newest are the ones a wave is made of.
+ *
+ * `createdBefore` is an upper bound, not a lower one. A lower bound would be free of meaning — every
+ * cohort account was created inside the run's window, so none of its images can predate it — while
+ * the upper bound is what makes the read a stable snapshot at the run's own clock, so two runs over
+ * the same window sample the same rows rather than drifting with whatever was uploaded meanwhile.
+ *
+ * Only `userId` and `name` are selected. Nothing else identifies a filename cluster, and an image's
+ * url, hash and dimensions would only widen what this module holds in memory.
+ */
+export function filenameSampleArgs(userIds: number[], take: number, createdBefore?: Date) {
+  return {
+    where: {
+      userId: { in: userIds },
+      ...(createdBefore ? { createdAt: { lte: createdBefore } } : {}),
+    },
+    select: { userId: true, name: true },
     orderBy: { id: 'desc' },
     take,
   } as const;
@@ -245,6 +325,10 @@ export function createEvidenceReader(
       ]);
       return [...comments, ...commentsV2];
     },
+    listFilenameSamples: async (userIds, take, createdBefore) => {
+      if (!userIds.length || take <= 0) return [];
+      return db.image.findMany(filenameSampleArgs(userIds, take, createdBefore));
+    },
   };
 }
 
@@ -309,6 +393,61 @@ export function contentFingerprint(raw: string): string | null {
 }
 
 /**
+ * How much of one filename is kept. Filenames are short; this exists to bound a pathological one
+ * rather than because anything is expected to reach it.
+ */
+export const MAX_FILENAME_CHARS = 256;
+
+/**
+ * A filename reduced to the shape the clustering check compares.
+ *
+ * 🔴 IT DELIBERATELY DOES NOT REUSE `normalizeContent`, AND THE REASON IS NOT STYLE. Two of that
+ * function's steps are actively wrong here:
+ *
+ *  - **DIGIT MASKING WOULD DESTROY THE SIGNAL BY OVER-CLUSTERING.** Under `normalizeContent`,
+ *    `1900.jpg.jpeg` and `2749.jpg.jpeg` both become `nummask jpg jpeg` — so every `<digits>.jpg` on
+ *    the site collapses into ONE key, and the largest cluster in any cohort becomes an artefact of
+ *    camera and export naming rather than a ring. Masking is correct for prose, where the digits are
+ *    the swapped payload; in a filename the digits are most of the identity.
+ *  - **THE PROSE LENGTH FLOORS WOULD DISCARD ALMOST EVERYTHING.** Measured by executing the shipped
+ *    normaliser rather than by reading it: `1900.jpg.jpeg` normalises to `"nummask jpg jpeg"` — 16
+ *    characters, 3 tokens — and `logo.jpg` to `"logo jpg"` — 8 characters, 2 tokens. Both fail
+ *    `MIN_FINGERPRINT_CHARS` (24) and `MIN_FINGERPRINT_TOKENS` (4); so does
+ *    `IMG_20240103_112233.png` at 23 characters. Those floors exist because a SHORT PROSE STRING is
+ *    written independently by unrelated people — "thanks", "nice work" — which is a fact about
+ *    sentences and not about filenames. A filename is an identifier, and a short one is no weaker
+ *    evidence than a long one.
+ *
+ * 🔴 SO WHAT DEFENDS AGAINST AN INNOCENT COLLISION HERE, given there is no length floor and no
+ * stoplist of generic names: the cluster floor and the cohort itself. `CLUSTER_ZERO_AT` requires at
+ * least THREE DISTINCT members before anything scores, and every member is an account less than a
+ * day old. Three strangers who all signed up today and all uploaded `logo.jpg` is already the
+ * observation worth making — a stoplist of "generic" names would remove precisely the filenames the
+ * measured rings actually share, because a ring's whole method is to look unremarkable.
+ *
+ * LOWERCASING IS LOAD-BEARING rather than cosmetic: in one real cohort `Logo.jpg` and `logo.jpg`
+ * were two separate clusters of ten, which is two groups below the scoring floor's interesting range
+ * instead of one group of twenty.
+ */
+export function normalizeFilename(raw: string): string {
+  return raw.slice(0, MAX_FILENAME_CHARS).toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * The cluster key for one uploaded filename, or `null` when there is nothing to key on.
+ *
+ * `null` for a missing or blank name — an upload with no filename is not a member of the
+ * empty-string cluster, and letting it become one would build the largest cluster in every cohort
+ * out of accounts that share nothing at all.
+ */
+export function filenameFingerprint(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const normalized = normalizeFilename(raw);
+  if (!normalized) return null;
+  return `${FILENAME_FINGERPRINT_PREFIX}${normalized}`;
+}
+
+/**
  * Everything the cohort-level heuristics read, indexed once per run.
  *
  * 🔴 EVERY COUNT HERE IS A COUNT OF DISTINCT ACCOUNTS, never of rows. One account pasting the same
@@ -324,9 +463,14 @@ export type CohortSignals = {
   membersPerIp: Map<string, number>;
   /** emailDomain → how many DISTINCT cohort members carry it. */
   membersPerDomain: Map<string, number>;
-  /** userId → the content fingerprints it produced. */
+  /**
+   * userId → the content fingerprints it produced, NAMESPACED.
+   *
+   * Keys carry `TEXT_FINGERPRINT_PREFIX` or `FILENAME_FINGERPRINT_PREFIX`; nothing reads a bare
+   * string out of here. See the prefix constants for why the two sources must not share a key.
+   */
   fingerprintsByUser: Map<number, string[]>;
-  /** fingerprint → how many DISTINCT cohort members produced it. */
+  /** namespaced fingerprint → how many DISTINCT cohort members produced it. */
   membersPerFingerprint: Map<string, number>;
   /**
    * 🔴 WHICH SOURCES ACTUALLY ANSWERED. A heuristic reading an empty index cannot tell "these
@@ -350,6 +494,21 @@ export type CohortSignals = {
     contentBudgetExhausted: boolean;
     /** How many members had content sampled at all. The denominator for the similarity heuristic. */
     membersSampledForContent: number;
+    /**
+     * The filename read ran to completion. `false` means it never ran, or a chunk THREW and the
+     * partial data was discarded — NOT that the cohort uploaded nothing.
+     *
+     * 🔴 ITS OWN FLAG, NOT A SHARE OF `contentSamples`, because the two reads fail independently:
+     * they hit different tables, and one can time out while the other returns. Folding them into a
+     * single flag would mean a dead filename read reported the comment half as unavailable too, or —
+     * far worse in the direction that matters — a live comment read vouching for a filename read
+     * that never happened.
+     */
+    filenameSamples: boolean;
+    /** The filename budget was spent before the whole cohort was sampled. */
+    filenameBudgetExhausted: boolean;
+    /** How many members had filenames sampled at all. */
+    membersSampledForFilenames: number;
   };
 };
 
@@ -367,6 +526,9 @@ export function emptyCohortSignals(): CohortSignals {
       contentSamples: false,
       contentBudgetExhausted: false,
       membersSampledForContent: 0,
+      filenameSamples: false,
+      filenameBudgetExhausted: false,
+      membersSampledForFilenames: 0,
     },
   };
 }
@@ -396,6 +558,9 @@ export function buildCohortSignals(args: {
   members: BotAccountCohortMember[];
   registrationIps: RegistrationIpRow[];
   contentSamples: ContentSampleRow[];
+  /** Optional so a caller indexing only text — every existing test, and any future source-by-source
+   *  grading run — does not have to pass an empty array to mean "did not read this". */
+  filenameSamples?: FilenameSampleRow[];
   sources: CohortSignals['sources'];
 }): CohortSignals {
   const signals = emptyCohortSignals();
@@ -428,19 +593,37 @@ export function buildCohortSignals(args: {
   }
   for (const [domain, members] of domainMembers) signals.membersPerDomain.set(domain, members.size);
 
+  // 🔴 BOTH SOURCES FOLD INTO ONE INDEX, THROUGH ONE FUNCTION, and that is deliberate: the
+  // distinct-account counting is the part that must not differ between them. A second hand-written
+  // loop for filenames is how one source quietly starts counting ROWS while the other counts
+  // members — which is exactly the invariant this file's header calls out, and the direction that
+  // lets a single prolific uploader manufacture a ring out of itself.
   const fingerprintMembers = new Map<string, Set<number>>();
-  for (const sample of args.contentSamples) {
-    if (!inCohort.has(sample.userId)) continue;
-    const fingerprint = contentFingerprint(sample.content);
-    if (!fingerprint) continue;
-    const owned = signals.fingerprintsByUser.get(sample.userId);
+  const addFingerprint = (userId: number, fingerprint: string | null) => {
+    if (!inCohort.has(userId) || !fingerprint) return;
+    const owned = signals.fingerprintsByUser.get(userId);
     if (owned) {
       if (!owned.includes(fingerprint)) owned.push(fingerprint);
-    } else signals.fingerprintsByUser.set(sample.userId, [fingerprint]);
+    } else signals.fingerprintsByUser.set(userId, [fingerprint]);
     let members = fingerprintMembers.get(fingerprint);
     if (!members) fingerprintMembers.set(fingerprint, (members = new Set()));
-    members.add(sample.userId);
+    members.add(userId);
+  };
+
+  for (const sample of args.contentSamples) {
+    const fingerprint = contentFingerprint(sample.content);
+    // Prefixed at the INDEX rather than inside `contentFingerprint`, so that function keeps meaning
+    // "the normalised form of this text" — which is what its own tests assert and what the reason
+    // string quotes — and the namespace stays a property of the shared map that needs it.
+    addFingerprint(
+      sample.userId,
+      fingerprint === null ? null : `${TEXT_FINGERPRINT_PREFIX}${fingerprint}`
+    );
   }
+
+  for (const sample of args.filenameSamples ?? [])
+    addFingerprint(sample.userId, filenameFingerprint(sample.name));
+
   for (const [fingerprint, members] of fingerprintMembers)
     signals.membersPerFingerprint.set(fingerprint, members.size);
 
@@ -471,14 +654,19 @@ export async function collectCohortSignals(
   opts: {
     chunkSize?: number;
     maxContentSamples?: number;
+    maxFilenameSamples?: number;
     /** The run's window opening, passed through to the ClickHouse read as its `time` bound. */
     createdAfter?: Date;
+    /** The run's own clock, passed to the filename read as its upper bound so the sample is a
+     *  snapshot rather than a moving target. */
+    createdBefore?: Date;
     checkCanceled?: () => void;
     log?: (name: string, data: Record<string, unknown>) => void;
   } = {}
 ): Promise<CohortSignals> {
   const chunkSize = opts.chunkSize ?? EVIDENCE_CHUNK_SIZE;
   const budgetTotal = opts.maxContentSamples ?? MAX_CONTENT_SAMPLES;
+  const filenameBudgetTotal = opts.maxFilenameSamples ?? MAX_FILENAME_SAMPLES;
   const checkCanceled = opts.checkCanceled ?? (() => undefined);
   const log = opts.log ?? (() => undefined);
 
@@ -558,15 +746,61 @@ export async function collectCohortSignals(
   }
   if (contentRead && budget <= 0 && membersSampled < members.length) budgetExhausted = true;
 
+  // The filename walk. Structurally the content walk above, with its own budget and its own flags —
+  // see `MAX_FILENAME_SAMPLES` for why the budgets are separate, and `sources.filenameSamples` for
+  // why the availability flags are. Partial data is DISCARDED on failure here too: a cluster count
+  // built from some of the chunks understates every ring that straddles the missing ones, and
+  // understating is the direction that produces a confident zero.
+  const filenameSamples: FilenameSampleRow[] = [];
+  let filenameBudget = filenameBudgetTotal;
+  let filenameBudgetExhausted = false;
+  let filenameMembersSampled = 0;
+  let filenameRead = true;
+  for (const ids of chunks) {
+    checkCanceled();
+    if (filenameBudget <= 0) {
+      filenameBudgetExhausted = true;
+      break;
+    }
+    let rows: FilenameSampleRow[];
+    try {
+      // One surface, so the take IS the remaining budget — no doubling, unlike the content read.
+      rows = await reader.listFilenameSamples(
+        ids,
+        Math.min(filenameBudget, chunkSize * 2),
+        opts.createdBefore
+      );
+    } catch (e) {
+      log('bot-account-detection:filename-samples-failed', {
+        chunkIds: ids.length,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      filenameSamples.length = 0;
+      filenameRead = false;
+      filenameBudgetExhausted = false;
+      filenameMembersSampled = 0;
+      break;
+    }
+    filenameMembersSampled += ids.length;
+    filenameBudget -= rows.length;
+    filenameSamples.push(...rows);
+  }
+  if (filenameRead && filenameBudget <= 0 && filenameMembersSampled < members.length)
+    filenameBudgetExhausted = true;
+
   return buildCohortSignals({
     members,
     registrationIps,
     contentSamples,
+    filenameSamples,
     sources: {
       registrationIps: ipsRead,
       contentSamples: contentRead,
       contentBudgetExhausted: budgetExhausted,
       membersSampledForContent: Math.min(membersSampled, members.length),
+      filenameSamples: filenameRead,
+      filenameBudgetExhausted,
+      membersSampledForFilenames: Math.min(filenameMembersSampled, members.length),
     },
   });
 }

--- a/src/server/services/bot-account-detection/fingerprint-keys.ts
+++ b/src/server/services/bot-account-detection/fingerprint-keys.ts
@@ -1,0 +1,42 @@
+/**
+ * The namespace contract for cluster keys — shared by the index that BUILDS them (`evidence.ts`)
+ * and the heuristic that READS them (`heuristics/similarity.ts`).
+ *
+ * 🔴 IT IS ITS OWN MODULE BECAUSE OF WHAT IT MUST NOT DRAG IN. `heuristics/` is deliberately pure:
+ * every scoring function there is pure over a structurally-typed `signals` argument, and nothing in
+ * that directory imports `evidence.ts` — which is what keeps the heuristics testable without a
+ * database and keeps the ClickHouse client and `dbRead` out of their module graph. Putting these
+ * three declarations in `evidence.ts` and importing them from `similarity.ts` would have quietly
+ * ended that property to share two string constants.
+ *
+ * 🔴 WHY THE KEYS ARE NAMESPACED AT ALL. `CohortSignals.membersPerFingerprint` is ONE
+ * `Map<string, number>` carrying both fingerprint sources, so without a prefix a filename and a
+ * normalised comment that spell the same thing become one cluster — and the two are not the same
+ * claim. That is not hypothetical: `normalizeContent` strips the dot out of `logo.jpg` to give
+ * `logo jpg`, and a comment reading "logo jpg" normalises to exactly that string too. Two accounts
+ * uploading `logo.jpg` and one commenting about it would have read as a ring of three.
+ *
+ * The prefixes are an implementation detail of the index and are stripped again before any of this
+ * reaches a moderator — see `unprefixFingerprint` and `similarity.ts`'s `explain`.
+ */
+
+/** Namespace for a fingerprint derived from posted TEXT (`evidence.ts#contentFingerprint`). */
+export const TEXT_FINGERPRINT_PREFIX = 'text:';
+
+/** Namespace for a fingerprint derived from an uploaded FILENAME
+ *  (`evidence.ts#filenameFingerprint`). */
+export const FILENAME_FINGERPRINT_PREFIX = 'file:';
+
+/**
+ * Strip whichever namespace a fingerprint key carries, for display.
+ *
+ * A key with no known prefix is returned UNCHANGED rather than mangled — a blind
+ * `slice(indexOf(':'))` would truncate a normalised comment at its first colon, which is a
+ * character ordinary text contains and every generation-parameter paste is full of.
+ */
+export function unprefixFingerprint(key: string): string {
+  if (key.startsWith(TEXT_FINGERPRINT_PREFIX)) return key.slice(TEXT_FINGERPRINT_PREFIX.length);
+  if (key.startsWith(FILENAME_FINGERPRINT_PREFIX))
+    return key.slice(FILENAME_FINGERPRINT_PREFIX.length);
+  return key;
+}

--- a/src/server/services/bot-account-detection/heuristics/index.ts
+++ b/src/server/services/bot-account-detection/heuristics/index.ts
@@ -41,5 +41,10 @@ export {
   isCommonEmailDomain,
   COMMON_EMAIL_DOMAINS,
 } from './clustering';
-export { contentTemplatingHeuristic } from './similarity';
+export {
+  contentTemplatingHeuristic,
+  contentTemplatingSourceScore,
+  largestContentCluster,
+  CONTENT_TEMPLATING_ID,
+} from './similarity';
 export { rampScore } from './ramp';

--- a/src/server/services/bot-account-detection/heuristics/similarity.ts
+++ b/src/server/services/bot-account-detection/heuristics/similarity.ts
@@ -1,3 +1,4 @@
+import { FILENAME_FINGERPRINT_PREFIX, unprefixFingerprint } from '../fingerprint-keys';
 import type { BotAccountHeuristic } from '../scoring';
 import { rampScore } from './ramp';
 
@@ -29,16 +30,37 @@ import { rampScore } from './ramp';
  * collide. `MIN_FINGERPRINT_CHARS`/`MIN_FINGERPRINT_TOKENS` are the only defence, they are set by
  * judgement, and measuring their false-positive rate is precisely what the shadow phase is for.
  *
- * 🔴 IT SEES COMMENTS ONLY. Model names, model descriptions and image prompts are all text a ring
- * could template, and none of them is read: comments are the surface shill text actually lands on,
- * they are the two tables with a `userId` index that makes the read cheap, and adding a third source
- * is a widening of `evidence.ts` rather than a change here. An account that templated only its model
- * descriptions scores 0 from this heuristic and is a KNOWN false negative, not an accident.
+ * 🔴 IT SEES TWO SOURCES: COMMENT TEXT AND UPLOADED FILENAMES. It used to see comments only, and
+ * that limitation is what this heuristic's own production record refuted. Across five runs the
+ * comment half fired ZERO times — not because rings do not template, but because new accounts on
+ * this site do not comment: three consecutive daily cohorts totalling roughly 25,000 new accounts
+ * produced 65 comments between them, and one entire run's content input was 4 rows from 3 accounts.
+ * A heuristic with no input is not a heuristic that found nothing, and because the blend divides by
+ * every REGISTERED weight rather than by the ones that ran, a permanently silent third of the
+ * registry also capped every account's confidence at 0.667.
  *
- * 🔴 IT SEES A SAMPLE, NOT A CENSUS. The content read is budgeted (`MAX_CONTENT_SAMPLES`), so on a
- * wave day the oldest end of the cohort may not be sampled at all. An unsampled account scores 0
- * here for want of data, which — again — is not the same as scoring 0 for want of a signal. The
- * budget state rides out on `sources.contentBudgetExhausted` and as a run counter.
+ * `Image.name` is the second fingerprint source, folded in HERE rather than added as a fourth
+ * heuristic. That is a deliberate constraint, not a convenience: `MIN_REPORTED_CONFIDENCE` is
+ * derived from the registry's size in `scoring.ts`, as is `SOLE_SIGNAL_DOMINANCE`, so a fourth
+ * entry would silently move the reporting threshold for every other signal. Keeping the registry at
+ * three is what makes this a widening of one heuristic's evidence rather than a recalibration of
+ * the whole detector.
+ *
+ * 🔴 FILENAMES ARE FINGERPRINTED ON THEIR OWN TERMS — see `evidence.ts#normalizeFilename`. Reusing
+ * `contentFingerprint` was measured and rejected: its digit masking collapses every `<digits>.jpg`
+ * into one key, and its length floors reject `1900.jpg.jpeg` and `logo.jpg` outright, which between
+ * them account for most of the filenames the measured rings actually share.
+ *
+ * 🔴 WHAT IT STILL DOES NOT SEE: model names, model descriptions and image prompts. All are text a
+ * ring could template; none is read. An account that templated only its model descriptions scores 0
+ * from this heuristic and is a KNOWN false negative, not an accident.
+ *
+ * 🔴 IT SEES A SAMPLE, NOT A CENSUS. Both reads are budgeted (`MAX_CONTENT_SAMPLES`,
+ * `MAX_FILENAME_SAMPLES`), so on a wave day the oldest end of the cohort may not be sampled at all.
+ * An unsampled account scores 0 here for want of data, which — again — is not the same as scoring 0
+ * for want of a signal. The budget state rides out on `sources.contentBudgetExhausted` /
+ * `sources.filenameBudgetExhausted` and as run counters, and the two sources carry SEPARATE flags
+ * because they fail separately.
  *
  * 🔴 THE KNOWN FALSE POSITIVE, NAMED, MEASURED AND DELIBERATELY NOT PATCHED: A GENERATION-PARAMETER
  * PASTE. `Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 1234567890, Size: 512x768` and the same
@@ -90,39 +112,90 @@ export const CLUSTER_ONE_AT = 10;
  *  that budget — an over-long quote here truncates the whole finding, not just itself. */
 export const QUOTE_CHARS = 60;
 
-/** The largest group of cohort members this account's text belongs to, with the text itself. */
+/**
+ * The largest group of cohort members this account shares a fingerprint with, and the fingerprint.
+ *
+ * The returned `fingerprint` is the NAMESPACED key (`text:…` / `file:…`), not a bare value — the
+ * caller decides whether it wants the source or the display form, and `unprefixFingerprint` is what
+ * strips it. Returning a bare string here would throw away the only thing that says which source
+ * produced the cluster.
+ *
+ * `prefix` restricts the search to one source. Omitted, it searches both, which is what the score
+ * itself uses: an account is as suspicious as the largest ring it belongs to, whichever surface
+ * that ring shows up on.
+ */
 export function largestContentCluster(
   userId: number,
-  signals: { fingerprintsByUser: Map<number, string[]>; membersPerFingerprint: Map<string, number> }
+  signals: {
+    fingerprintsByUser: Map<number, string[]>;
+    membersPerFingerprint: Map<string, number>;
+  },
+  prefix?: string
 ): { size: number; fingerprint: string | null } {
   let best = { size: 0, fingerprint: null as string | null };
   for (const fingerprint of signals.fingerprintsByUser.get(userId) ?? []) {
+    if (prefix !== undefined && !fingerprint.startsWith(prefix)) continue;
     const size = signals.membersPerFingerprint.get(fingerprint) ?? 0;
     if (size > best.size) best = { size, fingerprint };
   }
   return best;
 }
 
+/**
+ * This account's score from ONE source alone.
+ *
+ * 🔴 THE DECOMPOSITION IS THE POINT, AND `fired` CANNOT PROVIDE IT. With two sources behind one
+ * heuristic id, `heuristic:content-templating:fired` no longer says WHICH source fired — and the
+ * shadow phase's entire philosophy, stated in `scoring.ts`'s header, is that a signal is graded on
+ * its own or not at all. Without this the filename half and the comment half would be permanently
+ * indistinguishable in the counters, which is how the zero-firing comment half survived five runs.
+ *
+ * 🔴 THE PER-SOURCE COUNTERS MAY SUM TO MORE THAN `fired`, DELIBERATELY. An account whose text AND
+ * whose filenames both cluster counts in both, because the alternative — attributing it to
+ * whichever source happened to win a `>` comparison — invents a tie-break the data does not
+ * support and would report a real double signal as a single one. They are two independent questions
+ * ("did the filename half fire on this account") rather than a partition of one.
+ */
+export function contentTemplatingSourceScore(
+  userId: number,
+  signals: {
+    fingerprintsByUser: Map<number, string[]>;
+    membersPerFingerprint: Map<string, number>;
+  },
+  prefix: string
+): number {
+  return rampScore(
+    largestContentCluster(userId, signals, prefix).size,
+    CLUSTER_ZERO_AT,
+    CLUSTER_ONE_AT
+  );
+}
+
 export const contentTemplatingHeuristic: BotAccountHeuristic = {
   id: CONTENT_TEMPLATING_ID,
   description:
-    'How many OTHER new accounts posted the same comment text, compared after masking links and ' +
-    'numbers so one template with a swapped payload still matches. Comments only, and over a ' +
-    'budgeted sample of them.',
+    'How many OTHER new accounts shared the same comment text — compared after masking links and ' +
+    'numbers so one template with a swapped payload still matches — or uploaded a file under the ' +
+    'same name, compared case-insensitively. Over a budgeted sample of each.',
   weight: 1,
   score: ({ member, signals }) =>
     rampScore(largestContentCluster(member.userId, signals).size, CLUSTER_ZERO_AT, CLUSTER_ONE_AT),
   explain: ({ member, signals }, score) => {
     if (score <= 0) return null;
     const { size, fingerprint } = largestContentCluster(member.userId, signals);
-    // The QUOTED text is the normalised form, not the raw comment: it is what was actually compared,
-    // so quoting anything else would show a moderator a different string from the one the score was
-    // computed on. The masks (`linkmask`, `nummask`) are visible on purpose — they are the reason
-    // two superficially different comments matched.
-    const quote = (fingerprint ?? '').slice(0, QUOTE_CHARS);
-    return (
-      `${size} new accounts posted the same text after masking links/numbers — ` +
-      `“${quote}${(fingerprint ?? '').length > QUOTE_CHARS ? '…' : ''}”`
-    );
+    const isFilename = (fingerprint ?? '').startsWith(FILENAME_FINGERPRINT_PREFIX);
+    // 🔴 THE PREFIX IS STRIPPED BEFORE A HUMAN SEES IT. The namespace exists so two sources can
+    // share one map; it is an implementation detail of the index, and a moderator reading
+    // “file:logo.jpg” would reasonably conclude the account uploaded a file called `file:logo.jpg`.
+    // The QUOTED value is otherwise exactly what was compared — for text that is the normalised
+    // form, masks (`linkmask`, `nummask`) visible on purpose, because they are the reason two
+    // superficially different comments matched.
+    const value = unprefixFingerprint(fingerprint ?? '');
+    const quote = value.slice(0, QUOTE_CHARS);
+    const ellipsis = value.length > QUOTE_CHARS ? '…' : '';
+    return isFilename
+      ? `${size} new accounts uploaded a file with the same name — “${quote}${ellipsis}”`
+      : `${size} new accounts posted the same text after masking links/numbers — ` +
+          `“${quote}${ellipsis}”`;
   },
 };

--- a/src/server/services/bot-account-detection/run.ts
+++ b/src/server/services/bot-account-detection/run.ts
@@ -9,12 +9,16 @@ import {
 } from './cohort';
 import {
   MAX_CONTENT_SAMPLES,
+  MAX_FILENAME_SAMPLES,
   collectCohortSignals,
   emptyCohortSignals,
   type EvidenceReader,
 } from './evidence';
+import { FILENAME_FINGERPRINT_PREFIX, TEXT_FINGERPRINT_PREFIX } from './fingerprint-keys';
 import {
   BOT_ACCOUNT_HEURISTICS,
+  CONTENT_TEMPLATING_ID,
+  contentTemplatingSourceScore,
   isCommonEmailDomain,
   registrationClusterGroupKey,
 } from './heuristics';
@@ -101,6 +105,9 @@ export type BotAccountDetectionOptions = {
   minConfidence?: number;
   /** Ceiling on content rows read for the templating heuristic. Defaults to `MAX_CONTENT_SAMPLES`. */
   maxContentSamples?: number;
+  /** Ceiling on image rows read for the templating heuristic's filename half. Defaults to
+   *  `MAX_FILENAME_SAMPLES`. Separate from the content budget — see that constant. */
+  maxFilenameSamples?: number;
 };
 
 export type BotAccountDetectionResult = {
@@ -162,6 +169,7 @@ export async function runBotAccountDetection(
   const maxFindingsPerReport = options.maxFindingsPerReport ?? MAX_FINDINGS_PER_REPORT;
   const minConfidence = options.minConfidence ?? MIN_REPORTED_CONFIDENCE;
   const maxContentSamples = options.maxContentSamples ?? MAX_CONTENT_SAMPLES;
+  const maxFilenameSamples = options.maxFilenameSamples ?? MAX_FILENAME_SAMPLES;
   const log = deps.log ?? (() => undefined);
   const checkCanceled = deps.checkCanceled ?? (() => undefined);
 
@@ -190,6 +198,10 @@ export async function runBotAccountDetection(
     ? await collectCohortSignals(deps.evidence, cohort.members, {
         chunkSize: pageSize,
         maxContentSamples,
+        maxFilenameSamples,
+        // The run's own clock as the filename read's upper bound, so the sample is a snapshot of
+        // the window rather than drifting with whatever was uploaded while the run walked.
+        createdBefore: startedAt,
         // The window this run already computed, handed to the ClickHouse read as its `time` bound.
         // Every cohort account was created after it, so it prunes the scan without removing a row
         // the query wants.
@@ -206,6 +218,9 @@ export async function runBotAccountDetection(
     distinctIps: signals.membersPerIp.size,
     distinctDomains: signals.membersPerDomain.size,
     distinctFingerprints: signals.membersPerFingerprint.size,
+    filenameSamples: signals.sources.filenameSamples,
+    filenameBudgetExhausted: signals.sources.filenameBudgetExhausted,
+    membersSampledForFilenames: signals.sources.membersSampledForFilenames,
   });
 
   const memberById = new Map(cohort.members.map((m) => [m.userId, m]));
@@ -252,6 +267,26 @@ export async function runBotAccountDetection(
     (m) => m.emailDomain !== null && isCommonEmailDomain(m.emailDomain)
   ).length;
 
+  /** Distinct cluster keys from ONE fingerprint source. See the counters below for why the two are
+   *  never summed into a single series. */
+  const distinctFingerprints = (prefix: string) => {
+    let n = 0;
+    for (const key of signals.membersPerFingerprint.keys()) if (key.startsWith(prefix)) n += 1;
+    return n;
+  };
+
+  // 🔴 WHICH HALF OF `content-templating` FIRED. The heuristic now has two fingerprint sources
+  // behind one id, so `heuristic:content-templating:fired` can no longer answer the only question
+  // the shadow phase asks of a signal — whether IT, specifically, is earning its place. The comment
+  // half fired zero times across five production runs while that was invisible inside a single
+  // counter; these are what make the same failure visible next time.
+  //
+  // Counted over EVERY scored member, matching `fired`'s own population so the three are directly
+  // comparable. They may sum to MORE than `fired` — see `contentTemplatingSourceScore`.
+  const firedFromSource = (prefix: string) =>
+    cohort.members.filter((m) => contentTemplatingSourceScore(m.userId, signals, prefix) > 0)
+      .length;
+
   const counters: Record<string, number> = {
     window_hours: windowHours,
     cohort_scanned: cohort.scanned,
@@ -292,10 +327,24 @@ export async function runBotAccountDetection(
     evidence_content_budget: maxContentSamples,
     evidence_distinct_registration_ips: signals.membersPerIp.size,
     evidence_distinct_email_domains: signals.membersPerDomain.size,
-    evidence_distinct_content_fingerprints: signals.membersPerFingerprint.size,
+    // 🔴 COUNTED PER NAMESPACE, NOT AS `membersPerFingerprint.size`. That map now carries both
+    // sources, so the bare size would have silently redefined an existing series: a run whose
+    // `evidence_distinct_content_fingerprints` jumped from 3 to 4,000 would read as an explosion of
+    // comment templating on the day the filename source shipped. The two are separate questions and
+    // get separate keys.
+    evidence_distinct_content_fingerprints: distinctFingerprints(TEXT_FINGERPRINT_PREFIX),
+    evidence_distinct_filename_fingerprints: distinctFingerprints(FILENAME_FINGERPRINT_PREFIX),
+    evidence_filename_samples: signals.sources.filenameSamples ? 1 : 0,
+    evidence_filename_budget_exhausted: signals.sources.filenameBudgetExhausted ? 1 : 0,
+    evidence_members_sampled_for_filenames: signals.sources.membersSampledForFilenames,
+    evidence_filename_budget: maxFilenameSamples,
     domains_suppressed_common: domainsSuppressed,
 
     ...heuristicCounters(scores),
+    [`heuristic:${CONTENT_TEMPLATING_ID}:fired_text`]: firedFromSource(TEXT_FINGERPRINT_PREFIX),
+    [`heuristic:${CONTENT_TEMPLATING_ID}:fired_filename`]: firedFromSource(
+      FILENAME_FINGERPRINT_PREFIX
+    ),
     // Over EVERY scored member, not only the reported ones — see `confidenceBucketCounters`.
     ...confidenceBucketCounters(scores),
     // Over the REPORTED members only: which findings rest on ONE heuristic and nothing else. See
@@ -353,6 +402,21 @@ export async function runBotAccountDetection(
         `${signals.sources.membersSampledForContent} of ${cohort.members.length} members. Members ` +
         `are sampled newest-first, so the unsampled remainder is the OLDEST end of the window and ` +
         `scored 0 on content templating for want of data.`
+      : '') +
+    // The filename half of `content-templating` gets its own disclosures, for the same reason the
+    // comment half has them: a zero from a source that never ran is not a zero from a source that
+    // found nothing, and only these sentences tell a reader which one they are looking at.
+    (signals.sources.filenameSamples
+      ? ''
+      : ` 🔴 UPLOADED-FILENAME DATA WAS UNAVAILABLE this run — the read either did not run or ` +
+        `failed and its partial result was discarded — so the filename half of the ` +
+        `content-templating heuristic scored 0 for every member for want of data. That is not ` +
+        `evidence that no accounts uploaded files under the same name.`) +
+    (signals.sources.filenameBudgetExhausted
+      ? ` 🔴 THE FILENAME SAMPLE BUDGET (${maxFilenameSamples} rows) WAS EXHAUSTED after ` +
+        `${signals.sources.membersSampledForFilenames} of ${cohort.members.length} members. ` +
+        `Members are sampled newest-first, so the unsampled remainder is the OLDEST end of the ` +
+        `window and scored 0 on filename clustering for want of data.`
       : '') +
     (cohort.capped
       ? ` 🔴 TRUNCATED at the ${maxAccounts}-account cap. Accounts are read NEWEST FIRST, so the ` +

--- a/src/server/services/bot-account-detection/scoring.ts
+++ b/src/server/services/bot-account-detection/scoring.ts
@@ -119,9 +119,23 @@ function clampScore(raw: number): { score: number; clamped: boolean } {
 /**
  * Run every heuristic over one account.
  *
- * The blend is a weighted mean over the heuristics that RAN, so a registry of one always-zero
- * placeholder yields 0 and a registry of none yields 0 — neither of which is a claim about the
- * account.
+ * 🔴 THE BLEND DIVIDES BY EVERY REGISTERED WEIGHT, NOT BY THE HEURISTICS THAT HAD INPUT — and this
+ * docstring claimed the opposite ("a weighted mean over the heuristics that RAN") until a heuristic
+ * with no input made the difference matter. The denominator below is `subScores.reduce(…weight…)`
+ * over the whole registry; a heuristic whose source was empty contributes 0 to the numerator and
+ * its full weight to the denominator. So a permanently silent third of an equally-weighted registry
+ * of three is not neutral — it is a fixed 1/3 haircut that caps every account at 0.667, which is
+ * exactly what a `registration-cluster` score of 0.6667 blending to 0.2222 records.
+ *
+ * That is a DELIBERATE choice and not a defect to be patched here: dividing by only the heuristics
+ * that found data would make an account's confidence depend on which sources happened to be up,
+ * so the same account would score differently on a day ClickHouse was down — and `sources` exists
+ * precisely so a grading pass can exclude those runs rather than have the blend silently rescale
+ * itself. But the arithmetic has to be stated correctly, because the next person to touch the
+ * denominator will read this sentence first.
+ *
+ * A registry of one always-zero placeholder still yields 0, and a registry of none yields 0 —
+ * neither of which is a claim about the account.
  */
 export function scoreAccount(
   heuristics: readonly BotAccountHeuristic[],


### PR DESCRIPTION
## The defect

`content-templating` is one of three equally-weighted heuristics in the bot-account detector, and it has fired **zero times across five production runs**.

The cause is not tuning — it is that the heuristic had no input. Its only content source was comments (`comment` + `commentV2`), and new accounts on this site do not comment. Across three consecutive 24h cohorts totalling roughly **25,000 new accounts** there were **65 comments**. One run's entire content input was **4 comment rows from 3 accounts**.

There is a second, quieter consequence. `scoreAccount` divides by the total weight of every **registered** heuristic, not by the ones that found data, so a permanently-zero third of the registry imposes a fixed 1/3 haircut and caps every account at 0.667. That is confirmed arithmetically in production data: a `registration-cluster` score of 0.6667 is stored as a blend of exactly 0.222222.

## The change

`Image.name` — the uploaded filename — becomes a **second fingerprint source inside the existing heuristic**. No fourth heuristic is added.

That constraint is deliberate. `MIN_REPORTED_CONFIDENCE` and `SOLE_SIGNAL_DOMINANCE` are both **derived from the registry's size**, so adding a fourth entry would silently move the reporting threshold for every other signal. Keeping the registry at three makes this a widening of one heuristic's evidence rather than a recalibration of the whole detector.

### Design points, each with its reason

**Filenames get their own normaliser — reusing `contentFingerprint` was measured and rejected.** Executing the shipped normaliser: `1900.jpg.jpeg` normalises to `"nummask jpg jpeg"` (16 chars, 3 tokens) and `logo.jpg` to `"logo jpg"` (8 chars, 2 tokens), against floors of 24 chars and 4 tokens — so the prose floors reject both outright, and they are filenames a confirmed ring actually shared. Separately, the digit masking would collapse every `<digits>.jpg` into a single key, making the largest cluster in any cohort an artefact of camera naming. Filenames are lowercased and trimmed, with no masking and no length floors.

Lowercasing is load-bearing rather than cosmetic: `Logo.jpg` and `logo.jpg` were two separate 10-account clusters in one real cohort, and are one cluster of 20 once folded.

**Cluster keys are namespaced (`text:` / `file:`).** `membersPerFingerprint` is one `Map<string, number>` shared by both sources. Without prefixes a filename and a normalised comment that spell the same thing merge into one cluster — not hypothetical, since `normalizeContent` turns `logo.jpg` into `logo jpg`, which a comment can spell exactly. The prefix is stripped before a moderator sees the quoted value, so the reason string still reads as a plain filename.

**The scoring floor is unchanged.** `CLUSTER_ZERO_AT` / `CLUSTER_ONE_AT` and `rampScore` are reused as-is: three distinct cohort members sharing a filename is the smallest scoring group. That floor, plus the fact that every member is an account under 24h old, **is** the innocent-collision defence. There is deliberately no stoplist of generic filenames — the measured rings share exactly the unremarkable names a stoplist would remove.

**The read does not filter on `ingestion` or `needsReview`.** A partial index covers the scanned-and-clean rows, so adding either predicate looks like free performance — and would delete exactly the population this heuristic depends on, because the images a templated ring uploads are the ones the scanner blocks. An account surviving while its content is removed is the case this detector exists to surface. Pinned as an exact `where`-key ledger so a filter of any name fails the test.

**It orders by `id`, not `createdAt`.** See "corrections" below.

**Its own budget and its own source flags**, separate from the content read's. A single shared budget spent in source order would let the empty comment half consume the allowance on a wave day and truncate the half with the signal in it — silently reproducing the defect being fixed. The two reads also fail independently, so a single availability flag would let a live comment read vouch for a filename read that never happened.

**New counters decompose the fire.** `heuristic:content-templating:fired_text` and `:fired_filename`, plus per-namespace distinct-fingerprint counts. Without them the existing `:fired` counter is ambiguous and the shadow phase cannot grade the two sub-signals apart — which is precisely how a zero-firing half survived five runs looking healthy. `evidence_distinct_content_fingerprints` keeps its existing meaning (text only) rather than silently absorbing filenames, which would have read as an explosion of comment templating on the day this shipped.

## Evidence this is worth shipping

Backtested against the real cohorts of all five production runs.

- The signal selects **18–34 accounts per cohort**, out of 205–254 that posted named images.
- Against existing moderation outcomes, flagged accounts are actioned at **2.35×** the non-flagged rate in one cohort and **3.9×** in another. Both comparisons are made **within** a cohort — the actioned label matures over days, so a cross-cohort comparison would be invalid.
- **8 of the 11 accounts in a human-graded true-positive ring carry a shared filename**, so the signal selects the ring. Only 3 of those 11 are actioned even now — so "actioned" is an incomplete ground truth that undercounts exactly the population this detector exists to surface. That is why actioned-rate is not the headline here.
- The most recent cohort contained **26 accounts sharing one filename**, all on a common email provider, on which the detector reported **0 findings**. That population is structurally invisible to the other three heuristics: the common-provider suppression removes the domain signal, they post no comments, and 1–3 items each sits below the velocity bar.

## Corrections to the brief, found by measuring

Two claims I was given did not survive contact with the code, and the implementation follows the measurement rather than the brief:

1. **There is no `Image_userId_createdAt` index.** The brief named `("userId","createdAt")` as the right index. `Image` carries `@@index([userId, postId])` and `@@index([userId, id], map: "image_userid_id_idx")` — and neither `schema.prisma` nor `schema.full.prisma` contains a `(userId, createdAt)` index under any name. Ordering on `createdAt` would therefore sort a user's whole image history outside any index. The read orders by **`id: 'desc'`**, which is index-supported, is monotonic on an append-only table (so descending `id` is descending upload order), and matches what the existing content read already does for the same reason. The `createdAt` upper bound is kept as a **filter** — it makes the sample a stable snapshot at the run's clock — but it is not the sort key.

2. **The prose floors reject more than the brief said.** The brief said the floors reject "2 of 3" of the ring's filenames. Measured, they also reject `IMG_20240103_112233.png` (23 chars — one short of the 24-char floor). The direction of the brief's argument holds and is if anything understated.

A third item is a nuance rather than a correction: the brief's reason for not reusing `contentFingerprint` was the length floors. The stronger reason turns out to be the **digit masking**, which would actively over-cluster (`1900.jpg.jpeg` and `2749.jpg.jpeg` become one key) rather than merely discard. Both are now pinned by tests.

## Test coverage

**42 new tests.** Full suite for the detector: **8 files, 349 passing** (was 309).

Red-at-base matrix, run by copying the new test files onto unmodified `main`:

| Guard | At base | At HEAD |
|---|---|---|
| `run.test.ts` — filename-only cohort reaches the board | **RED** (assertion: `expected 0 to be greater than 0`) | green |
| `run.test.ts` — filename source reported unavailable, not a quiet zero | **RED** (assertion: `expected undefined to be +0`) | green |
| `evidence.test.ts` — all new guards (normaliser, fingerprint, namespacing, index fold, budgets, query shape) | **RED** — file cannot load at base | green |
| `heuristics.test.ts` — all new guards (boundary, prose-floor regression, `explain()`, source decomposition) | **RED** — file cannot load at base | green |

Stated honestly: only the two `run.test.ts` cases fail at base by a **behavioural assertion**. The other two files fail by module-resolution error, because they import a module that does not exist at base — that is red-by-absence, which is the weaker form and is what a new capability can offer.

So the guards were additionally **mutation-tested at HEAD**, with a positive control (unmutated source → 0 failures) and each mutant applied in isolation:

| Mutant | Killed by |
|---|---|
| `filenameFingerprint` drops the `file:` prefix | namespacing guard (+4 others) |
| `normalizeFilename` stops lowercasing | both case-folding guards (+3) |
| prose length floors applied to filenames | prose-floor regression guard (+15) |
| filename clusters count **rows**, not distinct accounts | **exactly 1** — the distinct-accounts guard |
| `where` gains an `ingestion` filter | **exactly 1** — the `where`-key ledger |
| `orderBy` becomes `createdAt` | **exactly 1** — the ordering guard |
| filename read shares the content budget | budget-independence guard (+2) |
| `explain()` stops stripping the prefix | `explain()` guard (+2) |

Every mutant died, and in each case the intended guard is among the dead — three of them killing exactly one test, which is the isolated form.

### Required cases, all covered

- Shared by exactly **3** distinct members scores; by **2** scores zero — the boundary, both sides, with literal sizes.
- `Logo.jpg` and `logo.jpg` are **one** cluster (asserted both at the key level and across accounts).
- One account uploading the same filename 90 times counts as **one** member.
- A filename cannot collide with a text fingerprint of the same string.
- `1900.jpg.jpeg` and `logo.jpg` both survive and cluster — the prose floors do not reach filenames.
- `explain()` quotes the plain filename, never the prefixed key, and still says "text" for a text cluster.

## Verification

- `pnpm typecheck` — **0 errors**. Instrument validated: a planted type error in one of the changed files is reported, and `pnpm typecheck` is structurally blind to `__tests__/` (a planted error there passes clean), so the test tree was checked separately.
- `tsconfig.tests.json` — **0 errors in the files this PR touches.** The repo-wide `typecheck-tests-gate` is already BLOCKED on `main` (measured control at base: 1253 errors / 237 files / 118 unbaselined). This branch measures **1251 / 236 / 117** — strictly better, because it also fixes two pre-existing type errors in `evidence.test.ts`. The block is pre-existing and unrelated to this change.
- `prettier --check` and `eslint` clean on the changed directory (base confirmed clean first, so the warnings were attributable).

One incidental fix worth flagging: several existing fake evidence readers in `run.test.ts` lacked the new method. At runtime that was swallowed by the read's own try/catch and silently degraded the filename read, so **vitest stayed green while the type system knew** — the reason the test-tree typecheck was run separately rather than trusted to the suite.

## Docstrings corrected

- `similarity.ts` stated "**IT SEES COMMENTS ONLY**" as a deliberate known limitation. That sentence is now false and is replaced with the two-source description plus the production record that refuted it.
- `scoreAccount` claimed the blend is "a weighted mean over the heuristics that **RAN**". It is not — it includes every registered heuristic whether or not it had input, which is exactly the arithmetic that produced the 1/3 haircut. Corrected, with the reason the behaviour is deliberate, so the next person to touch the denominator does not read the old sentence first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
