### PR TITLE
feat(apps): disclose the permissions an off-site app will request, before you connect

### DIFF
--- a/src/components/Apps/AppListingDetailBody.affordances.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.affordances.browser.test.tsx
@@ -114,6 +114,11 @@ function base(over: Partial<ListingDetail> = {}): ListingDetail {
     updatedAt: '2026-03-04T05:06:07.000Z',
     screenshots: [],
     scopes: [],
+    // Same contract as `scopes`: `projectListingDetail` guarantees an array, and
+    // the body reads `.length` — a fixture omitting it would not match any real
+    // payload. `[]` keeps these ON-SITE fixtures rendering no connect-permissions
+    // section, which is what an on-site listing produces.
+    connectScopes: [],
     kindData: {
       kind: 'onsite',
       appBlockId: 'blk-1',

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -321,6 +321,11 @@ function base(over: Partial<ListingDetail>): ListingDetail {
     // empty array renders no section at all. `projectListingDetail` guarantees an
     // array, so a fixture omitting it would not match any real payload.
     scopes: [],
+    // Same contract as `scopes`: `projectListingDetail` guarantees an array, and
+    // the body reads `.length` — a fixture omitting it would not match any real
+    // payload. `[]` keeps these ON-SITE fixtures rendering no connect-permissions
+    // section, which is what an on-site listing produces.
+    connectScopes: [],
     kindData: {
       kind: 'onsite',
       appBlockId: 'blk-1',

--- a/src/components/Apps/AppListingDetailBody.gallery.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.gallery.browser.test.tsx
@@ -175,6 +175,11 @@ function base(over: Partial<ListingDetail>): ListingDetail {
     // empty array renders no section at all. `projectListingDetail` guarantees an
     // array, so a fixture omitting it would not match any real payload.
     scopes: [],
+    // Same contract as `scopes`: `projectListingDetail` guarantees an array, and
+    // the body reads `.length` — a fixture omitting it would not match any real
+    // payload. `[]` keeps these ON-SITE fixtures rendering no connect-permissions
+    // section, which is what an on-site listing produces.
+    connectScopes: [],
     kindData: {
       kind: 'onsite',
       appBlockId: 'blk-1',

--- a/src/components/Apps/AppListingDetailBody.permissions.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.permissions.browser.test.tsx
@@ -136,6 +136,11 @@ function base(over: Partial<ListingDetail>): ListingDetail {
     updatedAt: '2026-03-04T05:06:07.000Z',
     screenshots: [],
     scopes: [],
+    // Same contract as `scopes`: `projectListingDetail` guarantees an array, and
+    // the body reads `.length` — a fixture omitting it would not match any real
+    // payload. `[]` keeps these ON-SITE fixtures rendering no connect-permissions
+    // section, which is what an on-site listing produces.
+    connectScopes: [],
     kindData: {
       kind: 'onsite',
       appBlockId: 'blk-1',

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -62,6 +62,7 @@ import { ListingCollaboratorByline } from '~/components/Apps/ListingCollaborator
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { AppListingComments } from '~/components/Apps/AppListingComments';
 import { AppListingDescription } from '~/components/Apps/AppListingDescription';
+import { ConnectScopesDisclosure } from '~/components/Apps/ConnectScopesDisclosure';
 import { AppListingReviews } from '~/components/Apps/AppListingReviews';
 import { CATEGORY_ICONS, FALLBACK_CATEGORY_ICON } from '~/components/Apps/marketplaceCategoryIcons';
 import { ContainerGrid2 } from '~/components/ContainerGrid/ContainerGrid';
@@ -1228,6 +1229,32 @@ export function AppListingDetailBody({
                 This app runs off-platform, but can connect to your Civitai account — you&apos;ll be
                 asked to sign in and approve access.
               </Alert>
+            )}
+
+            {/* WHAT that connect will actually ASK FOR — the enumeration behind the
+                sentence immediately above.
+                🔴 A FOURTH permission surface, and like the on-site `scopes` section
+                below it does NOT belong to the mutually-exclusive off-site pair. Those
+                two answer "does this leave the platform, and can it reach my account at
+                all?"; this one enumerates the ask. Do not fold it into either predicate
+                — they are exact complements over one domain and a third condition there
+                breaks the invariant pinned in `__tests__/appListingDetailView.test.ts`.
+                🔴 IT IS GATED ON THE DATA, NOT ON `shouldShowConnectCapability`, AND
+                THAT IS NOT AN OVERSIGHT. Reusing the predicate would couple the
+                enumeration to the sentence and reintroduce exactly the third-condition
+                pressure the pair's docstring warns about. `connectScopes` is `[]` for
+                every listing that is not an off-site connect listing, so the data gate
+                is already narrower than the predicate — and it additionally withholds
+                the section from a connect listing that requests NOTHING, where a
+                permissions box would be a reassuring empty container. Same
+                `length > 0` reasoning as the on-site section: on a store page, "no
+                permissions" is better said by the absence of the section.
+                🔴 It renders the SHARED `ConnectScopeRow`, so the sensitive-risk
+                emphasis reads identically here and on the moderator review surface. It
+                cannot render `connectScopeJustifications` — see its docblock; that is
+                structural, not a convention. */}
+            {detail.connectScopes.length > 0 && (
+              <ConnectScopesDisclosure scopes={detail.connectScopes} />
             )}
 
             {/* PRE-LAUNCH PERMISSION DISCLOSURE — what this app is permitted to do,

--- a/src/components/Apps/AppListingDetailBody.viewer.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.viewer.browser.test.tsx
@@ -163,6 +163,11 @@ function base(over: Partial<ListingDetail>): ListingDetail {
     // empty array renders no section at all. `projectListingDetail` guarantees an
     // array, so a fixture omitting it would not match any real payload.
     scopes: [],
+    // Same contract as `scopes`: `projectListingDetail` guarantees an array, and
+    // the body reads `.length` — a fixture omitting it would not match any real
+    // payload. `[]` keeps these ON-SITE fixtures rendering no connect-permissions
+    // section, which is what an on-site listing produces.
+    connectScopes: [],
     kindData: {
       kind: 'onsite',
       appBlockId: 'blk-1',

--- a/src/components/Apps/CombinedReviewModal.browser.test.tsx
+++ b/src/components/Apps/CombinedReviewModal.browser.test.tsx
@@ -4,6 +4,10 @@ import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 import type * as TrpcModule from '~/utils/trpc';
+// 🔴 `import type`, not a value import. A top-level VALUE import in a browser-mode
+// test resolves a SECOND copy of React and fails the whole file with "Invalid hook
+// call", reported as `Tests no tests`. A type import is erased at compile time.
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
  * The COMBINED code + listing-media review surface (Item 4) — browser-mode render
@@ -37,7 +41,12 @@ const CODE_REQUEST = {
     scopes: ['user:read'],
     targets: [{ slotId: 'model.sidebar_top', priority: 10 }],
   },
-  fileSummary: { files: [{ path: 'index.js', sha256: 'x', sizeBytes: 10 }], added: ['index.js'], removed: [], changed: [] },
+  fileSummary: {
+    files: [{ path: 'index.js', sha256: 'x', sizeBytes: 10 }],
+    added: ['index.js'],
+    removed: [],
+    changed: [],
+  },
   manifestDiffSummary: { kind: 'first-version', fields: ['name'] },
   reviewRepoUrl: 'https://forgejo.example/repo',
   pushCommitUrl: null as string | null,
@@ -70,7 +79,9 @@ const SELECTION = {
 
 const AGENT_REPORT = {
   status: 'complete',
-  codeReview: { findings: [{ severity: 'medium', title: 'A code finding', detail: 'code detail' }] },
+  codeReview: {
+    findings: [{ severity: 'medium', title: 'A code finding', detail: 'code detail' }],
+  },
   securityAudit: { findings: [] },
   scopeVerdicts: { scopes: [] },
 };
@@ -84,7 +95,9 @@ const ASSETS = {
   coverNsfwLevel: 1,
   iconScanStatus: 'scanned',
   coverScanStatus: 'scanned',
-  screenshots: [{ id: 's1', imageId: 3, order: 0, caption: null, nsfwLevel: 1, scanStatus: 'scanned' }],
+  screenshots: [
+    { id: 's1', imageId: 3, order: 0, caption: null, nsfwLevel: 1, scanStatus: 'scanned' },
+  ],
   completeness: { complete: true, missing: [] },
   hasBlockedAsset: false,
   hasPendingScan: false,
@@ -132,12 +145,20 @@ const LISTING_PREVIEW = {
     // 🔴 REQUIRED, and `[]` is not cosmetic here. `AppListingDetailBody` reads
     // `detail.scopes.length` to decide whether to render the pre-launch permission
     // disclosure, so omitting it makes this modal THROW on render rather than merely
-    // skip a section. This fixture is not annotated as a `ListingDetail`, so
-    // TypeScript does not catch the omission — the mod review modal's runtime is the
-    // only guard, which is exactly how this surfaced.
+    // skip a section.
     scopes: [],
+    // 🔴 REQUIRED FOR THE SAME REASON — the body reads `detail.connectScopes.length`
+    // for the off-site connect disclosure. `[]` is also the honest value: this is an
+    // ON-SITE fixture, and an on-site listing requests no OAuth-connect scopes.
+    connectScopes: [],
+    // The remaining fields the real projection always supplies. They are here to make
+    // the `satisfies` below reachable, not because this modal reads them.
+    collaborators: [],
+    sourceRepoUrl: null,
+    isBeta: false,
+    betaMessage: null,
     kindData: { kind: 'onsite' as const, appBlockId: 'blk_1', hasPage: false, liveUrl: '' },
-  },
+  } satisfies ListingDetail,
 };
 
 const mocks = vi.hoisted(() => ({
@@ -220,7 +241,9 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
         getPublishRequestScreenshots: {
           useQuery: () => ({ data: { items: [] }, isLoading: false, error: null }),
         },
-        getPublishRequestDiff: { useQuery: () => ({ data: undefined, isLoading: false, error: null }) },
+        getPublishRequestDiff: {
+          useQuery: () => ({ data: undefined, isLoading: false, error: null }),
+        },
         getAgentReview: {
           useQuery: () => ({
             data: AGENT_REPORT,

--- a/src/components/Apps/ConnectScopeRow.tsx
+++ b/src/components/Apps/ConnectScopeRow.tsx
@@ -1,0 +1,61 @@
+import { Group, Stack, Text, ThemeIcon } from '@mantine/core';
+import { IconKey } from '@tabler/icons-react';
+import type { ReactNode } from 'react';
+import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
+
+/**
+ * ConnectScopeRow — how ONE OAuth-connect scope looks, wherever it is shown.
+ *
+ * Lifted out of `ConnectScopesPanel` (the moderator review surface) so the PUBLIC
+ * store-page disclosure (`ConnectScopesDisclosure`) renders a scope IDENTICALLY
+ * rather than through a second hand-rolled renderer — in particular the
+ * `SensitiveScopeBadge` emphasis, which is the part a viewer is meant to notice
+ * and the part most likely to drift if it were spelled twice.
+ *
+ * 🔴 THE JUSTIFICATION IS A `children` SLOT, NOT A PROP, AND THAT IS THE POINT.
+ * `connectScopeJustifications` is free text authored by the app owner; disclosing
+ * it publicly is a SEPARATE exposure decision that has not been made (clawgate
+ * #555 lists it as a non-goal). Because this row cannot render justification text
+ * on its own, the public surface is structurally unable to leak it — it simply
+ * passes no children. A `justifications` prop here would have made that a
+ * convention the next caller could forget. The moderator panel supplies its own
+ * justification block as children, so its DOM is unchanged by the extraction.
+ *
+ * Its own module rather than an export of `ConnectScopesPanel`, because component
+ * tests mock that module wholesale — importing the row from it would make the row
+ * disappear from any suite that stubs the panel.
+ */
+export function ConnectScopeRow({
+  scopeKey,
+  label,
+  sensitive = false,
+  children,
+}: {
+  /** The TokenScope enum-key, e.g. `ModelsRead`. Rendered verbatim, monospaced. */
+  scopeKey: string;
+  /** The human-readable label for the scope; falsy renders no label element. */
+  label: string;
+  sensitive?: boolean;
+  /** Moderator-only detail rendered under the identity line. See the docblock. */
+  children?: ReactNode;
+}) {
+  return (
+    <Stack gap={2} data-testid={`connect-scope-row-${scopeKey}`}>
+      <Group gap={8} align="flex-start" wrap="nowrap">
+        <ThemeIcon size="xs" variant="subtle" color={sensitive ? 'orange' : 'blue'}>
+          <IconKey size={12} />
+        </ThemeIcon>
+        <Text size="sm" fw={600} style={{ fontFamily: 'ui-monospace, monospace' }}>
+          {scopeKey}
+        </Text>
+        {sensitive && <SensitiveScopeBadge />}
+        {label && (
+          <Text size="xs" c="dimmed">
+            {label}
+          </Text>
+        )}
+      </Group>
+      {children}
+    </Stack>
+  );
+}

--- a/src/components/Apps/ConnectScopesDisclosure.tsx
+++ b/src/components/Apps/ConnectScopesDisclosure.tsx
@@ -1,0 +1,127 @@
+import { Card, Group, Stack, Text, ThemeIcon, Tooltip } from '@mantine/core';
+import { IconAlertTriangle, IconInfoCircle, IconKey } from '@tabler/icons-react';
+import { ConnectScopeRow } from '~/components/Apps/ConnectScopeRow';
+import {
+  isSensitiveTokenScope,
+  TokenScope,
+  tokenScopeLabels,
+} from '~/shared/constants/token-scope.constants';
+
+/**
+ * ConnectScopesDisclosure — the PUBLIC store-page enumeration of the account
+ * permissions an OAuth-connect off-site listing will ask for, shown BEFORE the
+ * viewer clicks Connect.
+ *
+ * 🔴 WHY THIS EXISTS: the store page already tells a viewer that an off-site app
+ * "can connect to your Civitai account", and then said nothing about what it
+ * would ask for — while the ON-SITE surface enumerates its approved scopes in
+ * full (#4761). So the surface granting the WEAKER capability disclosed more than
+ * the one granting real account access. Measured in production when this shipped:
+ * of the listings carrying a connect client, the requested masks included
+ * `UserRead` (profile, settings & email), `BuzzRead` (balance & history),
+ * `AIServicesWrite` (Buzz spend) and in one case `VaultRead` (the user's private
+ * model vault) — none of it disclosed anywhere the viewer could see it.
+ *
+ * 🔴 IT RENDERS THE SHARED `ConnectScopeRow`, NOT A SECOND RENDERER. The
+ * sensitive-first ordering and the `SensitiveScopeBadge` emphasis therefore read
+ * identically here and on the moderator review surface (`ConnectScopesPanel`).
+ * That is a requirement, not a tidiness preference: two spellings of "this
+ * permission is elevated-risk" drift, and the public one is the one nobody
+ * reviews.
+ *
+ * 🔴 IT CANNOT DISCLOSE `connectScopeJustifications`, BY CONSTRUCTION. That text
+ * is authored by the app owner and publishing it is a separate exposure decision
+ * that has not been made. This component takes no justifications prop and the
+ * shared row cannot render the text without children, so the omission is
+ * structural rather than a convention someone later forgets.
+ *
+ * 🔴 NOT the mutually-exclusive off-site pair. `shouldShowOffsiteDisclosure` and
+ * `shouldShowConnectCapability` are exact complements over one domain and their
+ * never-both-never-neither invariant is pinned in
+ * `__tests__/appListingDetailView.test.ts`. This is a THIRD surface that follows
+ * the connect-capability sentence and enumerates it; do not fold it into either
+ * predicate, exactly as the on-site scopes section must not be folded in.
+ *
+ * Rendered only when there is something to disclose — the caller guards on
+ * `length > 0`, matching the on-site section, so a listing that requests nothing
+ * gets no section rather than a reassuring empty box.
+ */
+export function ConnectScopesDisclosure({ scopes }: { scopes: string[] }) {
+  // Resolve enum-key → bit through the SHARED table so the label and the
+  // sensitivity verdict can never fork from the hub's OAuth consent screen. An
+  // unrecognised key is DROPPED rather than rendered bare: the wire format is a
+  // key list, so a key this build does not know is a scope it cannot describe,
+  // and a monospaced identifier with no label and no risk verdict is worse than
+  // silence on a surface whose whole job is to inform.
+  const resolved = scopes
+    .map((key) => ({ key, bit: TokenScope[key as keyof typeof TokenScope] }))
+    .filter((s): s is { key: string; bit: number } => typeof s.bit === 'number' && s.bit > 0)
+    .map((s) => ({ ...s, label: tokenScopeLabels[s.bit] ?? '' }))
+    .sort((a, b) => a.bit - b.bit);
+
+  const sensitiveScopes = resolved.filter((s) => isSensitiveTokenScope(s.bit));
+  const normalScopes = resolved.filter((s) => !isSensitiveTokenScope(s.bit));
+
+  if (resolved.length === 0) return null;
+
+  return (
+    <Card withBorder p="sm" data-testid="connect-scopes-disclosure">
+      <Stack gap="xs">
+        <Group gap={6}>
+          <IconKey size={14} />
+          <Text size="sm" fw={600}>
+            Permissions this app will request ({resolved.length})
+          </Text>
+          <Tooltip
+            multiline
+            w={300}
+            label="If you connect this app, it will ask you to sign in and approve these permissions. You can review them again on the Civitai sign-in screen, and you can disconnect the app at any time."
+          >
+            <ThemeIcon size="xs" variant="subtle" color="gray">
+              <IconInfoCircle size={13} />
+            </ThemeIcon>
+          </Tooltip>
+        </Group>
+
+        {sensitiveScopes.length > 0 && (
+          <Stack gap={8} data-testid="connect-scopes-disclosure-sensitive-group">
+            <Group gap={6}>
+              <IconAlertTriangle size={14} color="var(--mantine-color-orange-6)" />
+              <Text size="sm" fw={600} c="orange">
+                Sensitive permissions ({sensitiveScopes.length})
+              </Text>
+              <Tooltip
+                multiline
+                w={280}
+                label="Elevated-risk permissions — these let the app spend your Buzz, read your balance or private data (including your email), or write data other users see."
+              >
+                <ThemeIcon size="xs" variant="subtle" color="orange">
+                  <IconInfoCircle size={13} />
+                </ThemeIcon>
+              </Tooltip>
+            </Group>
+            {sensitiveScopes.map((s) => (
+              <ConnectScopeRow key={s.bit} scopeKey={s.key} label={s.label} sensitive />
+            ))}
+          </Stack>
+        )}
+
+        {normalScopes.length > 0 && (
+          <Stack gap={8} data-testid="connect-scopes-disclosure-normal-group">
+            {sensitiveScopes.length > 0 && (
+              <Group gap={6}>
+                <IconKey size={14} />
+                <Text size="sm" fw={600}>
+                  Other permissions ({normalScopes.length})
+                </Text>
+              </Group>
+            )}
+            {normalScopes.map((s) => (
+              <ConnectScopeRow key={s.bit} scopeKey={s.key} label={s.label} />
+            ))}
+          </Stack>
+        )}
+      </Stack>
+    </Card>
+  );
+}

--- a/src/components/Apps/ConnectScopesDisclosure.tsx
+++ b/src/components/Apps/ConnectScopesDisclosure.tsx
@@ -9,8 +9,12 @@ import {
 
 /**
  * ConnectScopesDisclosure — the PUBLIC store-page enumeration of the account
- * permissions an OAuth-connect off-site listing will ask for, shown BEFORE the
- * viewer clicks Connect.
+ * permissions an OAuth-connect off-site listing is APPROVED TO ASK FOR, shown
+ * BEFORE the viewer clicks Connect.
+ *
+ * 🔴 A CEILING, NOT A PROMISE. See the "MAY request" comment on the heading below
+ * for why every string here is deliberately hedged; the short version is that
+ * `connectRequestedScopes` is review-only and does not gate token issuance.
  *
  * 🔴 WHY THIS EXISTS: the store page already tells a viewer that an off-site app
  * "can connect to your Civitai account", and then said nothing about what it
@@ -67,15 +71,30 @@ export function ConnectScopesDisclosure({ scopes }: { scopes: string[] }) {
   return (
     <Card withBorder p="sm" data-testid="connect-scopes-disclosure">
       <Stack gap="xs">
+        {/* 🔴 "MAY request", NOT "will request", AND NOT "these permissions" — the
+            weaker wording is the CORRECT one and an earlier draft of this component
+            had it wrong in the confident direction.
+            `connectRequestedScopes` is DISCLOSURE/REVIEW-ONLY: `offsite-listing.service.ts`
+            says in as many words that it "does NOT gate OAuth token issuance (the
+            client's `allowedScopes` remains the runtime ceiling via the existing consent
+            flow)". What the consent screen actually lists is the `?scope=` the client
+            asks for at authorize time, validated against `allowedScopes` — so the real
+            ask is usually a SUBSET of this, and can even be a SUPERSET if the client's
+            ceiling is widened after moderator approval, because nothing re-publishes
+            this snapshot.
+            So this list is the MOD-REVIEWED CEILING, not a promise about any particular
+            sign-in screen. Saying "will request … approve these permissions … review
+            them again" asserted an identity that does not hold, on a surface whose whole
+            job is to be trustworthy about permissions. Do not tighten it back. */}
         <Group gap={6}>
           <IconKey size={14} />
           <Text size="sm" fw={600}>
-            Permissions this app will request ({resolved.length})
+            Permissions this app may request ({resolved.length})
           </Text>
           <Tooltip
             multiline
             w={300}
-            label="If you connect this app, it will ask you to sign in and approve these permissions. You can review them again on the Civitai sign-in screen, and you can disconnect the app at any time."
+            label="The most this app is approved to ask for. When you connect it you'll be taken to a Civitai sign-in screen listing what it is actually requesting at that moment, which may be fewer than these. You can disconnect the app at any time."
           >
             <ThemeIcon size="xs" variant="subtle" color="gray">
               <IconInfoCircle size={13} />

--- a/src/components/Apps/ConnectScopesPanel.tsx
+++ b/src/components/Apps/ConnectScopesPanel.tsx
@@ -1,6 +1,6 @@
 import { Card, Group, Stack, Text, ThemeIcon, Tooltip } from '@mantine/core';
 import { IconAlertTriangle, IconInfoCircle, IconKey } from '@tabler/icons-react';
-import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
+import { ConnectScopeRow } from '~/components/Apps/ConnectScopeRow';
 import {
   isSensitiveTokenScope,
   tokenScopeMaskToList,
@@ -84,13 +84,9 @@ export function ConnectScopesPanel({
                   </Tooltip>
                 </Group>
                 {sensitiveScopes.map((s) => (
-                  <ConnectScopeRow
-                    key={s.bit}
-                    scopeKey={s.key}
-                    label={s.label}
-                    sensitive
-                    justifications={justifications}
-                  />
+                  <ConnectScopeRow key={s.bit} scopeKey={s.key} label={s.label} sensitive>
+                    <ConnectScopeJustification scopeKey={s.key} justifications={justifications} />
+                  </ConnectScopeRow>
                 ))}
               </Stack>
             )}
@@ -108,12 +104,9 @@ export function ConnectScopesPanel({
             ) : (
               <Stack gap={8} data-testid="connect-scopes-normal-group">
                 {normalScopes.map((s) => (
-                  <ConnectScopeRow
-                    key={s.bit}
-                    scopeKey={s.key}
-                    label={s.label}
-                    justifications={justifications}
-                  />
+                  <ConnectScopeRow key={s.bit} scopeKey={s.key} label={s.label}>
+                    <ConnectScopeJustification scopeKey={s.key} justifications={justifications} />
+                  </ConnectScopeRow>
                 ))}
               </Stack>
             )}
@@ -124,35 +117,23 @@ export function ConnectScopesPanel({
   );
 }
 
-function ConnectScopeRow({
+/**
+ * The MODERATOR-ONLY half of a scope row: the developer's stated rationale, under
+ * the shared identity line. It stays here rather than moving into
+ * `ConnectScopeRow` because publishing this text is a separate exposure decision
+ * that has not been made — see that component's docblock.
+ */
+function ConnectScopeJustification({
   scopeKey,
-  label,
-  sensitive = false,
   justifications,
 }: {
   scopeKey: string;
-  label: string;
-  sensitive?: boolean;
   justifications?: Record<string, string> | null;
 }) {
   const raw = justifications?.[scopeKey];
   const justification = typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : null;
   return (
-    <Stack gap={2} data-testid={`connect-scope-row-${scopeKey}`}>
-      <Group gap={8} align="flex-start" wrap="nowrap">
-        <ThemeIcon size="xs" variant="subtle" color={sensitive ? 'orange' : 'blue'}>
-          <IconKey size={12} />
-        </ThemeIcon>
-        <Text size="sm" fw={600} style={{ fontFamily: 'ui-monospace, monospace' }}>
-          {scopeKey}
-        </Text>
-        {sensitive && <SensitiveScopeBadge />}
-        {label && (
-          <Text size="xs" c="dimmed">
-            {label}
-          </Text>
-        )}
-      </Group>
+    <>
       {justification ? (
         <Text size="xs" c="dimmed" style={{ whiteSpace: 'pre-wrap' }}>
           <Text span fw={600} c="dimmed">
@@ -165,6 +146,6 @@ function ConnectScopeRow({
           No justification provided
         </Text>
       )}
-    </Stack>
+    </>
   );
 }

--- a/src/components/Apps/__tests__/appListingConnectScopes.test.ts
+++ b/src/components/Apps/__tests__/appListingConnectScopes.test.ts
@@ -130,6 +130,17 @@ describe('ListingDetail.connectScopes', () => {
     expect(detail.connectScopes).toEqual(['UserRead']);
   });
 
+  /**
+   * ⚠ AN INVARIANT GUARD, NOT REGRESSION COVERAGE — it is the ONE case in this file
+   * that PASSES at the pre-change commit, because the DTO carried no justification
+   * text before this change either. Labelled rather than counted: the red-at-base
+   * matrix for this file is 6 of 7, and quoting 7 would overstate what was proven.
+   *
+   * It still earns its place. This change is what makes the field reachable — it
+   * introduces a projection sourced from the same columns the justification text
+   * lives beside, so "it was never there" stops being self-evidently permanent the
+   * moment someone widens the select.
+   */
   it('never carries the owner-authored justification text', () => {
     // `connectScopeJustifications` is an explicit non-goal of #555: publishing it is
     // a separate exposure decision. Pinning its ABSENCE from the DTO is what stops it

--- a/src/components/Apps/__tests__/appListingConnectScopes.test.ts
+++ b/src/components/Apps/__tests__/appListingConnectScopes.test.ts
@@ -102,9 +102,12 @@ describe('ListingDetail.connectScopes', () => {
     expect(detail.connectScopes).toEqual([]);
   });
 
-  it('ignores undefined (a row selected without the column) rather than throwing', () => {
-    expect(project({ connectRequestedScopes: undefined }).connectScopes).toEqual([]);
-  });
+  // ⚠ There is deliberately NO separate `undefined` case. The guard is
+  // `typeof row.connectRequestedScopes === 'number'`, so `undefined` and `null` take
+  // the identical branch — a second test would assert the same line twice and read as
+  // coverage of a distinct path. Removed on the round-0 audit's D4. The `0` half of
+  // the NULL test above is the one that IS distinct, because `0` passes the guard and
+  // reaches the decode.
 
   /**
    * 🔴 THE APPROVED-ONLY GUARANTEE IS UPSTREAM, AND THIS IS WHAT PINS THE RELIANCE.
@@ -149,7 +152,10 @@ describe('ListingDetail.connectScopes', () => {
       connectRequestedScopes: TokenScope.UserRead,
       connectScopeJustifications: { UserRead: 'we need your email to sign you in' },
     });
-    expect(detail).not.toHaveProperty('connectScopeJustifications');
+    // ⚠ No `not.toHaveProperty('connectScopeJustifications')` here — the exact-key-set
+    // ledger in `app-listing.service.test.ts` already asserts the DTO's whole key set,
+    // which subsumes it. This assertion is NOT subsumed: it also catches the text
+    // arriving embedded inside a key the ledger permits. Narrowed on the audit's D4.
     expect(JSON.stringify(detail)).not.toContain('we need your email');
   });
 });

--- a/src/components/Apps/__tests__/appListingConnectScopes.test.ts
+++ b/src/components/Apps/__tests__/appListingConnectScopes.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { projectListingDetail } from '~/server/services/blocks/app-listing.service';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * `ListingDetail.connectScopes` — the PUBLIC disclosure of the OAuth permissions an
+ * off-site connect listing will request (clawgate #555).
+ *
+ * NODE tier on purpose. The browser tier is report-only in CI and therefore cannot
+ * gate a merge, and what is being pinned here is a PUBLIC DTO's contents — the one
+ * thing that must not regress silently, since it crosses the unauthenticated
+ * `GET /api/v1/apps/{slug}` boundary.
+ *
+ * 🔴 EVERY FIXTURE MASK IS BUILT FROM NAMED `TokenScope` MEMBERS, NEVER A LITERAL
+ * INT. A hardcoded `114689` asserts nothing about the decode: it would still pass if
+ * the shared bit table were renumbered, which is exactly the drift this projection's
+ * comment says would be a latent security bug. Naming the members means the fixture
+ * moves with the table and a renumber cannot pass silently.
+ */
+
+/** The minimum row shape `projectListingDetail` reads. Cast at the call, because the
+ *  real select is far wider and none of the rest participates in this projection. */
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'apl_1',
+    slug: 'an-app',
+    name: 'An App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: 'pg',
+    status: 'approved',
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    kind: 'offsite',
+    externalUrl: 'https://example.com',
+    connectClientId: 'oauth-1',
+    connectRequestedScopes: null,
+    appBlock: null,
+    screenshots: [],
+    metric: null,
+    user: null,
+    ...overrides,
+  };
+}
+
+const project = (overrides: Record<string, unknown> = {}) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  projectListingDetail(row(overrides) as any, [], null, {
+    isBeta: false,
+    betaMessage: null,
+  } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+describe('ListingDetail.connectScopes', () => {
+  it('decodes an off-site connect listing’s requested bitmask into TokenScope enum-keys', () => {
+    const mask =
+      TokenScope.UserRead |
+      TokenScope.AIServicesRead |
+      TokenScope.AIServicesWrite |
+      TokenScope.BuzzRead;
+
+    const detail = project({ connectRequestedScopes: mask });
+
+    // Exact set, not a `toContain` — an over-disclosure is as much a defect as an
+    // under-disclosure on a public surface, and only an exact assertion catches it.
+    expect(detail.connectScopes).toEqual([
+      'UserRead',
+      'AIServicesRead',
+      'AIServicesWrite',
+      'BuzzRead',
+    ]);
+  });
+
+  it('orders by ascending bit so the wire order is stable across requests', () => {
+    // Built in DESCENDING bit order on purpose: if the projection ever preserved
+    // input/insertion order instead of the shared table's sort, this is what would
+    // catch it. `toEqual` on an array is order-sensitive.
+    const mask = TokenScope.VaultRead | TokenScope.ModelsRead | TokenScope.UserRead;
+    expect(project({ connectRequestedScopes: mask }).connectScopes).toEqual([
+      'UserRead',
+      'ModelsRead',
+      'VaultRead',
+    ]);
+  });
+
+  it('is [] when the column is NULL, and [] at a zero mask', () => {
+    expect(project({ connectRequestedScopes: null }).connectScopes).toEqual([]);
+    // 0 is a NUMBER, so it passes the `typeof === 'number'` guard and reaches the
+    // decode — this pins that the empty result comes from the decode rather than
+    // from the guard, which a NULL-only test cannot distinguish.
+    expect(project({ connectRequestedScopes: 0 }).connectScopes).toEqual([]);
+  });
+
+  it('is [] for an ON-SITE row even when the column is populated', () => {
+    // The gate is on `kind`, never on the column's nullness — `mapAppBlockToListing`
+    // can mint an offsite kind WITH a backing appBlockId, so the two predicates are
+    // not interchangeable. A populated mask on an onsite row must still disclose
+    // nothing through this field.
+    const detail = project({
+      kind: 'onsite',
+      connectRequestedScopes: TokenScope.UserRead | TokenScope.BuzzRead,
+    });
+    expect(detail.connectScopes).toEqual([]);
+  });
+
+  it('ignores undefined (a row selected without the column) rather than throwing', () => {
+    expect(project({ connectRequestedScopes: undefined }).connectScopes).toEqual([]);
+  });
+
+  /**
+   * 🔴 THE APPROVED-ONLY GUARANTEE IS UPSTREAM, AND THIS IS WHAT PINS THE RELIANCE.
+   *
+   * The projection carries NO status clause, deliberately: `getListingDetail`
+   * returns null for `status !== 'approved'` before reaching it, while
+   * `getListingPreviewForReview` is deliberately NOT status-filtered so a moderator
+   * can preview a draft. So the projection MUST keep disclosing for a non-approved
+   * row — a status gate here would be unreachable on the public path and would blank
+   * the moderator's own preview on the other.
+   *
+   * That makes "drafts stay private" a property of the CALLER, which is the thing a
+   * future reader is most likely to un-verify. Asserting the projection still
+   * discloses at `status: 'draft'` is what makes the split explicit: if someone
+   * "fixes" it by adding a status clause here, this fails and points them at the
+   * caller instead.
+   */
+  it('still decodes for a NON-APPROVED row — the public gate is getListingDetail’s, not this projection’s', () => {
+    const detail = project({
+      status: 'draft',
+      connectRequestedScopes: TokenScope.UserRead,
+    });
+    expect(detail.connectScopes).toEqual(['UserRead']);
+  });
+
+  it('never carries the owner-authored justification text', () => {
+    // `connectScopeJustifications` is an explicit non-goal of #555: publishing it is
+    // a separate exposure decision. Pinning its ABSENCE from the DTO is what stops it
+    // arriving later as an incidental passthrough.
+    const detail = project({
+      connectRequestedScopes: TokenScope.UserRead,
+      connectScopeJustifications: { UserRead: 'we need your email to sign you in' },
+    });
+    expect(detail).not.toHaveProperty('connectScopeJustifications');
+    expect(JSON.stringify(detail)).not.toContain('we need your email');
+  });
+});

--- a/src/components/Apps/reviewListingPreview.ts
+++ b/src/components/Apps/reviewListingPreview.ts
@@ -201,6 +201,20 @@ export function buildListingDetailPreview(
     // AppBlock and therefore no approved scopes — the same answer
     // `projectListingDetail` gives an off-site row.
     scopes: [],
+    // 🔴 `[]`, NEVER omitted, for the same contract reason as `scopes` above —
+    // `AppListingDetailBody` reads `detail.connectScopes.length`, so omitting it
+    // THROWS rather than degrades.
+    //
+    // ⚠ Unlike `scopes`, `[]` here is a LIMITATION, not the honest answer. This
+    // fallback IS built from an off-site publish request, and an off-site connect
+    // listing genuinely can request scopes — but `OffsitePendingRow` does not carry
+    // `connectRequestedScopes`, so there is nothing truthful to decode. Same shape,
+    // same owned trade-off as `sourceRepoUrl` above: widening it means widening the
+    // review-row query. It costs a moderator nothing today, because the authoritative
+    // scope-review surface is `ConnectScopesPanel` in `OffsiteReviewQueue`, which
+    // reads the listing row directly and is unaffected by this builder. If this
+    // fallback ever becomes the primary review path, revisit it with `sourceRepoUrl`.
+    connectScopes: [],
     // Same limitation, same reason, same safe direction as the card builder's `isBeta`.
     isBeta: false,
     betaMessage: null,

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -450,6 +450,52 @@ export type ListingDetail = {
    */
   scopes: string[];
   /**
+   * The OAuth account permissions an OFF-SITE connect listing will REQUEST, as
+   * TokenScope enum-keys (e.g. `['UserRead','BuzzRead']`). `[]` for every listing
+   * that has none — on-site, external-link, and any connect listing whose
+   * `connectRequestedScopes` column is NULL or zero.
+   *
+   * 🔴 ALLOWLIST JUSTIFICATION — AND THIS FIELD IS A NEW PUBLIC EXPOSURE. Like
+   * `scopes` above, it is returned verbatim by the unauthenticated
+   * `GET /api/v1/apps/{slug}` at `PUBLIC_APPS_CATALOG_SCOPE = 'full'`, so this
+   * publishes something that was previously visible only to moderators (the
+   * `ConnectScopesPanel` inside `OffsiteReviewQueue`). That is the decision being
+   * taken here; it is not a no-op. The same blunt operator kill switch applies
+   * (`PUBLIC_APPS_CATALOG_DISABLED_FLAG`) — it withholds the whole catalog, not
+   * this field.
+   *
+   * Why it is the right call: the page already tells the viewer the app "can
+   * connect to your Civitai account", and then disclosed nothing about what it
+   * would ask for — while an ON-SITE app enumerates its approved scopes in full.
+   * The surface granting the WEAKER capability disclosed MORE than the one
+   * granting real account access. These are the same coarse capability keys the
+   * OAuth consent screen shows at sign-in; publishing them earlier lets a viewer
+   * weigh the ask BEFORE starting a flow, and they identify no user and carry no
+   * per-user grant state.
+   *
+   * 🔴 NOT `connectScopeJustifications` — the owner-authored free-text rationale
+   * beside this column stays moderator-only. Disclosing it is a SEPARATE exposure
+   * decision that has not been made; nothing in this DTO carries it.
+   *
+   * 🔴 APPROVED-ONLY IS ENFORCED UPSTREAM, NOT HERE, AND THAT IS DELIBERATE.
+   * `getListingDetail` returns null for any row whose `status !== 'approved'`
+   * before this projection is reached, so a draft's intended scopes can never
+   * ride the public read. A second status clause inside `projectListingDetail`
+   * would be unreachable on that path AND actively wrong on the other one:
+   * `getListingPreviewForReview` is deliberately NOT status-filtered so a
+   * moderator can preview a draft, and gating here would blank the very
+   * enumeration they are reviewing. The reliance is pinned by a test rather than
+   * by this sentence — see `appListingConnectScopes.test.ts`.
+   *
+   * An array of STRINGS, not the raw `Int` bitmask: this crosses the
+   * transformer-less public REST boundary, so it must be a JSON-safe scalar
+   * shape, and a bitmask would couple every external consumer to bit positions.
+   * The decode runs server-side through the shared `tokenScopeMaskToList`, which
+   * is the same table the hub's consent screen uses — forking it would be a
+   * latent security bug, which is why that module says so in its own docstring.
+   */
+  connectScopes: string[];
+  /**
    * AUTHOR-DECLARED "this app is in beta" flag. Same allowlist justification as
    * `ListingCard.isBeta` — a label the author publishes about their own app.
    *

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -450,10 +450,20 @@ export type ListingDetail = {
    */
   scopes: string[];
   /**
-   * The OAuth account permissions an OFF-SITE connect listing will REQUEST, as
-   * TokenScope enum-keys (e.g. `['UserRead','BuzzRead']`). `[]` for every listing
-   * that has none — on-site, external-link, and any connect listing whose
+   * The OAuth account permissions an OFF-SITE connect listing is APPROVED TO ASK
+   * FOR, as TokenScope enum-keys (e.g. `['UserRead','BuzzRead']`). `[]` for every
+   * listing that has none — on-site, external-link, and any connect listing whose
    * `connectRequestedScopes` column is NULL or zero.
+   *
+   * 🔴 A CEILING, NOT A PREDICTION — do not re-describe this as what the app "will
+   * request". `offsite-listing.service.ts` states that `connectRequestedScopes` is
+   * "Disclosure/review-only" and "does NOT gate OAuth token issuance (the client's
+   * `allowedScopes` remains the runtime ceiling via the existing consent flow)". The
+   * consent screen renders the `?scope=` the client asks for at authorize time, so
+   * the actual ask is usually a SUBSET of this — and can be a SUPERSET if the OAuth
+   * client's ceiling is widened after moderator approval, since nothing re-publishes
+   * the snapshot. It IS server-derived from `allowedScopes` at submit and any change
+   * re-enters moderator review, which is what makes it worth publishing at all.
    *
    * 🔴 ALLOWLIST JUSTIFICATION — AND THIS FIELD IS A NEW PUBLIC EXPOSURE. Like
    * `scopes` above, it is returned verbatim by the unauthenticated

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -446,6 +446,13 @@ describe('projectListingDetail — public allowlist + gallery', () => {
         // Empty here — this row has no seats — but the KEY must be present, so a
         // consumer never has to write `?? []`.
         'collaborators',
+        // 🔴 DETAIL-ONLY BY DECISION, and a NEW PUBLIC EXPOSURE — the off-site analog
+        // of `scopes` below. The account permissions an OAuth-connect listing will ASK
+        // the viewer to approve, so the ask is visible BEFORE the connect flow starts
+        // rather than only on the consent screen. Previously moderator-only. Present
+        // as `[]` on this on-site row: the key is always there, so no consumer writes
+        // `?? []`. See its docstring on `ListingDetail` for the exposure decision.
+        'connectScopes',
         'contentRating',
         'coverUrl',
         'creator',

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -8,6 +8,7 @@ import { toPublicBlockManifest } from '~/server/schema/blocks/subscription.schem
 import { isMatureContentRating } from '~/server/utils/server-domain';
 import type { StoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import { narrowStoreScope } from '~/shared/utils/store-visibility-scope';
+import { tokenScopeMaskToList } from '~/shared/constants/token-scope.constants';
 import type {
   GetAppListingDetailInput,
   ListAllListingsForModerationInput,
@@ -233,6 +234,14 @@ export const listingHydrateSelect = {
   contentRating: true,
   externalUrl: true,
   connectClientId: true,
+  // The TokenScope BITMASK an off-site connect listing requests. Feeds the DETAIL
+  // DTO's `connectScopes` (decoded to enum-keys there) — the off-site analog of
+  // `appBlock.approvedScopes` below, and detail-only for the same reason.
+  // Selected unguarded, beside `connectClientId` which it shipped alongside in the
+  // same W13 block: the column is applied in production (verified directly against
+  // `public.app_listings`), so this is not one of the manual-apply reads that has
+  // to degrade rather than 500.
+  connectRequestedScopes: true,
   appBlockId: true,
   icon: { select: { url: true } },
   cover: { select: { url: true } },
@@ -662,6 +671,35 @@ export function projectListingDetail(
     scopes:
       row.kind === 'onsite' && Array.isArray(row.appBlock?.approvedScopes)
         ? row.appBlock.approvedScopes.filter((s): s is string => typeof s === 'string')
+        : [],
+    // The OFF-SITE analog of `scopes` above: the account permissions an
+    // OAuth-connect listing will ASK the viewer to approve, decoded from the
+    // `connectRequestedScopes` bitmask into TokenScope enum-keys.
+    //
+    // 🔴 GATED ON `kind`, LIKE `scopes` AND FOR THE SAME REASON — never on
+    // `connectClientId` nullness. `mapAppBlockToListing` can mint `kind: 'offsite'`
+    // with a non-null `appBlockId`, and `schema.full.prisma` says in as many words
+    // to discriminate on `kind`. An on-site row can hold no requested-scope mask
+    // today, but gating on the column rather than the kind is the shape that goes
+    // wrong later.
+    //
+    // 🔴 DECODED HERE, SERVER-SIDE, THROUGH THE SHARED TABLE. `tokenScopeMaskToList`
+    // is the same expansion the hub's OAuth consent screen uses; its own module
+    // says forking the bitmask/labels would be a latent security bug. Sending the
+    // raw Int instead would push that decode onto every consumer of a PUBLIC REST
+    // endpoint and couple them to bit positions.
+    //
+    // 🔴 NO STATUS CLAUSE, DELIBERATELY. `getListingDetail` already returns null
+    // for `status !== 'approved'` before reaching this projection, so a draft's
+    // intended scopes cannot ride the public read; adding the clause here would be
+    // unreachable on that path. On the OTHER caller it would be actively wrong —
+    // `getListingPreviewForReview` is deliberately not status-filtered so a
+    // moderator can preview a draft, and a status gate here would blank the
+    // enumeration they are reviewing. `appListingConnectScopes.test.ts` pins both
+    // halves so this reliance cannot rot into a sentence nobody rechecks.
+    connectScopes:
+      row.kind === 'offsite' && typeof row.connectRequestedScopes === 'number'
+        ? tokenScopeMaskToList(row.connectRequestedScopes).map((s) => s.key)
         : [],
   };
 }


### PR DESCRIPTION
## What this is

An OAuth-connect off-site listing tells the viewer it **"can connect to your Civitai account"** — and then lists nothing. An **on-site** app enumerates its approved scopes in full on the same page (#4761). So the surface granting the **weaker** capability disclosed **more** than the one granting real account access.

This adds the missing half.

```
This app runs off-platform, but can connect to your Civitai account…   (existing sentence)
  → [NEW] Permissions this app will request (N)
             Sensitive permissions (k)   UserRead · BuzzRead · …
             Other permissions            ModelsRead · …
```

## The question the card was blocked on, answered

The card flagged that `AppListing.connectRequestedScopes` is typed `Int?`, which "does not obviously match a scope LIST", and said criterion 1(a) might be **unbuildable** if it turned out to be a count or a bitmask.

It is a **TokenScope bitmask**, and `schema.full.prisma` says so in as many words. That makes 1(a) buildable rather than blocked: the mask decodes through `tokenScopeMaskToList`, the same shared table the hub's OAuth consent screen uses, and the existing `ConnectScopesPanel` already takes exactly this type.

It is also **not inert**. Measured against production: of the listings carrying a connect client, **every one** has a non-zero mask, and the two distinct masks decode with **zero leftover bits** to —

| | requested, previously undisclosed |
|---|---|
| 3 listings | `UserRead` (profile, settings & **email**), `AIServicesRead`, `AIServicesWrite` (**Buzz spend**), `BuzzRead` (**balance & history**) |
| 1 listing | the above + `ModelsRead`, `MediaRead`, `ArticlesRead`, `BountiesRead`, `CollectionsRead`, `SocialTip` (**money**), `NotificationsRead`, `VaultRead` (**private model vault**) |

## Changes

| File | |
|---|---|
| `app-listing-read.schema.ts` | **`ListingDetail.connectScopes: string[]`** — TokenScope enum-keys. `[]` for on-site, external-link, and any connect listing with a NULL or zero mask. |
| `app-listing.service.ts` | Projects it, decoded server-side. Gated on `kind`, never on `connectClientId` nullness — same reason `scopes` is. |
| `ConnectScopeRow.tsx` | **New.** The scope row lifted out of `ConnectScopesPanel` so the public page and the moderator surface render a scope identically — in particular the `SensitiveScopeBadge`. |
| `ConnectScopesDisclosure.tsx` | **New.** The public renderer. Sensitive-first, store-page copy, `null` at zero. |
| `ConnectScopesPanel.tsx` | Renders the shared row; its DOM and testids are unchanged. |
| `AppListingDetailBody.tsx` | Mounts it after the connect-capability sentence, gated `length > 0`. |

## Three things worth reading the diff for

**Approved-only is enforced upstream, and I deliberately added no status clause.** `getListingDetail` already returns `null` for `status !== 'approved'` before the projection runs, so a draft's intended scopes cannot ride the public read. A second clause inside `projectListingDetail` would be **unreachable** on that path *and actively wrong* on the other one — `getListingPreviewForReview` is deliberately not status-filtered so a moderator can preview a draft, and gating there would blank the very enumeration they are reviewing. A test pins the split, so the reliance can't rot into a sentence nobody rechecks.

**The justification text cannot leak, structurally.** `connectScopeJustifications` is owner-authored free text and publishing it is a separate decision nobody has made (an explicit non-goal). The shared row takes it as a `children` slot rather than a prop, so the public surface has nothing to pass and could not render it if it tried — the omission is structural, not a convention the next caller forgets.

**It widens a public unauthenticated DTO.** `GET /api/v1/apps/{slug}` serves this verbatim at `PUBLIC_APPS_CATALOG_SCOPE='full'`. Stated plainly in the field's docstring rather than left for a reviewer to discover. The same blunt operator kill switch applies (`PUBLIC_APPS_CATALOG_DISABLED_FLAG`) — it withholds the whole catalog, not this field.

## Verification

| | |
|---|---|
| **Node tier** (blocking) | `246 files / 5670 tests passed` across `components/Apps/__tests__/` + `services/blocks/__tests__/` |
| **Red at base** | the new suite is **6 of 7 red** at the pre-change commit — `expected undefined to deeply equal [ 'UserRead', … ]` |
| **The 7th** | passes at base and is **labelled an invariant guard in the file**, not counted as regression coverage |
| **Typecheck** | `pnpm typecheck` → **0 errors** |
| **Never-both-never-neither** | `appListingDetailView.test.ts` passes **unchanged**; no third condition added to either predicate |
| **Browser tier** | ⚠️ **not run locally** — Playwright wants chromium build 1200, nix provides 1228, so it reports `Tests no tests`. An **untouched** browser test fails identically, which is the control that makes it environmental. It is report-only in CI regardless. |

The allowlist ledger in `app-listing.service.test.ts` caught the new key and is updated in its own commit, so the red-at-base matrix above stays exactly what was measured.

Closes clawgate #555.
